### PR TITLE
[6.x] Fix inactive tab text color legibility

### DIFF
--- a/packages/ui/src/Tabs/List.vue
+++ b/packages/ui/src/Tabs/List.vue
@@ -7,8 +7,8 @@ const hasTabIndicatorComponent = hasComponent('TabsIndicator');
 
 <template>
     <TabsList
-        class="relative flex shrink-0 mx-2 lg:mx-0 space-x-2 lg:space-x-4 border-b border-gray-200 text-sm text-gray-400 
-        dark:border-gray-700 dark:text-gray-500
+        class="relative flex shrink-0 mx-2 lg:mx-0 space-x-2 lg:space-x-4 border-b border-gray-200 text-sm text-gray-500 
+        dark:border-gray-700
         [.live-preview_&]:px-4 [.live-preview_&]:py-2 [.live-preview_&]:mb-3"
         data-ui-tabs-list
     >


### PR DESCRIPTION
This restores text legibility (WCAG 2.2) for inactive tabs, which regressed during the dark mode improvements