### PR TITLE
[6.x] Fix "Contained data table" styling

### DIFF
--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -19,7 +19,7 @@
             @apply px-4 py-2;
 
             .data-table--contained & {
-                @apply py-2.5 border-b dark:border-gray-700;
+                @apply py-2.5 border-b border-gray-200 dark:border-gray-700;
             }
         }
 
@@ -95,12 +95,6 @@
                 @apply bg-white dark:bg-gray-900;
                 @apply pl-4.5 pr-2.5 py-3 border-t border-gray-200 dark:border-white/10;
                 @apply text-gray-900 dark:text-gray-200;
-                &:first-child {
-                    @apply border-s border-s-gray-200 dark:border-s-gray-800;
-                }
-                &:last-child {
-                    @apply border-e border-e-gray-200 dark:border-e-gray-800;
-                }
             }
 
             /* When the row is hovered, change the background of all its cells to a hover state color */

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -32,6 +32,36 @@
         }
     }
 
+    /* Make sure we only apply this where the data table "head" is in the gray wrapper, i.e. _not_ assets, since otherwise we would be rounding the second row */
+    &:not(.data-table--contained) {
+        tbody {
+            tr:first-child {
+                /* [1] Round the corners */
+                td:first-child,
+                th:first-child {
+                    @apply ltr:rounded-tl-xl rtl:rounded-tr-xl;
+                }
+                td:last-child,
+                th:last-child {
+                    @apply ltr:rounded-tr-xl rtl:rounded-tl-xl;
+                }
+                /* [2] Add a border */
+                td {
+                    @apply border-t border-t-gray-200 dark:border-t-gray-800;
+                }
+            }
+            tr td {
+                /* [3] Add left and right borders */
+                &:first-child {
+                    @apply border-s border-s-gray-200 dark:border-s-gray-800;
+                }
+                &:last-child {
+                    @apply border-e border-e-gray-200 dark:border-e-gray-800;
+                }
+            }
+        }
+    }
+
     tbody {
         @apply text-sm shadow-sm-b rounded-xl outline-none;
         .data-table--contained & {
@@ -39,22 +69,6 @@
         }
 
         tr {
-            &:first-child {
-                td:first-child,
-                th:first-child {
-                    @apply ltr:rounded-tl-xl rtl:rounded-tr-xl;
-                }
-
-                td {
-                    @apply border-t border-t-gray-200 dark:border-t-gray-800;
-                }
-
-                td:last-child,
-                th:last-child {
-                    @apply ltr:rounded-tr-xl rtl:rounded-tl-xl;
-                }
-            }
-
             &:last-child {
                 @apply border-none;
 
@@ -102,6 +116,12 @@
 
     .date-index-field {
         @apply whitespace-nowrap;
+    }
+}
+
+.data-table--contained tbody {
+    tr:first-child td {
+        border-top: unset;
     }
 }
 

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -64,9 +64,6 @@
 
     tbody {
         @apply text-sm shadow-sm-b rounded-xl outline-none;
-        .data-table--contained & {
-            @apply shadow-none rounded-none;
-        }
 
         tr {
             &:last-child {

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -1,10 +1,15 @@
 /* ==========================================================================
    TABLES
    ========================================================================== */
+/* Modifiers...
+
+    - .data-table--contained is used when the table head appears _inside_ the container, for example /assets.
+
+*/
 .data-table {
     @apply w-full max-w-full outline-hidden text-gray-500 antialiased border-separate border-spacing-y-0 min-w-full overflow-x-auto text-start;
 
-    &.contained {
+    &.data-table--contained {
         @apply rounded-xl;
     }
 
@@ -13,7 +18,7 @@
             @apply whitespace-nowrap text-sm font-medium text-gray-900 dark:text-gray-300 text-start;
             @apply px-4 py-2;
 
-            .contained & {
+            .data-table--contained & {
                 @apply py-2.5 border-b dark:border-gray-700;
             }
         }
@@ -29,7 +34,7 @@
 
     tbody {
         @apply text-sm shadow-sm-b rounded-xl outline-none;
-        .contained & {
+        .data-table--contained & {
             @apply shadow-none rounded-none;
         }
 
@@ -104,7 +109,7 @@
 .data-table {
     thead th.checkbox-column {
         @apply sticky z-1 ps-3 w-8;
-        .contained & {
+        .data-table--contained & {
             @apply sticky ps-4;
         }
     }
@@ -117,7 +122,7 @@
 
     tbody .checkbox-column {
         @apply sticky px-3 -start-px;
-        .contained & {
+        .data-table--contained & {
             @apply sticky ps-4;
         }
     }

--- a/resources/js/components/assets/Browser/Table.vue
+++ b/resources/js/components/assets/Browser/Table.vue
@@ -1,5 +1,5 @@
 <template>
-    <Card inset>
+    <Card inset variant="flat">
         <ListingTable contained>
             <template #tbody-start>
                 <tr

--- a/resources/js/components/ui/Listing/Table.vue
+++ b/resources/js/components/ui/Listing/Table.vue
@@ -47,7 +47,7 @@ const forwardedTableCellSlots = computed(() => {
         :class="{
             'select-none': shifting,
             'data-table': !unstyled,
-            contained: contained,
+            'data-table--contained': contained,
             'opacity-50': loading,
         }"
         data-table


### PR DESCRIPTION
This closes #12518 by adjusting the way `.data-table` works, adding some exceptions for contained tables.

This regression was caused by https://github.com/statamic/cms/pull/12233, which changed the way table borders are styled, as there are subtle differences in how browsers handle table styling.

Contained tables have a different container, and we need to make adjustments accordingly. While I was here I made it a bit clearer that "contained" is explicitly a `.data-table` modifier class, using BEM notation—since initially this was not clear to me.

