### PR TITLE
[6.x] Make radio and checkbox options consistent

### DIFF
--- a/packages/ui/src/Checkbox/Item.vue
+++ b/packages/ui/src/Checkbox/Item.vue
@@ -93,7 +93,7 @@ const conditionalProps = computed(() => {
             </span>
         </CheckboxRoot>
         <div class="flex flex-col" v-if="!solo">
-            <label class="text-sm font-normal antialiased" :for="id">
+            <label class="text-sm font-normal antialiased dark:text-gray-200" :for="id">
                 <slot>{{ label || value }}</slot>
             </label>
             <p v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500 dark:text-gray-200">{{ description }}</p>

--- a/packages/ui/src/Radio/Item.vue
+++ b/packages/ui/src/Radio/Item.vue
@@ -33,7 +33,7 @@ const id = useId();
             />
         </RadioGroupItem>
         <label class="flex flex-col" :class="{ 'opacity-50': disabled }" :for="id">
-            <span class="text-sm font-normal text-gray-600 antialiased dark:text-gray-200">
+            <span class="text-sm font-normal antialiased dark:text-gray-200">
                 <slot>{{ label || value }}</slot>
             </span>
             <span v-if="description" class="mt-0.5 block text-xs leading-snug text-gray-500">{{ description }}</span>


### PR DESCRIPTION
This makes radio and checkbox options aesthetically consistent and closes #12590.

I thought the default `gray-900` worked well for light mode, especially since options are right underneath the label so there's sufficient contrast.

![2025-09-26 at 12 27 35@2x](https://github.com/user-attachments/assets/aeed2510-2eed-432d-802e-a359c1142639)

The options are better when they're toned down a tiny bit in dark mode, so I made that consistent.

![2025-09-26 at 12 27 46@2x](https://github.com/user-attachments/assets/f84f3f73-f543-4e49-8b51-11e948090b47)
