### PR TITLE
[6.x] Inception tree selector padding fix

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -63,6 +63,7 @@
                 <div class="mx-4 flex-1 overflow-auto">
                     <Panel>
                         <page-tree
+                            panel-class="px-0"
                             ref="tree"
                             :pages-url="tree.url"
                             :show-slugs="tree.showSlugs"

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -4,7 +4,7 @@
             <slot name="empty" />
         </div>
 
-        <ui-panel v-show="treeData.length">
+        <ui-panel v-show="treeData.length" :class="panelClass">
             <div class="loading card" v-if="loading">
                 <Icon name="loading" />
             </div>
@@ -117,6 +117,7 @@ export default {
         preferencesPrefix: { type: String },
         editable: { type: Boolean, default: true },
         blueprints: { type: Array },
+        panelClass: { type: [String, Array, Object], default: null },
     },
 
     data() {


### PR DESCRIPTION
Another tree selector fix related to https://github.com/statamic/cms/pull/13040

This fix prevents a doubling up of padding when we have a tree selector, which uses the ui-panel, within a parent ui-panel.

## Before

(Double horizontal padding)

![2025-11-13 at 17 01 59@2x](https://github.com/user-attachments/assets/ba4eee6b-5bc4-445e-a00a-40edba86b90e)


## After

Fixed by passing px-0 to the tree

![2025-11-13 at 17 01 50@2x](https://github.com/user-attachments/assets/cc99306d-4e70-4413-893a-2ece12cadb7e)
