### PR TITLE
[6.x] Adjust empty state empty screens on mobile

### DIFF
--- a/packages/ui/src/EmptyState/Item.vue
+++ b/packages/ui/src/EmptyState/Item.vue
@@ -34,7 +34,7 @@ const hasSlot = !!slots.default;
             class="w-full flex gap-2 px-3 pt-4 pb-5.5 items-start hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md group cursor-pointer"
         >
             <Icon :name="icon" class="size-6 me-4 mt-1 text-gray-400" />
-            <div class="flex-1 mb-4 md:mb-0 me-6 text-start">
+            <div class="flex-1 me-6 text-start">
                 <ui-heading size="xl" :level="3" :text="heading" class="mb-1.5 font-semibold" />
                 <ui-description v-if="description" :text="description" />
                 <slot />


### PR DESCRIPTION
A small PR that removes mobile-specific margin for the empty state, which seems not needed

## Before

![2025-11-06 at 15 49 08@2x](https://github.com/user-attachments/assets/7a74da7c-ca7b-470d-9eb9-b2f2a4d00fec)

## After

![2025-11-06 at 15 49 26@2x](https://github.com/user-attachments/assets/3d721bb1-000c-4b96-acf2-e3ce242529e4)
