### PR TITLE
[6.x] Widget headers are optional

### DIFF
--- a/resources/js/components/ui/Widget.vue
+++ b/resources/js/components/ui/Widget.vue
@@ -20,7 +20,7 @@ const hasHeader = computed(() => Boolean(props.title || props.icon || slots.acti
             <header v-if="hasHeader" class="flex items-center min-h-[49px] justify-between border-b border-gray-200 px-4.5 py-2 dark:border-gray-700">
                 <component :is="href ? Link : 'div'" class="flex items-center gap-2 sm:gap-3" :href>
                     <Icon v-if="icon" :name="icon" class="hidden! size-5 text-gray-500 @xs/widget:block!" />
-                    <span v-text="title" />
+                    <span v-if="title" v-text="title" />
                 </component>
                 <div class="flex items-center gap-4 -mr-2.5">
                     <slot name="actions" />


### PR DESCRIPTION
Wrap the widget component's header in a named slot to allow components without headers or with custom headers.

### Example

Use case: we have a map widget that doesn't need – and looks better without – a header. Rendering an empty slot requires passing in an empty `span` or `div`. Just an empty `template` tag won't do, that's a limitation of Vue I think.

```html
<ui-widget>
    <template v-slot:header><span></span></template>
    <div id="map"></div>
    <script type="module">
        const map = new mapboxgl.Map({ container: 'map', center: [2.2940, 48.8598] });
    </script>
</ui-widget>
```

<img width="759" height="514" alt="Screenshot 2025-11-07 at 10 08 58" src="https://github.com/user-attachments/assets/0d5ed338-5942-4620-a323-922b854b7564" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> `Widget.vue` now shows the header only if `title`, `icon`, or `actions` slot exist; props updated and icon/title rendered conditionally.
> 
> - **UI: `resources/js/components/ui/Widget.vue`**
>   - **Conditional header**: Introduces `hasHeader` (via `useSlots`/`computed`) to render `<header>` only when `title`, `icon`, or `actions` slot is present.
>   - **Conditional content**: Renders `Icon` and title only if corresponding props are provided.
>   - **Props update**: Replaces loose `defineProps` with typed `props`; removes default icon and `href` requirement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 737dadcd09366aaeafd9e13bb3c37ffbe454d6de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->