### PR TITLE
[6.x] Change wording of "Submit" button in nav page editor

### DIFF
--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -45,7 +45,7 @@
             >
                 <div v-if="!readOnly">
                     <Button variant="ghost" class="me-2" :text="__('Cancel')" @click="confirmClose(close)" />
-                    <Button variant="primary" :text="__('Submit')" @click="submit" />
+                    <Button variant="primary" :text="__('Apply')" @click="submit" />
                 </div>
                 <div v-if="type === 'entry'">
                     <Button icon="external-link" variant="ghost" :text="__('Edit Entry')" :href="editEntryUrl" target="_blank" />


### PR DESCRIPTION
Probably a preference thing, but I agree with the issue creator:  "Submit" makes me think it's going to save the changes right away, but "Apply" makes me think it's going to be part of the next save.

Closes #12562