### PR TITLE
[6.x] Fix error from `RelationshipInput` when items aren't displayed

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -314,6 +314,8 @@ export default {
         },
 
         makeSortable() {
+            if (! this.$refs.items) return;
+
             this.sortable = new Sortable(this.$refs.items, {
                 draggable: '.related-item',
                 handle: '.item-move',


### PR DESCRIPTION
This pull request prevents an error from the `RelationshipInput`'s `makeSortable` method when the relationship items aren't being displayed (causing the DOM node to not get rendered).