### PR TITLE
[5.x] Support multiple sites on the search tag

### DIFF
--- a/src/Search/Tags.php
+++ b/src/Search/Tags.php
@@ -60,6 +60,6 @@ class Tags extends BaseTags
             return;
         }
 
-        $query->whereIn('site', $sites);
+        return $query->whereIn('site', $sites);
     }
 }


### PR DESCRIPTION
This allows the `search:results` tag to query multiple sites.

```
{{ search:results site="one" }}
or {{ search:results site="one|two" }}
```
