### PR TITLE
[6.x] Add `prepend` and `append` options to Float fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/FloatFieldtype.vue
+++ b/resources/js/components/fieldtypes/FloatFieldtype.vue
@@ -8,6 +8,8 @@
         :read-only="isReadOnly"
         :disabled="config.disabled"
         :id="fieldId"
+        :prepend="__(config.prepend)"
+        :append="__(config.append)"
         @update:model-value="updateDebounced"
         @focus="$emit('focus')"
         @blur="$emit('blur')"

--- a/src/Fieldtypes/Floatval.php
+++ b/src/Fieldtypes/Floatval.php
@@ -20,6 +20,18 @@ class Floatval extends Fieldtype
                 'instructions' => __('statamic::messages.fields_default_instructions'),
                 'type' => 'text',
             ],
+            'prepend' => [
+                'display' => __('Prepend'),
+                'instructions' => __('statamic::fieldtypes.text.config.prepend'),
+                'type' => 'text',
+                'width' => '50',
+            ],
+            'append' => [
+                'display' => __('Append'),
+                'instructions' => __('statamic::fieldtypes.text.config.append'),
+                'type' => 'text',
+                'width' => '50',
+            ],
         ];
     }
 


### PR DESCRIPTION
This pull request adds `prepend` and `append` options to the Float fieldtype, like the Integer fieldtype has.