### PR TITLE
[6.x] Fix reordering in asset fieldtype's grid view

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="asset-tile"
+        class="asset-tile asset-thumb-container"
         :class="{
             'is-image': isImage && !canShowSvg,
             'is-svg': canShowSvg,


### PR DESCRIPTION
The `SortableList` component was expecting the `asset-thumb-container` class on child elements in order to trigger the re-ordering, but that class wasn't there, so nothing was re-orderable.

Fixes #12591. 