### PR TITLE
[6.x] Fix Bard's floating toolbar in fullscreen mode

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -61,7 +61,7 @@
                         <bubble-menu
                             :editor="editor"
                             :key="`bubble-menu-${fullScreenMode}`"
-                            :options="{ placement: 'bottom', offset: [0, 10] }"
+                            :options="{ placement: 'top', offset: [0, 10] }"
                             v-if="editor && toolbarIsFloating && !readOnly"
                         >
                         <div class="bard-floating-toolbar">


### PR DESCRIPTION
This pull request fixes an issue where Bard's floating toolbar wasn't showing in fullscreen mode. 

This PR fixes it by adding a dynamic key to TipTap's `bubble-menu` component, ensuring its remounted when switching between modes.

Fixes #12142