### PR TITLE
[6.x] Blue text fix

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -22,7 +22,7 @@
                 <a :href="laravelDocsLink" target="_blank">{{ __('Learn more') }}</a>
                 <span v-if="helpBlock" class="italic text-gray-500 ltr:float-right rtl:float-left">
                     {{ __('Example') }}:
-                    <span class="italic text-ui-accent-text">{{ helpBlock }}</span>
+                    <span class="italic text-ui-accent-text dark:text-dark-ui-accent-text">{{ helpBlock }}</span>
                 </span>
             </Description>
 


### PR DESCRIPTION
A small fix for blue text that should be a ui accent text color instead of blue.

This is found in Validation hints like this, where it gives an example

![2025-11-05 at 14 43 13@2x](https://github.com/user-attachments/assets/a86e68c7-1a5f-4f94-8048-b2f72fc454f6)
