### PR TITLE
[6.x] Fix missing translation for user group blueprint

### DIFF
--- a/translator
+++ b/translator
@@ -49,6 +49,7 @@ $additionalStrings = [
     'All rights reserved.',
     'The given data was invalid.',
     'Protected Page',
+    'User group',
 ];
 
 // Additional keys to be translated that aren't picked up by the scanner.


### PR DESCRIPTION
This pull request fixes an issue where the `User group` string used as the title of the user group blueprint wasn't being generated by the `translator` because it's "dynamic".

Fixes #12631