### PR TITLE
[6.x] Fix failing test

### DIFF
--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -408,7 +408,7 @@ class FrontendTest extends TestCase
         $page->set('protect', 'test')->save();
 
         $this
-            ->actingAs(User::make())
+            ->actingAs(User::make()->save())
             ->get('/about')
             ->assertOk()
             ->assertHeaderMissing('X-Statamic-Protected');


### PR DESCRIPTION
This pull request fixes the failing test on `master` (`FrontendTest::header_is_not_added_to_cacheable_protected_responses`).

For reference, this is the failure:

```
1) Tests\FrontendTest::header_is_not_added_to_cacheable_protected_responses
Expected response status code [200] but received 500.
Failed asserting that 500 is identical to 200.

The following exception occurred during the last request:

TypeError: Statamic\Auth\PermissionCache::get(): Argument #1 ($user) must be of type string, null given, called in /home/runner/work/cms/cms/src/Auth/File/User.php on line 270 and defined in /home/runner/work/cms/cms/src/Auth/PermissionCache.php:9
Stack trace:
#0 /home/runner/work/cms/cms/src/Auth/File/User.php(270): Statamic\Auth\PermissionCache->get()
#1 /home/runner/work/cms/cms/src/Auth/File/User.php(293): Statamic\Auth\File\User->permissions()
#2 /home/runner/work/cms/cms/src/Auth/User.php(106): Statamic\Auth\File\User->hasPermission()
#3 /home/runner/work/cms/cms/src/Auth/User.php(374): Statamic\Auth\User->isSuper()
#4 /home/runner/work/cms/cms/src/Http/Middleware/RedirectIfTwoFactorSetupIncomplete.php(15): Statamic\Auth\User->isTwoFactorAuthenticationRequired()
#5 /home/runner/work/cms/cms/vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php(209): Statamic\Http\Middleware\RedirectIfTwoFactorSetupIncomplete->handle()
```

The test was added in https://github.com/statamic/cms/pull/11542. The error occurs when attempting to resolve the user's permissions from the `PermissionsCache`, which doesn't work as the user doesn't have an ID yet.

I remember running into this error a few months ago and it came down to simply saving users in our tests.