### PR TITLE
[6.x] Improve blueprint breadcrumbs

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionBlueprintsController.php
@@ -129,7 +129,7 @@ class CollectionBlueprintsController extends CpController
 
         Breadcrumbs::push(new Breadcrumb(
             text: $collection->title(),
-            url: request()->url(),
+            url: cp_route('blueprints.collections.index', $collection),
             icon: 'collections',
             links: Collection::all()
                 ->reject(fn ($c) => $c->handle() === $collection->handle())

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomyBlueprintsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomyBlueprintsController.php
@@ -129,7 +129,7 @@ class TaxonomyBlueprintsController extends CpController
 
         Breadcrumbs::push(new Breadcrumb(
             text: $taxonomy->title(),
-            url: request()->url(),
+            url: cp_route('blueprints.taxonomies.index', $taxonomy),
             icon: 'taxonomies',
             links: Taxonomy::all()
                 ->reject(fn ($t) => $t->handle() === $taxonomy->handle())


### PR DESCRIPTION
This pull request slightly improves blueprint breadcrumbs by making the collection/taxonomy breadcrumb link to the relevant index page.