### PR TITLE
[6.x] Fix text bottom margin in table cell

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -333,6 +333,10 @@
         ul {
             margin-top: 0;
             margin-bottom: 0.85em;
+            table &:last-child {
+                /* If you type a single line of text in a table fieldtype cell you don't want it to have a bottom margin */
+                margin-block-end: 0;
+            }
 
             b,
             strong {


### PR DESCRIPTION
This should close #12433 by fixing margins in table cells with a single line of text