### PR TITLE
[6.x] Use correct mathematical symbol for display of dimensions

### DIFF
--- a/resources/lang/ar/messages.php
+++ b/resources/lang/ar/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'يمكن تعيين المستخدمين إلى أدوار تخصص أذوناتهم، وصولهم، وقدراتهم في لوحة التحكم.',
     'user_wizard_super_admin_instructions' => 'يمنح المستخدم سوبر أدمن وصولاً غير محدود إلى كل شيء في لوحة التحكم. يرجى توخي الحذر عند منح هذا الدور.',
     'view_more_count' => 'عرض :count المزيد',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/az/messages.php
+++ b/resources/lang/az/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'İstifadəçilərə İdarəetmə Panelində icazələrini, girişlərini və bacarıqlarını fərdiləşdirən rollar təyin edilə bilər.',
     'user_wizard_super_admin_instructions' => 'Super administratorlar idarə panelində hər şeyə tam nəzarət və giriş imkanı verir. Bu rolu ağılla verin.',
     'view_more_count' => ':count daha çoxunu göstər',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/cs/messages.php
+++ b/resources/lang/cs/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Uživatelům lze přidělit role, které přizpůsobí jejich oprávnění, přístup a možnosti v celém ovládacím panelu.',
     'user_wizard_super_admin_instructions' => 'Superadministrátoři mají úplnou kontrolu a přístup ke všemu v ovládacím panelu. Tuto roli přidělujte s rozmyslem.',
     'view_more_count' => 'Zobrazit :count více',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/da/messages.php
