### PR TITLE
[6.x] Add alternative keyboard shortcut for toggling the nav

### DIFF
--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -90,7 +90,7 @@ function handleChildClick(item, child) {
     }
 }
 
-Statamic.$keys.bind(['command+\\'], (e) => {
+Statamic.$keys.bind(['command+\\', ['[']], (e) => {
     e.preventDefault();
     toggle();
 });


### PR DESCRIPTION
This pull request adds an alternative keyboard shortcut for toggling the nav: `[`. 

HelpScout (the ticketing software) uses the same shortcut. Personally, I quite like it. 

Fixes #12230