### PR TITLE
[6.x] Fix week hour format

### DIFF
--- a/resources/js/components/entries/calendar/Week.vue
+++ b/resources/js/components/entries/calendar/Week.vue
@@ -63,7 +63,7 @@ const selectDate = (date) => {
 function getHourLabel(hour) {
     const date = new Date
     date.setHours(hour, 0, 0, 0);
-    return DateFormatter.format(date, { hour: 'numeric', hour12: true });
+    return DateFormatter.format(date, { hour: 'numeric' });
 }
 </script>
 


### PR DESCRIPTION
Closes #12805

The `hour12` wasn't needed.

Now `7 PM` in English, `19 Uhr` in German, `19 h` in French, etc.