### PR TITLE
[6.x] Clear page-specific command palette commands when navigating

### DIFF
--- a/resources/js/components/CommandPalette.js
+++ b/resources/js/components/CommandPalette.js
@@ -1,6 +1,7 @@
 import { ref } from 'vue';
 import uniqid from 'uniqid';
 import { CATEGORY } from './command-palette/Constants.js';
+import { router } from '@inertiajs/vue3';
 
 const commands = ref({});
 
@@ -37,6 +38,10 @@ class Command {
 }
 
 export default class CommandPalette {
+    constructor() {
+        router.on('success', () => commands.value = []);
+    }
+
     get category() {
         return CATEGORY;
     }


### PR DESCRIPTION
This pull request ensures that page-specific commands are cleared from the Command Palette's state when navigating to a successful page.

Otherwise, commands will remain visible after navigating away.

## Before


https://github.com/user-attachments/assets/fbb4f584-a0d1-4e1f-9d52-f84c02c67b74



## After


https://github.com/user-attachments/assets/a912171d-1ac2-4bcd-82c8-044f5c9452c9


