### PR TITLE
[6.x] Fix Reupload Asset action

### DIFF
--- a/resources/js/components/actions/ConfirmableAction.vue
+++ b/resources/js/components/actions/ConfirmableAction.vue
@@ -20,7 +20,7 @@ const emit = defineEmits(['confirmed']);
 let confirming = ref(false);
 let running = ref(false);
 let fieldset = ref({ tabs: [{ fields: props.action.fields }] });
-let values = ref(props.action.values);
+let values = ref(clone(props.action.values));
 
 let confirmationText = computed(() => {
     if (!props.action.confirmationText) return;


### PR DESCRIPTION
This pull request fixes an issue with the "Reupload" asset action, where the value state would be retained after saving.

1. Reupload an asset
2. Click to reupload the same asset again
3. See the same file you reuploaded previously

This PR fixes it by ensuring the `values` state in the `ConfirmableAction` clones the original state, instead of modifying it by reference.

Closes #12557