### PR TITLE
[5.x] Allow Cache Tags for POST requests

### DIFF
--- a/src/Tags/Cache.php
+++ b/src/Tags/Cache.php
@@ -68,8 +68,7 @@ class Cache extends Tags implements CachesOutput
             return false;
         }
 
-        // Only GET requests.
-        return request()->method() === 'GET';
+        return true;
     }
 
     private function getCacheKey()


### PR DESCRIPTION
This PR allows Cache Tags to be enabled not only for GET but POST requests.

**Backstory**
I've detected that Cache Tags are not enabled for POST requests (Livewire subsequent requests), and had a little chat with Duncan about how I could support that in the Livewire addon. We came up with three approaches:

1. We add another condition to check if the request URL matches the Livewire update URL:
```php
private function isEnabled()
{
    if (! config('statamic.system.cache_tags_enabled', true)) {
        return false;
    }

    if (request()->isLivePreview()) {
        return false;
    }

    // THIS
    if (request()->getRequestUri() === Livewire::getUpdateUri()) {
        return true;
    }

    // Only GET requests.
    return request()->method() === 'GET';
}
```

2. We make `Tags/Cache::isEnabled()` `protected`, I extend the cache tag in the Livewire addon, and overwrite that method with the check from the first approach
3. **We allow all request types, since we have a dedicated check for Live Preview now (https://github.com/statamic/cms/commit/bab78228c42f2959e30ed1e8f4a2cbbf6d7a6043), which was probably the original reason for disabling it for POST requests. (Implemented approach)**

Fixes: #12909 