### PR TITLE
[6.x] Fix empty dashboard

### DIFF
--- a/src/Http/Controllers/CP/DashboardController.php
+++ b/src/Http/Controllers/CP/DashboardController.php
@@ -72,6 +72,7 @@ class DashboardController extends CpController
             })
             ->reject(function ($widget) {
                 return empty($widget['html']);
-            });
+            })
+            ->values();
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where the Dashboard's empty state would be rendered, even if you have widgets configured in the `config/statamic/cp.php` config file.

It only seems to happen when the `widgets` config contains a string option:

```php
'widgets' => [
    'getting_started',
    [
        'type' => 'collection',
        'collection' => 'pages',
        'limit' => 5,
        'width' => 50,
    ],
],
```

_(I know the `getting_started` widget has been removed in v6, but it'll still be in the configs of updated apps)._