### PR TITLE
[6.x] If you're focused on a checkbox, Enter now submits the nearest form. 

### DIFF
--- a/packages/ui/src/Checkbox/Item.vue
+++ b/packages/ui/src/Checkbox/Item.vue
@@ -25,10 +25,7 @@ const handleKeydown = (event) => {
     emit('keydown', event);
 
     if (event.key === 'Enter' && !event.defaultPrevented) {
-        const form = event.target.closest('form');
-        if (form) {
-            form.requestSubmit();
-        }
+        event.target.closest('form')?.requestSubmit();
     }
 };
 

--- a/packages/ui/src/Checkbox/Item.vue
+++ b/packages/ui/src/Checkbox/Item.vue
@@ -21,6 +21,15 @@ const emit = defineEmits(['update:modelValue']);
 
 const id = useId();
 
+const handleKeydown = (event) => {
+    if (event.key === 'Enter') {
+        const form = event.target.closest('form');
+        if (form) {
+            form.requestSubmit();
+        }
+    }
+};
+
 const checkboxClasses = computed(() => {
     return cva({
         base: [
@@ -82,6 +91,7 @@ const conditionalProps = computed(() => {
             :value="value"
             v-bind="conditionalProps"
             @update:modelValue="emit('update:modelValue', $event)"
+            @keydown="handleKeydown"
             :class="checkboxClasses"
             :tabindex="tabindex"
         >

--- a/packages/ui/src/Checkbox/Item.vue
+++ b/packages/ui/src/Checkbox/Item.vue
@@ -17,12 +17,14 @@ const props = defineProps({
     value: { type: [String, Number, Boolean] },
 });
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'keydown']);
 
 const id = useId();
 
 const handleKeydown = (event) => {
-    if (event.key === 'Enter') {
+    emit('keydown', event);
+
+    if (event.key === 'Enter' && !event.defaultPrevented) {
         const form = event.target.closest('form');
         if (form) {
             form.requestSubmit();


### PR DESCRIPTION
Closes #12131.

This was necessary because [Reka](https://reka-ui.com/docs/components/checkbox) uses a Button component for Checkboxes to give you full styling control while still maintaining (most but not all, apparently) natural keyboard events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pressing Enter on a focused checkbox now submits the nearest enclosing form.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 758b8bb5814265726fdbe31db9900a6ded73da09. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->