### PR TITLE
[6.x] Fix button text on password reset page

### DIFF
--- a/resources/views/auth/passwords/reset.blade.php
+++ b/resources/views/auth/passwords/reset.blade.php
@@ -47,7 +47,7 @@
                     />
                 </ui-field>
 
-                <ui-button type="submit" variant="primary" :text="$title" />
+                <ui-button type="submit" variant="primary" text="{{ $title }}" />
             </form>
         </ui-auth-card>
     </div>


### PR DESCRIPTION
This pull request fixes an issue where the text wasn't being passed to the button correctly on the password reset page.

Fixes https://github.com/statamic/cms/issues/12538