### PR TITLE
[6.x] Delete background aa

### DIFF
--- a/packages/ui/src/Button/Button.vue
+++ b/packages/ui/src/Button/Button.vue
@@ -44,7 +44,7 @@ const buttonClasses = computed(() => {
                 primary: [
                     'bg-linear-to-b from-primary/90 to-primary hover:bg-primary-hover text-white disabled:text-white/60 dark:disabled:text-white/50 border border-primary-border shadow-ui-md inset-shadow-2xs inset-shadow-white/25 [&_svg]:text-white [&_svg]:opacity-60',
                 ],
-                danger: 'btn-danger bg-linear-to-b from-red-600/90 to-red-600 dark:from-red-600/85 dark:to-red-600 hover:bg-red-600/90 text-white border border-red-600 inset-shadow-2xs inset-shadow-red-300 [&_svg]:text-red-200 disabled:text-red-200',
+                danger: 'btn-danger bg-linear-to-b from-red-700/90 to-red-700 hover:bg-red-700/90 text-white border border-red-700 inset-shadow-xs inset-shadow-red-300 [&_svg]:text-red-200 disabled:text-red-200',
                 filled: 'bg-black/5 hover:bg-black/10 hover:text-gray-900 dark:hover:text-white dark:bg-white/15 dark:hover:bg-white/20 [&_svg]:opacity-70',
                 ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200',
                 'ghost-pressed': 'bg-transparent hover:bg-gray-400/10 text-black dark:text-white dark:hover:bg-white/7 dark:hover:text-white [&_svg]:opacity-100',


### PR DESCRIPTION
I noticed the "delete" background was a little bright (e.g. you can see this when you try to "Disable Two Factor Authentication"). 

I checked, and sure enough, it's not quite AA, so I shifted it one shade darker.
I also adjusted the shadow inset from `2xs` to `xs`. Maybe it's because red is a stark color, but I found it slightly distracting at `2xs` 