### PR TITLE
[6.x] Improve collection listing badges

### DIFF
--- a/packages/ui/src/Badge.vue
+++ b/packages/ui/src/Badge.vue
@@ -82,7 +82,7 @@ const badgeClasses = computed(() => {
         <span v-if="props.prepend" class="font-medium border-e border-inherit ps-0.5 pe-1.5">{{ prepend }}</span>
         <Icon v-if="icon" :name="icon" />
         <slot v-if="hasDefaultSlot" />
-        <template v-else><span class="st-text-trim-cap">{{ text }}</span></template>
+        <template v-else><span :class="{ 'st-text-trim-cap': prepend || append }">{{ text }}</span></template>
         <Icon v-if="iconAppend" :name="iconAppend" />
         <span v-if="props.append" class="font-medium border-s border-inherit ps-1.5 pe-0.5">{{ append }}</span>
     </component>


### PR DESCRIPTION
This PR better optically aligns badges with append/prepend.

This is related to the recent addition here https://github.com/statamic/cms/pull/12740

Here's a before/after screenshot:

## Before
![2025-10-15 at 15 37 04@2x](https://github.com/user-attachments/assets/44fd40e4-80f4-4b4c-bc86-73186155efce)

## After
The badge text and append numbers now feel more aligned 

![2025-10-15 at 15 36 21@2x](https://github.com/user-attachments/assets/30214fc0-3988-4ce8-b534-b16cb5bcb95c)

