### PR TITLE
[6.x] Sticky toolbars

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -123,15 +123,27 @@
     }
 
     /* Only top-level Bard fields should have a sticky header */
+    /* =Jay. I don't think we have the "workspace" class anymore, in which case this should be removed */
     .workspace .publish-fields:not(.replicator-set-body) > .bard-fieldtype .bard-fixed-toolbar,
     .live-preview .publish-fields:not(.replicator-set-body) > .bard-fieldtype .bard-fixed-toolbar {
         @apply sticky;
     }
 
-    /*  Fixed toolbar inside another bard field */
-    .bard-fieldtype .bard-fieldtype .bard-fixed-toolbar {
+    .bard-fixed-toolbar {
         z-index: 4;
-        top: 40px;
+        position: sticky;
+        @apply -top-2;
+        /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
+        margin-block-end: 8px;
+        /* Pull the subsequent element up to compensate for this */
+        + * {
+            margin-block-start: -8px;
+        }
+    }
+
+    /*  Fixed toolbar inside another bard field */
+    .bard-content .bard-fixed-toolbar {
+        @apply top-8;
     }
 
     /*  Fixed toolbar inside a stack */
@@ -143,13 +155,7 @@
     @media (width >= theme(--breakpoint-md)) {
         /*  Fixed toolbar below fixed global header */
         .bard-fixed-toolbar {
-            top: 52px;
-
-            .bard-fieldtype .bard-fieldtype & {
-                top: 92px;
-            }
-
-            /*  Fixed toolbar inside a stack */
+            /* Fixed toolbar inside a stack */
             .stack-content .bard-fieldtype .bard-fieldtype & {
                 top: 16px;
             }

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -145,6 +145,10 @@
     .bard-content .bard-fixed-toolbar {
         @apply top-8;
     }
+    /* Bard > Grid > Bard */
+    .bard-content .grid-fieldtype .bard-fixed-toolbar {
+        @apply top-16;
+    }
 
     /*  Fixed toolbar inside a stack */
     .stack-content .bard-fixed-toolbar {

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -141,7 +141,7 @@
         }
     }
 
-    /*  Fixed toolbar inside another bard field */
+    /* Fixed toolbar inside another bard field */
     .bard-content .bard-fixed-toolbar {
         @apply top-8;
     }

--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -13,7 +13,7 @@
     }
 
     thead th {
-        @apply sticky -top-2 table-cell z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100;
+        @apply sticky -top-2 table-cell z-10 border-b bg-gray-100/75 backdrop-blur-[10px] p-2 text-sm font-medium text-gray-900 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100;
         /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
         margin-block-end: 8px;
         /* Pull the subsequent element up to compensate for this */

--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -13,7 +13,7 @@
     }
 
     thead th {
-        @apply sticky -top-2 table-cell z-10 border-b bg-gray-100/75 p-2 text-sm font-medium text-gray-900 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100;
+        @apply sticky -top-2 table-cell z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100;
         /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
         margin-block-end: 8px;
         /* Pull the subsequent element up to compensate for this */

--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -14,6 +14,12 @@
 
     thead th {
         @apply sticky -top-2 table-cell z-10 border-b bg-gray-100/75 p-2 text-sm font-medium text-gray-900 dark:border-gray-900 dark:bg-gray-800 dark:text-gray-100;
+        /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
+        margin-block-end: 8px;
+        /* Pull the subsequent element up to compensate for this */
+        + * {
+            margin-block-start: -8px;
+        }
     
         &:first-child {
             @apply rounded-ss-lg ps-3;
@@ -25,6 +31,11 @@
 
         .stack-container & {
             top: auto;
+        }
+
+        /* Fixed toolbar inside another bard field */
+        .bard-content & {
+            @apply top-8;
         }
     }
 

--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -33,10 +33,20 @@
             top: auto;
         }
 
-        /* Fixed toolbar inside another bard field */
+        /* Bard fieldtype > Grid fieldtype */
         .bard-content & {
             @apply top-8;
         }
+    }
+
+    /* Grid fieldtype > Bard fieldtype */
+    .bard-fixed-toolbar {
+        @apply top-8;
+    }
+
+    /* Bard fieldtype > Grid fieldtype > Bard fieldtype */
+    .bard-content & .bard-fixed-toolbar {
+        @apply top-16;
     }
 
     > tbody {

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -10,10 +10,22 @@ Table Fieldtype
 
     thead {
         th {
-            @apply z-10 border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-gray-800 dark:border-b-gray-700 dark:bg-gray-900 dark:text-gray-100 not-last:border-e overflow-hidden;
+            @apply
+                z-10
+                p-2
+                dark:bg-gray-900
+                border-b bg-gray-50
+                not-last:border-e overflow-hidden
+                dark:border-gray-800 dark:border-b-gray-700
+                text-sm font-medium text-gray-900
+                dark:text-gray-100
+                -top-2
+            ;
+            .bard-content & {
+                @apply top-8;
+            }
             display: table-cell;
             position: sticky;
-            top: -1px;
             text-align: left;
 
             &:first-child {
@@ -26,6 +38,13 @@ Table Fieldtype
 
             &.grid-drag-handle-header {
                 @apply w-3;
+            }
+
+            /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
+            margin-block-end: 8px;
+            /* Pull the subsequent element up to compensate for this */
+            + * {
+                margin-block-start: -8px;
             }
         }
     }

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -79,7 +79,7 @@
             <Motion
                 layout
                 v-if="index !== undefined"
-                class="overflow-hidden"
+                class="contain-paint"
                 :initial="{ height: collapsed ? '0px' : 'auto' }"
                 :animate="{ height: collapsed ? '0px' : 'auto' }"
                 :transition="{ duration: 0.25, type: 'tween' }"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -197,7 +197,7 @@ function destroy() {
             </header>
 
             <Motion
-                class="overflow-hidden"
+                class="contain-paint"
                 :initial="{ height: collapsed ? '0px' : 'auto' }"
                 :animate="{ height: collapsed ? '0px' : 'auto' }"
                 :transition="{ duration: 0.25, type: 'tween' }"


### PR DESCRIPTION
This fixes #12431.

## The sticky positioning on the Bard fixed toolbar was broken for a few reasons:

- Primarily because of the `overflow: hidden;` on the `v-motion` container. This prevents `position: sticky;` from working. There are a few more "modern" ways of preventing overflow, `contain: paint;` being the most performant, so I went with that.
- The selectors needed to be changed a little—probably because of the new components

## Other notes

- I fixed sticky tables while I was here
- I added a bit of margin / negative margin to the subsequent element to stop the straight corners from bumping up to the rounded corners of the bottom of the container, like this:

![2025-10-02 at 12 16 02@2x](https://github.com/user-attachments/assets/e2196212-2faa-47c3-9811-af3cd36f686e)

(instead of this)
![2025-10-02 at 12 16 49@2x](https://github.com/user-attachments/assets/20284ae5-e3ea-4e62-b0fc-beaf5432af5d)
