### PR TITLE
[6.x] Fix avatar squishing

### DIFF
--- a/resources/js/components/ui/Avatar.vue
+++ b/resources/js/components/ui/Avatar.vue
@@ -168,7 +168,7 @@ const meshGradientStyle = computed(() => {
 
 const avatarClasses = computed(() => {
     const classes = cva({
-        base: 'size-7 rounded-xl [button:has(&)]:rounded-xl shape-squircle',
+        base: 'size-7 rounded-xl [button:has(&)]:rounded-xl shape-squircle object-cover',
         variants: {
             type: {
                 avatar: '',


### PR DESCRIPTION
Currently if you pick an image that's _not_ square as your avatar, it gets squished like this:

## Before

![2025-11-05 at 17 16 41@2x](https://github.com/user-attachments/assets/2df931e1-df0f-4baa-bd8c-7ba4f37d5d00)


## After

This fixes that by using object-cover for avatars

![2025-11-05 at 17 16 26@2x](https://github.com/user-attachments/assets/3e9d55f5-cb5b-48a9-81a8-6409cc27da00)
