### PR TITLE
[6.x] Ensure publish form actions are visible on smaller screens

### DIFF
--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -108,6 +108,8 @@ function tabHasError(tab) {
                         <slot :tab="tab">
                             <Sections />
                         </slot>
+
+                        <slot name="actions" />
                     </TabProvider>
                 </TabContent>
 


### PR DESCRIPTION
This pull request fixes an issue where the `actions` slot used for the "Visit URL" button, revisions, localisations wasn't showing on smaller screens.

This was because we were only rendering it when the sidebar was visible, which it isn't on mobile. This PR fixes it by rendering its contents below the publish form if there's no visible sidebar.

Fixes #12469