### PR TITLE
[6.x] Right-align toggles in config publish forms

### DIFF
--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex items-center gap-2" :class="{ 'h-full': publishContainer.asConfig }">
+    <div class="flex items-center gap-2" :class="{ 'h-full justify-end': publishContainer.asConfig }">
         <Switch
             @update:model-value="update"
             :disabled="config.disabled || isReadOnly"


### PR DESCRIPTION
This pull request right-aligns toggles in config publish forms.

## Before

<img width="829" height="182" alt="CleanShot 2025-10-27 at 16 10 14" src="https://github.com/user-attachments/assets/cf31ec9c-c151-4e2c-ab02-1cada0fadf33" />


## After

<img width="829" height="182" alt="CleanShot 2025-10-27 at 16 10 02" src="https://github.com/user-attachments/assets/8e6bf761-35d4-483f-95ce-ca398b9a095c" />
