### PR TITLE
[6.x] Fix button tag/target logic

### DIFF
--- a/packages/ui/src/Button/Button.vue
+++ b/packages/ui/src/Button/Button.vue
@@ -6,7 +6,7 @@ import Icon from '../Icon/Icon.vue';
 import { Link } from '@inertiajs/vue3';
 
 const props = defineProps({
-    as: { type: String, default: 'button' },
+    as: { type: String, default: null },
     href: { type: String, default: null },
     target: { type: String, default: null },
     icon: { type: String, default: null },
@@ -24,10 +24,11 @@ const props = defineProps({
 const slots = useSlots();
 const hasDefaultSlot = !!slots.default;
 const tag = computed(() => {
+    if (props.as) return props.as;
     if (props.href) {
         return props.target === '_blank' ? 'a' : Link;
     }
-    return props.as;
+    return 'button';
 });
 const iconOnly = computed(() => (props.icon && !hasDefaultSlot && !props.text) || props.iconOnly);
 


### PR DESCRIPTION
The `tag` computed was already checking for the `target` prop, except it wasn't actually defined as a prop so it didn't work. Fixes #12713
While in here, I fixed the `as` prop logic. If you pass an `as`, we'll use that since you're being explicit.
