### PR TITLE
[6.x] Allow extra config on ALL fieldtypes

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -292,7 +292,10 @@ abstract class Fieldtype implements Arrayable
 
     protected function extraConfigFieldItems(): array
     {
-        return self::$extraConfigFields[static::class] ?? [];
+        return array_merge(
+            self::$extraConfigFields[static::class] ?? [],
+            Fieldtype::$extraConfigFields[Fieldtype::class] ?? [],
+        );
     }
 
     public static function appendConfigFields(array $config): void


### PR DESCRIPTION
For a new addon I'm working on I'd love to be able to add a config field to ALL fieldtypes, not just specific ones.

This PR extends appendConfigFields() to allow it to be applied to the base fieldtype, so you can call:

```php
Fieldtype::appendConfigField('group', [
    'type' => 'text',
    'display' => 'A new group',
]);
```

And it will return it for all field types.

I've targeted 6 as my add-on will, but I guess no reason this couldn't be 5.x if you wanted me to change it.