### PR TITLE
[6.x] Prevent divide y borders where child is hidden

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -1,3 +1,12 @@
+/* UTILITIES / EXTENDED TAILWIND CLASSES
+=================================================== */
+/* Here we extend Tailwind's classes to add additional functionality where we're sure it won't break anything. */
+
+/* If the next sibling is hidden (by a Vue conditional), remove the bottom border. For example, /cp/asset-containers/assets/edit, the Image Manipulation toggle. */
+.divide-y > *:has(+[style*="display: none"]) {
+    border-block-end: none;
+}
+
 /* UTILITIES / LAYOUT
 =================================================== */
 [v-cloak],


### PR DESCRIPTION
## The problem

Where `divide-y` is present, sometimes there is a row that's conditionally hidden by Vue by an added `style=" display: none;"`.

This essentially breaks the logic of `divide-y` because the child is still in the DOM, so we see a bottom border in the screenshot below.

![2025-11-11 at 11 21 41@2x](https://github.com/user-attachments/assets/57f7c1cb-98bf-4d0f-876a-02718c433fe3)

To replicate this, go to `cp/asset-containers/assets/edit` and make sure the Image Manipulation toggle is turned on, which hides the subsequent row.

## Solution

Rather than add an inline style or another class I thought it was best to effectively "extend" the Tailwind class. This is a very specific selector and I can't see a situation where we _wouldn't_ want this to happen