### PR TITLE
[6.x] Bard focus ring adjustment

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -154,9 +154,10 @@
         @apply -top-2;
         /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
         margin-block-end: 8px;
-        /* Pull the subsequent element up to compensate for this */
+        /* Pull the subsequent element up to compensate for this. The focus ring adjustment here keeps the focus ring from disappearing into the toolbar, which would make the focus ring appear bottom heavy. */
         + * {
-            margin-block-start: -8px;
+            --focus-ring-adjustment: 0.7px;
+            margin-block-start: calc(-8px + var(--focus-ring-adjustment));
         }
     }
 


### PR DESCRIPTION
This is a minor adjustment to prevent the focus ring from appearing uneven in Bard fields due to the way the toolbar overshadows the focus.

It's easier to show this to understand what I mean…

I've zoomed in to 200% so it's clearer

## Before
Look at the top border and notice how it's visibly thinner compared to the other borders. This is due to the way the sticky-positioned toolbar is overlapping the focus ring.

![2025-11-12 at 14 44 47@2x](https://github.com/user-attachments/assets/36995608-8e08-4b0c-aa97-033b896dc81f)

and here at 0% zoom
![2025-11-12 at 14 46 24@2x](https://github.com/user-attachments/assets/680aac0f-16ce-4aaf-ac31-3be288606fc3)


## After

Notice how the blue focus ring is now optically even on all sides, now that we've made a minor adjustment. It's less distracting 😄 
![2025-11-12 at 14 44 30@2x](https://github.com/user-attachments/assets/e1b9ad1d-303f-4359-b31e-c9c67b7a29f5)

and here at 0% zoom

![2025-11-12 at 14 47 12@2x](https://github.com/user-attachments/assets/2b2668ca-6372-4c1d-b65d-612eac950f36)

