### PR TITLE
[6.x] Prevent publish form jumping to top as sidebar shows/hides

### DIFF
--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -107,7 +107,7 @@ function tabHasError(tab) {
                     v-for="tab in mainTabs"
                     :key="tab.handle"
                     :name="tab.handle"
-                    :is="visibleMainTabs.length > 1 ? TabContent : 'template'"
+                    :is="visibleMainTabs.length > 1 ? TabContent : 'div'"
                 >
                     <TabProvider :tab="tab">
                         <slot :tab="tab">


### PR DESCRIPTION
This pull request fixes an issue where the browser would jump to the top of the page as the sidebar shows/hides at various page widths. 

It looks like it had to do with the duplicated section logic. As the window is resized, the sidebar is shown/hidden, which changes the length of the `visibleMainItems` state.

Due to the fact that we were rendering the `<Sections />` twice, it meant the component was mounted/remounted as the window width changed, causing the user to jump to the top of the page and the currently focused element to be reset.

Instead of rendering the sections twice, I've made them only render once, but the `TabContent` component only renders when there's more than 1 tab visible (for accessibility reasons).

Closes #12731
