### PR TITLE
[6.x] Publish migration for `webauthn` table during upgrade process

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -253,6 +253,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Updates\RemoveParentField::class,
         Updates\UpdateGlobalVariables::class,
         Updates\PublishMigrationForTwoFactorColumns::class,
+        Updates\PublishMigrationForWebauthnTable::class,
         Updates\AddAddonSettingsToGitConfig::class,
     ];
 

--- a/src/UpdateScripts/PublishMigrationForWebauthnTable.php
+++ b/src/UpdateScripts/PublishMigrationForWebauthnTable.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Statamic\UpdateScripts;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class PublishMigrationForWebauthnTable extends UpdateScript
+{
+    public function shouldUpdate($newVersion, $oldVersion)
+    {
+        return $this->isUpdatingTo('6.0.0')
+            && config('statamic.users.repository', 'file') === 'eloquent';
+    }
+
+    public function update()
+    {
+        if (! $this->migrationExists('statamic_webauthn_table')) {
+            $stub = __DIR__.'/../Console/Commands/stubs/auth/statamic_webauthn_table.php.stub';
+            $filename = date('Y_m_d_His').'_statamic_webauthn_table.php';
+
+            File::put(database_path("migrations/$filename"), File::get($stub));
+
+            $this->console->line(sprintf(
+                'Migration <info>database/migrations/%s</info> created successfully.',
+                $filename
+            ));
+
+            $this->console->line('Run <comment>php artisan migrate</comment> to apply the migration.');
+        }
+    }
+
+    protected function migrationExists(string $name): bool
+    {
+        return collect(File::allFiles(database_path('migrations')))
+            ->map->getFilename()
+            ->filter(fn (string $filename) => Str::contains($filename, $name))
+            ->isNotEmpty();
+    }
+}


### PR DESCRIPTION
This pull request adds an update script to publish the migration for the new `webauthn` table, similar to how we're publishing the 2FA migrations.

Closes #12884