### PR TITLE
[6.x] Prevent addon settings blueprints from being edited 

### DIFF
--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -300,7 +300,9 @@ class BlueprintRepository
             $files = File::withAbsolutePaths()
                 ->getFilesByType($directory, 'yaml')
                 ->mapWithKeys(fn ($path) => [Str::after($path, $directory.'/') => $path])
-                ->reject(fn ($path) => Str::endsWith($path, Path::tidy('/settings.yaml')));
+                ->when(isset($this->additionalNamespaces[$namespace]), function ($files) {
+                    return $files->reject(fn ($path) => Str::endsWith($path, Path::tidy('/settings.yaml')));
+                });
 
             if (File::exists($directory = $this->directory().'/vendor/'.$namespaceDir)) {
                 $overrides = File::withAbsolutePaths()


### PR DESCRIPTION
Right now, if an addon has a `resources/blueprints/settings.yaml` file, the blueprint will show as editable in the Control Panel.

This PR ensures that `settings.yaml` blueprints are filtered out when finding blueprints in a given namespace.

Closes #12859