### PR TITLE
[6.x] New folder placeholder length

### DIFF
--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -65,8 +65,8 @@
                         v-model:modelValue="newFolderName"
                         :start-with-edit-mode="true"
                         submit-mode="enter"
-                        :placeholder="__('name')"
-                        class="flex w-[80px] items-center justify-center overflow-hidden mt-2 text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
+                        :placeholder="__('Name')"
+                        class="flex w-[80px] items-center placeholder:lowercase justify-center overflow-hidden mt-2 text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
                         @submit="$emit('create-folder', newFolderName)"
                         @cancel="
                             () => {

--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -65,7 +65,7 @@
                         v-model:modelValue="newFolderName"
                         :start-with-edit-mode="true"
                         submit-mode="enter"
-                        :placeholder="__('new-folder')"
+                        :placeholder="__('name')"
                         class="flex w-[80px] items-center justify-center overflow-hidden mt-2 text-center font-mono text-xs text-ellipsis whitespace-nowrap text-gray-500"
                         @submit="$emit('create-folder', newFolderName)"
                         @cancel="

--- a/resources/js/components/assets/Browser/Table.vue
+++ b/resources/js/components/assets/Browser/Table.vue
@@ -70,7 +70,8 @@
                                 v-model:modelValue="newFolderName"
                                 :start-with-edit-mode="true"
                                 submit-mode="enter"
-                                :placeholder="__('name')"
+                                :placeholder="__('Name')"
+                                class="placeholder:lowercase"
                                 @submit="$emit('create-folder', newFolderName)"
                                 @cancel="
                                     () => {

--- a/resources/js/components/assets/Browser/Table.vue
+++ b/resources/js/components/assets/Browser/Table.vue
@@ -70,7 +70,7 @@
                                 v-model:modelValue="newFolderName"
                                 :start-with-edit-mode="true"
                                 submit-mode="enter"
-                                :placeholder="__('new-folder')"
+                                :placeholder="__('name')"
                                 @submit="$emit('create-folder', newFolderName)"
                                 @cancel="
                                     () => {

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -705,7 +705,6 @@
     "New Set Group": "Neue Setgruppe",
     "New Tab": "Neuer Tab",
     "New View": "Neue Ansicht",
-    "name": "Name",
     "Next": "Weiter",
     "Next Asset": "Nächste Datei",
     "No available filters": "Keine Filter verfügbar",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -705,7 +705,7 @@
     "New Set Group": "Neue Setgruppe",
     "New Tab": "Neuer Tab",
     "New View": "Neue Ansicht",
-    "new-folder": "neuer-ordner",
+    "name": "Name",
     "Next": "Weiter",
     "Next Asset": "Nächste Datei",
     "No available filters": "Keine Filter verfügbar",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -705,7 +705,6 @@
     "New Set Group": "Neue Setgruppe",
     "New Tab": "Neuer Tab",
     "New View": "Neue Ansicht",
-    "name": "Name",
     "Next": "Weiter",
     "Next Asset": "Nächste Datei",
     "No available filters": "Keine Filter verfügbar",

--- a/resources/lang/de_CH.json
+++ b/resources/lang/de_CH.json
@@ -705,7 +705,7 @@
     "New Set Group": "Neue Setgruppe",
     "New Tab": "Neuer Tab",
     "New View": "Neue Ansicht",
-    "new-folder": "neuer-ordner",
+    "name": "Name",
     "Next": "Weiter",
     "Next Asset": "Nächste Datei",
     "No available filters": "Keine Filter verfügbar",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -707,7 +707,7 @@
     "New Set Group": "Nouveau groupe d'ensembles",
     "New Tab": "Nouvel onglet",
     "New View": "Nouvelle vue",
-    "new-folder": "nouveau-dossier",
+    "name": "Nom",
     "Next": "suivant",
     "Next Asset": "Ressource suivante",
     "No available filters": "Aucun filtre disponible",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -707,7 +707,6 @@
     "New Set Group": "Nouveau groupe d'ensembles",
     "New Tab": "Nouvel onglet",
     "New View": "Nouvelle vue",
-    "name": "Nom",
     "Next": "suivant",
     "Next Asset": "Ressource suivante",
     "No available filters": "Aucun filtre disponible",


### PR DESCRIPTION
…This is because translations of "new-folder" often result in longer characters, where overflow is hidden / obscured.

Initially, I tried to fix this with an ellipsis, but you cannot do this since it's placeholder text rather than a block element. I think the simplest solution is just to use "name" which should safely fit.

I noticed that `Name` is already translated so I've re-used that but forced the placeholder value to lowercase.

