### PR TITLE
[6.x] More dropdown breadcrumb fixes

### DIFF
--- a/resources/views/components/breadcrumbs/dropdown.blade.php
+++ b/resources/views/components/breadcrumbs/dropdown.blade.php
@@ -60,7 +60,7 @@
             text="{{ __($breadcrumb->createLabel()) }}"
             href="{{ $breadcrumb->createUrl() }}"
             role="menuitem"
-            aria-label="'{{ __('Create new') }} {{ __($breadcrumb->createLabel()) }}'"
+            aria-label="'{{ __($breadcrumb->createLabel()) }}'"
         ></ui-dropdown-footer>
     @endif
 </ui-dropdown>

--- a/resources/views/components/breadcrumbs/dropdown.blade.php
+++ b/resources/views/components/breadcrumbs/dropdown.blade.php
@@ -49,7 +49,7 @@
                     icon="{{ $link->icon }}"
                     href="{{ $link->url }}"
                     role="menuitem"
-                    :aria-label="'{{ __($link->text) }} - {{ __('Navigate to') }}'"
+                    aria-label="'{{ __('Navigate to') }} {{ __($link->text) }}'"
                 ></ui-dropdown-item>
             @endforeach
         </ui-dropdown-menu>
@@ -60,7 +60,7 @@
             text="{{ __($breadcrumb->createLabel()) }}"
             href="{{ $breadcrumb->createUrl() }}"
             role="menuitem"
-            :aria-label="'{{ __($breadcrumb->createLabel()) }} - {{ __('Create new') }}'"
+            aria-label="'{{ __('Create new') }} {{ __($breadcrumb->createLabel()) }}'"
         ></ui-dropdown-footer>
     @endif
 </ui-dropdown>


### PR DESCRIPTION
As earlier explained in #12602
I faced it again with a second collection added, then the Aria-label in the if($breadcrumb->hasLinks)-part caused the same JS-errors
<img width="1401" height="641" alt="image" src="https://github.com/user-attachments/assets/7215a008-4f46-499d-b548-69865951eed1" />
<img width="510" height="419" alt="image" src="https://github.com/user-attachments/assets/409eae14-0b99-4ca0-bf12-638af2c17a0b" />

So therefore this PR to solve this issue. I also took the liberty to change the text order in the aria-labels to make it consistent with the other ones, and the 'Create new' is double for the createLabel (resolving into 'Create new Create Collection'), so I removed that (although, maybe the idea was to have it like 'Create new Collection', but couldn't figure out a nice way to just have the 'label' be rendered instead of the createLabel, so I think this the right approach).

After the changes it resolves without errors, to this Accessibility Tree view (in Dutch):
<img width="1000" height="230" alt="image" src="https://github.com/user-attachments/assets/db8ec660-531e-4e11-91dd-8ef94f283b54" />
