### PR TITLE
[6.x] Fix the Markdown fieldtype from being pulled above the sidebar nav

### DIFF
--- a/resources/css/components/fieldtypes/markdown.css
+++ b/resources/css/components/fieldtypes/markdown.css
@@ -51,7 +51,7 @@
 ========================================================================== */
 [data-markdown-toolbar] {
     @apply flex items-center justify-between rounded-t-[calc(var(--radius-lg)-1px)] bg-gray-50 px-2 py-1 overflow-x-auto;
-    @apply sticky -top-2 z-8 border-b border-gray-300 dark:border-white/20 dark:border-b-white/10 dark:bg-gray-925;
+    @apply sticky z-(--z-index-global-header) -top-2 border-b border-gray-300 dark:border-white/20 dark:border-b-white/10 dark:bg-gray-925;
     /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
     margin-block-end: 8px;
     /* Pull the subsequent element up to compensate for this */

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -72,7 +72,7 @@
                                 @drop="draggingFile = false"
                                 @keydown="shortcut"
                             >
-                                <div class="editor relative top-[0.5px] z-6 st-text-legibility focus-within:focus-outline" ref="codemirror">
+                                <div class="editor relative top-[0.5px] z-(--z-index-above) st-text-legibility focus-within:focus-outline" ref="codemirror">
                                     <div
                                         v-if="showFloatingToolbar && toolbarIsFloating && !isReadOnly"
                                         class="markdown-floating-toolbar absolute z-50 flex items-center gap-1 rounded-lg border border-gray-300 bg-white px-2 py-1 shadow-lg dark:border-white/10 dark:bg-gray-900"


### PR DESCRIPTION
I noticed that the Markdown field was being pulled above the nav sidebar like this:

![2025-11-06 at 11 13 52@2x](https://github.com/user-attachments/assets/60a970af-44c4-4284-b947-c4fd01b69eee)

This PR fixes that, assigning the hard-coded z-indexes to variables