### PR TITLE
[5.x] Throw exception if collection is queried after status

### DIFF
--- a/src/Stache/Query/EntryQueryBuilder.php
+++ b/src/Stache/Query/EntryQueryBuilder.php
@@ -18,6 +18,8 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
     public function where($column, $operator = null, $value = null, $boolean = 'and')
     {
         if ($column === 'collection') {
+            $this->verifyCollectionBeforeStatus();
+
             $this->collections[] = $operator;
 
             return $this;
@@ -33,6 +35,8 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
     public function whereIn($column, $values, $boolean = 'and')
     {
         if (in_array($column, ['collection', 'collections'])) {
+            $this->verifyCollectionBeforeStatus();
+
             $this->collections = array_merge($this->collections ?? [], $values);
 
             return $this;
@@ -43,6 +47,13 @@ class EntryQueryBuilder extends Builder implements QueryBuilder
         }
 
         return parent::whereIn($column, $values, $boolean);
+    }
+
+    private function verifyCollectionBeforeStatus()
+    {
+        if ($this->queriedByStatus) {
+            throw new \LogicException('The collection clause must come before the status clause.');
+        }
     }
 
     protected function collect($items = [])

--- a/src/Stache/Query/QueriesEntryStatus.php
+++ b/src/Stache/Query/QueriesEntryStatus.php
@@ -6,8 +6,12 @@ use Illuminate\Support\Collection;
 
 trait QueriesEntryStatus
 {
+    private $queriedByStatus = false;
+
     public function whereStatus(string $status)
     {
+        $this->queriedByStatus = true;
+
         if ($status === 'any') {
             return $this;
         }


### PR DESCRIPTION
The `whereStatus` method determines what subqueries are used by checking what collections are being queried.
It needs the collections to be defined ahead of time.
This gives you a heads up by way of an exception if you do it in reverse.

Resolves #12737
