### PR TITLE
[6.x] Set the default dated collections view to list

### DIFF
--- a/resources/js/pages/collections/Show.vue
+++ b/resources/js/pages/collections/Show.vue
@@ -359,19 +359,15 @@ export default {
         },
 
         initialView() {
-            // Get from preferences instead of localStorage
             const savedView = this.$preferences.get(`collections.${this.handle}.view`);
 
-            // If we have a saved view, validate it's available and return it
             if (savedView) {
                 if (savedView === 'tree' && this.canUseStructureTree) return 'tree';
                 if (savedView === 'calendar' && this.canUseCalendar) return 'calendar';
                 if (savedView === 'list') return 'list';
             }
 
-            // Fallback logic
-            if (this.canUseStructureTree) return 'tree';
-            return 'list';
+            return this.canUseStructureTree ? 'tree' : 'list';
         },
 
         deleteTreeBranch(branch, removeFromUi) {


### PR DESCRIPTION
This removes the logic that sets the calendar view to the default, closing #12821

I ❤️ the calendar view, but I don't think it should be the default—it can be challenging to get an idea of where articles are when you haven't posted in a while. It seems like a few other people agree based on the comments on the issue.