### PR TITLE
[6.x] Fix inertia pro logic

### DIFF
--- a/resources/js/pages/layout/Outside.vue
+++ b/resources/js/pages/layout/Outside.vue
@@ -5,9 +5,9 @@ import useStatamicPageProps from '@/composables/page-props.js';
 
 useBodyClasses('bg-gray-50 font-sans leading-normal scheme-light p-2');
 const { logos, cmsName } = useStatamicPageProps();
-const customLogo = logos.light.outside ?? logos.dark.outside ?? null;
-const lightCustomLogo = logos.light.outside ?? null;
-const darkCustomLogo = logos.dark.outside ?? logos.light.outside ?? null;
+const customLogo = logos?.light?.outside ?? logos?.dark?.outside ?? null;
+const lightCustomLogo = logos?.light?.outside ?? null;
+const darkCustomLogo = logos?.dark?.outside ?? logos?.light?.outside ?? null;
 </script>
 
 <template>

--- a/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
@@ -45,6 +45,7 @@ class HandleAuthenticatedInertiaRequests
     private function alwaysProps()
     {
         return [
+            'isPro' => Statamic::pro(),
             'nav' => $this->nav(),
             'cmsName' => __(Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic'),
         ];
@@ -57,7 +58,6 @@ class HandleAuthenticatedInertiaRequests
         }
 
         return [
-            'isPro' => Statamic::pro(),
             'selectedSiteUrl' => Site::selected()->url(),
             'licensing' => $this->licensing(),
             'sessionExpiry' => $this->sessionExpiry(),


### PR DESCRIPTION
- Fixes #12690
- Fixes the "Create Form" button disappearing when you return to that page because `isPro` would not be in the props.
