### PR TITLE
[6.x] Fix double page tree panel in selector

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -61,38 +61,38 @@
                 </div>
 
                 <div class="mx-4 flex-1 overflow-auto">
-                        <page-tree
-                            ref="tree"
-                            :pages-url="tree.url"
-                            :show-slugs="tree.showSlugs"
-                            :blueprints="tree.blueprints"
-                            :expects-root="tree.expectsRoot"
-                            :site="site"
-                            :preferences-prefix="`selector-field.${name}`"
-                            :editable="false"
-                            @branch-clicked="toggleSelection($event.id)"
-                        >
-                            <template #branch-action="{ branch, index }">
-                                <div>
-                                    <Checkbox
-                                        :ref="`tree-branch-${branch.id}`"
-                                        class="mt-3 mx-3"
-                                        :value="branch.id"
-                                        :model-value="isSelected(branch.id)"
-                                        :disabled="reachedSelectionLimit && !singleSelect && !isSelected(branch.id)"
-                                        :label="getCheckboxLabel(branch)"
-                                        :description="getCheckboxDescription(branch)"
-                                        size="sm"
-                                        solo
-                                        @update:model-value="toggleSelection(branch.id)"
-                                    />
-                                </div>
-                            </template>
+                    <page-tree
+                        ref="tree"
+                        :pages-url="tree.url"
+                        :show-slugs="tree.showSlugs"
+                        :blueprints="tree.blueprints"
+                        :expects-root="tree.expectsRoot"
+                        :site="site"
+                        :preferences-prefix="`selector-field.${name}`"
+                        :editable="false"
+                        @branch-clicked="toggleSelection($event.id)"
+                    >
+                        <template #branch-action="{ branch, index }">
+                            <div>
+                                <Checkbox
+                                    :ref="`tree-branch-${branch.id}`"
+                                    class="mt-3 mx-3"
+                                    :value="branch.id"
+                                    :model-value="isSelected(branch.id)"
+                                    :disabled="reachedSelectionLimit && !singleSelect && !isSelected(branch.id)"
+                                    :label="getCheckboxLabel(branch)"
+                                    :description="getCheckboxDescription(branch)"
+                                    size="sm"
+                                    solo
+                                    @update:model-value="toggleSelection(branch.id)"
+                                />
+                            </div>
+                        </template>
 
-                            <template #branch-icon="{ branch }">
-                                <ui-icon name="external-link" v-if="isRedirectBranch(branch)" v-tooltip="__('Redirect')" />
-                            </template>
-                        </page-tree>
+                        <template #branch-icon="{ branch }">
+                            <ui-icon name="external-link" v-if="isRedirectBranch(branch)" v-tooltip="__('Redirect')" />
+                        </template>
+                    </page-tree>
                 </div>
             </template>
 


### PR DESCRIPTION
The big diff is due to indentation. The only actual change in this PR is removing the `<Panel>` wrapper.
