### PR TITLE
[6.x] Improve send password reset modal

### DIFF
--- a/resources/js/components/actions/ConfirmableAction.vue
+++ b/resources/js/components/actions/ConfirmableAction.vue
@@ -4,6 +4,7 @@ import {
     PublishContainer,
     PublishFieldsProvider as FieldsProvider,
     PublishFields,
+    Description,
 } from '@ui';
 import { requireElevatedSessionIf } from '@/components/elevated-sessions/index.js';
 
@@ -94,9 +95,9 @@ defineExpose({
         @confirm="confirmed"
         @cancel="reset"
     >
-        <div
+        <Description
             v-if="confirmationText"
-            v-text="confirmationText"
+            :text="confirmationText"
             :class="{ 'mb-4': warningText || showDirtyWarning || action.fields.length }"
         />
 

--- a/resources/lang/ar.json
+++ b/resources/lang/ar.json
@@ -858,7 +858,7 @@
     "Seller": "بائع",
     "Send Email Invitation": "إرسال دعوة عبر البريد الإلكتروني",
     "Send Password Reset": "إرسال إعادة تعيين كلمة المرور",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "إرسال بريد إعادة تعيين كلمة المرور إلى هذا المستخدم؟|إرسال بريد إعادة تعيين كلمة المرور إلى هؤلاء :count المستخدمين؟",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "إرسال بريد إعادة تعيين كلمة المرور إلى هذا المستخدم؟|إرسال بريد إعادة تعيين كلمة المرور إلى هؤلاء :count المستخدمين؟",
     "Send Test Email": "إرسال بريد إلكتروني تجريبي",
     "Sender": "المرسل",
     "Sendmail": "إرسال بريد",

--- a/resources/lang/az.json
+++ b/resources/lang/az.json
@@ -858,7 +858,7 @@
     "Seller": "Satıcı",
     "Send Email Invitation": "E-poçt dəvəti göndər",
     "Send Password Reset": "Şifrəni sıfırlamaq üçün göndər",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Bu istifadəçiyə şifrə sıfırlama e-poçtu göndərin?|Bu :count istifadəçiyə şifrə sıfırlama e-poçtu göndərin?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Bu istifadəçiyə şifrə sıfırlama e-poçtu göndərin?|Bu :count istifadəçiyə şifrə sıfırlama e-poçtu göndərin?",
     "Send Test Email": "Test e-poçtu göndər",
     "Sender": "Göndərən",
     "Sendmail": "Sendmail",

--- a/resources/lang/cs.json
+++ b/resources/lang/cs.json
@@ -858,7 +858,7 @@
     "Seller": "Prodavač",
     "Send Email Invitation": "Odeslat pozvánku e-mailem",
     "Send Password Reset": "Odeslat nové heslo",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Odeslat e-mail s novým heslem pro tohoto uživatele?|Odeslat e-mail s novým heslem pro těchto :count uživatelů?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Odeslat e-mail s novým heslem pro tohoto uživatele?|Odeslat e-mail s novým heslem pro těchto :count uživatelů?",
     "Send Test Email": "Odeslat testovací e-mail",
     "Sender": "Odesílatel",
     "Sendmail": "Odeslat e-mail",

--- a/resources/lang/da.json
+++ b/resources/lang/da.json
@@ -858,7 +858,7 @@
     "Seller": "Sælger",
     "Send Email Invitation": "Send e-mail-invitation",
     "Send Password Reset": "Send nulstilling af adgangskode",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Send e-mail til nulstilling af adgangskode til denne bruger? | Send e-mail til nulstilling af adgangskode til disse :count brugere?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Send e-mail til nulstilling af adgangskode til denne bruger? | Send e-mail til nulstilling af adgangskode til disse :count brugere?",
     "Send Test Email": "Send test-e-mail",
     "Sender": "Afsender",
     "Sendmail": "Send mail",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -921,7 +921,7 @@
     "Send": "Senden",
     "Send Email Invitation": "Einladung per E-Mail senden",
     "Send Password Reset": "Passwort zurücksetzen",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "E-Mail zum Zurücksetzen des Passworts an diese Benutzer:in senden?|E-Mail zum Zurücksetzen des Passworts an diese :count Benutzer:innen senden?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "E-Mail zum Zurücksetzen des Passworts an diese Benutzer:in senden?|E-Mail zum Zurücksetzen des Passworts an diese :count Benutzer:innen senden?",
     "Send Test Email": "Test-E-Mail senden",
     "Sender": "Absender:in",
     "Sendmail": "Sendmail",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -921,7 +921,7 @@
     "Send": "Senden",
     "Send Email Invitation": "Einladung per E-Mail senden",
     "Send Password Reset": "Passwort zurücksetzen",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "E-Mail zum Zurücksetzen des Passworts an diese Benutzer:in senden?|E-Mail zum Zurücksetzen des Passworts an diese :count Benutzer:innen senden?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "E-Mail zum Zurücksetzen des Passworts an diese Benutzer:in senden?|E-Mail zum Zurücksetzen des Passworts an diese :count Benutzer:innen senden?",
     "Send Test Email": "Test-E-Mail senden",
     "Sender": "Absender:in",
     "Sendmail": "Sendmail",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -858,7 +858,7 @@
     "Seller": "Vendedor",
     "Send Email Invitation": "Enviar invitación por correo electrónico",
     "Send Password Reset": "Enviar restablecimiento de contraseña",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "¿Enviar correo para restablecer de contraseña a este usuario?|¿Enviar correo para restablecer contraseña a estos :count usuarios?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "¿Enviar correo para restablecer de contraseña a este usuario?|¿Enviar correo para restablecer contraseña a estos :count usuarios?",
     "Send Test Email": "Enviar correo de prueba",
     "Sender": "Remitente",
     "Sendmail": "Sendmail",

--- a/resources/lang/et.json
+++ b/resources/lang/et.json
@@ -861,7 +861,7 @@
     "Seller": "Müüja",
     "Send Email Invitation": "Saada e-posti kutse",
     "Send Password Reset": "Saada parooli lähtestamine",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Saada sellele kasutajale parooli lähtestamise e-kiri?|Saada nendele :count kasutajale parooli lähtestamise e-kiri?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Saada sellele kasutajale parooli lähtestamise e-kiri?|Saada nendele :count kasutajale parooli lähtestamise e-kiri?",
     "Send Test Email": "Saada test-e-kiri",
     "Sender": "Saatja",
     "Sendmail": "Sendmail",

--- a/resources/lang/fa.json
+++ b/resources/lang/fa.json
@@ -858,7 +858,7 @@
     "Seller": "فروشنده",
     "Send Email Invitation": "ارسال ایمیل دعوت",
     "Send Password Reset": "ارسال بازسازی گذرواژه",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "ارسال ایمیل بازسازی گذروژاه برای این کاربر؟|ارسال ایمیل بازسازی گذرواژه برای :count کاربر؟",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "ارسال ایمیل بازسازی گذروژاه برای این کاربر؟|ارسال ایمیل بازسازی گذرواژه برای :count کاربر؟",
     "Send Test Email": "ارسال ایمیل تستی",
     "Sender": "فرستنده",
     "Sendmail": "ارسال ایمیل (Sendmail)",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -921,7 +921,7 @@
     "Send": "Envoyer",
     "Send Email Invitation": "Envoyer une invitation par courrier électronique",
     "Send Password Reset": "Envoyer une réinitialisation du mot de passe",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Envoyer un email de réinitialisation du mot de passe à cet utilisateur ?|Envoyer un email de réinitialisation du mot de passe à ces :count utilisateurs ?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Envoyer un email de réinitialisation du mot de passe à cet utilisateur ?|Envoyer un email de réinitialisation du mot de passe à ces :count utilisateurs ?",
     "Send Test Email": "Envoyer un email de test",
     "Sender": "Emetteur",
     "Sendmail": "Envoyer un mail",

--- a/resources/lang/hu.json
+++ b/resources/lang/hu.json
@@ -858,7 +858,7 @@
     "Seller": "Eladó",
     "Send Email Invitation": "Meghívó küldése e-mailben",
     "Send Password Reset": "Jelszó visszaállítás küldése",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Jelszó-visszaállítási e-mailt küld ennek a felhasználónak?|Jelszó-visszaállítási e-mailt küld ennek a :count felhasználónak?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Jelszó-visszaállítási e-mailt küld ennek a felhasználónak?|Jelszó-visszaállítási e-mailt küld ennek a :count felhasználónak?",
     "Send Test Email": "Teszt e-mail küldése",
     "Sender": "Feladó",
     "Sendmail": "Sendmail",

--- a/resources/lang/id.json
+++ b/resources/lang/id.json
@@ -858,7 +858,7 @@
     "Seller": "Penjual",
     "Send Email Invitation": "Kirim Email Undangan",
     "Send Password Reset": "Kirim Setel Ulang Kata Sandi",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Kirim Setel Ulang Kata Sandi ke pengguna ini?|Kirim Setel Ulang Kata Sandi ke :count pengguna ini?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Kirim Setel Ulang Kata Sandi ke pengguna ini?|Kirim Setel Ulang Kata Sandi ke :count pengguna ini?",
     "Send Test Email": "Kirim Email Uji",
     "Sender": "Pengirim",
     "Sendmail": "Sendmail",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -858,7 +858,7 @@
     "Seller": "Venditore",
     "Send Email Invitation": "Invia email di invito",
     "Send Password Reset": "Invia reimpostazione password",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Inviare a questo utente una mail per reimpostare la password?|Inviare a questi :count utenti una mail per reimpostare la password?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Inviare a questo utente una mail per reimpostare la password?|Inviare a questi :count utenti una mail per reimpostare la password?",
     "Send Test Email": "Invia email di prova",
     "Sender": "Mittente",
     "Sendmail": "Sendmail",

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -858,7 +858,7 @@
     "Seller": "売り手",
     "Send Email Invitation": "招待メールを送信する",
     "Send Password Reset": "パスワードリセットを送信",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "このユーザーにパスワード リセットの電子メールを送信しますか?|これらの:countユーザーにパスワード リセットの電子メールを送信しますか?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "このユーザーにパスワード リセットの電子メールを送信しますか?|これらの:countユーザーにパスワード リセットの電子メールを送信しますか?",
     "Send Test Email": "テストメールを送信する",
     "Sender": "送信者",
     "Sendmail": "メールの送信",

--- a/resources/lang/ms.json
+++ b/resources/lang/ms.json
@@ -858,7 +858,7 @@
     "Seller": "Penjual",
     "Send Email Invitation": "Hantar Email Undangan",
     "Send Password Reset": "Hantar Tetapan Semula Kata Laluan",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Hantar tetapan semula kata laluan ke pengguna ini?|Hantar Setel Ulang Kata laluan ke :count pengguna ini?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Hantar tetapan semula kata laluan ke pengguna ini?|Hantar Setel Ulang Kata laluan ke :count pengguna ini?",
     "Send Test Email": "Hantar Email Cubaan",
     "Sender": "penghantar",
     "Sendmail": "Sendmail",

--- a/resources/lang/nb.json
+++ b/resources/lang/nb.json
@@ -858,7 +858,7 @@
     "Seller": "Selger",
     "Send Email Invitation": "Send e-postinvitasjon",
     "Send Password Reset": "Send tilbakestilling av passord",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Sende e-post med tilbakestilling av passord til denne brukeren?|Sende e-post med tilbakestilling av passord til disse :count brukerne?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Sende e-post med tilbakestilling av passord til denne brukeren?|Sende e-post med tilbakestilling av passord til disse :count brukerne?",
     "Send Test Email": "Test utsendelse av e-post",
     "Sender": "Sender",
     "Sendmail": "Send e-post",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -890,7 +890,7 @@
     "Seller": "Verkoper",
     "Send Email Invitation": "E-mailuitnodiging versturen",
     "Send Password Reset": "Wachtwoordreset versturen",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Stuur een wachtwoorresetmail naar deze gebruiker?|Stuur een wachtwoordresetmail naar :count gebruikers?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Stuur een wachtwoorresetmail naar deze gebruiker?|Stuur een wachtwoordresetmail naar :count gebruikers?",
     "Send Test Email": "Verstuur testmail",
     "Sender": "Verzender",
     "Sendmail": "Verstuur mail",

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -858,7 +858,7 @@
     "Seller": "Sprzedawca",
     "Send Email Invitation": "Wyślij zaproszenie e-mailem",
     "Send Password Reset": "Wyślij prośbę o zresetowanie hasła",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Wysłać e-mail dotyczący resetowania hasła do tego użytkownika?|Wyślij e-mail dotyczący resetowania hasła do :count użytkowników?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Wysłać e-mail dotyczący resetowania hasła do tego użytkownika?|Wyślij e-mail dotyczący resetowania hasła do :count użytkowników?",
     "Send Test Email": "Wyślij testowy e-mail",
     "Sender": "Nadawca",
     "Sendmail": "Wyślij maila",

--- a/resources/lang/pt.json
+++ b/resources/lang/pt.json
@@ -858,7 +858,7 @@
     "Seller": "Vendedor",
     "Send Email Invitation": "Enviar convite por correio electrónico",
     "Send Password Reset": "Enviar Redefinição de Senha",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Enviar email de redefinição de senha para este utilizador? | Enviar email de redefinição de senha para estes :count utilizadores?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Enviar email de redefinição de senha para este utilizador? | Enviar email de redefinição de senha para estes :count utilizadores?",
     "Send Test Email": "Enviar mensagem de teste",
     "Sender": "Remetente",
     "Sendmail": "Enviar correio",

--- a/resources/lang/pt_BR.json
+++ b/resources/lang/pt_BR.json
@@ -858,7 +858,7 @@
     "Seller": "Vendedor",
     "Send Email Invitation": "Enviar convite por e-mail",
     "Send Password Reset": "Enviar redefinição de senha",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Enviar email de redefinição de senha para este usuário?|Enviar email de redefinição de senha para estes :count usuários?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Enviar email de redefinição de senha para este usuário?|Enviar email de redefinição de senha para estes :count usuários?",
     "Send Test Email": "Enviar Email de Teste",
     "Sender": "Remetente",
     "Sendmail": "Enviar um email",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -858,7 +858,7 @@
     "Seller": "Автор",
     "Send Email Invitation": "Отправить имейл с приглашением",
     "Send Password Reset": "Отправить имейл для сброса пароля",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Отправить имейл для сброса пароля этому пользователю?|Отправить имейлы для сброса паролей этим :count пользователям?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Отправить имейл для сброса пароля этому пользователю?|Отправить имейлы для сброса паролей этим :count пользователям?",
     "Send Test Email": "Отправить тестовый имейл",
     "Sender": "Отправитель",
     "Sendmail": "Sendmail",

--- a/resources/lang/sl.json
+++ b/resources/lang/sl.json
@@ -858,7 +858,7 @@
     "Seller": "Prodajalec",
     "Send Email Invitation": "Pošlji vabilo po e-pošti",
     "Send Password Reset": "Pošlji ponastavitev gesla",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Želite uporabniku poslati e-poštno sporočilo za ponastavitev gesla? | Pošljite e-poštno sporočilo za ponastavitev gesla tem :count uporabnikom?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Želite uporabniku poslati e-poštno sporočilo za ponastavitev gesla? | Pošljite e-poštno sporočilo za ponastavitev gesla tem :count uporabnikom?",
     "Send Test Email": "Pošlji testno e-pošto",
     "Sender": "Pošiljatelj",
     "Sendmail": "Pošlji pošto",

--- a/resources/lang/sv.json
+++ b/resources/lang/sv.json
@@ -858,7 +858,7 @@
     "Seller": "Säljare",
     "Send Email Invitation": "Skicka e-postinbjudan",
     "Send Password Reset": "Skicka lösenordsåterställning",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Skicka e-postmeddelande för lösenordsåterställning till den här användaren?|Skicka e-postmeddelande för återställning av lösenord till de här :count användarna?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Skicka e-postmeddelande för lösenordsåterställning till den här användaren?|Skicka e-postmeddelande för återställning av lösenord till de här :count användarna?",
     "Send Test Email": "Skicka testmail",
     "Sender": "Avsändare",
     "Sendmail": "Sendmail",

--- a/resources/lang/tr.json
+++ b/resources/lang/tr.json
@@ -858,7 +858,7 @@
     "Seller": "Satıcı",
     "Send Email Invitation": "E-Posta Davetiyesi Gönder",
     "Send Password Reset": "Şifre Sıfırlama Gönder",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Bu kullanıcıya şifre sıfırlama e-postası gönderilsin mi?|:count kullanıcıya şifre sıfırlama e-postası gönderilsin mi?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Bu kullanıcıya şifre sıfırlama e-postası gönderilsin mi?|:count kullanıcıya şifre sıfırlama e-postası gönderilsin mi?",
     "Send Test Email": "Test E-Postası Gönder",
     "Sender": "Gönderici",
     "Sendmail": "Sendmail",

--- a/resources/lang/uk.json
+++ b/resources/lang/uk.json
@@ -858,7 +858,7 @@
     "Seller": "Продавець",
     "Send Email Invitation": "Надіслати запрошення електронною поштою",
     "Send Password Reset": "Надіслати скидання пароля",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Надіслати лист для скидання пароля цьому користувачу?|Надіслати лист для скидання пароля цим :count користувачам?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Надіслати лист для скидання пароля цьому користувачу?|Надіслати лист для скидання пароля цим :count користувачам?",
     "Send Test Email": "Надіслати тестовий лист",
     "Sender": "Відправник",
     "Sendmail": "Sendmail",

--- a/resources/lang/vi.json
+++ b/resources/lang/vi.json
@@ -858,7 +858,7 @@
     "Seller": "Bán",
     "Send Email Invitation": "Gởi giấy mời thư điện tử",
     "Send Password Reset": "Đặt lại mật khẩu",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "Name Name?",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "Name Name?",
     "Send Test Email": "Gửi thư thử ra",
     "Sender": "Gửi",
     "Sendmail": "Gởi thư",

--- a/resources/lang/zh_CN.json
+++ b/resources/lang/zh_CN.json
@@ -858,7 +858,7 @@
     "Seller": "商家",
     "Send Email Invitation": "发送电子邮件邀请",
     "Send Password Reset": "发送重设密码",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "要发送密码重置电子邮件给该用户吗？|将密码重置电子邮件发送给这些 :count 个用户？",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "要发送密码重置电子邮件给该用户吗？|将密码重置电子邮件发送给这些 :count 个用户？",
     "Send Test Email": "发送测试邮件",
     "Sender": "发件人",
     "Sendmail": "发送邮件",

--- a/resources/lang/zh_TW.json
+++ b/resources/lang/zh_TW.json
@@ -858,7 +858,7 @@
     "Seller": "販售人",
     "Send Email Invitation": "傳送電子郵件邀請",
     "Send Password Reset": "傳送密碼重設",
-    "Send password reset email to this user?|Send password reset email to these :count users?": "要傳送密碼重設信件給這個使用者嗎？|要傳送密碼重設信件給 :count 位使用者嗎？",
+    "Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?": "要傳送密碼重設信件給這個使用者嗎？|要傳送密碼重設信件給 :count 位使用者嗎？",
     "Send Test Email": "傳送測試信件",
     "Sender": "傳送者",
     "Sendmail": "Sendmail",

--- a/src/Actions/SendPasswordReset.php
+++ b/src/Actions/SendPasswordReset.php
@@ -26,7 +26,7 @@ class SendPasswordReset extends Action
     public function confirmationText()
     {
         /** @translation */
-        return 'Send password reset email to this user?|Send password reset email to these :count users?';
+        return 'Would you like to email a reset link to this user?|Would you like to email a reset link to these :count users?';
     }
 
     public function dirtyWarningText()


### PR DESCRIPTION
This should close #12536, making the modal look less repetitive—both visually and content-wise.

I did notice that it looks worse in dark mode because of some heavy shadowing but that's a separate "dark mode" issue that we'll tackle later