### PR TITLE
[6.x] Fix relationship input size edge cases

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -11,14 +11,15 @@
 
             <!-- Entry select -->
             <relationship-fieldtype
-                v-if="option === 'entry'"
-                ref="entries"
-                handle="entry"
-                :value="selectedEntries"
                 :config="meta.entry.config"
                 :meta="meta.entry.meta"
-                @update:value="entriesSelected"
+                :value="selectedEntries"
                 @update:meta="meta.entry.meta = $event"
+                @update:value="entriesSelected"
+                button-size="base"
+                handle="entry"
+                ref="entries"
+                v-if="option === 'entry'"
             />
 
             <!-- Asset select -->
@@ -35,12 +36,6 @@
         </div>
     </div>
 </template>
-
-<style scoped>
-    /* :deep(.relationship-input) > div:first-child {
-        @apply h-full;
-    } */
-</style>
 
 <script>
 import Fieldtype from './Fieldtype.vue';

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -48,10 +48,10 @@
             </div>
             <div
                 v-if="canSelectOrCreate"
-                class="relationship-input-buttons @container relative h-full"
+                class="relationship-input-buttons @container relative"
                 :class="{ 'mt-3': items.length > 0 }"
             >
-                <div class="flex flex-wrap items-center gap-2 h-full">
+                <div class="flex flex-wrap items-center gap-2">
                     <CreateButton
                         v-if="canCreate && creatables.length"
                         :creatables="creatables"
@@ -62,15 +62,13 @@
                         :site="site"
                         :stack-size="formStackSize"
                         @created="itemCreated"
-                        class="h-full"
                     />
                     <Button
                         ref="existing"
                         icon="link"
-                        size="sm"
+                        :size="buttonSize"
                         :text="linkLabel"
                         @click.prevent="isSelecting = true"
-                        class="h-full"
                     />
                 </div>
             </div>
@@ -133,6 +131,7 @@ export default {
         search: { type: Boolean },
         selectionsUrl: { type: String },
         site: { type: String },
+        buttonSize: { type: String, default: 'sm' },
         statusIcons: { type: Boolean },
         taggable: { type: Boolean },
         tree: { type: Object },


### PR DESCRIPTION
When used in the Link fieldtype, the Link Entry button should be full sized, but is otherwise small. This gives us the control we need to stop playing whack-a-mole.
![source](https://github.com/user-attachments/assets/3dcc2baf-7e3a-45ad-ba66-aba784bedaff)
