### PR TITLE
[6.x] Tweak config of set preview asset field

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -99,6 +99,9 @@
                                 folder: previewImageFolder,
                                 restrict: !! previewImageFolder,
                                 allow_uploads: true,
+                                show_set_alt: false,
+                                mode: 'list',
+                                max_items: 1
                             }"
                             :initial-value="editingSection.image"
                             v-slot="{ meta, value, loading, config }"


### PR DESCRIPTION
This pull request tweaks the config of the Set Preview asset field, disabling the "Set Alt" button, preventing multiple images from being selected (we only save 1 anyway) and switching it to "List" mode (which IMO looks better for a single asset).

Fixes #12679