### PR TITLE
[6.x] Ensure `hiddenFields` state is correct

### DIFF
--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -110,7 +110,7 @@ function tabHasError(tab) {
                         :key="tab.handle"
                         :name="tab.handle"
                         :is="hasMultipleVisibleMainTabs ? TabContent : 'div'"
-                        force-mount
+                        :force-mount="hasMultipleVisibleMainTabs ? true : null"
                         :class="{ 'hidden': tab.handle !== activeTab }"
                     >
                         <TabProvider :tab="tab">


### PR DESCRIPTION
This pull request fixes an issue where the `hiddenFields` state for conditional fields in publish forms wouldn't be correct until you navigate to all the tabs.

This was happening because the `TabsContent` component only mounts the active tab by default, which meant that `ShowField.js` wouldn't set the hidden field state for fields in other tabs.

This PR fixes it by ensuring all tabs are mounted when the publish form loads, mirroring the behaviour in v5.

Fixes #12478