### PR TITLE
[6.x] Translate "Saved" string when saving user

### DIFF
--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -156,7 +156,7 @@ export default {
                     }),
                 ])
                 .then((response) => {
-                    Statamic.$toast.success('Saved');
+                    Statamic.$toast.success(__('Saved'));
 
                     this.title = response.data.title;
 


### PR DESCRIPTION
This pull request wraps the "Saved" string with the `__()` helper so the string can be translated.

Fixes #12760