### PR TITLE
[5.x] Detect imported fields by checking field value instead of config key

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -647,7 +647,8 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
         $field = $this->contents['tabs'][$tab]['sections'][$sectionKey]['fields'][$fieldKey];
 
-        $isImportedField = Arr::has($field, 'config');
+        $fieldValue = Arr::get($field, 'field');
+        $isImportedField = is_string($fieldValue);
 
         if ($isImportedField) {
             $existingConfig = Arr::get($field, 'config', []);

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -869,6 +869,7 @@ class BlueprintTest extends TestCase
                     [
                         'fields' => [
                             ['handle' => 'the_field', 'field' => 'the_partial.the_field', 'config' => ['type' => 'text', 'do_not_touch_other_config' => true]],
+                            ['handle' => 'imported_field_without_config_key', 'field' => 'the_partial.the_field'],
                         ],
                     ],
                 ],
@@ -878,6 +879,7 @@ class BlueprintTest extends TestCase
         $fields = $blueprint
             ->ensureFieldHasConfig('author', ['visibility' => 'read_only'])
             ->ensureFieldHasConfig('the_field', ['visibility' => 'read_only'])
+            ->ensureFieldHasConfig('imported_field_without_config_key', ['visibility' => 'read_only'])
             ->fields();
 
         $this->assertEquals(['type' => 'text'], $fields->get('title')->config());
@@ -891,6 +893,7 @@ class BlueprintTest extends TestCase
 
         $this->assertEquals($expectedConfig, $fields->get('author')->config());
         $this->assertEquals($expectedConfig, $fields->get('the_field')->config());
+        $this->assertEquals($expectedConfig, $fields->get('imported_field_without_config_key')->config());
     }
 
     // todo: duplicate or tweak above test but make the target field not in the first section.


### PR DESCRIPTION
Fixes an incorrect detection of imported fields in Blueprint::ensureFieldInTabHasConfig() which was checking for a `config` key and instead checks for `field` having a value of type `string`
