### PR TITLE
[6.x] Fix collection listing badges

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -144,20 +144,20 @@
                     v-if="collection.published_entries_count > 0"
                     color="green"
                     :text="__('Published')"
-                    :append="String(collection.published_entries_count)"
+                    :append="collection.published_entries_count"
                     pill
                 />
                 <ui-badge
                     v-if="collection.scheduled_entries_count > 0"
                     color="yellow"
                     :text="__('Scheduled')"
-                    :append="String(collection.scheduled_entries_count)"
+                    :append="collection.scheduled_entries_count"
                     pill
                 />
                 <ui-badge
                     v-if="collection.draft_entries_count > 0"
                     :text="__('Drafts')"
-                    :append="String(collection.draft_entries_count)"
+                    :append="collection.draft_entries_count"
                     pill
                 />
             </div>


### PR DESCRIPTION
This pull request pluralizes "Draft" on the collection listings when there is more than one draft.

Fixes #12724

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pluralizes "Drafts" and switches entry count badges to use `append` for counts in collections listings.
> 
> - **Collections UI (`resources/js/components/collections/Listing.vue`)**:
>   - **Grid footer**: Change `"Draft"` to `"Drafts"` label.
>   - **List view `entries_count` badges**:
>     - Use `:text` with labels only and move counts to `:append` for `Published`, `Scheduled`, and `Drafts`.
>     - Pluralize `"Drafts"` label.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a892f189a0c61d8dd948ed656a915ead03a025b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->