### PR TITLE
[6.x] `AddonTestCase` should load Inertia's `ServiceProvider`

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -97,6 +97,7 @@ abstract class AddonTestCase extends OrchestraTestCase
             ],
         ];
 
+        $app['config']->set('inertia.testing.ensure_pages_exist', false);
         $app['config']->set('inertia.testing.page_paths', [$directory.'/../resources/js/pages']);
 
         $app['config']->set('statamic.users.repository', 'file');


### PR DESCRIPTION
This pull request ensures that Inertia's `ServiceProvider` is loaded when running addon tests.