### PR TITLE
[6.x] Checkbox item component shouldnt have required value prop

### DIFF
--- a/packages/ui/src/Checkbox/Item.vue
+++ b/packages/ui/src/Checkbox/Item.vue
@@ -14,7 +14,7 @@ const props = defineProps({
     size: { type: String, default: 'base' },
     solo: { type: Boolean, default: false },
     tabindex: { type: Number, default: null },
-    value: { type: [String, Number, Boolean], required: true },
+    value: { type: [String, Number, Boolean] },
 });
 
 const emit = defineEmits(['update:modelValue']);


### PR DESCRIPTION
When using `ui-checkbox` on its own, you shouldn't need a `value` prop.

```<ui-checkbox v-model="toggleMe" />```
