### PR TITLE
[6.x] Filters close button position fix

### DIFF
--- a/resources/js/components/ui/Listing/Filters.vue
+++ b/resources/js/components/ui/Listing/Filters.vue
@@ -119,7 +119,7 @@ function handleStackClosed() {
                     icon="x"
                     variant="ghost"
                     size="sm"
-                    class="absolute! top-1.75 right-3! z-(--z-index-above) [&_svg]:size-4"
+                    class="absolute! top-1.75 right-3 z-(--z-index-above) [&_svg]:size-4"
                     @click="handleStackClosed"
                 />
                 <Heading size="lg" :text="__('Filters')" class="mb-4 px-1.5 pr-12 [&_svg]:size-4" icon="sliders-horizontal" />


### PR DESCRIPTION
This fixes the "close" filter button, which was broken because other properties had higher specificity.
While I was there, I changed the z-index to a variable, like we use for other components.