### PR TITLE
[6.x] Bard tweaks

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -28,6 +28,11 @@
         p, ol, li {
             @apply st-text-legibility;
         }
+        &:has(.bard-content *:focus) {
+            /* When we're focused on something else inside the .bard-editor, remove the outline on the .bard-editor, otherwise we have two focus outlines.
+            E.g. If you have Bard > Replicator > Text field, when you focus on the internal text field, the outside .bard-editor should lose its outline */
+            outline: none;
+        }
     }
 }
 /* BARD / MODES


### PR DESCRIPTION
A couple of Bard tweaks based on seeing more complex blueprints.

- Minor heading spacing tweaks to give them a bit more breathing room
- Add focus outline exceptions for "focus states within focus states", e.g.

## Before

Notice there are two blue focus outlines here, but really there should only be one focus outline shown at a time

![2025-10-24 at 10 38 35@2x](https://github.com/user-attachments/assets/407f96b9-aa94-43a2-97ea-a1d9bae55b23)

## After

- A touch more space around Bard headings
- Only one outline

![2025-10-24 at 10 39 42@2x](https://github.com/user-attachments/assets/5dc109e9-fd6a-4eb9-804b-89f2fc084abb)


