### PR TITLE
[6.x] Fix "Create Entry" button in collection grid view

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -68,7 +68,13 @@ class CollectionsController extends CpController
                 'published_entries_count' => $collection->queryEntries()->where('site', Site::selected())->where('status', 'published')->count(),
                 'draft_entries_count' => $collection->queryEntries()->where('site', Site::selected())->where('status', 'draft')->count(),
                 'scheduled_entries_count' => $collection->queryEntries()->where('site', Site::selected())->where('status', 'scheduled')->count(),
-                'blueprints' => $collection->entryBlueprints()->reject->hidden()->values(),
+                'blueprints' => $collection->entryBlueprints()->reject->hidden()
+                    ->map(fn ($blueprint) => [
+                        ...$blueprint->toArray(),
+                        'createEntryUrl' => cp_route('collections.entries.create', [$collection->handle(), Site::selected(), 'blueprint' => $blueprint->handle()]),
+                    ])
+                    ->values()
+                    ->all(),
                 'columns' => [
                     ['label' => 'Title', 'field' => 'title', 'visible' => true],
                     ['label' => 'Date', 'field' => 'date', 'visible' => true],


### PR DESCRIPTION
This pull request fixes the "Create Entry" button in collection grid view, where it'd incorrectly take you to `/cp/undefined` because the `createEntryUrl` was being passed down from the server.

Caused by https://github.com/statamic/cms/pull/12610