### PR TITLE
[6.x] Improve scrolling cut-off point on the page editor

### DIFF
--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -2,7 +2,7 @@
     <stack narrow name="page-tree-linker" :before-close="shouldClose" @closed="$emit('closed')" v-slot="{ close }">
         <div class="flex h-full flex-col bg-gray-100 dark:bg-dark-700">
             <header
-                class="mb-4 flex items-center justify-between border-b bg-white py-2 text-lg font-medium shadow-md dark:border-dark-950 dark:bg-dark-600 ltr:pl-6 ltr:pr-3 rtl:pl-3 rtl:pr-6"
+                class="flex items-center justify-between border-b bg-white py-2 text-lg font-medium shadow-md dark:border-dark-950 dark:bg-dark-600 ltr:pl-6 ltr:pr-3 rtl:pl-3 rtl:pr-6"
             >
                 <Heading size="lg">{{ headerText }}</Heading>
                 <Button icon="x" variant="ghost" @click="close" />
@@ -16,7 +16,7 @@
                 </div>
             </div>
 
-            <div v-if="!loading" class="flex-1 overflow-auto px-1">
+            <div v-if="!loading" class="flex-1 overflow-auto px-1 pt-4">
                 <div
                     v-if="saving"
                     class="absolute inset-0 z-10 flex items-center justify-center bg-white bg-opacity-75 dark:bg-dark-500"


### PR DESCRIPTION
This PR nudges around the padding/margin so the overflow effect is cleaner.

## Before

while scrolling—you can see the a gray border which means the overflow is not cut off as nicely. This is caused by margin on the header element.

![2025-10-16 at 17 07 13@2x](https://github.com/user-attachments/assets/2f5df299-c0b4-455c-a814-f8b3ae8d854a)


## After

While scrolling the head is neatly cut off, the same way the footer is when scrolling the other way

![2025-10-16 at 17 06 00@2x](https://github.com/user-attachments/assets/b0d43cf6-e68c-4c1f-bf72-d627684fa634)
