### PR TITLE
[5.x] Fix field config overrides being lost when ensuring referenced fields

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -258,7 +258,9 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
                 // override array, but only keys that don't already exist in the actual partial field's config.
                 $referencedField = FieldRepository::find($existingField['field']);
                 $referencedFieldConfig = $referencedField->config();
-                $config = array_merge($config, $referencedFieldConfig);
+                $fieldOverrides = $existingField['config'] ?? [];
+
+                $config = array_merge($config, $referencedFieldConfig, $fieldOverrides);
                 $config = Arr::except($config, array_keys($referencedFieldConfig));
                 $field = ['handle' => $handle, 'field' => $existingField['field'], 'config' => $config];
             } else {


### PR DESCRIPTION
Blueprint field overrides were being discarded when Collection.ensureEntryBlueprintFields() called Blueprint.ensureField().

The merge logic in Blueprint.addEnsuredFieldToContents() now correctly prioritizes: fieldOverrides > referencedFieldConfig > ensuredConfig.


example:
```yaml
- handle: slug
  field: common.slug
  config:
    visibility: read_only
```

before:
```yaml
- handle: slug
  field: common.slug
  config:
    validate: 'max:200'
    localizable: true
```

after:
```yaml
- handle: slug
  field: common.slug
  config:
    visibility: read_only
    validate: 'max:200'
    localizable: true
```