### PR TITLE
[6.x] Use object-contain instead of object-cover in the thumbnail view

### DIFF
--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -55,7 +55,7 @@
                         >
                             <div @click="addSet(item.handle)" class="p-2.5">
                                 <div class="h-40 w-full flex items-center justify-center">
-                                    <img :src="item.image" class="rounded-lg h-40 object-cover" v-if="item.image" />
+                                    <img :src="item.image" class="rounded-lg h-40 object-contain bg-gray-50 dark:bg-gray-850" v-if="item.image" />
                                     <ui-icon :name="item.icon || 'add-section'" :set="iconSet" class="size-8 text-gray-600 dark:text-gray-300" v-else />
                                 </div>
                                 <div class="line-clamp-1 text-base mt-1 text-center text-gray-900 dark:text-gray-200">


### PR DESCRIPTION
This resolves #12678.

I tested a few different image crops, and there seems to be no disadvantage to `object-contain`—it only kicks in when images have more of a letterbox crop.

The only drawback may be that images feel "floaty" when they don't fill the container, so I've added a subtle background to offset this, which you can see in the top right image in this gallery

![2025-10-15 at 17 37 24@2x](https://github.com/user-attachments/assets/7a2e4faf-566a-4c18-9f95-7504e62f195c)
