### PR TITLE
[6.x] Markdown fieldtype - Remove/Comment out the purple-ish selection colo…

### DIFF
--- a/resources/css/vendors/codemirror.css
+++ b/resources/css/vendors/codemirror.css
@@ -438,7 +438,7 @@ div.CodeMirror-dragcursors {
 .CodeMirror-crosshair {
     cursor: crosshair;
 }
-.CodeMirror-line::selection,
+/* .CodeMirror-line::selection,
 .CodeMirror-line > span::selection,
 .CodeMirror-line > span > span::selection {
     background: #d7d4f0;
@@ -447,7 +447,7 @@ div.CodeMirror-dragcursors {
 .CodeMirror-line > span::-moz-selection,
 .CodeMirror-line > span > span::-moz-selection {
     background: #d7d4f0;
-}
+} */
 
 .cm-searching {
     background-color: #ffa;


### PR DESCRIPTION
This resolves #12658 by commenting out the purple-ish selection colour in `codemirror.css`. The selection colour should be the same as/inherited from the body.

Interestingly, this behaviour has been present for a long time—it's also in v5.