### PR TITLE
[6.x] Fix front-end 2FA pages

### DIFF
--- a/src/Http/Controllers/TwoFactorChallengeController.php
+++ b/src/Http/Controllers/TwoFactorChallengeController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use Inertia\Inertia;
 use Statamic\Events\TwoFactorAuthenticationFailed;
 use Statamic\Events\ValidTwoFactorAuthenticationCodeProvided;
+use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Http\Middleware\RedirectIfAuthenticated;
 use Statamic\Http\Requests\TwoFactorChallengeRequest;
 
@@ -16,6 +17,7 @@ class TwoFactorChallengeController extends Controller
     public function __construct(Request $request)
     {
         $this->middleware('throttle:two-factor');
+        $this->middleware(HandleInertiaRequests::class);
         $this->middleware(RedirectIfAuthenticated::class);
     }
 

--- a/src/Http/Controllers/TwoFactorSetupController.php
+++ b/src/Http/Controllers/TwoFactorSetupController.php
@@ -5,12 +5,14 @@ namespace Statamic\Http\Controllers;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Statamic\Facades\User;
+use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 
 class TwoFactorSetupController extends Controller
 {
     public function __construct(Request $request)
     {
         $this->middleware('auth');
+        $this->middleware(HandleInertiaRequests::class);
     }
 
     public function __invoke(Request $request)


### PR DESCRIPTION
The front-end 2FA pages weren't using the Inertia middleware, so they were missing props and the page was erroring out.
Fixes #12708 
