### PR TITLE
[6.x] Add asset upload support to register and profile forms

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -89,6 +89,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Delete replaced profile form assets
+    |--------------------------------------------------------------------------
+    |
+    | When uploading replacement assets through the user:profile_form
+    | should existing assets be deleted from the container. If false
+    | they will be unlinked from the user but left in the container.
+    |
+    */
+
+    'delete_replaced_profile_form_assets' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | User Wizard Invitation Email
     |--------------------------------------------------------------------------
     |

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -731,9 +731,7 @@ class UserTags extends Tags
                         'display' => $section->display(),
                         'instructions' => $section->instructions(),
                         'fields' => $section->fields()->addValues($values)->preProcess()->all()
-                            ->reject(fn ($field) => in_array($field->handle(), ['password', 'password_confirmation', 'roles', 'groups'])
-                                    || $field->fieldtype()->handle() === 'assets'
-                            )
+                            ->reject(fn ($field) => in_array($field->handle(), ['password', 'password_confirmation', 'roles', 'groups']))
                             ->map(fn ($field) => $this->getRenderableField($field, 'user.profile'))
                             ->values()
                             ->all(),

--- a/src/Http/Controllers/User/ProfileController.php
+++ b/src/Http/Controllers/User/ProfileController.php
@@ -30,6 +30,7 @@ class ProfileController
                 ->values()
                 ->flatten()
                 ->map(fn ($id) => Asset::findById($id))
+                ->filter()
                 ->each->delete();
         }
         foreach ($processedAssets as $key => $value) {

--- a/src/Http/Controllers/User/ProfileController.php
+++ b/src/Http/Controllers/User/ProfileController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Controllers\User;
 
+use Statamic\Facades\Asset;
 use Statamic\Facades\User;
 use Statamic\Http\Requests\UserProfileRequest;
 
@@ -16,6 +17,22 @@ class ProfileController
         }
 
         foreach ($request->processedValues() as $key => $value) {
+            $user->set($key, $value);
+        }
+
+        $processedAssets = $request->processedAssets();
+        if (config('statamic.users.delete_replaced_profile_form_assets')) {
+            User::blueprint()
+                ->fields()
+                ->addValues($user->data()->all())
+                ->only($processedAssets->keys())
+                ->preProcess()
+                ->values()
+                ->flatten()
+                ->map(fn ($id) => Asset::findById($id))
+                ->each->delete();
+        }
+        foreach ($processedAssets as $key => $value) {
             $user->set($key, $value);
         }
 

--- a/src/Http/Controllers/User/RegisterController.php
+++ b/src/Http/Controllers/User/RegisterController.php
@@ -19,7 +19,10 @@ class RegisterController
         $user = User::make()
             ->email($request->email)
             ->password($request->password)
-            ->data($request->processedValues());
+            ->data(array_merge(
+                $request->processedValues()->all(),
+                $request->processedAssets()->all(),
+            ));
 
         if ($roles = config('statamic.users.new_user_roles')) {
             $user->explicitRoles($roles);

--- a/src/Http/Requests/UserRegisterRequest.php
+++ b/src/Http/Requests/UserRegisterRequest.php
@@ -59,7 +59,7 @@ class UserRegisterRequest extends FormRequest
             ->process()
             ->values()
             ->only(array_keys($this->submittedValues))
-            ->except(['email', 'password', 'groups', 'roles', 'super']);
+            ->except(['email', 'groups', 'roles', 'super', 'password_confirmation']);
     }
 
     public function processedAssets()


### PR DESCRIPTION
This PR is a follow up to https://github.com/statamic/cms/pull/6400 and second attempt at asset upload support in the user register and profile tags.

The implementation is fairly basic, but it's the most logical approach I can think of when using simple HTML file input fields. More advanced asset management would be great (particularly when dealing with multi-asset fields), but that's beyond the scope of this PR and may be more appropriate for an addon or custom implementation.

This works as follows:

1. Asset fields can now be output in the register and profile forms
2. If no files are uploaded the existing assets remain in place
3. If files are uploaded they replace the existing assets
4. There is a new config option `delete_replaced_profile_form_assets`
    - If `false` replaced assets are unlinked but remain in the container (default)
    - If `true` replaced assets are completely deleted from the container

As HTML file inputs are always blank by default there is no way to completely clear an assets field with this basic implementation. That would require sending some kind of extra hint(s) with the form submission, or a separate endpoint. 

Part of my motivation for submitting this is that I'm deprecating my Memberbox addon, and this feature is pretty much the only reason anyone uses that. I think this should cover most basic use cases (it's already better than the version in my addon).