### PR TITLE
[6.x] Improve relationship field padding

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="shadow-ui-sm relative z-2 flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-x-0 dark:border-t-0 dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
+        class="shadow-ui-sm relative z-2 flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-x-0 dark:border-t-0 dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
         :class="{ invalid: item.invalid }"
     >
         <ui-icon name="handles" class="item-move sortable-handle size-4 cursor-grab text-gray-300" v-if="sortable" />


### PR DESCRIPTION
This closes #12470 by setting a higher default inline padding value and then using `:has` to detect the presence of a grab handle to selectively reduce the padding.

This improves the following fields:

- Link field
- User field (when set to Stack selector with max items of 1)
- User field with a select dropdown stays the same

## Before

See the fields with blue text highlighted. The padding is inconsistent and sometimes too tight

![2025-09-29 at 10 31 51@2x](https://github.com/user-attachments/assets/84043150-a099-46aa-9e35-f8e1450e9333)

## After

See the fields with blue text highlighted. Here you can see a bit more horizontal padding to match the other fields

![2025-09-29 at 10 30 40@2x](https://github.com/user-attachments/assets/a26309cd-d136-4d78-b3b9-eec4f5ae129c)
