### PR TITLE
[6.x] Revert right-aligning toggles

### DIFF
--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="flex items-center gap-2" :class="{ 'h-full justify-end': publishContainer.asConfig }">
+    <div class="flex items-center gap-2" :class="{ 'h-full': publishContainer.asConfig }">
         <Switch
             @update:model-value="update"
             :disabled="config.disabled || isReadOnly"


### PR DESCRIPTION
Reverts statamic/cms#12889. It's weird when combined with left-aligned fields, like this:

<img width="1076" height="250" alt="image" src="https://github.com/user-attachments/assets/b2cf0fc5-7702-47cf-9968-0527e11f0204" />

