### PR TITLE
[6.x] Improve combobox legibility to pass AA

### DIFF
--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -302,8 +302,8 @@ defineExpose({
                             />
 
                             <button type="button" class="w-full text-start flex items-center gap-2 bg-transparent cursor-pointer focus:outline-none" v-else-if="!searchable && (dropdownOpen || !modelValue)" @keydown.space="openDropdown" data-ui-combobox-placeholder>
-                            <Icon v-if="icon" :name="icon" class="text-gray-400 dark:text-white dark:opacity-50" />
-                                <span class="block truncate text-gray-400 dark:text-gray-500" v-text="placeholder" />
+                            <Icon v-if="icon" :name="icon" class="text-gray-500 dark:text-white dark:opacity-50" />
+                                <span class="block truncate text-gray-500" v-text="placeholder" />
                             </button>
 
                             <button type="button" v-else class="w-full text-start bg-transparent flex items-center gap-2 cursor-pointer focus-none" @keydown.space="openDropdown" data-ui-combobox-selected-option>


### PR DESCRIPTION
I found the "unselected" state of the combobox difficult to read, so I increased its contrast by 100.
This now reaches the minimum contrast for AA, and it still sufficiently contrasts with the selected state, so it remains easy to distinguish.

## Before
(see the Link field)
![2025-09-23 at 11 23 44@2x](https://github.com/user-attachments/assets/afc79085-976d-4dfa-bccd-4c331cf3aa8b)

## After
![2025-09-23 at 11 24 26@2x](https://github.com/user-attachments/assets/23506a94-65ed-4bc6-a754-ce91f575d10c)
