### PR TITLE
[6.x] Tidy up stack headers

### DIFF
--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -2,7 +2,7 @@
     <stack narrow name="publish-options" @closed="$emit('closed')" v-slot="{ close }">
         <div class="m-2 flex h-full flex-col rounded-xl bg-white dark:bg-gray-800">
             <header
-                class="flex items-center justify-between rounded-t-xl border-b border-gray-300 bg-gray-50 px-4 py-2 dark:border-gray-950 dark:bg-gray-900"
+                class="flex items-center justify-between rounded-t-xl border-b border-gray-300 px-4 mb-3 py-2 dark:border-gray-950 dark:bg-gray-800"
             >
                 <Heading size="lg">{{ __('Publish') }}</Heading>
                 <Button icon="x" variant="ghost" class="-me-2" @click="close" />

--- a/resources/js/components/nav/ItemEditor.vue
+++ b/resources/js/components/nav/ItemEditor.vue
@@ -2,7 +2,7 @@
     <stack narrow name="nav-item-editor" @closed="$emit('closed')" v-slot="{ close }">
         <div class="m-2 flex h-full flex-col rounded-xl bg-white dark:bg-gray-800">
             <div
-                class="flex items-center justify-between rounded-t-xl border-b border-gray-300 bg-gray-50 px-4 py-2 dark:border-gray-950 dark:bg-gray-900"
+                class="flex items-center justify-between rounded-t-xl border-b border-gray-300 px-4 mb-3 py-2 dark:border-gray-950 dark:bg-gray-800"
             >
                 <Heading size="lg">{{ creating ? __('Add Nav Item') : __('Edit Nav Item') }}</Heading>
                 <Button icon="x" variant="ghost" class="-me-2" @click="close" />

--- a/resources/js/components/nav/SectionEditor.vue
+++ b/resources/js/components/nav/SectionEditor.vue
@@ -2,7 +2,7 @@
     <stack narrow name="nav-item-editor" @closed="$emit('closed')" v-slot="{ close }">
         <div class="m-2 flex h-full flex-col rounded-xl bg-white dark:bg-gray-800">
             <div
-                class="flex items-center justify-between rounded-t-xl border-b border-gray-300 bg-gray-50 px-4 py-2 dark:border-gray-950 dark:bg-gray-900"
+                class="flex items-center justify-between rounded-t-xl border-b border-gray-300 px-4 mb-3 py-2 dark:border-gray-950 dark:bg-gray-800"
             >
                 <Heading size="lg">{{ creating ? __('Add Section') : __('Edit Section') }}</Heading>
                 <Button icon="x" variant="ghost" class="-me-2" @click="close" />

--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="m-2 flex h-full flex-col rounded-xl bg-white dark:bg-gray-800">
         <header
-            class="flex items-center justify-between rounded-t-xl border-b border-gray-300 bg-gray-50 px-4 py-2 dark:border-gray-950 dark:bg-gray-900"
+            class="flex items-center justify-between rounded-t-xl border-b border-gray-300 px-4 mb-3 py-2 dark:border-gray-950 dark:bg-gray-800"
         >
             <Heading size="lg">{{ __('Revision History') }}</Heading>
             <Button icon="x" variant="ghost" class="-me-2" @click="close" />


### PR DESCRIPTION
This tidies up the stack headers, for example, when editing a revision.

## Before

Currently, before this commit, the header section has a light-gray background, which feels like it's floating because of the border surrounding the stack.

The gap between the header and the first field also feels a bit off—I think it looks better if we match the vertical space between the fields here.

![2025-11-03 at 17 32 07@2x](https://github.com/user-attachments/assets/f4fc92b1-0f6c-471b-9d55-2f7842af3452)

This looks slightly better in dark mode because the stack border is more visible, but it's still distracting.

![2025-11-03 at 17 34 37@2x](https://github.com/user-attachments/assets/0f2fa3d8-dd5f-44fd-a8b2-5f90b14997f1)

## After

![2025-11-03 at 17 33 42@2x](https://github.com/user-attachments/assets/5b7ba9ac-4eea-46e8-a498-f4b648cb5a10)

![2025-11-03 at 17 34 20@2x](https://github.com/user-attachments/assets/49e25831-97f5-48a8-b50a-710773136444)
