### PR TITLE
[6.x] Bard sets fix inset pseudo content from blocking pointer events

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -6,7 +6,7 @@
                 // We’re styling a Set so that it shows a “selection outline” when selected with the mouse or keyboard.
                 // The extra `&:not(:has(:focus-within))` rule turns that outline off if any element inside the Set has focus (e.g. when editing inside a Bard field).
                 // This prevents the outer selection outline from showing while the user is actively working inside the Set.
-                '[&:not(:has(:focus-within))]:border-blue-300! [&:not(:has(:focus-within))]:dark:border-blue-400! [&:not(:has(:focus-within))]:before:content-[\'\'] [&:not(:has(:focus-within))]:before:absolute [&:not(:has(:focus-within))]:before:inset-[-1px] [&:not(:has(:focus-within))]:before:border-2 [&:not(:has(:focus-within))]:before:border-blue-300 [&:not(:has(:focus-within))]:dark:before:border-blue-400 [&:not(:has(:focus-within))]:before:rounded-lg': selected || withinSelection,
+                '[&:not(:has(:focus-within))]:border-blue-300! [&:not(:has(:focus-within))]:dark:border-blue-400! [&:not(:has(:focus-within))]:before:content-[\'\'] [&:not(:has(:focus-within))]:before:absolute [&:not(:has(:focus-within))]:before:inset-[-1px] [&:not(:has(:focus-within))]:before:pointer-events-none [&:not(:has(:focus-within))]:before:border-2 [&:not(:has(:focus-within))]:before:border-blue-300 [&:not(:has(:focus-within))]:dark:before:border-blue-400 [&:not(:has(:focus-within))]:before:rounded-lg': selected || withinSelection,
                 'border-red-500': hasError,
             }"
             :data-type="config.handle"


### PR DESCRIPTION
This should fix #12828.

The issue was reported as a Safari issue, but it could affect any browser.
I believe what's happening here is the "selected set" border is created using a pseudo-element, which is then inset. This blocks pointer events on the toolbar, so it's no longer possible to collapse the set.

Since this is simply a decorative border, I've added `pointer-events: none`, which should fix this.

Here is a screenshot of the offending pseudo-element. Although it's not captured in the screenshot, this takes up 100% of the container.

<img width="1653" height="890" alt="image" src="https://github.com/user-attachments/assets/19242ed3-59e5-440a-b0e4-a2e7189eb2ac" />