### PR TITLE
[6.x] Fix `container` config option on asset folder fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
+++ b/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
@@ -19,11 +19,7 @@ export default {
 
     computed: {
         container() {
-            if (this.config.container) {
-                 return this.config.container;
-            }
-
-            return this.publishContainer.values?.container[0];
+            return this.publishContainer.values?.container?.[0] ?? this.config.container;
         },
 
         relationshipMeta() {


### PR DESCRIPTION
This pull request fixes an error from the Asset Folder fieldtype when the container is provided as a config option, rather than available in the publish container's values.

<img width="521" height="162" alt="image" src="https://github.com/user-attachments/assets/099163a6-af6c-4513-9eda-b2c9e8043b0a" />
