### PR TITLE
[6.x] Rearrange collections index modes

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -1,8 +1,8 @@
 <template>
     <ui-header :title="__('Collections')" icon="collections">
         <ui-toggle-group v-model="mode">
-            <ui-toggle-item icon="layout-list" value="list" aria-label="__('List view')" />
-            <ui-toggle-item icon="layout-grid" value="grid" aria-label="__('Grid view')" />
+            <ui-toggle-item icon="layout-list" value="list" :aria-label="__('List view')" />
+            <ui-toggle-item icon="layout-grid" value="grid" :aria-label="__('Grid view')" />
         </ui-toggle-group>
         <ui-button
             :href="createUrl"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches collections index to a default "list" mode (formerly "table"), reorders toggles, and updates command palette plus localized aria-labels.
> 
> - **Collections UI (`resources/js/components/collections/Listing.vue`)**:
>   - **Mode updates**:
>     - Rename `table` mode to `list` across conditionals and command palette actions/guards.
>     - Set default mode preference from `grid` to `list`.
>   - **Toggle group**:
>     - Reorder to show `list` before `grid` and localize `aria-label`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40aa3b27802ad64cfa5a7ff922d86466cc2863bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->