### PR TITLE
[6.x] Increase combobox text size

### DIFF
--- a/packages/ui/src/Combobox.vue
+++ b/packages/ui/src/Combobox.vue
@@ -66,9 +66,9 @@ const triggerClasses = cva({
         size: {
             xl: 'px-5 h-12 text-lg rounded-lg',
             lg: 'px-4 h-12 text-base rounded-lg',
-            base: 'px-4 h-10 text-sm rounded-lg',
-            sm: 'px-3 h-8 text-[0.8125rem] rounded-lg',
-            xs: 'px-2 h-6 text-xs rounded-md',
+            base: 'px-4 h-10 text-md rounded-lg',
+            sm: 'px-3 h-8 text-sm rounded-lg',
+            xs: 'px-2 h-6 text-[0.8125rem] rounded-md',
         },
         readOnly: {
             true: 'border-dashed',


### PR DESCRIPTION
I think the combobox font-size should be bumped up a level so it's the same as regular text fields.

At its current size, I find it strains my eyes a touch. See what you think…

## Before

Here it's `text-sm` and a little smaller than a regular text field.

![2025-11-10 at 12 23 45@2x](https://github.com/user-attachments/assets/f1e9826a-9305-456e-8c23-15ea747bc627)

## After

I've bumped to `text-md` which makes it the same size as a text field. I've also shifted the rest of the size scale so the're bumped up a level.

![2025-11-10 at 12 23 19@2x](https://github.com/user-attachments/assets/a13ff45f-378f-40a5-96ce-39d633438aa3)
