### PR TITLE
[6.x] Add option for addons to opt-out of config layouts for settings

### DIFF
--- a/src/Addons/Addon.php
+++ b/src/Addons/Addon.php
@@ -348,6 +348,11 @@ final class Addon
         return config($this->handle());
     }
 
+    public function useContentLayoutForSettings(): bool
+    {
+        return app()->bound("statamic.addons.{$this->slug()}.use_content_layout");
+    }
+
     public function hasSettingsBlueprint(): bool
     {
         return $this->settingsBlueprint() !== null;

--- a/src/CP/PublishForm.php
+++ b/src/CP/PublishForm.php
@@ -69,9 +69,9 @@ class PublishForm implements Responsable
         return $this;
     }
 
-    public function asConfig()
+    public function asConfig($asConfig = true)
     {
-        $this->asConfig = true;
+        $this->asConfig = $asConfig;
 
         return $this;
     }

--- a/src/Http/Controllers/CP/Addons/AddonSettingsController.php
+++ b/src/Http/Controllers/CP/Addons/AddonSettingsController.php
@@ -22,7 +22,7 @@ class AddonSettingsController extends CpController
         $this->authorize('editSettings', $addon);
 
         return PublishForm::make($addon->settingsBlueprint())
-            ->asConfig()
+            ->asConfig(! $addon->useContentLayoutForSettings())
             ->icon('cog')
             ->title($addon->name())
             ->values($addon->settings()->raw())

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -811,6 +811,13 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $this;
     }
 
+    protected function useContentLayoutForSettings(): self
+    {
+        $this->app->bind("statamic.addons.{$this->getAddon()->slug()}.use_content_layout", fn () => true);
+
+        return $this;
+    }
+
     protected function bootSettingsBlueprint()
     {
         if (! $this->shouldBootRootItems()) {


### PR DESCRIPTION
Addon Settings publish forms currently use the "config" (50 / 50) layout for displaying fields. 

While we aim for all configuration & settings pages to use the config layout, this PR adds an option for addons to opt-out and use the "content" layout instead (the layout used on entries, terms, etc) if it better suits their use case:

```php
// src/ServiceProvider.php

public function bootAddon()
{
    $this->useContentLayoutForSettings();
}
```

Closes #12810