### PR TITLE
[6.x] Display asset modification date in tooltip

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -178,7 +178,6 @@
 </template>
 
 <script>
-import DateFormatter from '@/components/DateFormatter.js';
 import FocalPointEditor from './FocalPointEditor.vue';
 import PdfViewer from './PdfViewer.vue';
 import { pick, flatten } from 'lodash-es';
@@ -489,7 +488,7 @@ export default {
             ];
 
             return actions.filter((action) => !buttonActions.includes(action.handle));
-        },
+        }
     },
 };
 </script>


### PR DESCRIPTION
The editors in a current project regularly need to check the exact modification date of assets. The relative timestamp in the asset editor is nice but doesn't show the exact time. This PR adds a tooltip to the badge with the exact datetime.


<img width="1174" height="270" alt="Screenshot 2025-11-11 at 17 20 04" src="https://github.com/user-attachments/assets/226122d9-911c-40e8-a3e6-263855466b66" />
