### PR TITLE
[6.x] Fix pro badge tooltip

### DIFF
--- a/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
@@ -71,7 +71,9 @@ class HandleAuthenticatedInertiaRequests
         return [
             'valid' => $licenses->valid(),
             'requestFailed' => $licenses->requestFailed(),
-            'requestFailureMessage' => $licenses->requestFailureMessage(),
+            'requestFailureMessage' => $licenses->requestFailed()
+                ? $licenses->requestFailureMessage()
+                : null,
             'isOnPublicDomain' => $licenses->isOnPublicDomain(),
             'alert' => ($alert = $licenses->licensingAlert()) ? [
                 ...$alert,


### PR DESCRIPTION
Currently, when you hover over the "Pro - Trial Mode" badge in the header, a tooltip is displayed complaining about communication issues with Statamic.com.

However.... there aren't any communication errors. Everything is fine. We just need a conditional around returning request failure messages.