### PR TITLE
[6.x] Fix JS errors caused by single quotes in translations

### DIFF
--- a/resources/views/components/docs-callout.blade.php
+++ b/resources/views/components/docs-callout.blade.php
@@ -5,7 +5,7 @@
 @if (config('statamic.cp.link_to_docs'))
     <div class="mt-12 flex justify-center text-center starting-style-transition starting-style-transition--siblings">
         <ui-command-palette-item
-            :text="[__('Statamic Documentation'), '{{ $topic }}']"
+            :text="[__('Statamic Documentation'), `{{ $topic }}`]"
             icon="book-next-page"
             url="{{ $url }}"
             open-new-tab


### PR DESCRIPTION
This pull request fixes an issue where JS errors would occur on some pages when using the Control Panel in French. 

This was happening because some translations include single quotes (`'`).

Fixes https://github.com/statamic/cms/issues/12535