### PR TITLE
[5.x] Fix `bard_text` modifier adding unwanted spaces

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -283,6 +283,7 @@ class CoreModifiers extends Modifier
         }
 
         $text = '';
+
         while (count($value)) {
             $item = array_shift($value);
 
@@ -291,8 +292,13 @@ class CoreModifiers extends Modifier
             }
 
             if ($item['type'] === 'text') {
-                $text .= ' '.($item['text'] ?? '');
+                $text .= ($item['text'] ?? '');
             }
+
+            if ($item['type'] === 'paragraph' && $text !== '') {
+                $text .= ' ';
+            }
+
             array_unshift($value, ...($item['content'] ?? []));
         }
 

--- a/tests/Modifiers/BardTextTest.php
+++ b/tests/Modifiers/BardTextTest.php
@@ -128,6 +128,34 @@ class BardTextTest extends TestCase
         $this->assertEquals($expected, $this->modify($data));
     }
 
+    #[Test]
+    public function it_preserves_text_without_adding_spaces_between_marks()
+    {
+        $data = [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'The "stat" in '],
+                    ['type' => 'text', 'marks' => [['type' => 'bold']], 'text' => 'Stat'],
+                    ['type' => 'text', 'text' => 'amic stands for "static".'],
+                ],
+            ],
+            [
+                // no type
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    ['type' => 'text', 'text' => 'Another paragraph.'],
+                ],
+            ],
+        ];
+
+        $expected = 'The "stat" in Statamic stands for "static". Another paragraph.';
+
+        $this->assertEquals($expected, $this->modify($data));
+    }
+
     public function modify($arr, ...$args)
     {
         return Modify::value($arr)->bard_text($args)->fetch();


### PR DESCRIPTION
This PR fixes an issue where the `bard_text` modifier would add unwanted spaces around marks. For instance, "**Stat**amic" would become "Stat amic". This PR changes the implementation to only add a space between paragraphs and preserve spacing of individual text nodes. 