### PR TITLE
[6.x] correct select icon and spacing

### DIFF
--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -289,18 +289,18 @@ defineExpose({
                                 @keydown.space="openDropdown"
                             />
 
-                            <button type="button" class="w-full text-start truncate flex items-center gap-2 bg-transparent cursor-pointer focus:outline-none" v-else-if="!searchable && (dropdownOpen || !modelValue)" @keydown.space="openDropdown" data-ui-combobox-placeholder>
+                            <button type="button" class="w-full text-start flex items-center gap-2 bg-transparent cursor-pointer focus:outline-none" v-else-if="!searchable && (dropdownOpen || !modelValue)" @keydown.space="openDropdown" data-ui-combobox-placeholder>
                             <Icon v-if="icon" :name="icon" class="text-gray-400 dark:text-white dark:opacity-50" />
-                                <span class="text-gray-400 dark:text-gray-500" v-text="placeholder" />
+                                <span class="block truncate text-gray-400 dark:text-gray-500" v-text="placeholder" />
                             </button>
 
-                            <button type="button" v-else class="w-full text-start bg-transparent truncate flex items-center gap-2 cursor-pointer focus-none" @keydown.space="openDropdown" data-ui-combobox-selected-option>
+                            <button type="button" v-else class="w-full text-start bg-transparent flex items-center gap-2 cursor-pointer focus-none" @keydown.space="openDropdown" data-ui-combobox-selected-option>
                                 <slot name="selected-option" v-bind="{ option: selectedOption }">
                                     <div v-if="icon" class="size-4">
                                         <Icon :name="icon" class="text-white/85 dark:text-white dark:opacity-50" />
                                     </div>
-                                    <span v-if="labelHtml" v-html="getOptionLabel(selectedOption)" />
-                                    <span v-else v-text="getOptionLabel(selectedOption)" />
+                                    <span v-if="labelHtml" v-html="getOptionLabel(selectedOption)" class="block truncate" />
+                                    <span v-else v-text="getOptionLabel(selectedOption)" class="block truncate" />
                                 </slot>
                             </button>
                         </div>

--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -296,8 +296,8 @@ defineExpose({
 
                             <button type="button" v-else class="w-full text-start bg-transparent truncate flex items-center gap-2 cursor-pointer focus-none" @keydown.space="openDropdown" data-ui-combobox-selected-option>
                                 <slot name="selected-option" v-bind="{ option: selectedOption }">
-                                    <div class="size-4">
-                                        <Icon v-if="icon" :name="icon" class="text-white/85 dark:text-white dark:opacity-50" />
+                                    <div v-if="icon" class="size-4">
+                                        <Icon :name="icon" class="text-white/85 dark:text-white dark:opacity-50" />
                                     </div>
                                     <span v-if="labelHtml" v-html="getOptionLabel(selectedOption)" />
                                     <span v-else v-text="getOptionLabel(selectedOption)" />
@@ -305,7 +305,7 @@ defineExpose({
                             </button>
                         </div>
 
-                        <div class="flex gap-1.5 items-center shrink-0 ms-1.5 size-4">
+                        <div class="flex gap-1.5 items-center shrink-0 ms-1.5">
                             <Button v-if="clearable && modelValue" icon="x" variant="ghost" size="xs" round @click="clear" data-ui-combobox-clear-button />
                             <Icon v-if="options.length || ignoreFilter" name="chevron-down" class="text-gray-400 dark:text-white/40" data-ui-combobox-chevron />
                         </div>


### PR DESCRIPTION
In Alpha 8, the trigger icon has a condition on the wrong element, and an unnecessary `size` on the clear and chevron container.

Also, longer items are not truncating correctly.

Before:
<img width="585" height="105" alt="image" src="https://github.com/user-attachments/assets/c15e97fa-04a0-49e2-9a48-08a0d036ecce" />

After:
<img width="564" height="103" alt="image" src="https://github.com/user-attachments/assets/69118278-107e-452b-84ae-e3ce26b89736" />

When the Select field is clearable, the "x" and chevron still sit oddly and take up a lot of space.

Perhaps the `gap-1.5` at line 308 is unnecessary, and perhaps the chevron itself needs to sit more to the right too - but that's starting to get opinionated.