### PR TITLE
[5.x] Registering a custom preset should update existing `Server` instance

### DIFF
--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Imaging;
 
+use League\Glide\Server;
 use Statamic\Contracts\Imaging\ImageManipulator;
 use Statamic\Facades\Glide;
 use Statamic\Support\Arr;
@@ -106,6 +107,9 @@ class Manager
         foreach ($presets as $name => $preset) {
             $this->customManipulationPresets[$name] = $this->normalizePreset($preset);
         }
+
+        $server = app(Server::class);
+        $server->setPresets([...$server->getPresets(), ...$this->customManipulationPresets()]);
     }
 
     /**


### PR DESCRIPTION
This pull request fixes an issue with the custom image manipulation presets feature added in #12624, where custom presets wouldn't be available on the Glide server if the `Server` instance had already been resolved. 

This was causing an issue in SEO Pro's tests because social images were returning their original width/height, instead of the width/heights defined in the preset.

It turned out that the Glide `Server` instance was being resolved before we were calling `Image::registerCustomManipulationPresets()` in SEO Pro's service provider.

This PR fixes it by updating the `Server` instance's presets array when registering a custom preset.

Related: statamic/seo-pro#427