### PR TITLE
[5.x] Fix GraphQL error when field doesnt have type

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -442,7 +442,7 @@ class Field implements Arrayable
             $type = ['type' => $type];
         }
 
-        if ($this->isRequired() && ! $this->hasSometimesRule() && $this->config['type'] !== 'assets') {
+        if ($this->isRequired() && ! $this->hasSometimesRule() && $this->type() !== 'assets') {
             $type['type'] = GraphQL::nonNull($type['type']);
         }
 


### PR DESCRIPTION
Introduced by #11975, if your config field doesn't have a `type` defined, you'd get an error. A missing type shouldn't error, it should fall back to text. This PR uses the `type()` method which already handles that fallback.
