### PR TITLE
[6.x] Replace `<a>` tags with Inertia's `<Link>` component

### DIFF
--- a/resources/js/components/globals/Listing.vue
+++ b/resources/js/components/globals/Listing.vue
@@ -2,7 +2,7 @@
     <CardList :heading="__('Title')">
         <CardListItem v-for="global in globals" :key="global.id">
             <Tooltip :text="global.handle" :delay="1000">
-                <a class="text-sm" :href="global.edit_url">{{ __(global.title) }}</a>
+                <Link class="text-sm" :href="global.edit_url">{{ __(global.title) }}</Link>
             </Tooltip>
             <Dropdown>
                 <DropdownMenu>
@@ -18,9 +18,10 @@
 
 <script>
 import { CardList, CardListItem, Tooltip, Dropdown, DropdownMenu, DropdownItem } from '@/components/ui';
+import { Link } from '@inertiajs/vue3';
 
 export default {
-    components: { CardList, CardListItem, Tooltip, Dropdown, DropdownMenu, DropdownItem },
+    components: { Link, CardList, CardListItem, Tooltip, Dropdown, DropdownMenu, DropdownItem },
 
     props: {
         initialGlobals: { type: Array, required: true },

--- a/resources/js/components/roles/Listing.vue
+++ b/resources/js/components/roles/Listing.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref } from 'vue';
 import { DropdownItem, Listing } from '@/components/ui';
+import { Link } from '@inertiajs/vue3';
 
 const props = defineProps(['initialRows', 'initialColumns']);
 const rows = ref(props.initialRows);
@@ -25,7 +26,7 @@ function removeRow(row) {
         @refreshing="reloadPage"
     >
         <template #cell-title="{ row: role, index }">
-            <a :href="role.edit_url">{{ __(role.title) }}</a>
+            <Link :href="role.edit_url">{{ __(role.title) }}</Link>
 
             <resource-deleter
                 :ref="`deleter_${role.id}`"

--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -7,7 +7,7 @@
             <div class="flex gap-2 sm:gap-3 grow items-center" @click="$emit('branch-clicked', page)">
                 <ui-status-indicator :status="page.status" v-tooltip="getStatusTooltip()" />
                 <ui-icon v-if="isRoot" name="home" class="size-4" v-tooltip="__('This is the root page')" />
-                <a
+                <Link
                     @click.prevent="$emit('edit', $event)"
                     :class="{ 'text-sm font-medium is-top-level-branch': isTopLevelBranch }"
                     :href="page.edit_url"
@@ -37,9 +37,9 @@
                 <div v-if="page.collection && editable" class="flex items-center gap-2">
                     <Icon name="navigation" class="size-3.5 text-gray-500" />
                     <div>
-                        <a :href="page.collection.create_url" v-text="__('Add')" class="hover:text-blue-600" />
+                        <Link :href="page.collection.create_url" v-text="__('Add')" class="hover:text-blue-600" />
                         <span class="mx-1 text-gray-400 dark:text-gray-500">/</span>
-                        <a :href="page.collection.edit_url" v-text="__('Edit')" class="hover:text-blue-600" />
+                        <Link :href="page.collection.edit_url" v-text="__('Edit')" class="hover:text-blue-600" />
                     </div>
                 </div>
             </div>
@@ -72,9 +72,10 @@
 
 <script>
 import { Dropdown, DropdownMenu, Icon } from '@/components/ui';
+import { Link } from '@inertiajs/vue3';
 
 export default {
-    components: { Dropdown, DropdownMenu, Icon },
+    components: { Link, Dropdown, DropdownMenu, Icon },
     props: {
         page: Object,
         depth: Number,

--- a/resources/js/components/updater/UpdaterWidget.vue
+++ b/resources/js/components/updater/UpdaterWidget.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Widget, Badge, Listing, Icon, Tooltip } from '@/components/ui';
 import { ref } from 'vue';
+import { Link } from '@inertiajs/vue3';
 
 defineProps({
     items: Object,
@@ -13,7 +14,7 @@ defineProps({
             <table v-if="items.length" class="">
                 <tr v-for="update in items" class="text-sm">
                     <td class="py-1 pr-4 leading-tight">
-                        <a :href="update.url" class="flex items-center gap-2" v-text="update.name" />
+                        <Link :href="update.url" class="flex items-center gap-2" v-text="update.name" />
                     </td>
                     <td>
                         <Badge pill variant="flat" :color="update.critical ? 'red' : 'green'" :text="update.count" />

--- a/resources/js/components/user-groups/Listing.vue
+++ b/resources/js/components/user-groups/Listing.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref } from 'vue';
 import { DropdownItem, Listing } from '@/components/ui';
+import { Link } from '@inertiajs/vue3';
 
 const props = defineProps({
     initialRows: Array,
@@ -33,7 +34,7 @@ function removeRow(row) {
         @refreshing="reloadPage"
     >
         <template #cell-title="{ row: group }">
-            <a :href="group.show_url">{{ __(group.title) }}</a>
+            <Link :href="group.show_url">{{ __(group.title) }}</Link>
             <resource-deleter :ref="`deleter_${group.id}`" :resource="group" @deleted="removeRow(group)" />
         </template>
         <template #cell-handle="{ value: handle }">

--- a/resources/js/components/users/Listing.vue
+++ b/resources/js/components/users/Listing.vue
@@ -13,10 +13,10 @@
             push-query
         >
             <template #cell-email="{ row: user }">
-                <a class="title-index-field" :href="user.edit_url" @click.stop>
+                <Link class="title-index-field" :href="user.edit_url" @click.stop>
                     <ui-avatar :user="user" class="size-8 text-xs ltr:mr-2 rtl:ml-2" />
                     <span v-text="user.email" />
-                </a>
+                </Link>
             </template>
             <template #cell-roles="{ row: user, value: roles }">
                 <div class="role-index-field">
@@ -48,9 +48,11 @@
 
 <script>
 import { Listing } from '@/components/ui';
+import { Link } from '@inertiajs/vue3';
 
 export default {
     components: {
+        Link,
         Listing,
     },
 

--- a/resources/js/pages/taxonomies/Show.vue
+++ b/resources/js/pages/taxonomies/Show.vue
@@ -1,9 +1,11 @@
 <script>
 import Head from '@/pages/layout/Head.vue';
 import { Header, Dropdown, DropdownMenu, DropdownItem, Listing } from '@ui';
+import { Link } from '@inertiajs/vue3';
 
 export default {
     components: {
+        Link,
         Head,
         Header,
         Dropdown,
@@ -130,7 +132,7 @@ export default {
         >
             <template #cell-title="{ row: term }">
                 <div class="flex items-center">
-                    <a :href="term.edit_url">{{ term.title }}</a>
+                    <Link :href="term.edit_url">{{ term.title }}</Link>
                 </div>
             </template>
             <template #cell-slug="{ row: term }">


### PR DESCRIPTION
This pull request replaces _most_ of the remaining `<a>` elements with Inertia's `<Link` component.

I haven't replaced `<a>` elements linking to external websites or `_blank` targets. 

Fixes #12771