### PR TITLE
[6.x] Fix re-used state in publish forms

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -284,9 +284,6 @@ import { computed, ref } from 'vue';
 import { Pipeline, Request, BeforeSaveHooks, AfterSaveHooks, PipelineStopped } from '@ui/Publish/SavePipeline.js';
 import { router } from '@inertiajs/vue3';
 
-let saving = ref(false);
-let errors = ref({});
-
 export default {
     mixins: [HasPreferences, HasActions],
 
@@ -395,16 +392,23 @@ export default {
             autosaveIntervalInstance: null,
             syncFieldConfirmationText: __('messages.sync_entry_field_confirmation_text'),
             pendingLocalization: null,
+
+            savingRef: ref(false),
+            errorsRef: ref({}),
         };
     },
 
     computed: {
+        containerRef() {
+            return computed(() => this.$refs.container);
+        },
+
         saving() {
-            return saving.value;
+            return this.savingRef.value;
         },
 
         errors() {
-            return errors.value;
+            return this.errorsRef.value;
         },
 
         formattedTitle() {
@@ -533,7 +537,11 @@ export default {
             }
 
             new Pipeline()
-                .provide({ container: computed(() => this.$refs.container), errors, saving })
+                .provide({
+                    container: this.containerRef,
+                    errors: this.errorsRef,
+                    saving: this.savingRef,
+                })
                 .through([
                     new BeforeSaveHooks('entry', {
                         collection: this.collectionHandle,

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -73,9 +73,6 @@ import { Button, Dropdown, DropdownItem, DropdownMenu, Header, PublishContainer,
 import { computed, ref } from 'vue';
 import { Pipeline, Request, BeforeSaveHooks, AfterSaveHooks, PipelineStopped } from '@ui/Publish/SavePipeline.js';
 
-let saving = ref(false);
-let errors = ref({});
-
 export default {
     components: {
         PublishComponents,
@@ -133,16 +130,23 @@ export default {
             readOnly: this.initialReadOnly,
             syncFieldConfirmationText: __('messages.sync_entry_field_confirmation_text'),
             pendingLocalization: null,
+
+            savingRef: ref(false),
+            errorsRef: ref({}),
         };
     },
 
     computed: {
+        containerRef() {
+            return computed(() => this.$refs.container);
+        },
+
         saving() {
-            return saving.value;
+            return this.savingRef.value;
         },
 
         errors() {
-            return errors.value;
+            return this.errorsRef.value;
         },
 
         somethingIsLoading() {
@@ -185,7 +189,11 @@ export default {
             if (!this.canSave) return;
 
             new Pipeline()
-                .provide({ container: computed(() => this.$refs.container), errors, saving })
+                .provide({
+                    container: this.containerRef,
+                    errors: this.errorsRef,
+                    saving: this.savingRef,
+                })
                 .through([
                     new BeforeSaveHooks('global-set', {
                         globalSet: this.initialHandle,

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -72,9 +72,6 @@ import { computed, ref } from 'vue';
 import { Pipeline, Request } from '@ui/Publish/SavePipeline.js';
 import { clone } from '@/bootstrap/globals.js';
 
-let saving = ref(false);
-let errors = ref({});
-
 export default {
     emits: ['closed', 'submitted', 'publish-info-updated', 'localized-fields-updated'],
 
@@ -97,13 +94,6 @@ export default {
         readOnly: Boolean,
     },
 
-    setup() {
-        return {
-            saving,
-            errors,
-        }
-    },
-
     data() {
         return {
             type: this.entry ? 'entry' : 'url',
@@ -117,10 +107,24 @@ export default {
             saveKeyBinding: null,
             publishContainer: 'tree-page',
             closingWithChanges: false,
+            savingRef: ref(false),
+            errorsRef: ref({}),
         };
     },
 
     computed: {
+        containerRef() {
+            return computed(() => this.$refs.container);
+        },
+
+        saving() {
+            return this.savingRef.value;
+        },
+
+        errors() {
+            return this.errorsRef.value;
+        },
+
         headerText() {
             return this.entry ? __('Link to Entry') : __('Nav Item');
         },
@@ -205,7 +209,11 @@ export default {
             const values = container.value.visibleValues;
 
             new Pipeline()
-                .provide({ container: computed(() => this.$refs.container), errors, saving })
+                .provide({
+                    container: this.containerRef,
+                    errors: this.errorsRef,
+                    saving: this.savingRef,
+                })
                 .through([new Request(postUrl, 'POST', {
                     type: this.type,
                     values,

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -155,9 +155,6 @@ import { ref, computed } from 'vue';
 import { Pipeline, Request, BeforeSaveHooks, AfterSaveHooks, PipelineStopped } from '@ui/Publish/SavePipeline.js';
 import ItemActions from '@/components/actions/ItemActions.vue';
 
-let saving = ref(false);
-let errors = ref({});
-
 export default {
     mixins: [HasPreferences, HasActions],
 
@@ -233,16 +230,23 @@ export default {
             quickSave: false,
             syncFieldConfirmationText: __('messages.sync_term_field_confirmation_text'),
             pendingLocalization: null,
+
+            savingRef: ref(false),
+            errorsRef: ref({}),
         };
     },
 
     computed: {
+        containerRef() {
+            return computed(() => this.$refs.container);
+        },
+
         saving() {
-            return saving.value;
+            return this.savingRef.value;
         },
 
         errors() {
-            return errors.value;
+            return this.errorsRef.value;
         },
 
         formattedTitle() {
@@ -329,7 +333,11 @@ export default {
             }
 
             new Pipeline()
-                .provide({ container: computed(() => this.$refs.container), errors, saving })
+                .provide({
+                    container: this.containerRef,
+                    errors: this.errorsRef,
+                    saving: this.savingRef,
+                })
                 .through([
                     new BeforeSaveHooks('entry', {
                         taxonomy: this.taxonomyHandle,

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -90,9 +90,6 @@ import ItemActions from '@/components/actions/ItemActions.vue';
 import { computed, ref } from 'vue';
 import { Pipeline, Request, BeforeSaveHooks, AfterSaveHooks, PipelineStopped } from '@ui/Publish/SavePipeline.js';
 
-let saving = ref(false);
-let errors = ref({});
-
 export default {
     mixins: [HasActions],
 
@@ -131,12 +128,25 @@ export default {
             values: clone(this.initialValues),
             meta: clone(this.initialMeta),
             error: null,
-            errors: {},
             title: this.initialTitle,
+            savingRef: ref(false),
+            errorsRef: ref({}),
         };
     },
 
     computed: {
+        containerRef() {
+            return computed(() => this.$refs.container);
+        },
+
+        saving() {
+            return this.savingRef.value;
+        },
+
+        errors() {
+            return this.errorsRef.value;
+        },
+
         isDirty() {
             return this.$dirty.has(this.publishContainer);
         },
@@ -145,7 +155,11 @@ export default {
     methods: {
         save() {
             new Pipeline()
-                .provide({ container: computed(() => this.$refs.container), errors, saving })
+                .provide({
+                    container: this.containerRef,
+                    errors: this.errorsRef,
+                    saving: this.savingRef,
+                })
                 .through([
                     new BeforeSaveHooks('user', {
                         values: this.values,


### PR DESCRIPTION
This pull request fixes an issue where the `container`, `errors` and `saving` state on Publish Form components was being shared across all instances of the components.

This wouldn't be an issue if we were using the Composition API for these components, but because we're not, the variables are being re-used. 

Fixes #12897