### PR TITLE
[6.x] Move blade badge to header

### DIFF
--- a/resources/js/components/global-header/Header.vue
+++ b/resources/js/components/global-header/Header.vue
@@ -5,6 +5,10 @@ import SiteSelector from './SiteSelector.vue';
 import Search from './Search.vue';
 import ViewSiteButton from './ViewSiteButton.vue';
 import UserDropdown from './UserDropdown.vue';
+import { Badge, Tooltip } from '@statamic/ui';
+import { useReactiveStatamicPageProps } from '@/composables/page-props.js';
+
+const { isInertia } = useReactiveStatamicPageProps();
 </script>
 
 <template>
@@ -21,6 +25,9 @@ import UserDropdown from './UserDropdown.vue';
         </div>
 
         <div class="dark flex-1 flex gap-1 md:gap-3 items-center justify-end shrink-0">
+            <Tooltip text="This page is rendered using a traditional Blade view, not Inertia. This badge is temporary.">
+                <Badge v-if="!isInertia" text="Blade" color="yellow" class="cursor-help" />
+            </Tooltip>
             <SiteSelector />
             <div class="flex items-center">
                 <Search />

--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -4,9 +4,7 @@ import { Badge, Icon, Tooltip } from '@ui';
 import useNavigation from './navigation.js';
 import { nextTick, onMounted, ref, watch } from 'vue';
 import DynamicHtmlRenderer from '@/components/DynamicHtmlRenderer.vue';
-import { useReactiveStatamicPageProps } from '@/composables/page-props.js';
 
-const { isInertia } = useReactiveStatamicPageProps();
 const { nav, setParentActive, setChildActive } = useNavigation();
 const localStorageKey = 'statamic.nav';
 const isOpen = ref(localStorage.getItem(localStorageKey) !== 'closed');
@@ -69,11 +67,6 @@ Statamic.$events.$on('nav.toggle', toggle);
                     </template>
                 </li>
             </ul>
-        </div>
-        <div>
-            <Tooltip text="This page is rendered using a traditional Blade view, not Inertia. This badge is temporary.">
-                <Badge v-if="!isInertia" text="Blade" color="yellow" />
-            </Tooltip>
         </div>
     </nav>
 </template>


### PR DESCRIPTION
We currently have a Blade badge at the bottom of the nav sidebar so we can tell at a glance what pages still need to be converted.

This moves it to the header so it's easier to spot without needing to scroll the page. If I have devtools open it's often covering the badge.

This is just a temporary thing before a stable release anyway.
