### PR TITLE
[6.x] Bard sticky stuck toolbar

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -124,6 +124,42 @@
                 border-top-right-radius: 0!important;
             }
         }
+
+        /* While the fixed toolbar is "stuck", mask the focus state of the editor to prevent blue focus lines appearing around the side of the toolbar while scrolling */
+        container-type: scroll-state;
+        @container scroll-state(stuck: top) {
+            > * {
+                position: relative;
+                &::after {
+                    content: '';
+                    position: absolute;
+                    inset: -4px -8px;
+                    box-shadow:
+                        /* Left Mask */
+                        -1px 0px 0px var(--color-gray-300),
+                        /* Right Mask */
+                        1px 0px 0px var(--color-gray-300),
+                        /* Bottom "Shadow" */
+                        0 4px 5px -3px hsl(0deg 0% 85%)
+                    ;
+                    border-inline-width: 2px;
+                    border-inline-color: var(--color-gray-50);
+                }
+                :is(.dark) & {
+                    &::after {
+                        box-shadow:
+                            /* Left Mask */
+                            -1px 0px 0px var(--color-gray-700),
+                            /* Right Mask */
+                            1px 0px 0px var(--color-gray-700),
+                            /* Bottom "Shadow" */
+                            0 4px 5px -3px hsl(0deg 0% 10%)
+                        ;
+                        border-inline-color: var(--color-gray-850);
+                    }
+                }
+            }
+        }
     }
 
     /* Only top-level Bard fields should have a sticky header */


### PR DESCRIPTION
This PR queries the scroll state of the Bard toolbar.

If the toolbar is in a "stuck" state, then a pseudo-element masks the focus state of the editor (you know, the lovely warm blue outline).

This prevents blue focus lines from appearing around the side of the toolbar while you're scrolling.

I've also added a subtle shadow while the toolbar is in a "stuck" state. 

It's easier to see this in a screenshot

## Before

Notice the annoying blue focus tramlines, and lack of shadow 

![2025-10-16 at 15 39 26@2x](https://github.com/user-attachments/assets/8caafd25-c896-49b9-a2f1-8dfa5fb2e874)

## After

Tram lines hidden, and a soft shadow

![2025-10-16 at 15 37 38@2x](https://github.com/user-attachments/assets/1f1f2abc-6b0d-4ee9-877c-5d64eb45d09f)


--

FYI the focus outline is usually pulled outwards by 1px so that it sits over the grey border for a cleaner look, which is why we need this fix. 