### PR TITLE
[6.x] Avoid rendering `DynamicHtmlRenderer` for Vue widgets

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -55,7 +55,7 @@ function tailwindWidthClass(width) {
                 :class="classes(widget)"
             >
                 <component v-if="widget.component" :is="widget.component.name" v-bind="widget.component.props" />
-                <DynamicHtmlRenderer :html="widget.html" />
+                <DynamicHtmlRenderer v-else :html="widget.html" />
             </div>
         </div>
     </template>


### PR DESCRIPTION
This pull request fixes an issue introduced by #12801, where the `DynamicHtmlRenderer` component was being rendered even if the widget is powered by a Vue component.

It was causing a console warning:

<img width="729" height="111" alt="CleanShot 2025-10-25 at 15 21 17" src="https://github.com/user-attachments/assets/03db21fd-03df-46be-b6ad-80c708522719" />
