### PR TITLE
[6.x] Remove header starting style

### DIFF
--- a/packages/ui/src/Header.vue
+++ b/packages/ui/src/Header.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 </script>
 
 <template>
-    <header class="flex flex-wrap items-center justify-between gap-4 py-8 starting-style-transition" data-ui-header>
+    <header class="flex flex-wrap items-center justify-between gap-4 py-8" data-ui-header>
         <h1 class="text-[25px] leading-[1.25] st-text-legibility font-medium antialiased flex items-center gap-2.5 flex-1">
             <!-- Wrap icon in a fixed size div (the same size as the icon) to prevent layout shift once it loads -->
             <div v-if="icon" class="size-5 relative bg-white dark:bg-gray-900">


### PR DESCRIPTION
This removes the starting style transition (entry animation) from the header area, e.g. the name of the collection such as "Pages" on the name of the CP area like "Navigation"

![2025-10-03 at 10 43 35@2x](https://github.com/user-attachments/assets/7929ef26-2b10-4572-90ba-23daf739b576)


I think it makes sense to keep entry animations for areas that frequently change structure; for example, the main panel area, but for the header area, it's almost _always_ the same structure on every page, so we don't need to transition it now that we have Inertia ⚡