### PR TITLE
[6.x] Relationship fields fix space after colon

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -42,8 +42,8 @@
                 />
             </div>
 
-            <div class="text-gray py-2 text-xs" v-if="maxItemsReached && maxItems != 1">
-                <span>{{ __('Maximum items selected:') }}</span>
+            <div class="ml-1 text-gray py-2 text-xs" v-if="maxItemsReached && maxItems != 1">
+                <span class="mr-1">{{ __('Maximum items selected:') }}</span>
                 <span>{{ maxItems }}/{{ maxItems }}</span>
             </div>
             <div

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -664,7 +664,7 @@
     "Max Items": "Nb maxi d'éléments",
     "Max Rows": "Nb maxi de rangées",
     "Max Sets": "Nb maxi d'ensembles",
-    "Maximum items selected:": "Nombre maximal d'éléments sélectionnés:",
+    "Maximum items selected:": "Nombre maximal d'éléments sélectionnés :",
     "Maximum Rows": "Nb maxi de rangées",
     "Media": "Médias",
     "Merge Cells": "Fusionner des cellules",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -664,7 +664,7 @@
     "Max Items": "Nb maxi d'éléments",
     "Max Rows": "Nb maxi de rangées",
     "Max Sets": "Nb maxi d'ensembles",
-    "Maximum items selected:": "Nombre maximal d'éléments sélectionnés :",
+    "Maximum items selected:": "Nombre maximal d'éléments sélectionnés:",
     "Maximum Rows": "Nb maxi de rangées",
     "Media": "Médias",
     "Merge Cells": "Fusionner des cellules",


### PR DESCRIPTION
Fixes #12523 by adding a margin after the "maximum items" instruction.

I considered adding a space to the end of the string but thought that would require every translation to add a space, and I can't imagine people's attention to detail is that great.
I also considered adding a space in the span but that's trimmed when output in the browser.

## Before
![2025-09-30 at 15 18 08@2x](https://github.com/user-attachments/assets/597442dc-89a7-4faf-97b8-dbda4fa62de1)


## After
![2025-09-30 at 15 17 42@2x](https://github.com/user-attachments/assets/29e08749-2a90-46fd-a374-6d0cac84383b)
