### PR TITLE
[6.x] Fix color fieldtype popover position

### DIFF
--- a/resources/js/components/fieldtypes/ColorFieldtype.vue
+++ b/resources/js/components/fieldtypes/ColorFieldtype.vue
@@ -2,7 +2,15 @@
     <div class="flex items-center">
         <!-- <div class="input-group w-auto" :class="{ 'max-w-[130px]': config.allow_any }"> -->
         <div class="flex items-center rounded-full relative border shadow-ui-sm">
-            <ui-popover ref="colorPopover" name="swatches" direction="bottom" class="md:w-[320px]" :open="popoverOpen" @update:open="popoverOpen = $event">
+            <ui-popover
+                ref="colorPopover"
+                name="swatches"
+                direction="bottom"
+                align="start"
+                class="md:w-[320px]"
+                :open="popoverOpen"
+                @update:open="popoverOpen = $event"
+            >
                 <template #trigger>
                     <button type="button" class="cursor-pointer size-9 border rounded-full flex items-center justify-center" :aria-label="__('Pick Color')">
                         <div


### PR DESCRIPTION
Currently, the colour popover does not align with the field and appears centred. This PR fixes that.

## Before

![2025-11-12 at 16 13 16@2x](https://github.com/user-attachments/assets/ec5f59bb-5fcc-454c-9c25-f6a9a05eb747)

## After

![2025-11-12 at 16 12 56@2x](https://github.com/user-attachments/assets/45d2e18f-55c9-4a60-8ad3-8bb6fb3c032f)
