### PR TITLE
[6.x] Bring sizes of custom logo and avatar closer together

### DIFF
--- a/resources/js/components/global-header/Logo.vue
+++ b/resources/js/components/global-header/Logo.vue
@@ -23,7 +23,7 @@ function toggleNav() {
             <div class="p-1 max-sm:ps-2 mr-2 size-5 flex items-center justify-center lg:inset-0">
                 <Icon name="burger-menu-no-border" class="size-3.5! sm:size-3.25! opacity-75 hover:opacity-100" />
             </div>
-            <img :src="customLogo" :alt="cmsName" class="max-w-[260px] max-h-9">
+            <img :src="customLogo" :alt="cmsName" class="max-w-[260px] max-h-8">
         </button>
     </template>
     <template v-else>


### PR DESCRIPTION
This is rather subjective, but I had a hard time getting a custom logo to look good in the new control panel. I realized it's because the custom logo is visually quite a bit larger than the other elements in the header, mostly the user avatar. Things become more balanced by taking down the max logo height a notch. It's easiest to see if you try to focus on the logo and the user avatar at the same time.

Feel free to close if a lot of thought has gone into the current value :)

## Filled logo

### Before

<img width="1044" height="350" alt="Screenshot 2025-11-12 at 19 17 31" src="https://github.com/user-attachments/assets/16269d91-678c-4339-9019-7fbf73582870" />
 
### After

<img width="1044" height="350" alt="Screenshot 2025-11-12 at 19 17 49" src="https://github.com/user-attachments/assets/b18c3116-f3f8-426a-bc43-d41db8de22e8" />

## Outline logo

### Before

<img width="1044" height="350" alt="Screenshot 2025-11-12 at 19 18 24" src="https://github.com/user-attachments/assets/ad3c29e7-e271-438f-bb26-43b269d57b65" />

### After

<img width="1044" height="350" alt="Screenshot 2025-11-12 at 19 18 51" src="https://github.com/user-attachments/assets/63f87c45-8d1d-491d-afee-557333c1c819" />
