### PR TITLE
[6.x] Fix breadcrumb dropdown with plurals including apostrophes.

### DIFF
--- a/resources/views/components/breadcrumbs/dropdown.blade.php
+++ b/resources/views/components/breadcrumbs/dropdown.blade.php
@@ -23,7 +23,7 @@
             variant="ghost"
             icon="chevron-vertical"
             class="[&_svg]:size-3! h-8! w-4! hover:bg-gray-300/5! -ml-3 mr-1 animate-in fade-in duration-500"
-            :aria-label="'{{ __('Options for') }} {{ __($breadcrumb->text()) }}'"
+            aria-label="'{{ __('Options for') }} {{ __($breadcrumb->text()) }}'"
             aria-haspopup="true"
             aria-expanded="false"
         ></ui-button>


### PR DESCRIPTION
For the Dutch language, the term 'Pages' translates into 'Pagina's' (reckon the apostrophe in the Dutch word. We need the apostrophe to keep the open a at the end of the word 'long' else the sound would change.). 

However, with the new breadcrumbs dropdown introduced, this actually breaks the possibility to edit an entry in the Pages-collection in the Dutch language.

See these screenshots:

<img width="1735" height="978" alt="Image" src="https://github.com/user-attachments/assets/3e2c1d63-fd18-4345-98d7-f045d69869ed" />
<img width="746" height="239" alt="Image" src="https://github.com/user-attachments/assets/a03eb3b4-5f4d-4a63-a37a-e5e451b8a6f9" />

It is caused by line 26 of this code:
https://github.com/statamic/cms/commit/2f74fbd6eaf700e2a0472344bd6f73ffcfeb3544#diff-06ff751bfeceb5fa3d7f99a7281d9308f41573791314d2da1e499b87dff7e95aR25

If I change that line to:
`aria-label="'{{ __('Options for') }} {{ __($breadcrumb->text()) }}'"` (so without the : (what was the reason to include it?))
it resolves correctly, so I guess this would do the trick (see also the difference with for the 'options for'-line)

<img width="1308" height="776" alt="Image" src="https://github.com/user-attachments/assets/f59ae1c1-41ce-4eed-9388-0343d10b2944" />

Of course this would also fix it for other collections that would include an apostrophe in their plurals.

