### PR TITLE
[6.x] Add dark mode variant to addon `tailwind.css`

### DIFF
--- a/packages/cms/src/tailwind.css
+++ b/packages/cms/src/tailwind.css
@@ -2,3 +2,5 @@
 @import "tailwindcss/theme.css" layer(addon-theme) source(none);
 @import "tailwindcss/utilities.css" layer(addon-utilities) source(none);
 @import "./ui.css";
+
+@custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
This pull request adds a dark mode variant to the `tailwind.css` file imported by addons, allowing them to generate `dark:*` classes.