### PR TITLE
[6.x] Add `show_mode_label` option to code fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -11,6 +11,7 @@
         :line-numbers="config.line_numbers"
         :line-wrapping="config.line_wrapping"
         :allow-mode-selection="config.mode_selectable"
+        :show-mode-label="config.show_mode_label"
         :mode="mode"
         :model-value="value.code"
         :title="config.display"

--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -62,6 +62,7 @@ return [
     'code.config.mode_selectable' => 'Whether the mode can be changed by the user.',
     'code.config.rulers' => 'Configure vertical rulers to help with indentation.',
     'code.config.rulers_value_header' => 'Line Style (dashed or solid)',
+    'code.config.show_mode_label' => 'Whether the mode label should be shown.',
     'code.config.theme' => 'Choose your preferred theme.',
     'code.title' => 'Code',
     'collections.title' => 'Collections',

--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -118,6 +118,16 @@ class Code extends Fieldtype
                         'default' => true,
                         'width' => '50',
                     ],
+                    'show_mode_label' => [
+                        'display' => __('Show Mode Label?'),
+                        'instructions' => __('statamic::fieldtypes.code.config.show_mode_label'),
+                        'type' => 'toggle',
+                        'default' => true,
+                        'width' => '50',
+                        'if' => [
+                            'mode_selectable' => 'equals false',
+                        ],
+                    ],
                     'rulers' => [
                         'display' => __('Rulers'),
                         'instructions' => __('statamic::fieldtypes.code.config.rulers'),


### PR DESCRIPTION
This pull request adds a `show_mode_label` config option to the Code Fieldtype, to avoid the mode label showing at the top of the Code Editor.

In SEO Pro, I'm using the `javascript` mode for a JSON code field. However, I don't want the "JavaScript" label visible at the top of the field.