### PR TITLE
[6.x] Fix create folder color

### DIFF
--- a/resources/js/components/assets/Browser/Table.vue
+++ b/resources/js/components/assets/Browser/Table.vue
@@ -63,7 +63,8 @@
                         <a class="group flex cursor-pointer items-center">
                             <file-icon
                                 extension="folder"
-                                class="me-2 inline-block size-8 text-ui-accent-text group-hover:text-ui-accent-text/80 dark:text-dark-ui-accent-text dark:group-hover:text-dark-ui-accent-text/80"
+                                class="me-2 inline-block size-8 text-blue-400/90 group-hover:text-blue-400
+                                dark:text-blue-400/90 dark:group-hover:text-blue-400"
                             />
                             <Editable
                                 ref="newFolderInput"


### PR DESCRIPTION
Newly created folders should be blue, like regular folders, rather than an accent color.
This falls in line with the convention of blue for selection/focus UI, and accent for other things