### PR TITLE
[6.x] Fix inconsistent gray border widths

### DIFF
--- a/packages/ui/src/Panel/Panel.vue
+++ b/packages/ui/src/Panel/Panel.vue
@@ -13,7 +13,7 @@ const props = defineProps({
     <div
         :class="[
             'relative bg-gray-200/50 dark:bg-gray-950 dark:inset-shadow-2xs dark:inset-shadow-black',
-            'w-full rounded-2xl mb-5 p-1.5 [&:has([data-ui-panel-header])]:pt-0 focus-none starting-style-transition starting-style-transition--siblings',
+            'w-full rounded-2xl mb-5 p-1.75 [&:has([data-ui-panel-header])]:pt-0 focus-none starting-style-transition starting-style-transition--siblings',
         ]"
         data-ui-panel
     >

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -79,15 +79,13 @@ function toggleSection(id) {
                 class="h-auto visible transition-[height,visibility] duration-[250ms,2s]"
                 :class="{ 'h-0! visibility-hidden overflow-clip': section.collapsed }"
             >
-                <div class="p-px">
-                    <Primitive :as="asConfig ? 'div' : Card">
-                        <FieldsProvider :fields="section.fields">
-                            <slot :section="section">
-                                <Fields />
-                            </slot>
-                        </FieldsProvider>
-                    </Primitive>
-                </div>
+                <Primitive :as="asConfig ? 'div' : Card">
+                    <FieldsProvider :fields="section.fields">
+                        <slot :section="section">
+                            <Fields />
+                        </slot>
+                    </FieldsProvider>
+                </Primitive>
             </div>
         </Panel>
     </div>


### PR DESCRIPTION
This resolves #12461.

There was a `p-px` container wrapped around the publish sections that Jack had added back in August. I asked Jack, and it was initially meant to prevent the border from appearing "chopped off" when overflow was active.

However, that problem seems to have resolved itself, so the `p-px` container is no longer needed.
To compensate for its removal, I've bumped the panel padding from `p-1.5` to `p-1.75` so we don't lose the lovely contrast between the panel and the white background