### PR TITLE
[6.x] Bard floating toolbar mode fix container focus state

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -11,7 +11,7 @@
     .bard-editor {
         /* We need a transparent border inside Bard to properly see the focus outline. Without this border, the focus outline is hairline-thin */
         border: 1px solid transparent;
-        @apply relative rounded-b-lg p-0 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
+        @apply relative rounded-lg p-0 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
         /* The focus state inherits this */
         > * {
             @apply rounded-b-lg;


### PR DESCRIPTION
This fixes the border-radius of the focus state when a Bard field is in floating toolbar mode

## Before

![2025-09-26 at 10 11 01@2x](https://github.com/user-attachments/assets/1676798e-5cf8-4145-b263-01ef2fbd2953)

## After

![2025-09-26 at 10 07 06@2x](https://github.com/user-attachments/assets/00721891-cbcf-4b7f-808b-7b1a290064ec)
 