### PR TITLE
[5.x] Fix form submission search query

### DIFF
--- a/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
+++ b/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
@@ -48,15 +48,17 @@ class FormSubmissionsController extends CpController
         $query = $form->querySubmissions();
 
         if ($search = request('search')) {
-            $query->where('date', 'like', '%'.$search.'%');
+            $query->where(function ($query) use ($form, $search) {
+                $query->where('date', 'like', '%'.$search.'%');
 
-            $form->blueprint()->fields()->all()
-                ->filter(function (Field $field): bool {
-                    return in_array($field->type(), ['text', 'textarea', 'integer']);
-                })
-                ->each(function (Field $field) use ($query, $search): void {
-                    $query->orWhere($field->handle(), 'like', '%'.$search.'%');
-                });
+                $form->blueprint()->fields()->all()
+                    ->filter(function (Field $field): bool {
+                        return in_array($field->type(), ['text', 'textarea', 'integer']);
+                    })
+                    ->each(function (Field $field) use ($query, $search): void {
+                        $query->orWhere($field->handle(), 'like', '%'.$search.'%');
+                    });
+            });
         }
 
         return $query;


### PR DESCRIPTION
This pull request fixes an issue with the form submission search query, where searching form submissions would return submissions from all forms, rather than just the current form.

This was happening due to the `->orWhere()` statements, which were effectively cancelling out the "where form = 'form_handle'` condition. 

Moving the search conditions into a nested `->where()` means they are evaluated as one, and can't negate other where statements on the query.

I was only able to replicate this issue on the Eloquent Driver, but the nested where can't do any harm.

Closes statamic/eloquent-driver#499