### PR TITLE
[6.x] Sticky table fixes

### DIFF
--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -132,7 +132,7 @@
     }
 
     tbody .checkbox-column {
-        @apply sticky px-3 -start-px;
+        @apply px-3 -start-px sticky -left-1.5;
         .data-table--contained & {
             @apply sticky ps-4;
         }

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -118,6 +118,13 @@
 
 /* Sticky Meta Columns */
 .data-table {
+    .checkbox-column {
+        /* When the table is scrolled on smaller screens, remove the left border radius from the sticky checkbox column */
+        @container scroll-state(scrollable: inline-start) {
+            @apply rounded-l-none!;
+        }
+    }
+
     thead th.checkbox-column {
         @apply sticky z-1 ps-3 w-8;
         .data-table--contained & {
@@ -133,6 +140,7 @@
 
     tbody .checkbox-column {
         @apply px-3 -start-px sticky -left-1.5;
+        container-type: scroll-state;
         .data-table--contained & {
             @apply sticky ps-4;
         }

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -698,7 +698,7 @@ autoApplyState();
             v-text="__('No results')"
         />
 
-        <Panel v-else class="relative overflow-x-auto overscroll-x-contain">
+        <Panel v-else class="relative overflow-x-auto overscroll-x-contain" style="container-type: scroll-state;">
             <Table>
                 <template v-for="(slot, slotName) in forwardedTableCellSlots" :key="slotName" #[slotName]="slotProps">
                     <component :is="slot" v-bind="slotProps" />


### PR DESCRIPTION
This fixes #12462, correcting the sticky position.

I've also added a progressive enhancement for browsers that support scroll-state container queries—when the table is scrolled on smaller screens, we remove the left border radius from the sticky checkbox column to make things a little neater.