### PR TITLE
[6.x] Differentiate border behaviour between the button group fieldtype and the button group in the floating toolbar

### DIFF
--- a/resources/css/elements/buttons.css
+++ b/resources/css/elements/buttons.css
@@ -4,9 +4,13 @@
     [data-ui-button-group] {
         /* Base styles for all buttons in groups */
         [data-ui-group-target] {
-            /* Only the first child gets a left border on higher MQs */
+            /* Only the first child gets a left border. Exclude the floating toolbar from this, because we handle things slightly differently for that */
+            &:not(:first-child, [data-floating-toolbar] *) {
+                border-inline-start: 0;
+            }
+            /* With the floating toolbar, we instead only group buttons at higher MQs. At lower MQs the buttons are separated and have borders on all sides */
             @media (width >= 1024px) {
-                &:not(:first-child) {
+                [data-floating-toolbar] &:not(:first-child) {
                     border-inline-start: 0;
                 }
             }


### PR DESCRIPTION
I think we need to handle button groups slightly differently depending on whether they're in the floating toolbar or if they're in the standard fieldtype.

The chances of "wrapping" in the floating toolbar is high at smaller MQs so it's sensible to change their appearance to button "islands" rather than a flush row, which we already do, like this:

(You can see this in Assets)

![2025-11-06 at 11 57 10@2x](https://github.com/user-attachments/assets/1310012a-76cd-4154-9d49-35d59bcdef50)

- This means that at lower media queries we should exclude the floating toolbar from the "remove the left button border" behaviour.
- Instead, we should only "remove the left button border" for the floating toolbar buttons at higher MQs when the floating toolbar switches to the standard button group layout 