### PR TITLE
[6.x] Pass existing data into asset thumbnail hook

### DIFF
--- a/src/Http/Resources/CP/Assets/HasThumbnails.php
+++ b/src/Http/Resources/CP/Assets/HasThumbnails.php
@@ -17,7 +17,7 @@ trait HasThumbnails
             default => ['thumbnail' => null],
         };
 
-        return array_merge($data, $this->runAssetHook() ?? []);
+        return array_merge($data, $this->runAssetHook($data) ?? []);
     }
 
     private function getImageThumbnail(): array
@@ -46,10 +46,10 @@ trait HasThumbnails
         ];
     }
 
-    private function runAssetHook(): array
+    private function runAssetHook(array $data): array
     {
         $payload = $this->runHooksWith('asset', [
-            'data' => new Fluent,
+            'data' => new Fluent($data),
         ]);
 
         return $payload->data->toArray();


### PR DESCRIPTION
I'm toying a bit with the new ability to add custom thumbnails to assets in the control panel, and it's working great!

The hook for getting the thumbnail data is currently called without arguments. The hook can't tell if a thumbnail url has already been generated from a previous hook call. This PR proposes passing in the existing resource data so that each hook can conditionally inject the data.

Example usage, now enabled with this PR:

```php
use Statamic\Http\Resources\CP\Assets\FolderAsset as FolderAssetResource;

FolderAssetResource::hook('asset', function ($payload, $next) {
    $payload->data->thumbnail ??= "https://custom-thumbnail-cdn.com/{$this->resource->id()}";

    return $next($payload);
});
```