### PR TITLE
[6.x] Fix live preview device select

### DIFF
--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -435,12 +435,12 @@ defineExpose({
 </template>
 
 <style scoped>
-    /* We can't use a direct descendant selector because the stack is inside a portal, so instead we'll check to see if there is a stack present. */
+    /* Override the hardcoded z-index of Reka's popper content wrapper. We can't use a direct descendant selector because the stack is inside a portal, so instead we'll check to see if there is a stack present. */
     body:has(.stack, .live-preview) [data-reka-popper-content-wrapper] {
         z-index: var(--z-index-portal)!important;
     }
 
-    /* When there's a modal present, we need to ensure the popper content is above it. We can't use a direct descendant selector because the modal is inside a portal, so instead we'll check to see if there is modal content present. */
+    /* Override the hardcoded z-index of Reka's popper content wrapper. When there's a modal present, we need to ensure the popper content is above it. We can't use a direct descendant selector because the modal is inside a portal, so instead we'll check to see if there is modal content present. */
     body:has([data-ui-modal-content]) [data-reka-popper-content-wrapper] {
         z-index: var(--z-index-modal)!important;
     }


### PR DESCRIPTION
This fixes the z-index of the device select on Live Preview. This is a little hacky but the z-index of Reka's popper content wrapper is hardcoded as a value, so this is the cleanest way to override it and make it fall into our defined z-index stack.

![2025-11-07 at 15 46 45@2x](https://github.com/user-attachments/assets/76103720-574d-4d9e-a06e-a4251d9a9d96)
