### PR TITLE
[6.x] Fix stack inset

### DIFF
--- a/resources/js/components/stacks/Stack.vue
+++ b/resources/js/components/stacks/Stack.vue
@@ -27,7 +27,7 @@
                         v-if="visible"
                         class="stack-content fixed flex flex-col sm:end-1.5 overflow-auto bg-white dark:bg-gray-850 rounded-xl shadow-[0_8px_5px_-6px_rgba(0,0,0,0.1),_0_3px_8px_0_rgba(0,0,0,0.02),_0_30px_22px_-22px_rgba(39,39,42,0.15)] dark:shadow-[0_5px_20px_rgba(0,0,0,.5)] transition-transform duration-150 ease-out"
                         :class="[
-                            full ? 'inset-2' : 'inset-y-2',
+                            full ? 'inset-2 w-[calc(100svw-1rem)]' : 'inset-y-2',
                             { '-translate-x-4 rtl:translate-x-4': isHovering }
                         ]"
                     >


### PR DESCRIPTION
This should close #12776 by fixing the side effects of using `inset-2`

## Before

(right side of "inset" stack is butted up against the edge of the screen)

![2025-10-20 at 10 49 49@2x](https://github.com/user-attachments/assets/3ea5d9b3-e903-476b-885c-67f66d459a66)


## After

(note the right side is now properly "inset")

![2025-10-20 at 10 49 38@2x](https://github.com/user-attachments/assets/fff8ca5d-1973-4f14-8d9a-0113b2e9c8c4)
