### PR TITLE
[6.x] Default content bg

### DIFF
--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -384,7 +384,7 @@ class Color
             'body-border' => self::Transparent,
             'dark-body-bg' => self::Zinc[900],
             'dark-body-border' => self::Zinc[950],
-            'content-bg' => 'linear-gradient(to right, hsl(0,0%,99%), #ffffff)',
+            'content-bg' => 'white',
             'content-border' => self::Zinc[200],
             'dark-content-bg' => self::Zinc[900],
             'dark-content-border' => self::Zinc[950],


### PR DESCRIPTION
We had previously added a subtle gradient to the light background in response to v6 legibility concerns, intended to improve contrast between section islands and the main background.

The legibility improvements implemented since—including thicker, darker section borders and updated Control Panel styling—make the gradient unnecessary now, in my opinion. Removing it simplifies the design without impacting readability.