### PR TITLE
[6.x] Bard sticky floating toolbar fixes

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -141,8 +141,8 @@
         }
     }
 
-    /* Fixed toolbar inside another bard field */
-    .bard-content .bard-fixed-toolbar {
+    /* Bard field with a fixed toolbar > then another fixed toolbar inside this */
+    .bard-fieldtype:has(> .bard-fixed-toolbar) .bard-content .bard-fixed-toolbar {
         @apply top-8;
     }
     /* Bard > Grid > Bard */
@@ -150,7 +150,7 @@
         @apply top-16;
     }
 
-    /*  Fixed toolbar inside a stack */
+    /* Fixed toolbar inside a stack */
     .stack-content .bard-fixed-toolbar {
         top: -24px;
     }

--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -33,8 +33,8 @@
             top: auto;
         }
 
-        /* Bard fieldtype > Grid fieldtype */
-        .bard-content & {
+        /* Bard field with a fixed toolbar > Grid fieldtype */
+        .bard-fieldtype:has(> .bard-fixed-toolbar) .bard-content & {
             @apply top-8;
         }
     }
@@ -44,8 +44,8 @@
         @apply top-8;
     }
 
-    /* Bard fieldtype > Grid fieldtype > Bard fieldtype */
-    .bard-content & .bard-fixed-toolbar {
+    /* Bard field with a fixed toolbar > Grid fieldtype > Bard fieldtype */
+    .bard-fieldtype:has(> .bard-fixed-toolbar) .bard-content & .bard-fixed-toolbar {
         @apply top-16;
     }
 

--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -21,7 +21,8 @@ Table Fieldtype
                 dark:text-gray-100
                 -top-2
             ;
-            .bard-content & {
+            /* Bard field with a fixed toolbar > Table fieldtype */
+            .bard-fieldtype:has(> .bard-fixed-toolbar) .bard-content & {
                 @apply top-8;
             }
             display: table-cell;


### PR DESCRIPTION
This fixes subsequent sticky Bard positioning when the main container has a floating toolbar, meaning further "sticky" toolbars don't need to be pushed down so far down.

Here we're checking if there is a fixed toolbar on the parent Bard field before we start shifting things down.

For example:

## Before

![2025-10-06 at 18 29 24@2x](https://github.com/user-attachments/assets/c7ca481e-a1ad-4421-a327-e92b086f3964)


## After

![2025-10-06 at 18 30 24@2x](https://github.com/user-attachments/assets/1daed392-6572-4495-bb5b-e2f6759216ab)
