### PR TITLE
[5.x] Add Glide Asset Cleared Event

### DIFF
--- a/src/Events/GlideAssetCacheCleared.php
+++ b/src/Events/GlideAssetCacheCleared.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Statamic\Events;
+
+class GlideAssetCacheCleared extends Event
+{
+    public function __construct(public $asset)
+    {
+    }
+}

--- a/src/Imaging/GlideManager.php
+++ b/src/Imaging/GlideManager.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
 use League\Glide\ServerFactory;
+use Statamic\Events\GlideAssetCacheCleared;
 use Statamic\Facades\Config;
 use Statamic\Facades\Image;
 use Statamic\Imaging\ResponseFactory as LaravelResponseFactory;
@@ -137,6 +138,8 @@ class GlideManager
 
         // Clear manifest itself from cache store.
         $this->cacheStore()->forget($manifestKey);
+
+        GlideAssetCacheCleared::dispatch($asset);
     }
 
     public function normalizeParameters($params)


### PR DESCRIPTION
## Add Glide Asset Cleared Event

This pull request adds a new event that is triggered when Glide assets are cleared.

### Changes

- New `AssetCleared` event for Glide cache asset cleanup operation

### Benefits

- Better traceability when clearing cache files