### PR TITLE
[5.x] Prevent empty cache tag when using Blade

### DIFF
--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -14,7 +14,7 @@ class Cache extends Tags implements CachesOutput
     public function index()
     {
         if (! $this->isEnabled()) {
-            return [];
+            return $this->parse([]);
         }
 
         $store = LaraCache::store($this->params->get('store'));


### PR DESCRIPTION
This pull request fixes https://github.com/statamic/cms/issues/12566.

When the cache tag is disabled, `$this->parse([])` should be returned instead of an empty array. This fixes the empty cache tag when using Blade instead of Antlers.
