### PR TITLE
[6.x] Fix column layout for publish fields

### DIFF
--- a/packages/ui/src/Field.vue
+++ b/packages/ui/src/Field.vue
@@ -106,25 +106,25 @@ const hasErrors = computed(() => {
 <template>
     <div :class="[rootClasses, $attrs.class]" data-ui-input-group>
         <div v-if="label || (instructions && !instructionsBelow) || $slots.label || $slots.actions">
-        <div
-            v-if="$slots.actions"
-            :class="[
-                'flex items-center gap-x-1 mb-0',
-                props.label || $slots.label ? 'justify-between' : 'justify-end',
-            ]"
-            data-ui-field-header
-        >
-            <slot name="label">
-                <Label v-if="label" v-bind="labelProps" class="flex-1" />
-            </slot>
-            <slot name="actions" />
-        </div>
-        <div v-if="label || (instructions && !instructionsBelow) || ($slots.label && !$slots.actions)" data-ui-field-text :class="inline ? 'mb-0' : 'mb-1.5'">
-            <slot v-if="!$slots.actions" name="label">
-                <Label v-if="label" v-bind="labelProps" class="flex-1" />
-            </slot>
-            <Description :text="instructions" v-if="instructions && !instructionsBelow" :class="descriptionClasses" />
-        </div>
+            <div
+                v-if="$slots.actions"
+                :class="[
+                    'flex items-center gap-x-1 mb-0',
+                    props.label || $slots.label ? 'justify-between' : 'justify-end',
+                ]"
+                data-ui-field-header
+            >
+                <slot name="label">
+                    <Label v-if="label" v-bind="labelProps" class="flex-1" />
+                </slot>
+                <slot name="actions" />
+            </div>
+            <div v-if="label || (instructions && !instructionsBelow) || ($slots.label && !$slots.actions)" data-ui-field-text :class="inline ? 'mb-0' : 'mb-1.5'">
+                <slot v-if="!$slots.actions" name="label">
+                    <Label v-if="label" v-bind="labelProps" class="flex-1" />
+                </slot>
+                <Description :text="instructions" v-if="instructions && !instructionsBelow" :class="descriptionClasses" />
+            </div>
         </div>
         <slot />
         <div v-if="(instructions && instructionsBelow) || hasErrors">


### PR DESCRIPTION
This fixes #12730, where sometimes field instructions or settings were outside the "left" grid column div, so they fell stray to the right.

## Before

(See in the **Input Behavior** section, the selected taxonomies are on the left but they should be on the right, and the instructions are on the right but should be on the left)

![2025-10-20 at 12 34 58@2x](https://github.com/user-attachments/assets/cc342795-deeb-4465-90a6-67b8142c5acc)

## After

![2025-10-20 at 12 34 08@2x](https://github.com/user-attachments/assets/23020d02-e64f-43e3-bd82-af4c7d63a534)
