### PR TITLE
[6.x] Fix duplicate impersonating badges in user dropdown

### DIFF
--- a/resources/js/components/global-header/UserDropdown.vue
+++ b/resources/js/components/global-header/UserDropdown.vue
@@ -26,6 +26,7 @@ const isImpersonating = computed((() => user.is_impersonating));
                         {{ __('Super Admin') }}
                         <Badge v-if="isImpersonating" size="sm" pill :text="__('Impersonating')" />
                     </div>
+                    <Badge v-else-if="isImpersonating" size="sm" pill :text="__('Impersonating')" />
                 </div>
             </div>
         </DropdownHeader>


### PR DESCRIPTION
## Before

<img width="277" height="324" alt="CleanShot 2025-10-17 at 14 00 29" src="https://github.com/user-attachments/assets/da38ecce-1395-4e0c-b271-9e1e58dd7049" />


## After

<img width="277" height="324" alt="CleanShot 2025-10-17 at 13 59 28" src="https://github.com/user-attachments/assets/f1cc3580-97d0-407c-89bd-f31bf91a1180" />
