### PR TITLE
[6.x] Remove stacked rounded corners

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="h-full overflow-auto bg-white dark:bg-gray-800 focus-none p-3 rounded-l-xl">
+    <div class="h-full overflow-auto bg-white dark:bg-gray-800 focus-none p-3">
         <div v-if="loading" class="absolute inset-0 z-200 flex items-center justify-center text-center">
             <Icon name="loading" />
         </div>


### PR DESCRIPTION
As discussed internally, the card aesthetic looks a bit strange with stacks, especially since they're usually long, scroll-able content.

## Before

<img width="3420" height="2136" alt="image" src="https://github.com/user-attachments/assets/41355b15-64ac-4914-9bf3-742647866f8d" />

## After

<img width="3420" height="2136" alt="image" src="https://github.com/user-attachments/assets/27769839-2f27-47ea-9749-cdaa821909d3" />
