### PR TITLE
[6.x] Bard slash command for single set

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -826,6 +826,17 @@ export default {
                             const { view, state } = this.editor;
 
                             if (this.options.allowed({ view, state})) {
+                                // Check if there's only one set available
+                                const totalSets = this.options.getTotalSets();
+                                if (totalSets === 1) {
+                                    // Auto-insert the single available set
+                                    const singleSetHandle = this.options.getSingleSetHandle();
+                                    if (singleSetHandle) {
+                                        this.options.addSet(singleSetHandle);
+                                        return true; // Prevent inserting a slash.
+                                    }
+                                }
+                                
                                 this.options.openSetPicker();
                                 return true; // Prevent inserting a slash.
                             }
@@ -844,6 +855,9 @@ export default {
                     shown: computed(() => this.showAddSetButton),
                     allowed: this.suitableToShowSetButton,
                     openSetPicker: this.openSetPicker,
+                    getTotalSets: this.getTotalSets,
+                    getSingleSetHandle: this.getSingleSetHandle,
+                    addSet: this.addSet,
                 }),
                 Dropcursor,
                 Gapcursor,
@@ -932,6 +946,17 @@ export default {
 
         openSetPicker() {
             this.$refs.setPicker.open();
+        },
+
+        getTotalSets() {
+            return this.setConfigs.length;
+        },
+
+        getSingleSetHandle() {
+            if (this.setConfigs.length === 1) {
+                return this.setConfigs[0].handle;
+            }
+            return null;
         }
     },
 };


### PR DESCRIPTION
Currently the "Type '/' to insert a set" command does not work if there is only a single set available. This check's if there's only one set available and inserts it

![2025-09-26 at 11 47 38@2x](https://github.com/user-attachments/assets/1881f187-b625-4a7c-867b-348ec9f00013)
