### PR TITLE
[6.x] Make "Cancel" in ConfirmationModal translatable

### DIFF
--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -21,7 +21,7 @@ const props = defineProps({
     },
     cancelText: {
         type: String,
-        default: 'Cancel',
+        default: () => __('Cancel'),
     },
     danger: {
         type: Boolean,


### PR DESCRIPTION
This pull request makes the "Cancel" string in the `ConfirmationModal` component translatable.

Fixes #12537