### PR TITLE
[6.x] Fix `Invalid Date` error on required date fields

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -22,7 +22,7 @@
 import Fieldtype from './Fieldtype.vue';
 import DateFormatter from '@/components/DateFormatter.js';
 import { DatePicker, DateRangePicker, Button } from '@/components/ui';
-import { parseAbsoluteToLocal, toTimeZone, toZoned } from '@internationalized/date';
+import { getLocalTimeZone, parseAbsoluteToLocal, toTimeZone, toZoned } from '@internationalized/date';
 
 export default {
     components: {
@@ -100,10 +100,6 @@ export default {
 
     created() {
         this.$events.$on(`container.${this.publishContainer.name}.saving`, this.triggerChangeOnFocusedField);
-
-        if ((this.hasDate || this.isInline) && !this.value) {
-            this.addDate();
-        }
     },
 
     unmounted() {
@@ -120,6 +116,12 @@ export default {
         datePickerUpdated(value) {
             if (!value) {
                 return this.update(null);
+            }
+
+            // Sometimes, we'll get a CalendarDateTime object, which doesn't include timezone
+            // information. In that case, we need to convert it to a ZonedDateTime object.
+            if (!this.isRange && !value.offset && !value.timeZone) {
+                value = toZoned(value, getLocalTimeZone());
             }
 
             // The date picker will give us CalendarDateTimes in the local time zone.


### PR DESCRIPTION
This pull request fixes an `Invalid Date` error which would occur when attempting to pick a date on a required or inline date field.

After some digging, I realised that the object passed to our `datePickerUpdated` method was different when the field was optional vs required.

When it's optional, we get a `ZonedDateTime` object (good), but when it's required, we get a `CalendarDateTime` object instead, which doesn't have `timeZone` or `offset` properties.

I tried looking at Reka's components to see if I could figure out when it'd return one vs the other but I couldn't figure it out.

This PR fixes it by adding a check to our `datePickerUpdated` method to convert objects to `ZonedDateTime` when appropriate.

Fixes #12778