### PR TITLE
Prevent caching during live preview

### DIFF
--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -64,7 +64,11 @@ class Cache extends Tags implements CachesOutput
             return false;
         }
 
-        // Only GET requests. This disables the cache during live preview.
+        if (request()->isLivePreview()) {
+            return false;
+        }
+
+        // Only GET requests.
         return request()->method() === 'GET';
     }
 


### PR DESCRIPTION
This pull request fixes https://github.com/statamic/cms/issues/12553.

Instead of checking just the request method, `isLivePreview()` is used to ensure that the request is a live preview request.