### PR TITLE
[5.x] Ability to register custom image presets

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -624,7 +624,10 @@ class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, 
                     return $presets;
                 }
 
-                $presets = Image::userManipulationPresets();
+                $presets = [
+                    ...Image::userManipulationPresets(),
+                    ...Image::customManipulationPresets(),
+                ];
 
                 $presets = Arr::except($presets, $this->sourcePreset);
 

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -100,9 +100,6 @@ class Manager
 
     /**
      * Register custom image manipulation presets.
-     *
-     * @param  array  $presets
-     * @return void
      */
     public function registerCustomManipulationPresets(array $presets): void
     {
@@ -113,8 +110,6 @@ class Manager
 
     /**
      * Get custom image manipulation presets.
-     *
-     * @return array
      */
     public function customManipulationPresets(): array
     {

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -8,6 +8,8 @@ use Statamic\Support\Arr;
 
 class Manager
 {
+    private array $customManipulationPresets = [];
+
     /**
      * Get a URL manipulator instance to continue chaining, or a URL right away if provided with params.
      *
@@ -49,7 +51,10 @@ class Manager
      */
     public function manipulationPresets()
     {
-        $presets = $this->userManipulationPresets();
+        $presets = [
+            ...$this->userManipulationPresets(),
+            ...$this->customManipulationPresets(),
+        ];
 
         if (config('statamic.cp.enabled')) {
             $presets = array_merge($presets, $this->cpManipulationPresets());
@@ -91,6 +96,29 @@ class Manager
                 "cp_thumbnail_{$name}_square" => ['w' => $size, 'h' => $size],
             ])
             ->all();
+    }
+
+    /**
+     * Register custom image manipulation presets.
+     *
+     * @param  array  $presets
+     * @return void
+     */
+    public function registerCustomManipulationPresets(array $presets): void
+    {
+        foreach ($presets as $name => $preset) {
+            $this->customManipulationPresets[$name] = $this->normalizePreset($preset);
+        }
+    }
+
+    /**
+     * Get custom image manipulation presets.
+     *
+     * @return array
+     */
+    public function customManipulationPresets(): array
+    {
+        return $this->customManipulationPresets;
     }
 
     /**

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -292,6 +292,28 @@ class AssetContainerTest extends TestCase
     }
 
     #[Test]
+    public function custom_manipulation_presets_are_included_in_warm_presets()
+    {
+        config(['statamic.assets.image_manipulation.presets' => [
+            'small' => ['w' => '15', 'h' => '15'],
+            'medium' => ['w' => '500', 'h' => '500'],
+            'large' => ['w' => '1000', 'h' => '1000'],
+            'max' => ['w' => '3000', 'h' => '3000', 'mark' => 'watermark.jpg'],
+        ]]);
+
+        Facades\Image::registerCustomManipulationPresets([
+            'og_image' => ['w' => 1146, 'h' => 600],
+            'twitter_image' => ['w' => 1200, 'h' => 600],
+        ]);
+
+        $container = (new AssetContainer);
+
+        $this->assertEquals([
+            'small', 'medium', 'large', 'max', 'og_image', 'twitter_image',
+        ], $container->warmPresets());
+    }
+
+    #[Test]
     public function it_saves_the_container_through_the_api()
     {
         Event::fake();

--- a/tests/Imaging/ManagerTest.php
+++ b/tests/Imaging/ManagerTest.php
@@ -4,7 +4,6 @@ namespace Tests\Imaging;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Imaging\ImageManipulator;
-use Statamic\Facades\Image;
 use Statamic\Imaging\Manager;
 use Tests\TestCase;
 

--- a/tests/Imaging/ManagerTest.php
+++ b/tests/Imaging/ManagerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Imaging;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Imaging\ImageManipulator;
+use Statamic\Facades\Image;
 use Statamic\Imaging\Manager;
 use Tests\TestCase;
 
@@ -71,12 +72,24 @@ class ManagerTest extends TestCase
             'cp_thumbnail_small_square' => ['w' => '400', 'h' => '400'],
         ], $this->manager->cpManipulationPresets());
 
+        $this->manager->registerCustomManipulationPresets([
+            'og_image' => ['w' => 1146, 'h' => 600],
+            'twitter_image' => ['w' => 1200, 'h' => 600],
+        ]);
+
+        $this->assertEquals([
+            'og_image' => ['w' => 1146, 'h' => 600],
+            'twitter_image' => ['w' => 1200, 'h' => 600],
+        ], $this->manager->customManipulationPresets());
+
         $this->assertEquals([
             'alfa' => ['w' => 100, 'h' => 200, 'q' => 50],
             'bravo' => ['w' => 200, 'h' => 100, 'q' => 20],
             'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '400', 'fit' => 'contain'],
             'cp_thumbnail_small_portrait' => ['h' => '400', 'fit' => 'contain'],
             'cp_thumbnail_small_square' => ['w' => '400', 'h' => '400'],
+            'og_image' => ['w' => 1146, 'h' => 600],
+            'twitter_image' => ['w' => 1200, 'h' => 600],
         ], $this->manager->manipulationPresets());
     }
 }


### PR DESCRIPTION
This pull request makes it possible for addons to register custom image manipulation presets, which can be generated via `php please assets:generate-presets`.

Addons can register presets like this:

```php
Facades\Image::registerCustomManipulationPresets([
    'og_image' => ['w' => 1146, 'h' => 600],
    'twitter_image' => ['w' => 1200, 'h' => 600],
]);
```

Related: https://github.com/statamic/seo-pro/issues/258