### PR TITLE
[6.x] Move blueprint tab edit fields into a stack

### DIFF
--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -27,7 +27,7 @@
         <stack
             narrow
             v-if="editing"
-            @opened="$refs.title?.focus()"
+            @opened="() => $nextTick(() => $refs.title.focus())"
             @closed="editCancelled"
         >
             <div class="h-full overflow-scroll overflow-x-auto bg-white px-6 dark:bg-dark-800">
@@ -41,7 +41,7 @@
                 </header>
                 <div class="space-y-6">
                     <Field :label="__('Title')" class="form-group field-w-100">
-                        <Input ref="title" autofocus :model-value="display" @update:model-value="fieldUpdated('display', $event)" />
+                        <Input ref="title" :model-value="display" @update:model-value="fieldUpdated('display', $event)" />
                     </Field>
                     <Field :label="__('Handle')" class="form-group field-w-100">
                         <Input class="font-mono" :model-value="handle" @update:model-value="fieldUpdated('handle', $event)" />


### PR DESCRIPTION
Sections are configured via a stack, but tabs aren't. This PR moves the tab edit fields into a stack for consistency. 

Closes #12490 _(the layering issue remains, but there's another issue for that)_

## Before

<img width="717" height="350" alt="CleanShot 2025-11-14 at 12 09 21" src="https://github.com/user-attachments/assets/d7011792-7a8f-4a06-8a99-84f7931da001" />


## After

<img width="648" height="840" alt="CleanShot 2025-11-14 at 12 09 10" src="https://github.com/user-attachments/assets/eb2f77d1-9636-4445-b83d-027a54f1b5f7" />
