### PR TITLE
[6.x] Fix global site selector popping in

### DIFF
--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -317,7 +317,7 @@ defineExpose({
                             </button>
                         </div>
 
-                        <div class="flex gap-1.5 items-center shrink-0 ms-1.5">
+                        <div v-if="(clearable && modelValue) || (options.length || ignoreFilter)" class="flex gap-1.5 items-center shrink-0 ms-1.5 size-4">
                             <Button v-if="clearable && modelValue" icon="x" variant="ghost" size="xs" round @click="clear" data-ui-combobox-clear-button />
                             <Icon v-if="options.length || ignoreFilter" name="chevron-down" class="text-gray-400 dark:text-white/40" data-ui-combobox-chevron />
                         </div>


### PR DESCRIPTION
This stops the global site selector layout "popping in" between pages by setting a fixed size if either child buttons are present. This is a reaction to PR #12486, which broke the smooth global site selector transition between Blade and Vue. Hopefully this is the best of both worlds.