### PR TITLE
[5.x] fix: on missing LivePreview $token/$item skip the LivePreview handling | Second try 

### DIFF
--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -14,14 +14,14 @@ class LivePreview
     public function handle(Token $token, $request, Closure $next)
     {
         $item = Facade::item($token);
-
-        $response = $next($request);
-
+        
         if (! $item) {
-            return $response;
+            return $next($request);
         }
 
         $item->repository()->substitute($item);
+
+        $response = $next($request);
 
         if (Sites::multiEnabled()) {
             /** @var Collection */

--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -15,9 +15,11 @@ class LivePreview
     {
         $item = Facade::item($token);
 
-        $item->repository()->substitute($item);
-
         $response = $next($request);
+
+        if (!$item) return $response;
+
+        $item->repository()->substitute($item);
 
         if (Sites::multiEnabled()) {
             /** @var Collection */

--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -17,7 +17,9 @@ class LivePreview
 
         $response = $next($request);
 
-        if (!$item) return $response;
+        if (!$item) {
+            return $response;
+        }
 
         $item->repository()->substitute($item);
 

--- a/src/Tokens/Handlers/LivePreview.php
+++ b/src/Tokens/Handlers/LivePreview.php
@@ -17,7 +17,7 @@ class LivePreview
 
         $response = $next($request);
 
-        if (!$item) {
+        if (! $item) {
             return $response;
         }
 


### PR DESCRIPTION
[5.x] fix: on missing LivePreview $token/$item skip the LivePreview handling