### PR TITLE
[6.x] Fix the custom "create entry" button in card view

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -55,7 +55,7 @@
                             :url="collection.create_entry_url"
                             variant="default"
                             :blueprints="collection.blueprints"
-                            :text="__('Create Entry')"
+                            :text="collection.create_label"
                             size="sm"
                         />
                     </aside>

--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -457,7 +457,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function createLabel()
     {
-        $key = "messages.{$this->handle()}_collection_create_entry";
+        $key = "statamic::messages.{$this->handle()}_collection_create_entry";
 
         $translation = __($key);
 

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -87,6 +87,7 @@ class CollectionsController extends CpController
                 'actions' => Action::for($collection),
                 'actions_url' => cp_route('collections.actions.run'),
                 'icon' => $collection->icon(),
+                'create_label' => $collection->createLabel(),
                 'sort_column' => $collection->sortField(),
                 'sort_direction' => $collection->sortDirection(),
             ];

--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -454,7 +454,7 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, Contract,
 
     public function createLabel()
     {
-        $key = "messages.{$this->handle()}_taxonomy_create_term";
+        $key = "statamic::messages.{$this->handle()}_taxonomy_create_term";
 
         $translation = __($key);
 

--- a/tests/Feature/Collections/ViewCollectionListingTest.php
+++ b/tests/Feature/Collections/ViewCollectionListingTest.php
@@ -59,6 +59,7 @@ class ViewCollectionListingTest extends TestCase
                     'actions' => Facades\Action::for($collectionA, ['view' => 'list']),
                     'actions_url' => 'http://localhost/cp/collections/actions',
                     'icon' => 'collections',
+                    'create_label' => 'Create Entry',
                     'sort_column' => 'title',
                     'sort_direction' => 'asc',
                     'filters' => Scope::filters('entries', [
@@ -93,6 +94,7 @@ class ViewCollectionListingTest extends TestCase
                     'actions' => Facades\Action::for($collectionB, ['view' => 'list']),
                     'actions_url' => 'http://localhost/cp/collections/actions',
                     'icon' => 'collections',
+                    'create_label' => 'Create Entry',
                     'sort_column' => 'title',
                     'sort_direction' => 'asc',
                     'filters' => Scope::filters('entries', [


### PR DESCRIPTION
This closes #12588 by hooking the handle up to create entry button in the new collection card view.

To try this:

- Switch the language to Spanish in `/cp/preferences/edit`
- Add `'pages_collection_create_entry' => 'Crear XY',` to `/resources/lang/es/messages.php`
- Visit `/cp/collections` and see the button above the Pages card now says `Crear XY`

![2025-09-26 at 16 42 19@2x](https://github.com/user-attachments/assets/cc241dff-7ba3-41a0-8957-305f5436272b)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use server-provided `create_label` for the collections grid button and switch label translation keys to `statamic::messages`, including taxonomy term labels.
> 
> - **CP UI (collections grid)**
>   - `resources/js/components/collections/Listing.vue`: `create-entry-button` now uses `collection.create_label` instead of hardcoded `__('Create Entry')`.
> - **Backend**
>   - `src/Http/Controllers/CP/Collections/CollectionsController.php`: Exposes `create_label` in collections payload via `$collection->createLabel()`.
>   - `src/Entries/Collection::createLabel()` and `src/Taxonomies/Taxonomy::createLabel()`:
>     - Update translation keys to `statamic::messages.{handle}_collection_create_entry` and `statamic::messages.{handle}_taxonomy_create_term`.
> - **Tests**
>   - `tests/Feature/Collections/ViewCollectionListingTest.php`: Expect `create_label` in collections response.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a70889c015d5fe3ec6650b75ccd33506b6bf86. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->