### PR TITLE
[5.x] Support whereHas etc in eloquent builder

### DIFF
--- a/src/Query/EloquentQueryBuilder.php
+++ b/src/Query/EloquentQueryBuilder.php
@@ -11,6 +11,7 @@ use InvalidArgumentException;
 use Statamic\Contracts\Query\Builder;
 use Statamic\Extensions\Pagination\LengthAwarePaginator;
 use Statamic\Facades\Blink;
+use Statamic\Query\Concerns\QueriesRelationships;
 use Statamic\Query\Exceptions\MultipleRecordsFoundException;
 use Statamic\Query\Exceptions\RecordsNotFoundException;
 use Statamic\Query\Scopes\AppliesScopes;
@@ -18,7 +19,7 @@ use Statamic\Support\Arr;
 
 abstract class EloquentQueryBuilder implements Builder
 {
-    use AppliesScopes;
+    use AppliesScopes, QueriesRelationships;
 
     protected $builder;
     protected $columns;


### PR DESCRIPTION
Following on from https://github.com/statamic/cms/pull/8476, this PR adds support to the base eloquent builder so we can support the new methods in eloquent driver.

See: https://github.com/statamic/eloquent-driver/pull/512