### PR TITLE
[5.x] Keep selects open if multiple is enabled

### DIFF
--- a/resources/js/components/fieldtypes/DictionaryFieldtype.vue
+++ b/resources/js/components/fieldtypes/DictionaryFieldtype.vue
@@ -6,7 +6,7 @@
             class="flex-1"
             append-to-body
             searchable
-            close-on-select
+            :close-on-select="!multiple"
             :calculate-position="positionOptions"
             :name="name"
             :disabled="config.disabled || isReadOnly || (multiple && limitReached)"

--- a/resources/js/components/fieldtypes/SelectFieldtype.vue
+++ b/resources/js/components/fieldtypes/SelectFieldtype.vue
@@ -16,7 +16,7 @@
             :push-tags="config.push_tags"
             :multiple="config.multiple"
             :reset-on-options-change="resetOnOptionsChange"
-            :close-on-select="true"
+            :close-on-select="!config.multiple"
             :value="selectedOptions"
             :create-option="(value) => ({ value, label: value })"
             @input="vueSelectUpdated"

--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -3,7 +3,7 @@
         ref="input"
         :name="name"
         :clearable="config.clearable"
-        :close-on-select="true"
+        :close-on-select="false"
         :options="config.options"
         :disabled="config.disabled || isReadOnly"
         :multiple="true"

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -6,7 +6,7 @@
             label="title"
             append-to-body
             :calculate-position="positionOptions"
-            :close-on-select="true"
+            :close-on-select="!multiple"
             :disabled="readOnly"
             :multiple="multiple"
             :options="options"


### PR DESCRIPTION
This PR comes in response from a client request where they can add multiple categories/tags to a property and would like to keep the select open to make that easier.

This makes sense as if multiple is enabled on the field then you probably want to select multiple.  6.x has already made this change.

I can move this functionality behind a field config option but that requires a lot more changes.