### PR TITLE
fix: on missing LivePreview $token/$item skip the LivePreview handling

### DIFF
--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -15,9 +15,11 @@ class LivePreview
     {
         $item = Facade::item($token);
 
-        $item->repository()->substitute($item);
-
         $response = $next($request);
+
+        if (!$item) return $response;
+
+        $item->repository()->substitute($item);
 
         if (Sites::multiEnabled()) {
             /** @var Collection */


### PR DESCRIPTION
This can occur as in issue https://github.com/statamic/cms/issues/11912#issuecomment-3311236909 listed and aims to fix that behavior

