### PR TITLE
[6.x] Add dependencies to UI package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,8 +14,18 @@
     "tailwindcss": "^4.0.0"
   },
   "dependencies": {
+    "@shopify/draggable": "^1.0.0-beta.12",
+    "autosize": "~6.0.1",
+    "codemirror": "5.65.12",
     "cva": "^1.0.0-beta.3",
-    "tailwind-merge": "^3.0.2"
+    "fuzzysort": "^3.1.0",
+    "lodash-es": "^4.17.21",
+    "marked": "^15.0.0",
+    "motion-v": "^1.0.0-beta.0",
+    "reka-ui": "^2.2.0",
+    "resize-observer-polyfill": "^1.5.1",
+    "tailwind-merge": "^3.0.2",
+    "uniqid": "^5.2.0"
   },
   "scripts": {
     "types": "rm -rf types && vue-tsc --declaration --emitDeclarationOnly || true"


### PR DESCRIPTION
This pull request adds the necessary dependencies to the UI package's `package.json`, so we don't need to require them separately on the docs.