### PR TITLE
[6.x] Ensure custom icons with fixed width/height are sized correctly

### DIFF
--- a/resources/js/components/fieldtypes/IconFieldtype.vue
+++ b/resources/js/components/fieldtypes/IconFieldtype.vue
@@ -79,7 +79,7 @@ request();
             <div class="flex items-center">
                 <div class="size-4">
                     <Icon v-if="!option.html" :name="option.label" class="size-4" />
-                    <div v-if="option.html" v-html="option.html" class="size-4" />
+                    <div v-if="option.html" v-html="option.html" class="[&>svg]:size-4" />
                 </div>
                 <span class="ms-3 truncate">
                     {{ __(option.label) }}
@@ -89,7 +89,7 @@ request();
         <template #selected-option="{ option }">
             <div class="flex items-center">
                 <Icon v-if="!option.html" :name="option.label" class="flex size-4 items-center" />
-                <div v-if="option.html" v-html="option.html" class="size-4" />
+                <div v-if="option.html" v-html="option.html" class="[&>svg]:size-4" />
                 <span class="ms-3 truncate text-sm text-gray-900 dark:text-gray-200">
                     {{ __(option.label) }}
                 </span>


### PR DESCRIPTION
This pull request fixes an issue where custom icons with fixed widths & heights aren't sized correctly in the Icon fieldtype.

Fixes #12944