### PR TITLE
[6.x] Prevent panel transparency

### DIFF
--- a/packages/ui/src/Panel/Panel.vue
+++ b/packages/ui/src/Panel/Panel.vue
@@ -12,7 +12,7 @@ const props = defineProps({
 <template>
     <div
         :class="[
-            'relative bg-gray-200/50 dark:bg-gray-950 dark:inset-shadow-2xs dark:inset-shadow-black',
+            'relative bg-gray-200/50 backdrop-blur-[10px] dark:bg-gray-950 dark:inset-shadow-2xs dark:inset-shadow-black',
             'w-full rounded-2xl mb-5 p-1.5 [&:has([data-ui-panel-header])]:pt-0 focus-none starting-style-transition starting-style-transition--siblings',
         ]"
         data-ui-panel


### PR DESCRIPTION
For panel backgrounds, we're using a transparent background color so it sits between `gray-100` and `gray-200`.

While I would usually avoid doing this, the cp is pretty much grayscale, so I think this halfway shade is needed to help legibility—100 is too light, and 200 is too muddy.

Anyway, this is fine _but_ there is a side effect when certain things run _behind_ the panel. I'm particularly thinking of the "architectural lines" background here, but it could be anything, really.

Here is an example:

## Before

![2025-10-02 at 15 43 58@2x](https://github.com/user-attachments/assets/38984bd3-7a7d-475e-90dd-e18605032395)

## After

If we add a slight backdrop blur this effectively mitigates the transparency. A value of about `5px` is enough but I've set it to `10px` to be safe.

Now we can't see anything underneath the panel, but we keep our halfway-house shade of gray.

![2025-10-02 at 15 40 19@2x](https://github.com/user-attachments/assets/d87ed889-897a-415d-ac0d-370c17752708)

_P.s. I initially thought of making a custom opaque grey color, but since we're using a Tailwind theming system, I don't think that would work._