### PR TITLE
[5.x] Fix declarative shadow root elements inside nocache tags

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -267,7 +267,7 @@ class FileCacher extends AbstractCacher
 
         const regions = data.regions;
         for (var key in regions) {
-            if (map[key]) map[key].outerHTML = regions[key];
+            if (map[key]) map[key].setHTMLUnsafe(regions[key]);
         }
 
         for (const input of document.querySelectorAll('input[value="$csrfPlaceholder"]')) {


### PR DESCRIPTION
This pull request fixes an issue where declarative root elements wouldn't work inside the Nocache tag when using full-measure static caching.

Fixes #12685