### PR TITLE
[6.x] Fix calendar cell aspect ratio in safari

### DIFF
--- a/resources/js/components/entries/calendar/Month.vue
+++ b/resources/js/components/entries/calendar/Month.vue
@@ -106,7 +106,7 @@ const selectDate = (date) => {
                         <CalendarCellTrigger
                             :day="weekDate"
                             :month="month.value"
-                            class="max-w-full max-h-full flex flex-col items-center justify-center @3xl:items-start @3xl:justify-start"
+                            class="max-w-full max-h-full aspect-square flex flex-col items-center justify-center @3xl:items-start @3xl:justify-start"
                             v-slot="{ dayValue, selected, today, outsideView }"
                             @click="selectDate(weekDate)"
                         >


### PR DESCRIPTION
Safari does not seem to respect aspect-ratio in CSS if width and height values are set, so I've adjusted these to max values instead, which does the trick.

## Before

<img width="3350" height="2880" alt="image" src="https://github.com/user-attachments/assets/b4a4b11d-7856-4cad-a2a4-06d2395e00aa" />

## After

![2025-10-17 at 11 48 16@2x](https://github.com/user-attachments/assets/fe55e561-f471-4199-8d72-bfdcae19868c)
