### PR TITLE
[6.x] Correct Grid fieldtype deleting row condition

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -41,7 +41,7 @@
         </element-container>
 
         <confirmation-modal
-            v-if="deletingRow"
+            v-if="deletingRow !== null"
             :title="__('Delete Row')"
             :body-text="__('Are you sure?')"
             :button-text="__('Delete')"


### PR DESCRIPTION
In the Grid fieldtype, there is a `v-if` for the delete confirmation modal that had the condition:
`v-if="deletingRow"`
The `deletingRow` is the row index, zero-based.

This does not work for the first row: this condition fails when `deletingRow` is 0.

This PR updates the condition to explicitly look for when `deletingRow` is not `null`