### PR TITLE
[6.x] Trigger full-page refresh after saving sites

### DIFF
--- a/resources/js/pages/sites/Edit.vue
+++ b/resources/js/pages/sites/Edit.vue
@@ -45,6 +45,10 @@ function save() {
         ])
         .then((response) => {
             Statamic.$toast.success(__('Saved'));
+
+            if (Statamic.$config.get('multisiteEnabled')) {
+                window.location.reload();
+            }
         });
 }
 


### PR DESCRIPTION
Currently, when you save your sites config, you need to do a full-page refresh before your changes will show in the global site selector.

This PR ensures a full-page reload happens after saving your sites config.