### PR TITLE
[6.x] Remove unnecessary padding from Grid & Group fieldtypes in config mode

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -16,7 +16,7 @@
                             :field-path-prefix="fieldPathPrefix ? `${fieldPathPrefix}.${handle}` : handle"
                             :meta-path-prefix="metaPathPrefix ? `${metaPathPrefix}.${handle}` : handle"
                         >
-                            <Fields class="p-4" />
+                            <Fields :class="{ 'p-4': !asConfig }" />
                         </FieldsProvider>
                     </div>
                 </section>
@@ -24,6 +24,12 @@
         </element-container>
     </portal>
 </template>
+
+<script setup>
+import { injectPublishContext as injectContainerContext } from '@ui';
+
+const { asConfig } = injectContainerContext();
+</script>
 
 <script>
 import Fieldtype from './Fieldtype.vue';

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -27,7 +27,7 @@
                 />
             </div>
         </header>
-        <div class="px-4 py-3">
+        <div :class="{ 'px-4 py-3': !asConfig }">
             <FieldsProvider
                 :fields="fields"
                 :field-path-prefix="`${fieldPathPrefix}.${index}`"
@@ -38,6 +38,12 @@
         </div>
     </div>
 </template>
+
+<script setup>
+import { injectPublishContext as injectContainerContext } from '@ui';
+
+const { asConfig } = injectContainerContext();
+</script>
 
 <script>
 import Row from './Row.vue';


### PR DESCRIPTION
This pull request aims to remove unnecessary padding from the Grid & Group fieldtypes when used in a config publish form.

## Before

<img width="1988" height="590" alt="CleanShot 2025-10-25 at 01 58 27@2x" src="https://github.com/user-attachments/assets/cfc6b9d0-9cf5-4651-95a4-9474e2fc02f1" />

<img width="1944" height="558" alt="CleanShot 2025-10-25 at 01 58 46@2x" src="https://github.com/user-attachments/assets/49079dbe-6d76-4d12-bdc7-f1e38c721cff" />


## After

<img width="1988" height="590" alt="CleanShot 2025-10-25 at 01 58 00@2x" src="https://github.com/user-attachments/assets/ba991a37-6820-4587-a62c-28ef0089a00c" />

<img width="1954" height="502" alt="CleanShot 2025-10-25 at 01 57 31@2x" src="https://github.com/user-attachments/assets/efc7e41d-a0a9-4ced-9f5b-cf08d6688cc6" />
