### PR TITLE
[6.x] "Visit URL" link should open in a new tab

### DIFF
--- a/packages/ui/src/Button/Button.vue
+++ b/packages/ui/src/Button/Button.vue
@@ -102,6 +102,7 @@ const buttonClasses = computed(() => {
         :disabled="loading"
         :data-ui-group-target="['subtle', 'ghost'].includes(props.variant) ? null : true"
         :href
+        :target
         :type="props.href ? null : type"
     >
         <Icon v-if="icon" :name="icon" />


### PR DESCRIPTION
This pull request fixes an issue where the "Visit URL" link on the entry publish form wasn't opening in a new tab, as expected.