### PR TITLE
[6.x] Publish Container should watch changes to `modifiedFields` prop

### DIFF
--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -129,6 +129,11 @@ watch(
 );
 
 watch(
+    () => props.modifiedFields,
+    (modifiedFields) => localizedFields.value = modifiedFields || [],
+);
+
+watch(
     values,
     (values) => {
         dirty();


### PR DESCRIPTION
Currently, if the `modifiedFields` prop changes in the parent component (eg. due to switching localizations), the publish container's internal `localizedFields` state isn't updated.

This causes issues when editing localizations because updating an inherited field won't update the parent's `modifiedData` state, leading to an incorrect `_localized` array being sent to the server.