### PR TITLE
[6.x] Remove `getting_started` widget from `cp` config

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -55,7 +55,7 @@ return [
     */
 
     'widgets' => [
-        'getting_started',
+        //
     ],
 
     /*


### PR DESCRIPTION
This pull request removes the `getting_started` widget from the widgets config in `config/statamic/cp.php` after it was removed in 52215f5.