### PR TITLE
[6.x] Hide "Your Session is Expiring" modal when 2FA modal is open

### DIFF
--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -1,8 +1,8 @@
 <template>
     <div class="session-expiry">
         <Modal
-            v-if="isWarning && !isShowingLogin"
-            :open="isWarning && !isShowingLogin"
+            v-if="isWarning && !isShowingLogin && !isShowingTwoFactorChallenge"
+            :open="isWarning && !isShowingLogin && !isShowingTwoFactorChallenge"
             :title="__('Your Session is Expiring')"
             class="max-w-[500px]!"
             :dismissible="false"


### PR DESCRIPTION
This pull request fixes an issue where the "Your Session is Expiring" modal would show on top of the 2FA modal.

Closes #12483
