### PR TITLE
[6.x] Fix page tree links

### DIFF
--- a/resources/js/components/structures/Branch.vue
+++ b/resources/js/components/structures/Branch.vue
@@ -7,8 +7,7 @@
             <div class="flex gap-2 sm:gap-3 grow items-center" @click="$emit('branch-clicked', page)">
                 <ui-status-indicator :status="page.status" v-tooltip="getStatusTooltip()" />
                 <ui-icon v-if="isRoot" name="home" class="size-4" v-tooltip="__('This is the root page')" />
-                <component
-                    :is="page.edit_url ? 'Link' : 'a'"
+                <a
                     @click.prevent="$emit('edit', $event)"
                     :class="{ 'text-sm font-medium is-top-level-branch': isTopLevelBranch }"
                     :href="page.edit_url"


### PR DESCRIPTION
This pull request fixes an issue where clicking an entry title in the nav tree would take you to the entry's edit page, rather than open up the page stack.

This link should stay as a normal `<a>` so right clicking and opening in a new tab works, but "normal" clicks will emit the `edit` event.