### PR TITLE
[6.x] Make Origin dropdown clearable on Global Set settings

### DIFF
--- a/resources/js/components/globals/Sites.vue
+++ b/resources/js/components/globals/Sites.vue
@@ -26,6 +26,7 @@
                     <Select
                         class="w-full"
                         :options="siteOriginOptions(site)"
+                        :clearable="true"
                         :model-value="site.origin"
                         @update:model-value="site.origin = $event"
                     />


### PR DESCRIPTION
This pull request makes the Origin dropdown clearable on the Global Set settings page.

Fixes https://github.com/statamic/cms/issues/12524