### PR TITLE
[6.x] Indent color vars nicerer

### DIFF
--- a/src/CP/Color.php
+++ b/src/CP/Color.php
@@ -417,6 +417,6 @@ class Color
     {
         return collect(static::theme())
             ->map(fn ($color, $name) => "--theme-color-{$name}: {$color};")
-            ->implode("\n");
+            ->implode(PHP_EOL.'    ');
     }
 }


### PR DESCRIPTION
This PR changes the way the style tag indents CSS theming vars in the browser so that they're nicer to read when you're inspecting theme vars

## Before

The indentation after the first variable is upsetting

![2025-11-13 at 10 08 58@2x](https://github.com/user-attachments/assets/2d160469-1222-483f-b061-2ceab879469b)


## After

See how they're all indented nicely, it's very pleasing

![2025-11-13 at 10 08 06@2x](https://github.com/user-attachments/assets/fc493f09-0fe3-4a69-9983-f8c9700bd087)
