### PR TITLE
[5.x] Fixed preProcessIndex options labels for numeric keys

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -54,7 +54,7 @@ trait HasSelectOptions
 
         // NOTE: Null-coalescing into `[null]` as that matches old behaviour.
         return collect($values ?? [null])->map(function ($value) {
-            return $this->getLabel($value);
+            return $this->getLabel($this->normalizeAugmentableValue($value));
         })->all();
     }
 
@@ -136,7 +136,7 @@ trait HasSelectOptions
             $value = $this->castFromBoolean($value);
         }
 
-        $option = collect($this->getOptions())->filter(fn ($option) => (string) $option['value'] === $value)->first();
+        $option = collect($this->getOptions())->filter(fn ($option) => $option['value'] === $value)->first();
 
         return $option ? $option['label'] : $actualValue;
     }


### PR DESCRIPTION
Fixes select option key is shown on index instead of label

Might fix #12667 as well