### PR TITLE
[6.x] Indigo 700 is now the default primary/accent color

### DIFF
--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -364,7 +364,7 @@ class Color
     public static function defaults(): array
     {
         return [
-            'primary' => self::Zinc[800],
+            'primary' => self::Indigo[700],
             'gray-50' => self::Zinc[50],
             'gray-100' => self::Zinc[100],
             'gray-200' => self::Zinc[200],
@@ -390,9 +390,9 @@ class Color
             'dark-content-border' => self::Zinc[950],
             'global-header-bg' => self::Zinc[800],
             'dark-global-header-bg' => self::Zinc[800],
-            'progress-bar' => self::Volt,
-            'ui-accent' => self::Zinc[800],
-            'dark-ui-accent' => self::Zinc[950],
+            'progress-bar' => self::Indigo[700],
+            'ui-accent' => self::Indigo[700],
+            'dark-ui-accent' => self::Indigo[700],
             'switch-bg' => 'var(--theme-color-ui-accent)',
             'dark-switch-bg' => 'var(--theme-color-dark-ui-accent)',
         ];


### PR DESCRIPTION
References #12093 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets default primary, progress bar, and UI accent colors to `Indigo[700]` across the CP theme defaults.
> 
> - **Theme defaults (`src/CP/Color.php`)**:
>   - `primary`: `Zinc[800]` → `Indigo[700]`
>   - `progress-bar`: `Volt` → `Indigo[700]`
>   - `ui-accent`: `Zinc[800]` → `Indigo[700]`
>   - `dark-ui-accent`: `Zinc[950]` → `Indigo[700]`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14b674bf35e7a3a452229e4ed2063efb604c3cab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->