### PR TITLE
[6.x] Ability to use custom components & hide "Run action" button in action modals

### DIFF
--- a/resources/js/components/actions/ConfirmableAction.vue
+++ b/resources/js/components/actions/ConfirmableAction.vue
@@ -95,25 +95,32 @@ defineExpose({
         @confirm="confirmed"
         @cancel="reset"
     >
-        <Description
-            v-if="confirmationText"
-            :text="confirmationText"
-            :class="{ 'mb-4': warningText || showDirtyWarning || action.fields.length }"
+        <component
+            v-if="action.component"
+            :is="action.component"
         />
 
-        <div
-            v-if="warningText"
-            v-text="warningText"
-            class="text-red-600"
-            :class="{ 'mb-4': showDirtyWarning || action.fields.length }"
-        />
+        <template v-else>
+            <Description
+                v-if="confirmationText"
+                :text="confirmationText"
+                :class="{ 'mb-4': warningText || showDirtyWarning || action.fields.length }"
+            />
 
-        <div
-            v-if="showDirtyWarning"
-            v-text="dirtyText"
-            class="text-red-600"
-            :class="{ 'mb-4': action.fields.length }"
-        />
+            <div
+                v-if="warningText"
+                v-text="warningText"
+                class="text-red-600"
+                :class="{ 'mb-4': showDirtyWarning || action.fields.length }"
+            />
+
+            <div
+                v-if="showDirtyWarning"
+                v-text="dirtyText"
+                class="text-red-600"
+                :class="{ 'mb-4': action.fields.length }"
+            />
+        </template>
 
         <PublishContainer
             v-if="action.fields.length"

--- a/resources/js/components/actions/ConfirmableAction.vue
+++ b/resources/js/components/actions/ConfirmableAction.vue
@@ -90,6 +90,7 @@ defineExpose({
         v-if="confirming"
         :title="action.title"
         :danger="action.dangerous"
+        :submittable="action.runnable"
         :buttonText="runButtonText"
         :busy="running"
         @confirm="confirmed"

--- a/resources/js/components/modals/ConfirmationModal.vue
+++ b/resources/js/components/modals/ConfirmationModal.vue
@@ -19,6 +19,10 @@ const props = defineProps({
         type: Boolean,
         default: true,
     },
+    submittable: {
+        type: Boolean,
+        default: true,
+    },
     cancelText: {
         type: String,
         default: () => __('Cancel'),
@@ -72,7 +76,7 @@ function submit() {
             <p>{{ __('Are you sure?') }}</p>
         </slot>
 
-        <template #footer>
+        <template v-if="cancellable || submittable" #footer>
             <div class="flex items-center justify-end space-x-3 pt-3 pb-1">
                 <ModalClose asChild>
                     <Button
@@ -83,6 +87,7 @@ function submit() {
                     />
                 </ModalClose>
                 <Button
+                    v-if="submittable"
                     type="submit"
                     :variant="danger ? 'danger' : 'primary'"
                     :disabled="disabled || busy"

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -102,6 +102,11 @@ abstract class Action implements Arrayable
         return $this->component;
     }
 
+    public function runnable(): bool
+    {
+        return true;
+    }
+
     public function buttonText()
     {
         /** @translation */
@@ -142,6 +147,7 @@ abstract class Action implements Arrayable
             'title' => $this->title(),
             'icon' => $this->icon(),
             'component' => $this->component(),
+            'runnable' => $this->runnable(),
             'confirm' => $this->confirm,
             'buttonText' => $this->buttonText(),
             'confirmationText' => $this->confirmationText(),

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -19,6 +19,7 @@ abstract class Action implements Arrayable
     protected $dangerous = false;
     protected $fields = [];
     protected $context = [];
+    protected $component;
 
     public function __construct()
     {
@@ -96,6 +97,11 @@ abstract class Action implements Arrayable
         return $this->icon ?? '';
     }
 
+    public function component(): ?string
+    {
+        return $this->component;
+    }
+
     public function buttonText()
     {
         /** @translation */
@@ -135,6 +141,7 @@ abstract class Action implements Arrayable
             'handle' => $this->handle(),
             'title' => $this->title(),
             'icon' => $this->icon(),
+            'component' => $this->component(),
             'confirm' => $this->confirm,
             'buttonText' => $this->buttonText(),
             'confirmationText' => $this->confirmationText(),

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -19,6 +19,7 @@ abstract class Action implements Arrayable
     protected $dangerous = false;
     protected $fields = [];
     protected $context = [];
+    protected $runnable = true;
     protected $component;
 
     public function __construct()
@@ -104,7 +105,7 @@ abstract class Action implements Arrayable
 
     public function runnable(): bool
     {
-        return true;
+        return $this->runnable;
     }
 
     public function buttonText()


### PR DESCRIPTION
This pull request allows action developers to render custom Vue components instead of our default confirmation text. It also allows developers to hide the "Run action" button in action modals.

## Use cases

* One use case for this is @ryanmitchell's cache tracker addon, where he wants to show a list of cache keys for a certain entry. 
  * The custom component is used to list cache keys, and the "Run action" button is hidden because there's no real "action" behind it. 
  * In this scenario, actions is the way of getting a dropdown item & modal for free on listings.
* Another use case for this might be refactoring the `fieldset-deleter` component.
  * Currently, it's not action because we display a list of places the fieldset is being used. All imports need to be replaced before the developer can delete the fieldset.