### PR TITLE
[6.x] Update `make:widget` stub

### DIFF
--- a/src/Console/Commands/stubs/widget.blade.php.stub
+++ b/src/Console/Commands/stubs/widget.blade.php.stub
@@ -1,3 +1,5 @@
-<div class="card p-0 content">
-    👋 I'm the {{ name }} widget!
-</div>
+<ui-widget title="{{ name }}">
+    <div class="px-4 py-3">
+        <p>👋 Hello world!</p>
+    </div>
+</ui-widget>


### PR DESCRIPTION
This pull request updates the stub used when running `php please make:widget`.

## Before
<img width="314" height="74" alt="CleanShot 2025-09-22 at 12 45 49" src="https://github.com/user-attachments/assets/fca7db6f-3790-49f6-b95e-9385826778b6" />



## After

<img width="1623" height="250" alt="CleanShot 2025-09-22 at 12 45 21" src="https://github.com/user-attachments/assets/647ad9fc-e4fa-4d2b-b3f1-2edbfcb9701e" />
