### PR TITLE
[6.x] Calendar narrow rows only for higher viewports

### DIFF
--- a/resources/js/components/entries/calendar/Month.vue
+++ b/resources/js/components/entries/calendar/Month.vue
@@ -156,7 +156,7 @@ const selectDate = (date) => {
 </template>
 
 <style scoped>
-@media (height < 1000px) and (width >= 1400px) {
+@media (height < 1000px) and (width >= 1200px) {
     .calendar-grid {
         tr:not([data-week-has-entries="true"]) td {
             aspect-ratio: 2 / 1;


### PR DESCRIPTION
This also sets a minimum width for the narrow "empty" rows to kick in on the calendar view, otherwise this optimisation looks too cramped at narrow viewports