### PR TITLE
[6.x] Add `HandleInertiaRequests` middleware to frontend auth routes

### DIFF
--- a/src/Http/Controllers/ActivateAccountController.php
+++ b/src/Http/Controllers/ActivateAccountController.php
@@ -11,8 +11,8 @@ class ActivateAccountController extends ResetPasswordController
 {
     public function __construct()
     {
-        $this->middleware(RedirectIfAuthorized::class);
         $this->middleware(HandleInertiaRequests::class);
+        $this->middleware(RedirectIfAuthorized::class);
     }
 
     protected function resetFormAction()

--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -18,8 +18,8 @@ class ResetPasswordController extends Controller
 
     public function __construct()
     {
-        $this->middleware(RedirectIfAuthorized::class);
         $this->middleware(HandleInertiaRequests::class);
+        $this->middleware(RedirectIfAuthorized::class);
     }
 
     public function showResetForm(Request $request, $token = null)


### PR DESCRIPTION
This pull request adds the `HandleInertiaRequests` middleware to the account activation & password reset routes.

I've added the middleware in the controller's constructor (because that's what #12711 did), but I noticed that the `protect/password` is adding the middleware directly from the `routes/web.php` file instead. 🤷‍♂️

Closes #12831.