### PR TITLE
[6.x] CP Nav Customisation - Add missing show item icon

### DIFF
--- a/resources/js/components/nav/Builder.vue
+++ b/resources/js/components/nav/Builder.vue
@@ -143,7 +143,7 @@
                                     variant="destructive"
                                     @click="isHideable(stat) ? hideItem(stat) : removeItem(stat)"
                                 />
-                                <DropdownItem v-else :text="__('Show')" @click="showItem(stat)" />
+                                <DropdownItem v-else :text="__('Show')" icon="eye" @click="showItem(stat)" />
                             </template>
                         </tree-branch>
                     </template>


### PR DESCRIPTION
This is a small fix and closes #12725. The "show" icon was missing