### PR TITLE
[5.x] Static cache middleware should respect configured strategy

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -49,7 +49,7 @@ class Cache
      */
     public function handle($request, Closure $next)
     {
-        if(!config('static_caching.strategy')) {
+        if(!config('statamic.static_caching.strategy')) {
             return $next($request);
         }
 


### PR DESCRIPTION
Not sure if it's desired behaviour or not to ignore config - but would love to be able to disable static caching globally without tearing out all the middleware off custom routes.