### PR TITLE
[6.x] Fix missing site name in header

### DIFF
--- a/resources/js/components/global-header/Logo.vue
+++ b/resources/js/components/global-header/Logo.vue
@@ -35,7 +35,7 @@ function toggleNav() {
                 <StatamicLogo class="size-7 group-hover:opacity-0 transition-opacity duration-150" />
             </button>
             <Link :href="cp_url('/')" class="hidden sm:block text-white/85 rounded-xs whitespace-nowrap" style="--focus-outline-offset: var(--outline-offset-button);">
-                {{ logos.text }}
+                {{ logos.text ?? logos.siteName }}
             </Link>
             <ProBadge v-if="isPro" />
         </div>

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -43,6 +43,7 @@ class HandleInertiaRequests extends Middleware
 
         return [
             'text' => config('statamic.cp.custom_logo_text'),
+            'siteName' => config('app.name'),
             'light' => [
                 'nav' => $light['nav'] ?? null,
                 'outside' => $light['outside'] ?? null,


### PR DESCRIPTION
This brings back the site name in the header that dropped off in #12610.

<img width="328" height="62" alt="CleanShot 2025-10-07 at 16 07 59" src="https://github.com/user-attachments/assets/88b283ea-96cc-479b-9246-6242d3637103" />
