### PR TITLE
[6.x] Fix missing asset folders when no assets

### DIFF
--- a/resources/js/components/ui/Listing/Table.vue
+++ b/resources/js/components/ui/Listing/Table.vue
@@ -20,6 +20,7 @@ const props = defineProps({
 const { visibleColumns, selections, items, hasActions, showBulkActions, loading, reorderable } = injectListingContext();
 const shifting = ref(false);
 const hasSelections = computed(() => selections.value.length > 0);
+const hasTbodyStartSlot = computed(() => !!slots['tbody-start']);
 
 const relativeColumnsSize = computed(() => {
     if (visibleColumns.value.length <= 4) return 'sm';
@@ -42,7 +43,7 @@ const forwardedTableCellSlots = computed(() => {
 
 <template>
     <table
-        v-if="items.length > 0"
+        v-if="items.length > 0 || hasTbodyStartSlot"
         :data-size="relativeColumnsSize"
         :class="{
             'select-none': shifting,
@@ -67,7 +68,7 @@ const forwardedTableCellSlots = computed(() => {
             </template>
         </TableBody>
     </table>
-    <div v-if="items.length === 0">
+    <div v-if="items.length === 0 && !hasTbodyStartSlot">
         <div class="text-center text-gray-500 text-sm py-4">
             {{ __('No items found') }}
         </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Table now renders if `tbody-start` slot exists even with zero items, and the empty state is hidden in that case.
> 
> - **Frontend – `resources/js/components/ui/Listing/Table.vue`**:
>   - **Behavior**:
>     - Add `hasTbodyStartSlot` computed to detect `tbody-start` slot.
>     - Render `<table>` when `items.length > 0` or `hasTbodyStartSlot`.
>     - Show empty state only when `items.length === 0` and no `tbody-start` slot.
>   - **Slots**:
>     - Continue forwarding `cell-*` slots; no changes to slot APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76383984d1656cec869a56220a9dddebdbae8c6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->