### PR TITLE
[6.x] Sticky blueprint heading

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -4,8 +4,8 @@
             <Icon name="loading" />
         </div>
 
-        <header v-if="!loading" class="flex items-center justify-between pl-3 pt-3 pb-3 -mb-3 sticky top-0 z-1 bg-gradient-to-b from-white from-25% dark:from-gray-800">
-            <Heading :text="__(values.display) || __(config.display) || config.handle" size="lg" :icon="fieldtype.icon" class="bg-gradient-to-b from-white from-75% dark:from-gray-800 pb-4 -mb-4 p-6 -m-6 pr-2" />
+        <header v-if="!loading" class="flex items-center justify-between pl-3 pt-3 pb-4 -mb-4 sticky top-0 z-1 bg-gradient-to-b from-white from-75% dark:from-gray-800">
+            <Heading :text="__(values.display) || __(config.display) || config.handle" size="lg" :icon="fieldtype.icon" />
             <div class="flex items-center gap-3">
                 <Button variant="ghost" :text="__('Cancel')" @click.prevent="close" />
                 <Button variant="primary" @click.prevent="commit()" :text="__('Apply')" />


### PR DESCRIPTION
This makes the blueprint header controls and title "sticky" so they follow you down the page.
I think this is particularly useful now that we have more controls in the blueprint header.

I tried several variations before I settled on this, with a subtle gradient effectively providing a mask. Here's an example of scrolling halfway down the page.

![2025-09-29 at 18 36 20@2x](https://github.com/user-attachments/assets/b462062a-934a-4299-8841-49037af519ac)
