### PR TITLE
[5.x] Revert "CP nav reordering fixes"

### DIFF
--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -3,7 +3,6 @@
 namespace Statamic\CP\Navigation;
 
 use Exception;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Preference;
@@ -255,8 +254,8 @@ class NavBuilder
             ->each(fn ($overrides) => $this->createPendingItemsForSection($overrides))
             ->each(fn ($overrides) => $this->applyPreferenceOverridesForSection($overrides));
 
-        if ($reorder = $navPreferencesConfig['reorder']) {
-            $this->setSectionOrder($reorder);
+        if ($navPreferencesConfig['reorder']) {
+            $this->setSectionOrder($sections);
         }
 
         return $this;
@@ -321,8 +320,8 @@ class NavBuilder
             ->filter()
             ->each(fn ($item) => $item->isChild(false));
 
-        if ($reorder = $sectionNav['reorder']) {
-            $this->setSectionItemOrder($section, $sectionNav['items'], $reorder);
+        if ($sectionNav['reorder']) {
+            $this->setSectionItemOrder($section, $sectionNav['items']);
         }
     }
 
@@ -445,33 +444,23 @@ class NavBuilder
 
     /**
      * Set section order.
+     *
+     * @param  array  $sections
      */
-    protected function setSectionOrder(array $reorder): void
+    protected function setSectionOrder($sections)
     {
-        // Get unconfigured core sections...
+        // Get conconfigured core sections...
         $unconfiguredCoreSections = $this->sections;
 
         // Get unconfigured sections...
-        $unconfiguredRegisteredSections = collect($this->items)
-            ->mapWithKeys(fn ($item) => [NavItem::snakeCase($item->section()) => $item->section()])
-            ->filter()
-            ->unique();
+        $unconfiguredRegisteredSections = collect($this->items)->map->section()->filter()->unique();
 
-        // Get merged unique list of sections...
-        $order = collect()
-            ->merge($unconfiguredCoreSections)
+        // Merge unconfigured sections onto the end of the list and map their order...
+        $this->sectionsOrder = collect($sections)
+            ->pluck('display')
             ->merge($unconfiguredRegisteredSections)
-            ->unique();
-
-        // Reorder to match `$reorder` config...
-        collect($reorder)
-            ->reverse()
-            ->each(fn ($key) => $order->prepend($order->pull($key), $key));
-
-        // Ensure `top_level` is always first...
-        $order->prepend($order->pull('top_level'), 'top_level');
-
-        $this->sectionsOrder = $order
+            ->merge($unconfiguredCoreSections)
+            ->unique()
             ->values()
             ->mapWithKeys(fn ($section, $index) => [$section => $index + 1])
             ->all();
@@ -479,17 +468,14 @@ class NavBuilder
 
     /**
      * Set section item order.
+     *
+     * @param  string  $section
+     * @param  array  $items
      */
-    protected function setSectionItemOrder(string $section, array $items, array $reorder): void
+    protected function setSectionItemOrder($section, $items)
     {
-        // Get unconfigured item IDs...
-        $unconfiguredItemIds = collect($this->items)
-            ->filter(fn ($item) => $item->section() === $section)
-            ->map
-            ->id();
-
         // Generate IDs for newly created items...
-        $createdItemIds = collect($items)
+        $itemIds = collect($items)
             ->map(function ($item, $id) use ($section, $items) {
                 return $items[$id]['action'] === '@create'
                     ? $this->generateNewItemId($section, $items[$id]['display'])
@@ -497,24 +483,23 @@ class NavBuilder
             })
             ->values();
 
-        // Merge unconfigured items into the end of the list...
-        $itemIds = collect()
-            ->merge($unconfiguredItemIds)
-            ->merge($createdItemIds)
-            ->unique()
-            ->flip();
+        // Get unconfigured item IDs...
+        $unconfiguredItemIds = collect($this->items)
+            ->filter(fn ($item) => $item->section() === $section)
+            ->map
+            ->id();
 
-        // Reorder to match `$reorder` config...
-        collect($reorder)
-            ->reverse()
-            ->each(fn ($key) => $itemIds->prepend($itemIds->pull($key), $key));
+        // Merge unconfigured items into the end of the list...
+        $itemIds = $itemIds
+            ->values()
+            ->merge($unconfiguredItemIds)
+            ->unique()
+            ->values();
 
         // Set an explicit order value on each item...
         $itemIds
-            ->flip()
             ->map(fn ($id) => $this->findItem($id, false))
             ->filter()
-            ->values()
             ->each(fn ($item, $index) => $item->order($index + 1));
 
         // Inform builder that section items should be ordered...
@@ -686,11 +671,8 @@ class NavBuilder
             ->reject(fn ($value, $setter) => in_array($setter, ['children', 'reorder']))
             ->each(fn ($value, $setter) => $item->{$setter}($value));
 
-        $childrenConfig = $config->get('children');
-        $reorder = $config->get('reorder');
-
-        if ($childrenConfig || $reorder) {
-            $this->userModifyItemChildren($item, $childrenConfig, $section, $reorder);
+        if ($children = $config->get('children')) {
+            $this->userModifyItemChildren($item, $children, $section, $config->get('reorder'));
         }
 
         return $item;
@@ -698,17 +680,20 @@ class NavBuilder
 
     /**
      * Modify NavItem children.
+     *
+     * @param  \Statamic\CP\Navigation\NavItem  $item
+     * @param  array  $childrenOverrides
+     * @param  string  $section
+     * @return \Illuminate\Support\Collection
      */
-    protected function userModifyItemChildren(NavItem $item, ?array $childrenConfig, string $section, ?array $reorder): void
+    protected function userModifyItemChildren($item, $childrenOverrides, $section, $reorder)
     {
-        // Get original item children...
         $itemChildren = collect($item->original()->resolveChildren()->children())
             ->each(fn ($item, $index) => $item->order($index + 1000))
             ->keyBy
             ->id();
 
-        // Apply children preferences from config...
-        collect($childrenConfig)
+        collect($childrenOverrides)
             ->map(fn ($config, $key) => $this->userModifyChild($config, $section, $key, $item))
             ->each(function ($item, $key) use (&$itemChildren) {
                 $item
@@ -719,25 +704,18 @@ class NavBuilder
             ->values()
             ->each(fn ($item, $index) => $item->order($index + 1));
 
-        // Reorder to match `$reorder` config...
-        if ($reorder) {
-            collect($reorder)
-                ->reverse()
-                ->each(fn ($key) => $itemChildren->prepend($itemChildren->pull($key), $key));
-        }
+        $newChildren = $reorder
+            ? $itemChildren->sortBy(fn ($item) => $item->order())->values()
+            : $itemChildren->values();
 
-        // Update final `order`...
-        $itemChildren
-            ->sortBy(fn ($item) => $item->order())->values()
-            ->values()
-            ->each(fn ($item, $index) => $item->order($index + 1));
-
-        $item->children($itemChildren, false);
+        $newChildren->each(fn ($item, $index) => $item->order($index + 1));
 
         $item->children(
-            items: $itemChildren,
+            items: $newChildren,
             generateNewIds: false,
         );
+
+        return $newChildren;
     }
 
     /**

--- a/src/CP/Navigation/NavPreferencesNormalizer.php
+++ b/src/CP/Navigation/NavPreferencesNormalizer.php
@@ -73,20 +73,19 @@ class NavPreferencesNormalizer
     {
         $navConfig = collect($this->preferences);
 
+        $normalized = collect()->put('reorder', (bool) $reorder = $navConfig->get('reorder', false));
+
         $sections = collect($navConfig->get('sections') ?? $navConfig->except('reorder'));
 
-        $normalized = collect();
-
-        $sections = collect($sections)
+        $sections = $this
+            ->normalizeToInheritsFromReorder($sections, $reorder)
             ->prepend($sections->pull('top_level') ?? '@inherit', 'top_level')
-            ->map(fn ($config, $section) => $this->normalizeSectionConfig($config, $section));
+            ->map(fn ($config, $section) => $this->normalizeSectionConfig($config, $section))
+            ->reject(fn ($config) => $config['action'] === '@inherit' && ! $reorder)
+            ->map(fn ($config) => $this->removeInheritFromConfig($config))
+            ->all();
 
-        $normalized->put('reorder', $this->normalizeReorder(
-            $navConfig->get('reorder', false),
-            $sections->reject(fn ($section, $key) => $key === 'top_level'),
-        ));
-
-        $normalized->put('sections', $this->rejectInherits($sections)->all());
+        $normalized->put('sections', $sections);
 
         $allowedKeys = ['reorder', 'sections'];
 
@@ -118,24 +117,42 @@ class NavPreferencesNormalizer
 
         $normalized->put('display', $sectionConfig->get('display', false));
 
+        $normalized->put('reorder', (bool) $reorder = $sectionConfig->get('reorder', false));
+
         $items = collect($sectionConfig->get('items') ?? $sectionConfig->except([
             'action',
             'display',
             'reorder',
         ]));
 
-        $items = $items
+        $items = $this
+            ->normalizeToInheritsFromReorder($items, $reorder)
             ->map(fn ($config, $itemId) => $this->normalizeItemConfig($itemId, $config, $sectionKey))
             ->keyBy(fn ($config, $itemId) => $this->normalizeItemId($itemId, $config))
-            ->filter();
+            ->filter()
+            ->reject(fn ($config) => $config['action'] === '@inherit' && ! $reorder)
+            ->all();
 
-        $normalized->put('reorder', $this->normalizeReorder($sectionConfig->get('reorder', false), $items));
-
-        $normalized->put('items', $this->rejectInherits($items)->all());
+        $normalized->put('items', $items);
 
         $allowedKeys = array_merge(['action'], static::ALLOWED_NAV_SECTION_MODIFICATIONS);
 
         return $normalized->only($allowedKeys)->all();
+    }
+
+    /**
+     * Remove inherit action from config.
+     *
+     * @param  array  $config
+     * @return array
+     */
+    protected function removeInheritFromConfig($config)
+    {
+        if ($config['action'] === '@inherit') {
+            $config['action'] = false;
+        }
+
+        return $config;
     }
 
     /**
@@ -173,19 +190,21 @@ class NavPreferencesNormalizer
             }
         }
 
-        // Normalize `children`.
-        $children = collect($normalized->get('children', []))
-            ->map(fn ($childConfig, $childId) => $this->normalizeChildItemConfig($childId, $childConfig, $sectionKey))
-            ->keyBy(fn ($childConfig, $childId) => $this->normalizeItemId($childId, $childConfig));
-
-        // Only output `reorder` if there are any `children`.
-        if ($children->isNotEmpty() && $reorder = $normalized->get('reorder', false)) {
-            $normalized->put('reorder', $this->normalizeReorder($reorder, $children));
+        // Normalize `reorder` bool.
+        if ($reorder = $normalized->get('reorder', false)) {
+            $normalized->put('reorder', (bool) $reorder);
         }
 
-        // Only output `children` if there are any.
-        $children->isNotEmpty()
-            ? $normalized->put('children', $this->rejectInherits($children)->all())
+        // Normalize `children`.
+        $children = $this
+            ->normalizeToInheritsFromReorder($normalized->get('children', []), $reorder)
+            ->map(fn ($childConfig, $childId) => $this->normalizeChildItemConfig($childId, $childConfig, $sectionKey))
+            ->keyBy(fn ($childConfig, $childId) => $this->normalizeItemId($childId, $childConfig))
+            ->all();
+
+        // Only output `children` in normalized output if there are any.
+        $children
+            ? $normalized->put('children', $children)
             : $normalized->forget('children');
 
         $allowedKeys = array_merge(['action'], static::ALLOWED_NAV_ITEM_MODIFICATIONS);
@@ -249,7 +268,9 @@ class NavPreferencesNormalizer
             return false;
         }
 
-        return collect(static::ALLOWED_NAV_ITEM_MODIFICATIONS)
+        $possibleModifications = array_merge(static::ALLOWED_NAV_ITEM_MODIFICATIONS);
+
+        return collect($possibleModifications)
             ->intersect(array_keys($config))
             ->isNotEmpty();
     }
@@ -267,23 +288,18 @@ class NavPreferencesNormalizer
     }
 
     /**
-     * Normalize legacy `reorder: true` boolean to array, introduced to sidestep ordering issues in SQL.
+     * Normalize to legacy style inherits from new `reorder: []` array schema, introduced to sidestep ordering issues in SQL.
      */
-    protected function normalizeReorder(array|bool $reorder, array|Collection $items): array|bool
+    protected function normalizeToInheritsFromReorder(array|Collection $items, array|bool $reorder): Collection
     {
-        if ($reorder === true) {
-            $reorder = collect($items)->keys()->all();
+        if (! is_array($reorder)) {
+            return collect($items);
         }
 
-        return $reorder;
-    }
-
-    /**
-     * Reject items with inherit actions.
-     */
-    protected function rejectInherits(Collection $items): Collection
-    {
-        return $items->reject(fn ($item) => Arr::get($item, 'action') === '@inherit');
+        return collect($reorder)
+            ->flip()
+            ->map(fn () => '@inherit')
+            ->merge($items);
     }
 
     /**

--- a/tests/CP/Navigation/NavPreferencesNormalizerTest.php
+++ b/tests/CP/Navigation/NavPreferencesNormalizerTest.php
@@ -189,7 +189,7 @@ class NavPreferencesNormalizerTest extends TestCase
     }
 
     #[Test]
-    public function it_removes_legacy_inherit_action_sections_when_not_reordering()
+    public function it_removes_inherit_action_sections_when_not_reordering()
     {
         $this->assertEquals(['users'], array_keys($this->normalize([
             'top_level' => '@inherit',
@@ -203,10 +203,10 @@ class NavPreferencesNormalizerTest extends TestCase
     }
 
     #[Test]
-    public function it_removes_legacy_inherit_action_sections_when_reordering()
+    public function it_doesnt_remove_inherit_action_sections_when_actually_reordering()
     {
         // With `reorder: true`
-        $this->assertEquals(['users'], array_keys($this->normalize([
+        $this->assertEquals(['top_level', 'users', 'tools'], array_keys($this->normalize([
             'reorder' => true,
             'top_level' => '@inherit',
             'users' => [
@@ -216,7 +216,7 @@ class NavPreferencesNormalizerTest extends TestCase
         ])['sections']));
 
         // With `reorder: []` array
-        $this->assertEquals(['users'], array_keys($this->normalize([
+        $this->assertEquals(['top_level', 'users', 'tools'], array_keys($this->normalize([
             'reorder' => ['top_level', 'users', 'tools'],
             'users' => [
                 'content::collections::profiles' => '@move',
@@ -224,7 +224,7 @@ class NavPreferencesNormalizerTest extends TestCase
         ])['sections']));
 
         // With `reorder: true` and sections properly nested
-        $this->assertEquals(['users'], array_keys($this->normalize([
+        $this->assertEquals(['top_level', 'users', 'tools'], array_keys($this->normalize([
             'reorder' => true,
             'sections' => [
                 'top_level' => '@inherit',
@@ -236,7 +236,7 @@ class NavPreferencesNormalizerTest extends TestCase
         ])['sections']));
 
         // With `reorder: []` array and sections properly nested
-        $this->assertEquals(['users'], array_keys($this->normalize([
+        $this->assertEquals(['top_level', 'users', 'tools'], array_keys($this->normalize([
             'reorder' => ['top_level', 'users', 'tools'],
             'sections' => [
                 'users' => [
@@ -247,7 +247,7 @@ class NavPreferencesNormalizerTest extends TestCase
     }
 
     #[Test]
-    public function it_removes_legacy_inherit_action_items_when_not_reordering()
+    public function it_removes_inherit_action_items_when_not_reordering()
     {
         $this->assertEquals(['content::collections::posts'], array_keys($this->normalize([
             'content' => [
@@ -259,10 +259,12 @@ class NavPreferencesNormalizerTest extends TestCase
     }
 
     #[Test]
-    public function it_removes_legacy_inherit_action_items_when_reordering()
+    public function it_doesnt_remove_inherit_action_items_when_actually_reordering()
     {
         $expected = [
+            'content::collections::pages',
             'content::collections::posts',
+            'content::collections::profiles',
         ];
 
         // With `reorder: true`
@@ -370,6 +372,46 @@ class NavPreferencesNormalizerTest extends TestCase
     public static function modifiersProvider()
     {
         return collect(NavPreferencesNormalizer::ALLOWED_NAV_ITEM_MODIFICATIONS)->map(fn ($key) => [$key]);
+    }
+
+    #[Test]
+    public function it_defaults_action_to_inherit_when_reordering_in_original_section()
+    {
+        // With `reorder: true`
+        $this->assertEquals('@inherit', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => true,
+                'content::collections::pages' => [],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
+
+        // With `reorder: []` array
+        $this->assertEquals('@inherit', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
+                ],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
+
+        // With `reorder: true` and sections properly nested
+        $this->assertEquals('@inherit', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => true,
+                'items' => [
+                    'content::collections::pages' => [],
+                ],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
+
+        // With `reorder: []` array and sections properly nested
+        $this->assertEquals('@inherit', Arr::get($this->normalize([
+            'content' => [
+                'reorder' => [
+                    'content::collections::pages',
+                ],
+            ],
+        ]), 'sections.content.items.content::collections::pages.action'));
     }
 
     #[Test]
@@ -527,7 +569,7 @@ class NavPreferencesNormalizerTest extends TestCase
                     'top_level::hide' => '@hide',
                     'top_level::modify' => '@modify',
                     'top_level::alias' => '@alias',
-                    'top_level::inherit' => '@inherit', // inherit actions should always get removed, and are only used when normalizing legacy `reorder` booleans
+                    'top_level::inherit' => '@inherit',
                     'top_level::move' => '@move', // if reordering use `@inherit`, or if modifying use `@modify`
                 ],
             ],
@@ -538,7 +580,7 @@ class NavPreferencesNormalizerTest extends TestCase
                     'top_level::hide' => '@hide', // if hiding, put item/action in it's proper section
                     'top_level::modify' => '@modify', // if you're moving or aliasing into this section, modifying will work with those actions
                     'top_level::alias' => '@alias',
-                    'top_level::inherit' => '@inherit', // inherit actions should always get removed, and are only used when normalizing legacy `reorder` booleans
+                    'top_level::inherit' => '@inherit', // if you're moving or aliasing into this section, reordering will work with those actions
                     'top_level::move' => '@move',
                 ],
             ],
@@ -552,6 +594,7 @@ class NavPreferencesNormalizerTest extends TestCase
             'top_level::hide',
             'top_level::modify',
             $topLevelAliasId,
+            'top_level::inherit',
             'top_level::move',
         ];
 
@@ -671,32 +714,43 @@ class NavPreferencesNormalizerTest extends TestCase
         ]);
 
         $expected = [
-            'reorder' => [
-                'fields',
-                'content',
-            ],
+            'reorder' => true,
             'sections' => [
+                'top_level' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
+                'fields' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
                 'content' => [
                     'action' => false,
                     'display' => false,
-                    'reorder' => [
-                        'content::globals',
-                        'content::collections',
-                        'content::assets',
-                    ],
+                    'reorder' => true,
                     'items' => [
+                        'content::globals' => [
+                            'action' => '@inherit',
+                        ],
                         'content::collections' => [
                             'action' => '@modify',
-                            'reorder' => [
-                                'content::collections::pages',
-                                'content::collections::articles',
-                            ],
+                            'reorder' => true,
                             'children' => [
+                                'content::collections::pages' => [
+                                    'action' => '@inherit',
+                                ],
                                 'content::collections::articles' => [
                                     'action' => '@modify',
                                     'display' => 'Featured Articles',
                                 ],
                             ],
+                        ],
+                        'content::assets' => [
+                            'action' => '@inherit',
                         ],
                     ],
                 ],
@@ -712,7 +766,6 @@ class NavPreferencesNormalizerTest extends TestCase
         $nav = $this->normalize([
             'reorder' => [
                 'fields',
-                'content',
             ],
             'sections' => [
                 'content' => [
@@ -726,7 +779,6 @@ class NavPreferencesNormalizerTest extends TestCase
                             'action' => '@modify',
                             'reorder' => [
                                 'content::collections::pages',
-                                'content::collections::articles',
                             ],
                             'children' => [
                                 'content::collections::articles' => [
@@ -741,32 +793,43 @@ class NavPreferencesNormalizerTest extends TestCase
         ]);
 
         $expected = [
-            'reorder' => [
-                'fields',
-                'content',
-            ],
+            'reorder' => true,
             'sections' => [
+                'top_level' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
+                'fields' => [
+                    'action' => false,
+                    'display' => false,
+                    'reorder' => false,
+                    'items' => [],
+                ],
                 'content' => [
                     'action' => false,
                     'display' => false,
-                    'reorder' => [
-                        'content::globals',
-                        'content::collections',
-                        'content::assets',
-                    ],
+                    'reorder' => true,
                     'items' => [
+                        'content::globals' => [
+                            'action' => '@inherit',
+                        ],
                         'content::collections' => [
                             'action' => '@modify',
-                            'reorder' => [
-                                'content::collections::pages',
-                                'content::collections::articles',
-                            ],
+                            'reorder' => true,
                             'children' => [
+                                'content::collections::pages' => [
+                                    'action' => '@inherit',
+                                ],
                                 'content::collections::articles' => [
                                     'action' => '@modify',
                                     'display' => 'Featured Articles',
                                 ],
                             ],
+                        ],
+                        'content::assets' => [
+                            'action' => '@inherit',
                         ],
                     ],
                 ],
@@ -774,78 +837,5 @@ class NavPreferencesNormalizerTest extends TestCase
         ];
 
         $this->assertSame($expected, $nav);
-    }
-
-    #[Test]
-    public function it_normalizes_new_array_reordering_style_without_actionable_config()
-    {
-        // At section level
-        $this->assertEquals([
-            'reorder' => [
-                'fields',
-                'content',
-            ],
-            'sections' => [],
-        ], $this->normalize([
-            'reorder' => [
-                'fields',
-                'content',
-            ],
-        ]));
-
-        // At item level
-        $this->assertEquals([
-            'reorder' => false,
-            'sections' => [
-                'content' => [
-                    'action' => false,
-                    'display' => false,
-                    'reorder' => [
-                        'content::globals',
-                        'content::collections',
-                        'content::assets',
-                    ],
-                    'items' => [],
-                ],
-            ],
-        ], $this->normalize([
-            'content' => [
-                'reorder' => [
-                    'content::globals',
-                    'content::collections',
-                    'content::assets',
-                ],
-            ],
-        ]));
-
-        // At child item level
-        $this->assertEquals([
-            'reorder' => false,
-            'sections' => [
-                'content' => [
-                    'action' => false,
-                    'display' => false,
-                    'reorder' => false,
-                    'items' => [
-                        'content::collections' => [
-                            'reorder' => [
-                                'content::collections::pages',
-                                'content::collections::articles',
-                            ],
-                            'action' => '@modify',
-                        ],
-                    ],
-                ],
-            ],
-        ], $this->normalize([
-            'content' => [
-                'content::collections' => [
-                    'reorder' => [
-                        'content::collections::pages',
-                        'content::collections::articles',
-                    ],
-                ],
-            ],
-        ]));
     }
 }

--- a/tests/CP/Navigation/NavPreferencesTest.php
+++ b/tests/CP/Navigation/NavPreferencesTest.php
@@ -39,67 +39,6 @@ class NavPreferencesTest extends TestCase
 
         // Recommended syntax...
         $this->assertEquals($reorderedSections, $this->buildNavWithPreferences([
-            'reorder' => [
-                'users',
-                'fields',
-                'content',
-                'tools',
-                'settings',
-            ],
-        ])->keys()->all());
-
-        // Merge unmentioned sections underneath...
-        $this->assertEquals($reorderedSections, $this->buildNavWithPreferences([
-            'reorder' => [
-                'users',
-                'fields',
-            ],
-        ])->keys()->all());
-
-        // Always merge top level section at top, even when explicitly defining in middle...
-        $this->assertEquals($reorderedSections, $this->buildNavWithPreferences([
-            'reorder' => [
-                'users',
-                'top_level',
-                'fields',
-            ],
-        ])->keys()->all());
-
-        // Ensure re-ordering sections still works when modifying a section...
-        $this->assertEquals($reorderedSections, $this->buildNavWithPreferences([
-            'reorder' => [
-                'users',
-                'fields',
-            ],
-            'sections' => [
-                'fields' => [
-                    'items' => [
-                        'top_level::dashboard' => '@alias',
-                    ],
-                ],
-            ],
-        ])->keys()->all());
-
-        // If `reorder: false`, it should just use default section order...
-        $this->assertEquals($defaultSections, $this->buildNavWithPreferences([
-            'reorder' => false,
-        ])->keys()->all());
-
-        // If `reorder` is not specified, it should just use default item order...
-        $this->assertEquals($defaultSections, $this->buildNavWithPreferences([])->keys()->all());
-    }
-
-    #[Test]
-    public function it_can_still_reorder_sections_using_legacy_reorder_boolean_with_inherits()
-    {
-        $defaultSections = ['Top Level', 'Content', 'Fields', 'Tools', 'Settings', 'Users'];
-
-        $this->assertEquals($defaultSections, $this->buildDefaultNav()->keys()->all());
-
-        $reorderedSections = ['Top Level', 'Users', 'Fields', 'Content', 'Tools', 'Settings'];
-
-        // Recommended syntax...
-        $this->assertEquals($reorderedSections, $this->buildNavWithPreferences([
             'reorder' => true,
             'sections' => [
                 'top_level' => '@inherit',
@@ -189,124 +128,7 @@ class NavPreferencesTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_created_and_renamed_sections_properly_when_reordering()
-    {
-        $expected = [
-            'Top Level',
-            'Users',
-            'Fieldios',
-            'New Section',
-            'Content',
-            'Tools',
-            'Settings',
-            'New Section At End',
-        ];
-
-        $this->assertEquals($expected, $this->buildNavWithPreferences([
-            'reorder' => [
-                'users',
-                'fields',
-                'new_section', // We want to explicitly show this section early in the order
-                // 'new_section_at_end', // But let this one generate as an appended section at the end
-            ],
-            'sections' => [
-                'fields' => [
-                    'display' => 'Fieldios', // Even though this section has been renamed, it should still reorder using original section id
-                    'items' => [
-                        'top_level::dashboard' => '@alias',
-                    ],
-                ],
-                'new_section' => [
-                    'items' => [
-                        'top_level::dashboard' => '@alias',
-                    ],
-                ],
-                'new_section_at_end' => [
-                    'items' => [
-                        'top_level::dashboard' => '@alias',
-                    ],
-                ],
-            ],
-        ])->keys()->all());
-    }
-
-    #[Test]
     public function it_can_reorder_items_within_sections()
-    {
-        $defaultContentItems = ['Collections', 'Navigation', 'Taxonomies', 'Assets', 'Globals'];
-
-        $this->assertEquals($defaultContentItems, $this->buildDefaultNav()->get('Content')->map->display()->all());
-
-        $reorderedContentItems = ['Globals', 'Taxonomies', 'Collections', 'Navigation', 'Assets'];
-
-        // Recommended syntax...
-        $this->assertEquals($reorderedContentItems, $this->buildNavWithPreferences([
-            'content' => [
-                'reorder' => [
-                    'content::globals',
-                    'content::taxonomies',
-                    'content::collections',
-                    'content::navigation',
-                    'content::assets',
-                ],
-            ],
-        ])->get('Content')->map->display()->all());
-
-        // With full nesting of sections...
-        $this->assertEquals($reorderedContentItems, $this->buildNavWithPreferences([
-            'sections' => [
-                'content' => [
-                    'reorder' => [
-                        'content::globals',
-                        'content::taxonomies',
-                        'content::collections',
-                        'content::navigation',
-                        'content::assets',
-                    ],
-                ],
-            ],
-        ])->get('Content')->map->display()->all());
-
-        // Merge unmentioned items underneath...
-        $this->assertEquals($reorderedContentItems, $this->buildNavWithPreferences([
-            'content' => [
-                'reorder' => [
-                    'content::globals',
-                    'content::taxonomies',
-                    'content::collections',
-                ],
-            ],
-        ])->get('Content')->map->display()->all());
-
-        // Ensure re-ordering items still works when modifying a item...
-        $this->assertEquals($reorderedContentItems, $this->buildNavWithPreferences([
-            'content' => [
-                'reorder' => [
-                    'content::globals',
-                    'content::taxonomies',
-                    'content::collections',
-                ],
-                'items' => [
-                    'content::taxonomies' => [
-                        'icon' => 'tag',
-                    ],
-                ],
-            ],
-        ])->get('Content')->map->display()->all());
-
-        // If `reorder: false`, it should just use default item order...
-        $this->assertEquals($defaultContentItems, $this->buildNavWithPreferences([
-            'content' => [
-                'reorder' => false,
-            ],
-        ])->get('Content')->map->display()->all());
-
-        // If `reorder` is not specified, it should just use default item order...
-        $this->assertEquals($defaultContentItems, $this->buildNavWithPreferences([])->get('Content')->map->display()->all());
-    }
-
-    #[Test]
-    public function it_can_still_reorder_items_within_sections_using_legacy_reorder_boolean_with_inherits()
     {
         $defaultContentItems = ['Collections', 'Navigation', 'Taxonomies', 'Assets', 'Globals'];
 
@@ -324,6 +146,7 @@ class NavPreferencesTest extends TestCase
                     'content::collections' => '@inherit',
                     'content::navigation' => '@inherit',
                     'content::assets' => '@inherit',
+                    'content::site' => '@inherit',
                 ],
             ],
         ])->get('Content')->map->display()->all());
@@ -337,6 +160,7 @@ class NavPreferencesTest extends TestCase
                 'content::collections' => '@inherit',
                 'content::navigation' => '@inherit',
                 'content::assets' => '@inherit',
+                'content::site' => '@inherit',
             ],
         ])->get('Content')->map->display()->all());
 
@@ -351,6 +175,7 @@ class NavPreferencesTest extends TestCase
                         'content::collections' => '@inherit',
                         'content::navigation' => '@inherit',
                         'content::assets' => '@inherit',
+                        'content::site' => '@inherit',
                     ],
                 ],
             ],
@@ -392,6 +217,7 @@ class NavPreferencesTest extends TestCase
                     'content::collections' => '@inherit',
                     'content::navigation' => '@inherit',
                     'content::assets' => '@inherit',
+                    'content::site' => '@inherit',
                 ],
             ],
         ])->get('Content')->map->display()->all());
@@ -405,45 +231,7 @@ class NavPreferencesTest extends TestCase
                     'content::collections' => '@inherit',
                     'content::navigation' => '@inherit',
                     'content::assets' => '@inherit',
-                ],
-            ],
-        ])->get('Content')->map->display()->all());
-    }
-
-    #[Test]
-    public function it_handles_created_and_renamed_items_within_sections_properly_when_reordering()
-    {
-        $expected = [
-            'Collections',
-            'Taxonomeees',
-            'New Item',
-            'Assets',
-            'Globals',
-            'New Item At End',
-        ];
-
-        $this->assertEquals($expected, $this->buildNavWithPreferences([
-            'content' => [
-                'reorder' => [
-                    'content::collections',
-                    'content::taxonomies',
-                    'content::new_item', // We want to explicitly show this section item early in the order
-                    // 'content::new_item_at_end', // But let this one generate as an appended section at the end
-                ],
-                'items' => [
-                    'content::taxonomies' => [
-                        'action' => '@modify',
-                        'display' => 'Taxonomeees', // Even though this item has been renamed, it should still reorder using original item id
-                    ],
-                    'content::navigation' => '@hide', // Hide this, why not
-                    'content::new_item' => [
-                        'action' => '@create',
-                        'display' => 'New Item',
-                    ],
-                    'content::new_item_at_end' => [
-                        'action' => '@create',
-                        'display' => 'New Item At End',
-                    ],
+                    'content::site' => '@inherit',
                 ],
             ],
         ])->get('Content')->map->display()->all());
@@ -451,95 +239,6 @@ class NavPreferencesTest extends TestCase
 
     #[Test]
     public function it_can_reorder_child_items_within_an_item()
-    {
-        $defaultUtilitiesItems = ['Cache', 'Email', 'Licensing', 'PHP Info', 'Search'];
-
-        $this->assertEquals($defaultUtilitiesItems, $this->buildDefaultNav()->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all());
-
-        $reorderedUtilitiesItems = ['Search', 'Cache', 'Licensing', 'Email', 'PHP Info'];
-
-        // Recommended syntax...
-        $this->assertEquals($reorderedUtilitiesItems, $this->buildNavWithPreferences([
-            'tools' => [
-                'tools::utilities' => [
-                    'reorder' => [
-                        'tools::utilities::search',
-                        'tools::utilities::cache',
-                        'tools::utilities::licensing',
-                        'tools::utilities::email',
-                        'tools::utilities::php_info',
-                    ],
-                ],
-            ],
-        ])->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all());
-
-        // With full nesting of sections...
-        $this->assertEquals($reorderedUtilitiesItems, $this->buildNavWithPreferences([
-            'sections' => [
-                'tools' => [
-                    'tools::utilities' => [
-                        'reorder' => [
-                            'tools::utilities::search',
-                            'tools::utilities::cache',
-                            'tools::utilities::licensing',
-                            'tools::utilities::email',
-                            'tools::utilities::php_info',
-                        ],
-                    ],
-                ],
-            ],
-        ])->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all());
-
-        // Merge unmentioned items underneath...
-        $this->assertEquals($reorderedUtilitiesItems, $this->buildNavWithPreferences([
-            'tools' => [
-                'tools::utilities' => [
-                    'reorder' => [
-                        'tools::utilities::search',
-                        'tools::utilities::cache',
-                        'tools::utilities::licensing',
-                    ],
-                ],
-            ],
-        ])->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all());
-
-        // Ensure re-ordering items still works when modifying a item...
-        $this->assertEquals($reorderedUtilitiesItems, $this->buildNavWithPreferences([
-            'tools' => [
-                'tools::utilities' => [
-                    'reorder' => [
-                        'tools::utilities::search',
-                        'tools::utilities::cache',
-                        'tools::utilities::licensing',
-                    ],
-                    'children' => [
-                        'tools::utilities::cache' => [
-                            'action' => '@modify',
-                            'url' => '/cache-money',
-                        ],
-                    ],
-                ],
-            ],
-        ])->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all());
-
-        // If `reorder: false`, it should just use default item order...
-        $this->assertEquals($defaultUtilitiesItems, $this->buildNavWithPreferences([
-            'tools' => [
-                'tools::utilities' => [
-                    'reorder' => false,
-                ],
-            ],
-        ])->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all());
-
-        // If `reorder` is not specified, it should just use default item order...
-        $this->assertEquals(
-            $defaultUtilitiesItems,
-            $this->buildNavWithPreferences([])->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all(),
-        );
-    }
-
-    #[Test]
-    public function it_can_still_reorder_child_items_within_an_item_using_legacy_reorder_boolean_with_inherits()
     {
         $defaultUtilitiesItems = ['Cache', 'Email', 'Licensing', 'PHP Info', 'Search'];
 
@@ -637,47 +336,6 @@ class NavPreferencesTest extends TestCase
                         'tools::utilities::licensing' => '@inherit',
                         'tools::utilities::email' => '@inherit',
                         'tools::utilities::php_info' => '@inherit',
-                    ],
-                ],
-            ],
-        ])->get('Tools')->keyBy->display()->get('Utilities')->resolveChildren()->children()->map->display()->all());
-    }
-
-    #[Test]
-    public function it_handles_created_and_renamed_child_items_properly_when_reordering()
-    {
-        $expected = [
-            'Search',
-            'Cache Moneys!',
-            'New Child Item',
-            'Email',
-            'Licensing',
-            'PHP Info',
-            'New Child Item At End',
-        ];
-
-        $this->assertEquals($expected, $this->buildNavWithPreferences([
-            'tools' => [
-                'tools::utilities' => [
-                    'reorder' => [
-                        'tools::utilities::search',
-                        'tools::utilities::cache',
-                        'tools::utilities::new_item', // We want to explicitly show this section item early in the order
-                        // 'tools::utilities::new_item_at_end', // But let this one generate as an appended section at the end
-                    ],
-                    'children' => [
-                        'tools::utilities::cache' => [
-                            'action' => '@modify',
-                            'display' => 'Cache Moneys!', // Even though this item has been renamed, it should still reorder using original item id
-                        ],
-                        'tools::utilities::new_item' => [
-                            'action' => '@create',
-                            'display' => 'New Child Item',
-                        ],
-                        'tools::utilities::new_item_at_end' => [
-                            'action' => '@create',
-                            'display' => 'New Child Item At End',
-                        ],
                     ],
                 ],
             ],
@@ -1867,6 +1525,12 @@ class NavPreferencesTest extends TestCase
         // But still show empty section when `withHidden` flag is true, so that user can re-add items to this core/extended section...
         $this->assertEquals(['Top Level', 'Content', 'Fields', 'Tools', 'Settings', 'Users', 'SEO Pro'], $navWithHidden->keys()->all());
         $this->assertTrue($navWithHidden->get('SEO Pro')->isEmpty());
+    }
+
+    #[Test]
+    public function it_can_handle_a_bunch_of_useless_config_without_erroring()
+    {
+        $this->markTestSkipped();
     }
 
     #[Test]

--- a/tests/CP/Navigation/NavTransformerTest.php
+++ b/tests/CP/Navigation/NavTransformerTest.php
@@ -22,9 +22,6 @@ class NavTransformerTest extends TestCase
     {
         parent::setUp();
 
-        Facades\Collection::make('pages')->title('Pages')->save();
-        Facades\Collection::make('articles')->title('Articles')->save();
-
         // TODO: Other tests are leaving behind forms without titles that are causing failures here?
         Facades\Form::shouldReceive('all')->andReturn(collect());
     }
@@ -507,18 +504,18 @@ class NavTransformerTest extends TestCase
                         ],
                         'children' => [
                             [
+                                'id' => 'content::collections::pages',
+                                'manipulations' => [
+                                    'action' => '@modify',
+                                    'display' => 'Pagerinos',
+                                ],
+                            ],
+                            [
                                 'id' => 'content::collections::articles',
                                 'manipulations' => [
                                     'action' => '@modify',
                                     'url' => '/modified-articles-url',
                                     'icon' => 'custom-svg', // This should get stripped out, because icons cannot be on children
-                                ],
-                            ],
-                            [
-                                'id' => 'content::collections::pages',
-                                'manipulations' => [
-                                    'action' => '@modify',
-                                    'display' => 'Pagerinos',
                                 ],
                             ],
                         ],
@@ -842,15 +839,7 @@ class NavTransformerTest extends TestCase
             [
                 'display' => 'Content',
                 'items' => [
-                    ['id' => 'content::collections'],
                     ['id' => 'content::navigation'],
-                    [
-                        'id' => 'content::custom_item_one',
-                        'manipulations' => [
-                            'action' => '@create',
-                            'display' => 'Custom Item One',
-                        ],
-                    ],
                     [
                         'id' => 'content::taxonomies',
                         'manipulations' => [
@@ -859,12 +848,13 @@ class NavTransformerTest extends TestCase
                         ],
                     ],
                     ['id' => 'content::assets'],
+                    ['id' => 'content::collections'],
                     ['id' => 'content::globals'],
                     [
-                        'id' => 'content::custom_item_two',
+                        'id' => 'content::custom_item',
                         'manipulations' => [
                             'action' => '@create',
-                            'display' => 'Custom Item Two',
+                            'display' => 'Custom Item',
                         ],
                     ],
                 ],
@@ -874,73 +864,20 @@ class NavTransformerTest extends TestCase
         $expected = [
             'content' => [
                 'reorder' => [
-                    'content::collections',
                     'content::navigation',
-                    'content::custom_item_one',
-                    // The rest should omitted because they're left in same order at the end of the list, therefore redundant
+                    'content::taxonomies',
+                    'content::assets',
+                    'content::collections',
+                    'content::globals',
                 ],
                 'items' => [
                     'content::taxonomies' => [
                         'action' => '@modify',
                         'display' => 'Favourite Taxonomies',
                     ],
-                    'content::custom_item_one' => [
+                    'content::custom_item' => [
                         'action' => '@create',
-                        'display' => 'Custom Item One',
-                    ],
-                    'content::custom_item_two' => [
-                        'action' => '@create',
-                        'display' => 'Custom Item Two',
-                    ],
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expected, $transformed);
-    }
-
-    #[Test]
-    public function it_can_reorder_child_items()
-    {
-        $transformed = $this->transform([
-            [
-                'display' => 'Content',
-                'items' => [
-                    [
-                        'id' => 'content::collections',
-                        'manipulations' => [
-                            'action' => '@modify',
-                        ],
-                        'children' => [
-                            ['id' => 'content::collections::new_item', 'manipulations' => ['action' => '@create', 'display' => 'New Item']],
-                            ['id' => 'content::collections::pages'],
-                            ['id' => 'content::collections::articles'],
-                            ['id' => 'content::taxonomies::topics', 'manipulations' => ['action' => '@move']],
-                            ['id' => 'content::collections::new_item_at_end', 'manipulations' => ['action' => '@create', 'display' => 'New Item At End']],
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $expected = [
-            'content' => [
-                'content::collections' => [
-                    'action' => '@modify',
-                    'reorder' => [
-                        'content::collections::new_item',
-                        'content::collections::pages',
-                    ],
-                    'children' => [
-                        'content::collections::new_item' => [
-                            'action' => '@create',
-                            'display' => 'New Item',
-                        ],
-                        'content::taxonomies::topics' => '@move',
-                        'content::collections::new_item_at_end' => [
-                            'action' => '@create',
-                            'display' => 'New Item At End',
-                        ],
+                        'display' => 'Custom Item',
                     ],
                 ],
             ],
@@ -1119,87 +1056,6 @@ class NavTransformerTest extends TestCase
     {
         $transformed = $this->transform([
             ['display_original' => 'Top Level'],
-            ['display_original' => 'Content'],
-            [
-                'display' => 'Fields Customized',
-                'display_original' => 'Fields',
-                'items' => [
-                    [
-                        'id' => 'content::collections',
-                        'manipulations' => [
-                            'action' => '@alias',
-                        ],
-                    ],
-                ],
-            ],
-            [
-                'display' => 'Custom Section',
-                'action' => '@create',
-                'items' => [
-                    [
-                        'id' => 'content::collections::pages',
-                        'manipulations' => [
-                            'action' => '@alias',
-                        ],
-                    ],
-                ],
-            ],
-            ['display_original' => 'Tools'],
-            ['display_original' => 'Settings'],
-            ['display_original' => 'Users'],
-            [
-                'display' => 'Custom Section At End',
-                'action' => '@create',
-                'items' => [
-                    [
-                        'id' => 'content::collections::pages',
-                        'manipulations' => [
-                            'action' => '@alias',
-                        ],
-                    ],
-                ],
-            ],
-        ]);
-
-        $expected = [
-            'reorder' => [
-                'content',
-                'fields',
-                'custom_section',
-                // The rest should omitted because they're left in same order at the end of the list, therefore redundant
-            ],
-            'sections' => [
-                'fields' => [
-                    'display' => 'Fields Customized',
-                    'items' => [
-                        'content::collections' => '@alias',
-                    ],
-                ],
-                'custom_section' => [
-                    'display' => 'Custom Section',
-                    'action' => '@create',
-                    'items' => [
-                        'content::collections::pages' => '@alias',
-                    ],
-                ],
-                'custom_section_at_end' => [
-                    'display' => 'Custom Section At End',
-                    'action' => '@create',
-                    'items' => [
-                        'content::collections::pages' => '@alias',
-                    ],
-                ],
-            ],
-        ];
-
-        $this->assertEquals($expected, $transformed);
-    }
-
-    #[Test]
-    public function it_can_reorder_sections_but_ignores_custom_sections_left_at_the_end()
-    {
-        $transformed = $this->transform([
-            ['display_original' => 'Top Level'],
             [
                 'display_original' => 'Fields',
                 'items' => [
@@ -1214,7 +1070,6 @@ class NavTransformerTest extends TestCase
             ['display_original' => 'Tools'],
             ['display_original' => 'Content'],
             ['display_original' => 'Users'],
-            ['display_original' => 'Settings'],
             [
                 'display' => 'Custom Section',
                 'action' => '@create',
@@ -1235,8 +1090,6 @@ class NavTransformerTest extends TestCase
                 'tools',
                 'content',
                 'users',
-                // `Settings` and `Custom Section` are omitted because they are left over items in the same order they originally were, therefore redundant
-                // Also `Custom Section` is omitted because it's a new item at the end of the list, so it doesn't need to be in the order
             ],
             'sections' => [
                 'fields' => [
@@ -1278,15 +1131,15 @@ class NavTransformerTest extends TestCase
                         ],
                         'children' => [
                             [
-                                'id' => 'content::collections::articles',
-                                'manipulations' => [], // This item should be ignored
-                            ],
-                            [
                                 'id' => 'content::collections::pages', // This is the only item we're actually modifying
                                 'manipulations' => [
                                     'action' => '@modify',
                                     'display' => 'Pagerinos',
                                 ],
+                            ],
+                            [
+                                'id' => 'content::collections::articles',
+                                'manipulations' => [], // This item should be ignored
                             ],
                         ],
                     ],
@@ -1392,17 +1245,17 @@ class NavTransformerTest extends TestCase
     #[Test]
     public function it_can_transform_complex_json_payload_copied_from_actual_vue_submission()
     {
-        $transformed = $this->transform(json_decode('[{"display":"Top Level","display_original":"Top Level","action":false,"items":[{"id":"top_level::dashboard","manipulations":[],"children":[]},{"id":"content::collections::pages","manipulations":{"action":"@alias"},"children":[]},{"id":"tools::updates","manipulations":{"action":"@move"},"children":[]},{"id":"new_top_level_item","manipulations":{"action":"@create","display":"New Top Level Item","url":"\/new-top-level-item","icon":null},"children":[{"id":"new_child_item","manipulations":{"action":"@create","display":"New Child Item","url":"\/new-child-item","icon":null},"children":[]}]}]},{"display":"Content","display_original":"Content","action":false,"items":[{"id":"content::collections","manipulations":{"action":"@modify","reorder":["content::collections::new_item","content::collections::pages"]},"children":[{"id":"content::collections::new_item","manipulations":{"action":"@create","display":"New Item","url":"\/new"},"children":[]},{"id":"content::collections::pages","manipulations":[],"children":[]},{"id":"content::collections::articles","manipulations":[],"children":[]},{"id":"content::taxonomies::topics","manipulations":{"action":"@move"},"children":[]},{"id":"content::collections::new_item_at_end","manipulations":{"action":"@create","display":"New Item At End","url":"\/new"},"children":[]}]},{"id":"content::navigation","manipulations":{"action":"@hide"},"children":[]},{"id":"content::new_item","manipulations":{"action":"@create","display":"New Item","url":"\/new"},"children":[]},{"id":"content::taxonomies","manipulations":[],"children":[]},{"id":"content::assets","manipulations":[],"children":[{"id":"content::assets::assets","manipulations":[],"children":[]}]},{"id":"content::globals","manipulations":[],"children":[{"id":"content::globals::pricing","manipulations":[],"children":[]},{"id":"content::globals::settings","manipulations":[],"children":[]}]},{"id":"content::new_item_at_end","manipulations":{"action":"@create","display":"New Item At End","url":"\/end"},"children":[]}]},{"display":"Fieldsss","display_original":"Fields","action":false,"items":[{"id":"fields::fieldsets","manipulations":[],"children":[]},{"id":"fields::blueprints","manipulations":[],"children":[]}]},{"display":"Custom Section","display_original":"My Section","action":"@create","items":[{"id":"my_section::my_item","manipulations":{"action":"@create","display":"Custom item","url":"\/url","icon":null},"children":[]}]},{"display":"Tools","display_original":"Tools","action":false,"items":[{"id":"tools::forms","manipulations":[],"children":[]},{"id":"tools::addons","manipulations":[],"children":[]},{"id":"tools::utilities","manipulations":[],"children":[{"id":"tools::utilities::cache","manipulations":[],"children":[]},{"id":"tools::utilities::email","manipulations":[],"children":[]},{"id":"tools::utilities::licensing","manipulations":[],"children":[]},{"id":"tools::utilities::php_info","manipulations":[],"children":[]},{"id":"tools::utilities::search","manipulations":[],"children":[]}]}]},{"display":"Settings","display_original":"Settings","action":false,"items":[{"id":"settings::site","manipulations":[],"children":[]},{"id":"settings::preferences","manipulations":[],"children":[{"id":"settings::preferences::general","manipulations":[],"children":[]},{"id":"settings::preferences::cp_nav","manipulations":[],"children":[]}]}]},{"display":"Users","display_original":"Users","action":false,"items":[{"id":"users::users","manipulations":[],"children":[]},{"id":"users::groups","manipulations":[],"children":[]}]},{"display":"Custom Section At End","display_original":"Another section","action":"@create","items":[{"id":"users::permissions","manipulations":{"action":"@move"},"children":[{"id":"users::permissions::author","manipulations":[],"children":[]}]}]}]', true));
+        $transformed = $this->transform(json_decode('[{"display":"Top Level","display_original":"Top Level","action":false,"items":[{"id":"top_level::dashboard","manipulations":[],"children":[]},{"id":"content::collections::posts","manipulations":{"action":"@alias"},"children":[]},{"id":"tools::updates","manipulations":{"action":"@move"},"children":[]},{"id":"new_top_level_item","manipulations":{"action":"@create","display":"New Top Level Item","url":"\/new-top-level-item"},"children":[{"id":"new_child_item","manipulations":{"action":"@create","display":"New Child Item","url":"\/new-child-item"},"children":[]}]}]},{"display":"Fields","display_original":"Fields","action":false,"items":[{"id":"fields::blueprints","manipulations":{"display":"Blueprints Renamed","action":"@modify"},"children":[]},{"id":"fields::fieldsets","manipulations":[],"children":[]}]},{"display":"Content Renamed","display_original":"Content","action":false,"items":[{"id":"content::collections::pages","manipulations":{"action":"@move"},"children":[]},{"id":"content::collections","manipulations":{"action":"@modify"},"children":[{"id":"content::collections::posts","manipulations":{"display":"Posterinos","action":"@modify"},"children":[]}]},{"id":"content::navigation","manipulations":[],"children":[{"id":"content::navigation::nav_test","manipulations":[],"children":[]}]},{"id":"content::taxonomies","manipulations":[],"children":[]},{"id":"content::assets","manipulations":[],"children":[{"id":"content::assets::assets","manipulations":[],"children":[]},{"id":"content::assets::essthree","manipulations":[],"children":[]}]}]},{"display":"Custom Section","display_original":"Custom Section","action":"@create","items":[{"id":"custom_section::new_item","manipulations":{"action":"@create","display":"New Item","url":"\/new-item"},"children":[]},{"id":"content::taxonomies::tags","manipulations":{"action":"@move"},"children":[]},{"id":"content::globals","manipulations":{"action":"@move"},"children":[{"id":"content::globals::global","manipulations":[],"children":[]}]}]},{"display":"Tools","display_original":"Tools","action":false,"items":[{"id":"tools::forms","manipulations":[],"children":[{"id":"tools::forms::test","manipulations":[],"children":[]}]},{"id":"tools::addons","manipulations":[],"children":[]},{"id":"tools::utilities","manipulations":[],"children":[{"id":"tools::utilities::cache","manipulations":[],"children":[]},{"id":"tools::utilities::email","manipulations":[],"children":[]},{"id":"tools::utilities::licensing","manipulations":[],"children":[]},{"id":"tools::utilities::php_info","manipulations":[],"children":[]},{"id":"tools::utilities::search","manipulations":[],"children":[]}]}]},{"display":"Users","display_original":"Users","action":false,"items":[{"id":"users::users","manipulations":[],"children":[]},{"id":"users::groups","manipulations":[],"children":[]},{"id":"users::permissions","manipulations":[],"children":[{"id":"users::permissions::author","manipulations":[],"children":[]},{"id":"users::permissions::not_social_media_manager","manipulations":[],"children":[]},{"id":"users::permissions::social_media_manager","manipulations":[],"children":[]}]}]}]', true));
 
         $expected = [
             'reorder' => [
-                'content',
                 'fields',
+                'content',
                 'custom_section',
             ],
             'sections' => [
                 'top_level' => [
-                    'content::collections::pages' => '@alias',
+                    'content::collections::posts' => '@alias',
                     'tools::updates' => '@move',
                     'top_level::new_top_level_item' => [
                         'action' => '@create',
@@ -1417,68 +1270,44 @@ class NavTransformerTest extends TestCase
                         ],
                     ],
                 ],
-                'content' => [
-                    'reorder' => [
-                        'content::collections',
-                        'content::navigation',
-                        'content::new_item',
-                    ],
-                    'items' => [
-                        'content::collections' => [
-                            'action' => '@modify',
-                            'reorder' => [
-                                'content::collections::new_item',
-                                'content::collections::pages',
-                            ],
-                            'children' => [
-                                'content::collections::new_item' => [
-                                    'action' => '@create',
-                                    'display' => 'New Item',
-                                    'url' => '/new',
-                                ],
-                                'content::taxonomies::topics' => '@move',
-                                'content::collections::new_item_at_end' => [
-                                    'action' => '@create',
-                                    'display' => 'New Item At End',
-                                    'url' => '/new',
-                                ],
-                            ],
-                        ],
-                        'content::navigation' => '@hide',
-                        'content::new_item' => [
-                            'action' => '@create',
-                            'display' => 'New Item',
-                            'url' => '/new',
-                        ],
-                        'content::new_item_at_end' => [
-                            'action' => '@create',
-                            'display' => 'New Item At End',
-                            'url' => '/end',
-                        ],
+                'fields' => [
+                    'fields::blueprints' => [
+                        'action' => '@modify',
+                        'display' => 'Blueprints Renamed',
                     ],
                 ],
-                'fields' => [
-                    'display' => 'Fieldsss',
+                'content' => [
+                    'display' => 'Content Renamed',
                     'reorder' => [
-                        'fields::fieldsets',
+                        'content::collections::pages',
+                        'content::collections',
+                        'content::navigation',
+                        'content::taxonomies',
+                    ],
+                    'items' => [
+                        'content::collections::pages' => '@move',
+                        'content::collections' => [
+                            'action' => '@modify',
+                            'children' => [
+                                'content::collections::posts' => [
+                                    'action' => '@modify',
+                                    'display' => 'Posterinos',
+                                ],
+                            ],
+                        ],
                     ],
                 ],
                 'custom_section' => [
-                    'action' => '@create',
                     'display' => 'Custom Section',
-                    'items' => [
-                        'custom_section::custom_item' => [
-                            'action' => '@create',
-                            'display' => 'Custom item',
-                            'url' => '/url',
-                        ],
-                    ],
-                ],
-                'custom_section_at_end' => [
                     'action' => '@create',
-                    'display' => 'Custom Section At End',
                     'items' => [
-                        'users::permissions' => '@move',
+                        'custom_section::new_item' => [
+                            'action' => '@create',
+                            'display' => 'New Item',
+                            'url' => '/new-item',
+                        ],
+                        'content::taxonomies::tags' => '@move',
+                        'content::globals' => '@move',
                     ],
                 ],
             ],


### PR DESCRIPTION
This pull request reverts statamic/cms#11054 as it broke stuff for sites with existing nav preferences.

Fixes #12832
Fixes #12891
Fixes #12895
Fixes #12925