### PR TITLE
[6.x] Fix error when augmenting icon field

### DIFF
--- a/src/Fieldtypes/Icon.php
+++ b/src/Fieldtypes/Icon.php
@@ -52,6 +52,10 @@ class Icon extends Fieldtype
 
     public function augment($value)
     {
+        if (! $value) {
+            return null;
+        }
+
         return $this->iconSet()->get($value);
     }
 


### PR DESCRIPTION
This pull request prevents an error being thrown when attempting to augment an empty Icon field.

Fixes #12718