### PR TITLE
[6.x] Array fieldtype table fixes

### DIFF
--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -79,6 +79,10 @@ Table Fieldtype
 
             &:first-child td {
                 @apply overflow-hidden;
+                &:last-child {
+                    /* e.g. the first row of an array fieldtype, keyed type, in dark mode */
+                    @apply rounded-tr-lg;
+                }
             }
 
             &:last-child td {


### PR DESCRIPTION
Some small fixes for tables based on the array fieldtype.

I've tested some other fieldtypes where they're using tables and this doesn't affect them; probably because they're using `th` elements for the first row, as opposed to a keyed array, where the first row is a straight up `tr`.

I noticed:

- The border colors were slightly off
- The background was wrong in dark mode
- There was a missing border radius

## Before

Notice how the borders of the first column of the "Address" field are too light against the gray background, so they look muddy.

![2025-11-11 at 16 10 34@2x](https://github.com/user-attachments/assets/61e94e81-95ba-4ac1-b6b4-fba852f4c19a)

### Before - Dark Mode

![2025-11-11 at 16 10 17@2x](https://github.com/user-attachments/assets/2836e8a3-7b14-4a33-a59c-fdf017aaa823)

## After

(The "Address" field here is the improved field.) I added some other fieldtypes that use tables below to ensure this doesn't cause a regression for them.

I've darkened the borders on the first column here to `gray-300` so the first column borders match the 2nd column borders

![2025-11-11 at 16 07 44@2x](https://github.com/user-attachments/assets/273a6c50-f58f-41fa-89cf-52efd23b72a9)

### After - Dark Mode

![2025-11-11 at 16 10 07@2x](https://github.com/user-attachments/assets/494d075a-f0b0-4fa2-bcaa-44558747afd7)
