### PR TITLE
[5.x] Require url in nocache request

### DIFF
--- a/src/StaticCaching/NoCache/Controller.php
+++ b/src/StaticCaching/NoCache/Controller.php
@@ -10,7 +10,9 @@ class Controller
 {
     public function __invoke(Request $request, Session $session)
     {
-        $url = $request->input('url', '');
+        $request->validate(['url' => 'required|string']);
+
+        $url = $request->input('url');
 
         if (config('statamic.static_caching.ignore_query_strings', false)) {
             $url = explode('?', $url)[0];

--- a/tests/StaticCaching/NocacheRouteTest.php
+++ b/tests/StaticCaching/NocacheRouteTest.php
@@ -55,10 +55,10 @@ class NocacheRouteTest extends TestCase
     }
 
     #[Test]
-    public function it_handles_null_url_in_route()
+    public function url_is_required()
     {
         $this
             ->postJson('/!/nocache')
-            ->assertOk();
+            ->assertJsonValidationErrorFor('url');
     }
 }


### PR DESCRIPTION
It's possible to generate 500 errors by sending POST requests to `/!/nocache` with no parameters, because the `$url` will be null which the `->setUrl` function doesn't like. This PR adds a default here which mitigates the error. Alternatively, we could handle it with a validation error.

I've also added a simple test to test this behavior.