### PR TITLE
[6.x] Date Picker: Avoid passing current time when time is disabled

### DIFF
--- a/packages/ui/src/DatePicker/DatePicker.vue
+++ b/packages/ui/src/DatePicker/DatePicker.vue
@@ -64,7 +64,16 @@ const calendarBindings = computed(() => ({
 }));
 
 const calendarEvents = computed(() => ({
-    'update:model-value': (event) => emit('update:modelValue', event),
+    'update:model-value': (event) => {
+        if (props.granularity === 'day') {
+            event.hour = 0;
+            event.minute = 0;
+            event.second = 0;
+            event.millisecond = 0;
+        }
+
+        emit('update:modelValue', event);
+    },
 }));
 
 const isInvalid = computed(() => {

--- a/packages/ui/src/DateRangePicker/DateRangePicker.vue
+++ b/packages/ui/src/DateRangePicker/DateRangePicker.vue
@@ -68,7 +68,21 @@ const calendarBindings = computed(() => ({
 const placeholder = parseAbsoluteToLocal(new Date().toISOString());
 
 const calendarEvents = computed(() => ({
-    'update:model-value': (event) => emit('update:modelValue', event),
+    'update:model-value': (event) => {
+        if (props.granularity === 'day') {
+            event.start.hour = 0;
+            event.start.minute = 0;
+            event.start.second = 0;
+            event.start.millisecond = 0;
+
+            event.end.hour = 0;
+            event.end.minute = 0;
+            event.end.second = 0;
+            event.end.millisecond = 0;
+        }
+
+        emit('update:modelValue', event)
+    },
 }));
 </script>
 


### PR DESCRIPTION
This pull request fixes an issue with the Date Picker components when `granularity: "day"`, where the current time was being passed up to the parent component, instead of midnight.

Fixes #12585
