### PR TITLE
[5.x] fix: on missing LivePreview $token/$item skip the LivePreview handling

### DIFF
--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -17,7 +17,7 @@ class LivePreview
 
         $response = $next($request);
 
-        if (!$item) {
+        if (! $item) {
             return $response;
         }
 


### PR DESCRIPTION
This can occur as in issue http://github.com/statamic/cms/issues/11912 listed and aims to fix that behavior