### PR TITLE
[6.x] Remove double shadow from toggle items

### DIFF
--- a/packages/ui/src/Toggle/Item.vue
+++ b/packages/ui/src/Toggle/Item.vue
@@ -36,7 +36,7 @@ const toggleItemClasses = computed(() => {
         variants: {
             variant: {
                 default: [
-                    'bg-linear-to-b from-white to-gray-50 hover:to-gray-100 text-gray-900 border border-gray-300 shadow-ui-sm data-[state=on]:from-gray-100 data-[state=on]:to-gray-100 data-[state=on]:text-gray-900 data-[state=on]:inset-shadow-sm/10',
+                    'bg-linear-to-b from-white to-gray-50 hover:to-gray-100 text-gray-900 border border-gray-300 data-[state=on]:from-gray-100 data-[state=on]:to-gray-100 data-[state=on]:text-gray-900 data-[state=on]:inset-shadow-sm/10',
                     'dark:from-gray-800 dark:to-gray-850 dark:hover:to-gray-800 hover:bg-gray-50 dark:hover:bg-gray-850 dark:border-b-0 dark:ring dark:ring-black dark:border-white/10 dark:text-gray-300 dark:shadow-lg dark:data-[state=on]:from-gray-950 dark:data-[state=on]:to-gray-850 dark:data-[state=on]:text-white',
                 ],
                 primary: [


### PR DESCRIPTION
This PR removes the `shadow-ui-sm` from toggle items.

Since the toggle items already have an inner shadow from a "pressed" state, I think this is a slightly cleaner presentation than having both an inner and an outer shadow below it.

Here are two examples showing before and after:

## Before

I think this example is the bigger issue for me, where you have a raised button state next to the input, together with multiple shadows, which looks a little muddy.

![2025-11-12 at 15 07 05@2x](https://github.com/user-attachments/assets/1aa1dcc3-e795-49ed-8ca8-8ae5a2d5b418)

![2025-11-12 at 15 08 43@2x](https://github.com/user-attachments/assets/24447a90-1e0b-4143-80a3-0c615ed70da0)


## After

The toggle item still pops with a shadow, but it's a less distracting presentation

![2025-11-12 at 15 02 20@2x](https://github.com/user-attachments/assets/8c25c742-05a7-4fb4-be71-588c55148b9e)
![2025-11-12 at 15 06 04@2x](https://github.com/user-attachments/assets/d6baa610-725f-48f4-9424-0a71b80997c5)
