### PR TITLE
[6.x] Improve Assets loading with skeleton

### DIFF
--- a/resources/css/core/animation.css
+++ b/resources/css/core/animation.css
@@ -81,8 +81,8 @@
         transition: opacity 0.1s;
     }
 
-    .starting-style-transition--slow {
-        transition: opacity 1s;
+    .starting-style-transition--delay {
+        transition-delay: 0.5s;
     }
 
     .starting-style-transition--siblings,

--- a/resources/css/core/animation.css
+++ b/resources/css/core/animation.css
@@ -71,14 +71,14 @@
     .starting-style-transition-children > *,
     .publish-fields > *,
     .publish-fields-fluid > *  {
-        transition: opacity 0.1s;
+        transition: opacity 0.2s;
         @starting-style {
             opacity: 0;
         }
     }
 
     .starting-style-transition--quick {
-        transition: opacity 0.05s;
+        transition: opacity 0.1s;
     }
 
     .starting-style-transition--slow {

--- a/resources/js/components/assets/AssetManager.vue
+++ b/resources/js/components/assets/AssetManager.vue
@@ -12,7 +12,11 @@
         @navigated="navigate"
         @selections-updated="updateSelections"
         @edit-asset="editAsset"
-    />
+    >
+        <template #initializing>
+            <slot name="initializing" />
+        </template>
+    </asset-browser>
 </template>
 
 <script>

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -29,12 +29,8 @@
                     v-model:search-query="searchQuery"
                     @request-completed="listingRequestCompleted"
                     @update:selections="$emit('selections-updated', $event)"
+                    class="starting-style-transition"
                 >
-                    <template #initializing>
-                        <slot name="initializing">
-                            <Icon name="loading" />
-                        </slot>
-                    </template>
                     <template #default="{ items }">
                         <slot name="header" v-bind="{ canUpload, openFileBrowser, canCreateFolders, startCreatingFolder, mode, modeChanged }">
                             <Header :title="__(container.title)" icon="assets">

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -671,7 +671,7 @@ autoApplyState();
 
 <template>
     <slot name="initializing" v-if="shouldShowSkeleton">
-        <div class="flex flex-col gap-4 justify-between mt-3 starting-style-transition starting-style-transition--slow">
+        <div class="flex flex-col gap-4 justify-between mt-3 starting-style-transition starting-style-transition--delay">
             <ui-skeleton class="h-5 w-48" />
             <div class="flex gap-3">
                 <ui-skeleton class="h-9 w-96" />

--- a/resources/views/assets/browse.blade.php
+++ b/resources/views/assets/browse.blade.php
@@ -14,7 +14,6 @@
             initial-path="{{ $folder }}"
             initial-editing-asset-id="{{ $editing ?? null }}"
             :columns="{{ $columns->toJson() }}"
-            class="starting-style-transition"
         >
             <template #initializing>
                 <!-- Header Skeleton -->
@@ -41,7 +40,6 @@
         <x-statamic::docs-callout
             topic="{{ __('Assets') }}"
             url="{{ Statamic::docsUrl('assets') }}"
-            class="starting-style-transition"
         />
     </div>
 @endsection

--- a/resources/views/assets/browse.blade.php
+++ b/resources/views/assets/browse.blade.php
@@ -33,7 +33,7 @@
                 </div>
                 <!-- Assets grid Skeleton -->
                 <div class="flex justify-between">
-                    <ui-skeleton class="h-100 w-full" />
+                    <ui-skeleton class="h-30 w-full" />
                 </div>
             </template>
         </asset-manager>

--- a/resources/views/assets/browse.blade.php
+++ b/resources/views/assets/browse.blade.php
@@ -37,9 +37,11 @@
             </template>
         </asset-manager>
 
-        <x-statamic::docs-callout
-            topic="{{ __('Assets') }}"
-            url="{{ Statamic::docsUrl('assets') }}"
-        />
+        <div class="starting-style-transition starting-style-transition--delay">
+            <x-statamic::docs-callout
+                topic="{{ __('Assets') }}"
+                url="{{ Statamic::docsUrl('assets') }}"
+            />
+        </div>
     </div>
 @endsection

--- a/resources/views/assets/browse.blade.php
+++ b/resources/views/assets/browse.blade.php
@@ -17,12 +17,21 @@
             class="starting-style-transition"
         >
             <template #initializing>
-                <!-- Toolbar skeleton -->
-                <div class="flex justify-between">
-                    <ui-skeleton class="h-9 w-95 mb-3" />
-                    <ui-skeleton class="h-9 w-10 mb-3" />
+                <!-- Header Skeleton -->
+                <div class="flex justify-between py-8">
+                    <ui-skeleton class="h-8 w-95" />
+                    <div class="flex gap-3">
+                        <ui-skeleton class="h-10 w-26" />
+                        <ui-skeleton class="h-10 w-36" />
+                        <ui-skeleton class="h-10 w-20" />
+                    </div>
                 </div>
-                <!-- Assets grid skeleton -->
+                <!-- Toolbar Skeleton -->
+                <div class="flex justify-between py-3">
+                    <ui-skeleton class="h-9 w-95" />
+                    <ui-skeleton class="h-9 w-10" />
+                </div>
+                <!-- Assets grid Skeleton -->
                 <div class="flex justify-between">
                     <ui-skeleton class="h-100 w-full" />
                 </div>

--- a/resources/views/assets/browse.blade.php
+++ b/resources/views/assets/browse.blade.php
@@ -6,17 +6,33 @@
 @section('title', Statamic::crumb('Assets', $container['title']))
 
 @section('content')
-    <asset-manager
-        :container="{{ json_encode($container) }}"
-        :can-create-containers="{{ Statamic\Support\Str::bool($user->can('create', \Statamic\Contracts\Assets\AssetContainer::class)) }}"
-        create-container-url="{{ cp_route('asset-containers.create') }}"
-        initial-path="{{ $folder }}"
-        initial-editing-asset-id="{{ $editing ?? null }}"
-        :columns="{{ $columns->toJson() }}"
-    ></asset-manager>
+    <div v-cloak>
+        <asset-manager
+            :container="{{ json_encode($container) }}"
+            :can-create-containers="{{ Statamic\Support\Str::bool($user->can('create', \Statamic\Contracts\Assets\AssetContainer::class)) }}"
+            create-container-url="{{ cp_route('asset-containers.create') }}"
+            initial-path="{{ $folder }}"
+            initial-editing-asset-id="{{ $editing ?? null }}"
+            :columns="{{ $columns->toJson() }}"
+            class="starting-style-transition"
+        >
+            <template #initializing>
+                <!-- Toolbar skeleton -->
+                <div class="flex justify-between">
+                    <ui-skeleton class="h-9 w-95 mb-3" />
+                    <ui-skeleton class="h-9 w-10 mb-3" />
+                </div>
+                <!-- Assets grid skeleton -->
+                <div class="flex justify-between">
+                    <ui-skeleton class="h-100 w-full" />
+                </div>
+            </template>
+        </asset-manager>
 
-    <x-statamic::docs-callout
-        topic="{{ __('Assets') }}"
-        url="{{ Statamic::docsUrl('assets') }}"
-    />
+        <x-statamic::docs-callout
+            topic="{{ __('Assets') }}"
+            url="{{ Statamic::docsUrl('assets') }}"
+            class="starting-style-transition"
+        />
+    </div>
 @endsection

--- a/resources/views/components/docs-callout.blade.php
+++ b/resources/views/components/docs-callout.blade.php
@@ -3,7 +3,7 @@
 @endphp
 
 @if (config('statamic.cp.link_to_docs'))
-    <div class="mt-12 flex justify-center text-center starting-style-transition starting-style-transition--siblings">
+    <div class="mt-12 flex justify-center text-center starting-style-transition">
         <ui-command-palette-item
             :text="[__('Statamic Documentation'), `{{ $topic }}`]"
             icon="book-next-page"


### PR DESCRIPTION
This closes #12466

- Removes the spinning loader icon
- Adds a skeleton for the Assets browser
- Very minor changes to transitions to improve the way this loads: adds 0.1s to the delay and adds a `.starting-style-delay` class, which is more effective at hiding the docs callout before the assets browser loads