### PR TITLE
[6.x] Asset table fixes for Safari

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -1,5 +1,6 @@
 <template>
-    <tr class="relative cursor-grab bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-900 border-b dark:border-dark-500 last:border-b-0">
+    <!-- Safari doesn't support `position: relative` on `<tr>` elements, but these two properties can be used as an alternative. Source: https://mtsknn.fi/blog/relative-tr-in-safari/ transform: translate(0); clip-path: inset(0); -->
+    <tr class="relative cursor-grab bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-900 border-b dark:border-dark-500 last:border-b-0" style="transform: translate(0); clip-path: inset(0);">
         <td class="flex gap-3 h-full items-center p-3">
             <div
                 v-if="canShowSvg"


### PR DESCRIPTION
This closes #12517 and fixes Safari not supporting `position: relative` on `<tr>` elements, which in turn made asset row info—which is absolutely positioned—pile on top of each other in Safari like this

![2025-09-25 at 10 40 58@2x](https://github.com/user-attachments/assets/f756ef5d-53f0-49e1-8429-b346d47b608f)

This is a weird fix, but it's documented and it works. I made the conscious decision to add these properties in a style tag to separate them the Tailwind styling—I think it's neater.

I also added a comment because it's really not obvious why these properties are here otherwise, and comments are stripped out in production anyway.
