### PR TITLE
[6.x] Collection grid missing v-for key

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -12,7 +12,7 @@
         />
     </ui-header>
     <div class="@container/collections flex flex-wrap py-2 gap-y-6 -mx-3" v-if="mode === 'grid'">
-        <div v-for="collection in items" class="w-full @4xl:w-1/2 px-3">
+        <div v-for="collection in items" class="w-full @4xl:w-1/2 px-3" :key="collection.id">
             <ui-panel>
                 <ui-panel-header class="flex items-center justify-between">
                     <div class="flex items-center gap-1.5">


### PR DESCRIPTION
The Collection grid view was missing the `key` for each item in the grid.

This resulted in incorrect behaviour when deleting a Collection. The correct Collection is deleted, however the UI shows the entries of the deleted collection.

## Steps to replicate
1. Install Statamic 6 alpha 7
2. Create a Collection (such as "C1")
3. Create an Entry in that Collection with a noticeable Title (i.e. "Entry 1")
4. Create a Collection that appears after C1 (such as "C2")
5. Create an Entry in that Collection with a noticeable Title (i.e. "Entry 2")
6. Go to the Collections view, and switch to Grid
7. Delete "C1" collection

C1 is deleted, and C2 takes the place of C1 in the UI. The entries shown under C2 are now those from C1.

The missing `key` attribute for the `v-for` loop causes this. 

This PR addresses this.
