### PR TITLE
fix: address null byte issue w/ postgres

### DIFF
--- a/src/StaticCaching/NoCache/DatabaseSession.php
+++ b/src/StaticCaching/NoCache/DatabaseSession.php
@@ -30,7 +30,7 @@ class DatabaseSession extends Session
             throw new RegionNotFound($key);
         }
 
-        return unserialize($region->region);
+        return unserialize(base64_decode($region->region));
     }
 
     protected function cacheRegion(Region $region)
@@ -39,7 +39,7 @@ class DatabaseSession extends Session
             'key' => $region->key(),
         ], [
             'url' => $this->url,
-            'region' => serialize($region),
+            'region' => base64_encode(serialize($region)),
         ]);
     }
 }


### PR DESCRIPTION
This is a proposal to fix https://github.com/statamic/cms/issues/12004 - I'm not a huge fan of it, but it's not the easiest problem to solve. Dropping a null byte could prove to be problematic if using basic string replacement to do so.