### PR TITLE
[6.x] Fix publish form actions showing at bottom when sidebar is visible

### DIFF
--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -109,7 +109,7 @@ function tabHasError(tab) {
                             <Sections />
                         </slot>
 
-                        <slot name="actions" />
+                        <slot v-if="!shouldShowSidebar" name="actions" />
                     </TabProvider>
                 </TabContent>
 


### PR DESCRIPTION
This pull request fixes an issue I introduced in #12500 where actions would show at the bottom of the publish form, even when the sidebar is visible.