### PR TITLE
[6.x] Make bard buttons setting responsive

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -103,6 +103,9 @@
 
         &.bard-toolbar-setting {
             @apply grid grid-cols-[repeat(auto-fit,minmax(--spacing(8),1fr))] rounded-[--spacing(5)];
+            button {
+                @apply justify-self-center;
+            }
         }
     }
 

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -100,6 +100,10 @@
                 @apply text-white;
             }
         }
+
+        &.bard-toolbar-setting {
+            @apply grid grid-cols-[repeat(auto-fit,minmax(--spacing(8),1fr))] rounded-[--spacing(5)];
+        }
     }
 
     /* Only top-level Bard fields should have a sticky header */


### PR DESCRIPTION
At the moment the bard buttons setting is not responsive and overflows the container on smaller screens:

<img width="510" height="124" alt="Screenshot 2025-09-16 at 16 36 53" src="https://github.com/user-attachments/assets/6788396c-47a4-4c8c-ae85-c9d26865ac19" />

This PR makes it responsive:

https://github.com/user-attachments/assets/e5f9a05f-8c75-483d-be47-92dfec8f616c

Uses grid instead of flex so that the last row's buttons are aligned with the others while ensuring the buttons are still spread evenly when there's only one row. Dragging the buttons around the grid still seems to work fine.