### PR TITLE
[6.x] Revision history tweaks

### DIFF
--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -19,7 +19,7 @@
             <div v-for="group in revisions" :key="group.day">
                 <Heading size="sm" class="p-3 text-gray-600 dark:text-gray-300" v-text="formatRelativeDate(group.day)" />
                 <div class="relative grid gap-3">
-                    <div class="absolute inset-y-0 left-6 border-l-1 border-gray-400 dark:border-gray-600 border-dashed" />
+                    <div class="absolute inset-y-0 left-6 top-3 border-l-1 border-gray-400 dark:border-gray-600 border-dashed" />
                     <revision
                         v-for="(revision, index) in group.revisions"
                         :key="revision.date"

--- a/resources/js/components/revision-history/Revision.vue
+++ b/resources/js/components/revision-history/Revision.vue
@@ -5,7 +5,7 @@
             'status-working-copy': revision.action === 'working',
             'status-published': revision.attributes.published,
             'border border-ui-accent-bg dark:border-dark-ui-accent-bg/90 rounded-lg py-2.5 bg-[hsl(from_var(--theme-color-ui-accent-bg)_h_s_97)] dark:bg-[hsl(from_var(--theme-color-dark-ui-accent-bg)_h_40_20)]': revision.attributes.current,
-            'bg-white dark:bg-gray-800 -mt-1': isLast,
+            'bg-gradient-to-b from-transparent from-60% to-white dark:to-gray-800 -mt-1': isLast,
         }"
         v-tooltip="revision.attributes.current ? __('Current Revision') : null"
         @click="open"


### PR DESCRIPTION
I'm sorry, I thought I was done with the revision history, but while making more screenshots today, I realised a few things needed tweaking.

Using `:last-child` in CSS wasn't reliable because of some extra DOM nodes to account for, so I did this in Vue instead, which is more robust in this instance.

I've faded out the connector line instead of blanking it out for the last child, which looks better when there's only one entry, e.g. one entry for today wouldn't get a line otherwise which looked odd.

Here's a screenshot anyway:

![2025-11-05 at 14 10 13@2x](https://github.com/user-attachments/assets/13cbe733-7de8-4de0-8c1d-e6658fb31794)

