### PR TITLE
[6.x] Ensure field names are always left-aligned in blueprint builder

### DIFF
--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -10,7 +10,7 @@
                         v-tooltip="tooltipText"
                     />
                     <div class="flex items-center gap-2">
-                        <button class="cursor-pointer overflow-hidden text-ellipsis text-sm hover:text-blue-600 text-left" type="button" v-text="__(labelText)" @click="$emit('edit')" />
+                        <button class="cursor-pointer overflow-hidden text-ellipsis text-sm hover:text-blue-600 text-start" type="button" v-text="__(labelText)" @click="$emit('edit')" />
                         <ui-icon v-if="isReferenceField" name="link" class="text-gray-400" />
                         <span v-if="isReferenceField" class="text-gray-500 font-mono text-2xs cursor-help" v-text="__('field')" v-tooltip="__('Imported from: :reference', { reference: field.field_reference })" />
                     </div>


### PR DESCRIPTION
This pull request fixes an issue where long field names were being centre-aligned in the blueprint builder. 

I wasn't able to track down exactly _why_ longer text was being centred but shorter text wasn't, but `text-left` seem to fix it. 🤷‍♂️

Fixes #12459

## Before
<img width="400" height="100" alt="CleanShot 2025-09-18 at 12 19 23" src="https://github.com/user-attachments/assets/9168247f-6e97-41ab-acef-7493b64d3296" />


## After

<img width="400" height="100" alt="CleanShot 2025-09-18 at 12 19 10" src="https://github.com/user-attachments/assets/3f1f3ba2-4345-49ee-a6fe-76fbd70cd576" />
