### PR TITLE
[6.x] Improve List fieldtype in dark mode

### DIFF
--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -97,7 +97,7 @@ Table Fieldtype
 
     [data-ui-control] {
         @apply block w-full max-w-full rounded-none appearance-none border p-2;
-        @apply border-none bg-white text-sm shadow-none outline-hidden;
+        @apply border-none bg-white dark:bg-gray-800 text-sm shadow-none outline-hidden;
         &:focus {
             @apply bg-gray-100 inset-shadow-xs ring-0 dark:bg-gray-700;
         }

--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -15,7 +15,6 @@
                         <td
                             class="sortable-handle table-drag-handle"
                             v-if="!isReadOnly"
-                            :class="{ 'rounded-tl': index === 0 }"
                         ></td>
                         <td>
                             <ui-input

--- a/resources/js/components/fieldtypes/ListFieldtype.vue
+++ b/resources/js/components/fieldtypes/ListFieldtype.vue
@@ -21,6 +21,7 @@
                             <ui-input
                                 type="text"
                                 ref="listItem"
+                                class="!inset-shadow-none focus:!inset-shadow-none"
                                 v-model="element.value"
                                 :readonly="isReadOnly"
                                 @blur="focused = false"


### PR DESCRIPTION
This pull request attempts to improve the List fieldtype in dark mode. Closes #12489

## Before
<img width="1221" height="135" alt="CleanShot 2025-09-18 at 10 54 11" src="https://github.com/user-attachments/assets/0c6e799c-8dbe-49b0-b296-a37ab5dc2171" />


## After

<img width="1221" height="135" alt="CleanShot 2025-09-18 at 10 53 48" src="https://github.com/user-attachments/assets/c7de8343-49cb-4c78-ba37-b2d137068f42" />
