### PR TITLE
[6.x] Combobox shouldn't be disabled when max selections limit has been reached

### DIFF
--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -397,7 +397,7 @@ defineExpose({
                 handle-class="sortable-item"
                 :distance="5"
                 :mirror="false"
-                :disabled
+                :disabled="disabled || readOnly"
                 :model-value="modelValue"
                 @update:modelValue="updateModelValue"
             >
@@ -412,7 +412,7 @@ defineExpose({
                             <div v-else>{{ __(getOptionLabel(option)) }}</div>
 
                             <button
-                                v-if="!disabled"
+                                v-if="!disabled && !readOnly"
                                 type="button"
                                 class="opacity-75 hover:opacity-100 cursor-pointer"
                                 :aria-label="__('Deselect option')"

--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -118,6 +118,13 @@ const getOptionLabel = (option) => option?.[props.optionLabel];
 const getOptionValue = (option) => option?.[props.optionValue];
 const isSelected = (option) => selectedOptions.value.filter((item) => getOptionValue(item) === getOptionValue(option)).length > 0;
 
+const isOptionDisabled = (option) => {
+    if (isSelected(option)) return false;
+    if (props.multiple && limitReached.value) return true;
+
+    return false;
+};
+
 const limitReached = computed(() => {
     if (! props.maxSelections) return false;
 
@@ -353,9 +360,10 @@ defineExpose({
                                 <ComboboxItem
                                     v-if="filteredOptions"
                                     v-for="(option, index) in filteredOptions"
-                                    :key="index"
+                                    :key="index + JSON.stringify(modelValue)"
                                     :value="getOptionValue(option)"
                                     :text-value="getOptionLabel(option)"
+                                    :disabled="isOptionDisabled(option)"
                                     :class="itemClasses({ size: size, selected: isSelected(option) })"
                                     as="button"
                                     data-ui-combobox-item

--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -270,7 +270,7 @@ defineExpose({
     <div>
         <div class="flex">
             <ComboboxRoot
-                :disabled="disabled || (multiple && limitReached) || readOnly"
+                :disabled="disabled || readOnly"
                 :model-value="modelValue"
                 :multiple
                 :open="dropdownOpen"

--- a/resources/js/components/fieldtypes/DictionaryFieldtype.vue
+++ b/resources/js/components/fieldtypes/DictionaryFieldtype.vue
@@ -17,14 +17,14 @@
             This slot is *basically* exactly the same as the default selected-options slot in Combobox. We're just looping
             through the Dictionary Fieldtype's selectedOptions state, rather than the one maintained by the Combobox component.
         -->
-        <template #selected-options="{ disabled, getOptionLabel, getOptionValue, labelHtml, deselect }">
+        <template #selected-options="{ disabled, readOnly, getOptionLabel, getOptionValue, labelHtml, deselect }">
             <sortable-list
                 v-if="multiple"
                 item-class="sortable-item"
                 handle-class="sortable-item"
                 :distance="5"
                 :mirror="false"
-                :disabled
+                :disabled="disabled || readOnly"
                 :model-value="value"
                 @update:modelValue="comboboxUpdated"
             >
@@ -39,7 +39,7 @@
                             <div v-else>{{ __(getOptionLabel(option)) }}</div>
 
                             <button
-                                v-if="!disabled"
+                                v-if="!disabled && !readOnly"
                                 type="button"
                                 class="-mx-3 cursor-pointer px-3 text-gray-400 hover:text-gray-700"
                                 :aria-label="__('Deselect option')"

--- a/resources/js/components/sortable/SortableList.vue
+++ b/resources/js/components/sortable/SortableList.vue
@@ -142,7 +142,7 @@ export default {
         },
 
         destroySortableList() {
-            this.sortable.destroy();
+            this.sortable?.destroy();
         },
     },
 


### PR DESCRIPTION
This pull request fixes an issue where it wasn't possible to deselect selected options when the max selections limit had been reached.

This was happening because we were disabling the whole combobox, not just disabling the ability to select new options.

This PR fixes it by passing the `disabled` prop to the `ComboboxItem` components, allowing us to determine which options can be selected.

I also had to change the `:key` to ensure the items get re-rendered when the selections change, otherwise when you deselect an option, the other options would remain disabled.

It took me a while to figure it out but it seems like Reka's`ListboxItem` component (used by `ComboboxItem`) uses [`v-memo`](https://github.com/unovue/reka-ui/blob/v2/packages/core/src/Listbox/ListboxItem.vue#L79) to determine what causes a re-render.

This PR also fixes an issue I spotted with the selected option list, where it wasn't taking the `readOnly` state into consideration.