### PR TITLE
[6.x] Adjust asset preview border radius

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -27,7 +27,7 @@
 
                 <div class="flex flex-1 grow flex-col overflow-auto md:flex-row md:justify-between">
                     <!-- Visual Area -->
-                    <div class="editor-preview md:min-h-auto flex min-h-[45vh] w-full flex-1 flex-col justify-between bg-gray-800 shadow-[inset_0px_4px_3px_0px_black] dark:bg-gray-900 md:w-1/2 md:flex-auto md:grow lg:w-2/3 md:ltr:rounded-se-md">
+                    <div class="editor-preview md:min-h-auto flex min-h-[45vh] w-full flex-1 flex-col justify-between bg-gray-800 shadow-[inset_0px_4px_3px_0px_black] dark:bg-gray-900 md:w-1/2 md:flex-auto md:grow lg:w-2/3 md:ltr:rounded-se-xl">
                         <!-- Toolbar -->
                         <div v-if="isToolbarVisible" class="@container/toolbar dark flex flex-wrap items-center justify-center gap-2 px-2 py-4">
                             <ItemActions


### PR DESCRIPTION
Tweak the asset editor's preview section top-right border radius to match the border radius of the publish form sections next to it.

### Before

<img width="1550" height="660" alt="Screenshot 2025-11-11 at 16 39 26" src="https://github.com/user-attachments/assets/89c09133-1535-47ea-8334-e48ca626b3ef" />

### After

<img width="1548" height="660" alt="Screenshot 2025-11-11 at 16 38 33" src="https://github.com/user-attachments/assets/b356b099-f565-467e-9325-2dd60f2e4d79" />
