### PR TITLE
[6.x] Fix error on navigation edit page

### DIFF
--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -7,7 +7,8 @@
             <div class="flex gap-2 sm:gap-3 grow items-center" @click="$emit('branch-clicked', page)">
                 <ui-status-indicator :status="page.status" v-tooltip="getStatusTooltip()" />
                 <ui-icon v-if="isRoot" name="home" class="size-4" v-tooltip="__('This is the root page')" />
-                <Link
+                <component
+                    :is="page.edit_url ? 'Link' : 'a'"
                     @click.prevent="$emit('edit', $event)"
                     :class="{ 'text-sm font-medium is-top-level-branch': isTopLevelBranch }"
                     :href="page.edit_url"


### PR DESCRIPTION
This pull request fixes an error from Inertia's `Link` component that would occur when `href` is `null`.