+++ b/resources/lang/da/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Brugere kan tildeles roller, der tilpasser deres tilladelser, adgang og muligheder i hele kontrolpanelet.',
     'user_wizard_super_admin_instructions' => 'Superadministratorer har fuld kontrol og adgang til alt i kontrolpanelet. Vær forsigtig med at tildele denne rolle.',
     'view_more_count' => 'Se :count mere',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -282,5 +282,5 @@ return [
     'user_wizard_invitation_subject' => 'Activate your new Statamic account on :site',
     'user_wizard_roles_groups_intro' => 'Users can be assigned to roles that customize their permissions, access, and abilities throughout the Control Panel.',
     'user_wizard_super_admin_instructions' => 'Super admins have complete control and access to everything in the control panel. Grant this role wisely.',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/es/messages.php
+++ b/resources/lang/es/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Los usuarios pueden ser asignados a roles que personalizan sus permisos, acceso y habilidades en todo el Panel de Control.',
     'user_wizard_super_admin_instructions' => 'Los super-administradores tienen control y acceso completos a todo en el Panel de Control. Concede este rol sabiamente.',
     'view_more_count' => 'Ver :count más',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/fr/messages.php
+++ b/resources/lang/fr/messages.php
@@ -284,5 +284,5 @@ return [
     'user_wizard_invitation_subject' => 'Activez votre nouveau compte Statamic sur :site',
     'user_wizard_roles_groups_intro' => 'Les utilisateurs peuvent se voir attribuer des rôles qui personnalisent leurs autorisations, accès et possibilités d’agir au sein du Panneau de configuration.',
     'user_wizard_super_admin_instructions' => 'Les super-admin ont le contrôle complet du système et l’accès à tout ce qui se trouve dans le Panneau de configuration. Accordez ce rôle à bon escient.',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/hu/messages.php
+++ b/resources/lang/hu/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'A felhasználók szerepekhez rendelhetők. Így könnyen személyre szabhatjuk a felhasználók hozzáféréseit a Vezérlőpult részeihez.',
     'user_wizard_super_admin_instructions' => 'A Szuper Adminisztrátorok teljes körű hozzáféréssel rendelkeznek mindenhez a Vezérlőpulton. Ügyeljen, kinek adja ezt a szerepet!',
     'view_more_count' => 'Nézd meg :count többet',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/id/messages.php
+++ b/resources/lang/id/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Pengguna dapat diberikan peran yang menyesuaikan izin, akses, dan kemampuannya di seluruh Panel Kontrol.',
     'user_wizard_super_admin_instructions' => 'Admin super memiliki kontrol penuh dan akses ke semua yang ada di panel kontrol. Berikan peran ini dengan bijak.',
     'view_more_count' => 'Lihat :count lebih banyak',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/it/messages.php
+++ b/resources/lang/it/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Gli utenti possono essere assegnati a ruoli che personalizzano le loro autorizzazioni, accesso e capacità in tutto il pannello di controllo.',
     'user_wizard_super_admin_instructions' => 'I Super Admin hanno il controllo completo e l\'accesso a tutto il pannello di controllo. Concedi saggiamente questo ruolo.',
     'view_more_count' => 'Visualizza ulteriori :count',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/ja/messages.php
+++ b/resources/lang/ja/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'ユーザーは、コントロール パネル全体で権限、アクセス、機能をカスタマイズする役割に割り当てることができます。',
     'user_wizard_super_admin_instructions' => 'スーパー管理者は、コントロール パネル内のすべてを完全に制御し、アクセスできます。この役割を賢明に与えてください。',
     'view_more_count' => '表示:count',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/ms/messages.php
+++ b/resources/lang/ms/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Pengguna boleh diberikan kepada peranan yang menyesuaikan kebenaran, akses dan kebolehan mereka di seluruh Panel Kawalan.',
     'user_wizard_super_admin_instructions' => 'Pentadbir super mempunyai kawalan penuh dan akses kepada semua dalam panel kawalan. Berikan peranan ini dengan bijak.',
     'view_more_count' => 'Lihat :count lagi',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/nb/messages.php
+++ b/resources/lang/nb/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Brukere kan tildeles roller som definerer hva de skal ha av tillatelser, tilganger og muligheter overalt i kontrollpanelet.',
     'user_wizard_super_admin_instructions' => 'Superadministratorer får full kontroll og tilgang til alt i kontrollpanelet. Tenk derfor nøye gjennom hvem du vil gi denne rollen til.',
     'view_more_count' => 'Vis :count flere',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/nl/messages.php
+++ b/resources/lang/nl/messages.php
@@ -294,5 +294,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Aan gebruikers kunnen rollen toegewezen worden die hun bevoegdheden, toegang en mogelijkheden in het Control Panel aanpassen.',
     'user_wizard_super_admin_instructions' => 'Super admins hebben volledige controle over het Control Panel en kunnen alles wijzigen. Ga hier verstandig mee om.',
     'view_more_count' => 'Bekijk :count meer',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/pl/messages.php
+++ b/resources/lang/pl/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Użytkownikom można przypisywać role, które dostosowują ich uprawnienia, dostęp i możliwości w całym Panelu Kontrolnym.',
     'user_wizard_super_admin_instructions' => 'Superadministratorzy mają pełną kontrolę i dostęp do wszystkiego w panelu kontrolnym. Przydziel tę rolę z rozwagą.',
     'view_more_count' => 'Zobacz więcej :count',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/pt/messages.php
+++ b/resources/lang/pt/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Os utilizadores podem ser atribuídos a funções que personalizam as suas permissões, acesso e habilidades em todo o Painel de Controlo.',
     'user_wizard_super_admin_instructions' => 'Os super administradores têm controlo completo e acesso a tudo no painel de controlo. <b>Use com cuidado</b>.',
     'view_more_count' => 'Ver :count mais',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/pt_BR/messages.php
+++ b/resources/lang/pt_BR/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Os usuários podem ser atribuídos a funções que personalizam suas permissões, acesso e habilidades em todo o Painel de Controle.',
     'user_wizard_super_admin_instructions' => 'Os superadministradores têm controle e acesso completos a tudo no painel de controle. Conceda essa função com sabedoria.',
     'view_more_count' => 'Ver :count mais',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/ru/messages.php
+++ b/resources/lang/ru/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Пользователям можно назначать роли, которые настраивают их разрешения, доступ и возможности на панели управления.',
     'user_wizard_super_admin_instructions' => 'Супер-администраторы имеют полный контроль и доступ ко всему в панели управления. Назначайте эту роль осторожно.',
     'view_more_count' => 'Посмотреть ещё :count',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/sl/messages.php
+++ b/resources/lang/sl/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Uporabnikom je na nadzorni plošči mogoče dodeliti vloge, ki prilagajajo njihova dovoljenja, dostop in sposobnosti.',
     'user_wizard_super_admin_instructions' => 'Super skrbniki imajo popoln nadzor in dostop do vsega na nadzorni plošči. Pametno dodelite to vlogo.',
     'view_more_count' => 'Ogled :count več',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/sv/messages.php
+++ b/resources/lang/sv/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Användare kan tilldelas roller som anpassar deras behörigheter, åtkomst och förmågor i hela kontrollpanelen.',
     'user_wizard_super_admin_instructions' => 'Superadmins har fullständig kontroll och tillgång till allt i kontrollpanelen. Ge denna roll klokt.',
     'view_more_count' => 'Visa :count till',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/tr/messages.php
+++ b/resources/lang/tr/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Kullanıcılara Denetim Masası üzerinden izinlerini, erişimlerini ve yeteneklerini özelleştiren roller atanabilir.',
     'user_wizard_super_admin_instructions' => 'Süper yöneticiler, kontrol panelindeki her şeye tam kontrol ve erişime sahiptir. Bu rolü akıllıca verin.',
     'view_more_count' => ':count daha fazlasını görüntüle',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/uk/messages.php
+++ b/resources/lang/uk/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Користувачам можна призначати ролі, які налаштовують їхні дозволи, доступ і можливості по всій Панелі керування.',
     'user_wizard_super_admin_instructions' => 'Суперадміністратори мають повний контроль та доступ до всього в панелі керування. Надавайте цю роль обережно.',
     'view_more_count' => 'Переглянути ще :count',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/vi/messages.php
+++ b/resources/lang/vi/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => 'Người dùng có thể được gán vai trò để tùy chỉnh quyền, quyền truy cập và khả năng trong Bảng Điều Khiển.',
     'user_wizard_super_admin_instructions' => 'Super admin có quyền kiểm soát hoàn toàn và truy cập tất cả mọi thứ trong bảng điều khiển. Chỉ cấp vai trò này khi cần thiết.',
     'view_more_count' => 'Xem thêm :count',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/zh_CN/messages.php
+++ b/resources/lang/zh_CN/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => '可以将用户分配给在整个控制面板中自定义其权限，访问和功能的角色。',
     'user_wizard_super_admin_instructions' => '超级管理员可以完全控制并访问控制面板中的所有内容。明智地授予这个角色。',
     'view_more_count' => '查看:count更多',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];

--- a/resources/lang/zh_TW/messages.php
+++ b/resources/lang/zh_TW/messages.php
@@ -249,5 +249,5 @@ return [
     'user_wizard_roles_groups_intro' => '可為使用者指派角色以自定其在控制面板的權限、存取、與能力。',
     'user_wizard_super_admin_instructions' => '超級管理員對於控制面板有完整的控制與存取權限。請妥善給予此權限。',
     'view_more_count' => '查看:count更多',
-    'width_x_height' => ':width x :height',
+    'width_x_height' => ':width × :height',
 ];


### PR DESCRIPTION
Adjust all `width × height` translations strings to use the correct mathematical symbol for dimenions: `×` instead of lowercase `x`. Looks like the German translations already had those symbols, this just matches the others to also use it.

### Before

<img width="1360" height="118" alt="Screenshot 2025-11-11 at 16 36 07" src="https://github.com/user-attachments/assets/21d3d8a4-29cf-46ea-b77f-320ffc7713d2" />

### After

<img width="1344" height="120" alt="Screenshot 2025-11-11 at 16 36 33" src="https://github.com/user-attachments/assets/7adec6c3-2f1a-4704-a2f8-d8b40a1c7b44" />
