### PR TITLE
[6.x] Prevent fieldtype components mounting twice 

### DIFF
--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -92,7 +92,7 @@ function tabHasError(tab) {
 <template>
     <ElementContainer @resized="width = $event.width">
         <div>
-            <Tabs v-if="width || true" v-model:modelValue="tab">
+            <Tabs v-if="width" v-model:modelValue="tab">
                 <TabList v-if="visibleMainTabs.length > 1" class="-mt-2 mb-6">
                     <TabTrigger
                         v-for="tab in visibleMainTabs"


### PR DESCRIPTION
This pull request fixes an issue where fieldtype components would be mounted twice.

This was happening because `width` is `null` by default, so `shouldShowSidebar` initially returns `false`.

However, when the `ElementContainer` component is mounted and emits a width, it causes `shouldShowSidebar` to return `true`, which in turn causes `mainTabs` to change (the sidebar isn't included anymore), which causes the fieldtype components to be re-mounted.

This PR fixes it by ensuring the tabs aren't rendered until we have the width back from the `ElementContainer`. We needed to add a wrapper `<div>` for the resize observer. 