### PR TITLE
[6.x] Add `@vitejs/plugin-vue` dependency to package

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -5,6 +5,9 @@
     "scripts": {
         "types": "rm -rf types && vue-tsc --declaration --emitDeclarationOnly || true"
     },
+    "dependencies": {
+        "@vitejs/plugin-vue": "^6.0.0"
+    },
     "exports": {
         ".": {
             "types": "./types/resources/js/bootstrap/cms/index.d.ts",


### PR DESCRIPTION
This pull request adds `@vitejs/plugin-vue` as a dependency to the `@statamic/cms` package. 

Otherwise, when you run `php please setup-cp-vite`, then `npm run cp:build`, you get an error about the Vue package missing:

```
failed to load config from /Users/duncan/Code/Throwaway/fieldtype-stubs/vite-cp.config.js
error during build:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@vitejs/plugin-vue' imported from /Users/duncan/Code/Throwaway/fieldtype-stubs/vendor/statamic/cms/resources/dist-package/src/vite-plugin/index.js
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:268:9)
    at packageResolve (node:internal/modules/esm/resolve:768:81)
    at moduleResolve (node:internal/modules/esm/resolve:854:18)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49)
```