### PR TITLE
[6.x] Fix inconsistent spacing in cp config

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -169,5 +169,5 @@ return [
     'thumbnail_presets' => [
         // 'medium' => 800,
     ],
-    
+
 ];

--- a/config/cp.php
+++ b/config/cp.php
@@ -169,4 +169,5 @@ return [
     'thumbnail_presets' => [
         // 'medium' => 800,
     ],
+    
 ];


### PR DESCRIPTION
The rest of the config files have an empty line after the last config option, but I noticed that `cp.php` doesn't so thought I'd fix it.