### PR TITLE
[6.x] Combobox: Only render `selected-option` slot when there's a selected option

### DIFF
--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -310,7 +310,7 @@ defineExpose({
                             </button>
 
                             <button type="button" v-else class="w-full text-start bg-transparent flex items-center gap-2 cursor-pointer focus-none" @keydown.space="openDropdown" data-ui-combobox-selected-option>
-                                <slot name="selected-option" v-bind="{ option: selectedOption }">
+                                <slot v-if="selectedOption" name="selected-option" v-bind="{ option: selectedOption }">
                                     <div v-if="icon" class="size-4">
                                         <Icon :name="icon" class="text-white/85 dark:text-white dark:opacity-50" />
                                     </div>


### PR DESCRIPTION
This pull request prevents the Combobox component from erroring when rendering the `selected-option` slot without an option selected.

```
TypeError: Cannot read properties of null (reading 'label')
    at cp-BWPV6B3G.js:6:32494
    at renderFnWithContext (chunk-OSCZLWFV.js?v=05af7089:3073:13)
    at renderSlot (chunk-OSCZLWFV.js?v=05af7089:5396:53)
    at Select.vue:51:13
    at Object.renderFnWithContext [as fn] (chunk-OSCZLWFV.js?v=05af7089:3073:13)
    at slots.<computed> (chunk-OSCZLWFV.js?v=05af7089:5367:26)
    at renderSlot (chunk-OSCZLWFV.js?v=05af7089:5396:53)
    at Combobox.vue:313:33
```