### PR TITLE
[6.x] Fix deletion modals on structure trees

### DIFF
--- a/packages/ui/src/Modal/Modal.vue
+++ b/packages/ui/src/Modal/Modal.vue
@@ -5,7 +5,7 @@ import { DialogContent, DialogOverlay, DialogPortal, DialogRoot, DialogTitle, Di
 import { computed, getCurrentInstance, ref, watch } from 'vue';
 import Icon from '../Icon/Icon.vue';
 
-const emit = defineEmits(['update:open']);
+const emit = defineEmits(['update:open', 'dismissed']);
 
 const props = defineProps({
     blur: { type: Boolean, default: true },
@@ -64,6 +64,8 @@ function updateOpen(value) {
 
 function preventIfNotDismissible(event) {
     if (!props.dismissible) event.preventDefault();
+
+    emit('dismissed');
 }
 </script>
 

--- a/resources/js/components/collections/DeleteEntryConfirmation.vue
+++ b/resources/js/components/collections/DeleteEntryConfirmation.vue
@@ -11,7 +11,7 @@ const shouldDeleteChildren = ref(false);
 </script>
 
 <template>
-    <Modal :title="__('Delete Entry')" v-model:open="modalOpen">
+    <Modal :title="__('Delete Entry')" v-model:open="modalOpen" @dismissed="$emit('cancel')">
         <p class="mb-4" v-text="__('Are you sure you want to delete this entry?')" />
         <label class="flex items-center" v-if="children">
             <input type="checkbox" class="ltr:mr-2 rtl:ml-2" v-model="shouldDeleteChildren" />

--- a/resources/js/components/navigation/RemovePageConfirmation.vue
+++ b/resources/js/components/navigation/RemovePageConfirmation.vue
@@ -13,7 +13,7 @@ const shouldDeleteChildren = ref(false);
 </script>
 
 <template>
-    <Modal :title="__('Remove Page')" v-model:open="modalOpen">
+    <Modal :title="__('Remove Page')" v-model:open="modalOpen" @dismissed="$emit('cancel')">
         <p class="mb-4" v-text="__('Are you sure you want to remove this page?')" />
         <p class="mb-4" v-text="__('Only the references will be removed. Entries will not be deleted.')" />
         <label class="flex items-center" v-if="children">


### PR DESCRIPTION
This pull request fixes an issue where you could dismiss the deletion modals on the collection/nav trees, but it meant you couldn't re-open it.

This PR fixes it by introducing a `dismissable` event which we can listen to and emit a `cancel` event to the parent component (we emit the same event when you click the "Cancel" button).

Fixes #12565.