### PR TITLE
[6.x] Page tree node transitions

### DIFF
--- a/resources/css/components/page-tree.css
+++ b/resources/css/components/page-tree.css
@@ -3,6 +3,11 @@
 .page-tree {
     .tree-node {
         @apply dark:pb-0.25;
+        transition: opacity var(--starting-style-transition-duration);
+        transition-delay: calc(sibling-index() * var(--starting-style-sibling-delay));
+        @starting-style {
+            opacity: 0;
+        }
     }
     .page-tree-branch {
         @apply relative rounded-xl bg-white text-xs shadow;

--- a/resources/css/core/animation.css
+++ b/resources/css/core/animation.css
@@ -90,6 +90,6 @@
     .starting-style-transition-children > *,
     .publish-fields > *,
     .publish-fields-fluid > * {
-        transition-delay: calc(sibling-index() * var(--starting-style-transition-duration));
+        transition-delay: calc(sibling-index() * var(--starting-style-sibling-delay));
     }
 }

--- a/resources/css/core/animation.css
+++ b/resources/css/core/animation.css
@@ -71,18 +71,18 @@
     .starting-style-transition-children > *,
     .publish-fields > *,
     .publish-fields-fluid > *  {
-        transition: opacity 0.1s;
+        transition: opacity var(--starting-style-transition-duration);
         @starting-style {
             opacity: 0;
         }
     }
 
     .starting-style-transition--quick {
-        transition: opacity 0.05s;
+        transition: opacity calc(var(--starting-style-transition-duration) / 2);
     }
 
     .starting-style-transition--delay {
-        transition-delay: 0.5s;
+        transition-delay: calc(var(--starting-style-transition-duration) * 5);
     }
 
     .starting-style-transition--siblings,
@@ -90,6 +90,6 @@
     .starting-style-transition-children > *,
     .publish-fields > *,
     .publish-fields-fluid > * {
-        transition-delay: calc(sibling-index() * 0.01s);
+        transition-delay: calc(sibling-index() * var(--starting-style-transition-duration));
     }
 }

--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -1,3 +1,5 @@
+/* VARIABLES
+=================================================== */
 :root {
     /* For animating height */
     interpolate-size: allow-keywords;
@@ -25,6 +27,9 @@
     --z-index-draggable: 5;
     --z-index-modal: 50;
     --z-index-max: 9999;
+
+    /* Used for entry animations */
+    --starting-style-transition-duration: 0.1s;
 }
 
 /* FOCUS STATES

--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -29,7 +29,8 @@
     --z-index-max: 9999;
 
     /* Used for entry animations */
-    --starting-style-transition-duration: 0.1s;
+    --starting-style-transition-duration: 0.125s;
+    --starting-style-sibling-delay: 0.01s;
 }
 
 /* FOCUS STATES


### PR DESCRIPTION
I'd previously missed adding starting style animations to the page tree component, e.g. below.

Since the `.page-tree` HTML is not really accessible I added it to the CSS file and converted values to variables to keep things nice and tidy.

![2025-10-03 at 11 10 12@2x](https://github.com/user-attachments/assets/29b9ccb3-2295-4db6-bb5f-5745dc02a6fe)
