### PR TITLE
[6.x] Add "Done" button to listing filters stack

### DIFF
--- a/resources/js/components/ui/Listing/Filters.vue
+++ b/resources/js/components/ui/Listing/Filters.vue
@@ -154,6 +154,7 @@ function handleStackClosed() {
                             />
                         </Card>
                     </Panel>
+                    <Button variant="primary" :text="__('Done')" @click="handleStackClosed" />
                 </div>
             </div>
         </stack>


### PR DESCRIPTION
This pull request adds a "Done" button to the listing filters stack. Useful if you're in a small window, and the filters stack is all you can see.

<img width="587" height="550" alt="CleanShot 2025-11-07 at 11 22 11" src="https://github.com/user-attachments/assets/f01111cd-4ca2-46f8-b550-a277dcb087e2" />


Closes #12372