### PR TITLE
[6.x] Fix locale select text contrast

### DIFF
--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -85,7 +85,7 @@ class CorePreferences
                 ['label' => $label, 'native' => $native] = $item;
 
                 if ($locale !== $current && $label !== $native) {
-                    $label .= '<span class="ms-4 text-gray-600">'.$native.'</span>';
+                    $label .= '<span class="ms-4 text-gray-500 dark:text-gray-400">'.$native.'</span>';
                 }
 
                 return $label;


### PR DESCRIPTION
Fix the text in this dropdown to pass AA in dark mode

## Before

![2025-11-06 at 14 39 11@2x](https://github.com/user-attachments/assets/1f4d9638-b261-4550-abad-8b85b24bd7f9)


## After

![2025-11-06 at 14 38 34@2x](https://github.com/user-attachments/assets/446e71a4-c920-4f03-ac75-d4c57f18f468)

![2025-11-06 at 14 38 28@2x](https://github.com/user-attachments/assets/5509866d-ef03-4a95-9069-95c7b33e9b07)
