### PR TITLE
[6.x] Inertia toast handling

### DIFF
--- a/resources/js/components/Toasts.js
+++ b/resources/js/components/Toasts.js
@@ -1,3 +1,5 @@
+import { router } from '@inertiajs/vue3';
+
 export default class Toasts {
     #app;
     #plugin;
@@ -20,6 +22,13 @@ export default class Toasts {
             promise.then((json) => this.#displayToasts(json._toasts ?? []));
 
             return response;
+        });
+
+        router.on('success', (event) => {
+            const toasts = event.detail.page.props._toasts;
+            if (toasts && Array.isArray(toasts)) {
+                this.#displayToasts(toasts);
+            }
         });
     }
 

--- a/src/CP/Toasts/Manager.php
+++ b/src/CP/Toasts/Manager.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Collection;
  * Toasts are either sent along with the next JSON response or in the next view.
  *
  * @see \Statamic\Http\Middleware\CP\AddToasts
+ * @see \Statamic\Http\Middleware\CP\HandleInertiaRequests
  * @see \Statamic\Http\View\Composers\JavascriptComposer
  */
 class Manager

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -23,9 +23,6 @@ class HandleInertiaRequests extends Middleware
 
     public function share(Request $request): array
     {
-        $toasts = $this->toasts->toArray();
-        $this->toasts->clear();
-
         return array_filter([
             ...parent::share($request),
             '_statamic' => [
@@ -33,7 +30,7 @@ class HandleInertiaRequests extends Middleware
                 'cmsName' => __(Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic'),
                 'logos' => $this->logos(),
             ],
-            '_toasts' => $toasts ?: null,
+            '_toasts' => $this->toasts($request),
         ]);
     }
 
@@ -62,5 +59,28 @@ class HandleInertiaRequests extends Middleware
                 'outside' => $dark['outside'] ?? null,
             ],
         ];
+    }
+
+    private function toasts(Request $request)
+    {
+        $session = $request->session();
+
+        if ($message = $session->get('success')) {
+            $this->toasts->success($message);
+        }
+
+        if ($message = $session->get('error')) {
+            $this->toasts->error($message);
+        }
+
+        if ($message = $session->get('info')) {
+            $this->toasts->info($message);
+        }
+
+        $toasts = $this->toasts->toArray();
+
+        $this->toasts->clear();
+
+        return $toasts;
     }
 }

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Middleware\CP;
 
 use Illuminate\Http\Request;
 use Inertia\Middleware;
+use Statamic\CP\Toasts\Manager;
 use Statamic\Statamic;
 
 class HandleInertiaRequests extends Middleware
@@ -15,8 +16,16 @@ class HandleInertiaRequests extends Middleware
         return parent::version($request);
     }
 
+    public function __construct(private Manager $toasts)
+    {
+        //
+    }
+
     public function share(Request $request): array
     {
+        $toasts = $this->toasts->toArray();
+        $this->toasts->clear();
+
         return array_filter([
             ...parent::share($request),
             '_statamic' => [
@@ -24,6 +33,7 @@ class HandleInertiaRequests extends Middleware
                 'cmsName' => __(Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic'),
                 'logos' => $this->logos(),
             ],
+            '_toasts' => $toasts ?: null,
         ]);
     }
 


### PR DESCRIPTION
Any toasts pushed with the facade will get shown for inertia requests.

e.g. `Toast::success('Nice.');`

If there's a redirect with a flash message, that'll also get shown for inertia requests.

e.g. `return back()->withSuccess('Nice.');`