### PR TITLE
[6.x] Apply correct icon classes to appended input icons

### DIFF
--- a/packages/ui/src/Input/Input.vue
+++ b/packages/ui/src/Input/Input.vue
@@ -125,21 +125,39 @@ const iconClasses = computed(() => {
                 xs: '[&_svg]:size-3',
             },
         },
-        compoundVariants: [
-            { size: 'base', hasPrependedIcon: true, class: 'ps-3 has-[button]:ps-1 start-0' },
-            { size: 'sm', hasPrependedIcon: true, class: 'ps-2 has-[button]:ps-1 start-0' },
-            { size: 'xs', hasPrependedIcon: true, class: 'ps-1.5 has-[button]:ps-0 start-0' },
-            { size: 'base', hasAppendedIcon: true, class: 'pe-3 has-[button]:pe-1 end-0' },
-            { size: 'sm', hasAppendedIcon: true, class: 'pe-2 has-[button]:pe-1 end-0' },
-            { size: 'xs', hasAppendedIcon: true, class: 'pe-1.5 has-[button]:pe-0 end-0' },
-        ],
-    })({
-        ...props,
-        hasPrependedIcon: hasPrependedIcon.value,
-        hasAppendedIcon: hasAppendedIcon.value,
-    });
+    })({ ...props });
 
     return twMerge(classes);
+});
+
+const prependedIconClasses = computed(() => {
+    const classes = cva({
+        base: 'start-0',
+        variants: {
+            size: {
+                base: 'ps-3 has-[button]:ps-1',
+                sm: 'ps-2 has-[button]:ps-1',
+                xs: 'ps-1.5 has-[button]:ps-0',
+            },
+        },
+    })({ ...props });
+
+    return twMerge(iconClasses.value, classes);
+});
+
+const appendedIconClasses = computed(() => {
+    const classes = cva({
+        base: 'end-0',
+        variants: {
+            size: {
+                base: 'pe-3 has-[button]:pe-1',
+                sm: 'pe-2 has-[button]:pe-1',
+                xs: 'pe-1.5 has-[button]:pe-0',
+            },
+        },
+    })({ ...props });
+
+    return twMerge(iconClasses.value, classes);
 });
 
 const emit = defineEmits(['update:modelValue']);
@@ -178,7 +196,7 @@ defineExpose({ focus });
     <ui-input-group v-bind="outerAttrs">
         <ui-input-group-prepend v-if="prepend" v-text="prepend" />
         <div class="group/input relative block w-full st-text-legibility" data-ui-input>
-            <div v-if="hasPrependedIcon" :class="iconClasses">
+            <div v-if="hasPrependedIcon" :class="prependedIconClasses">
                 <slot name="prepend">
                     <Icon :name="iconPrepend || icon" />
                 </slot>
@@ -198,7 +216,7 @@ defineExpose({ focus });
                 v-bind="inputAttrs"
                 @input="$emit('update:modelValue', $event.target.value)"
             />
-            <div v-if="hasAppendedIcon" :class="iconClasses">
+            <div v-if="hasAppendedIcon" :class="appendedIconClasses">
                 <slot name="append">
                     <Button size="sm" icon="x" variant="ghost" v-if="clearable" @click="clear" />
                     <Button


### PR DESCRIPTION
Been working on a custom listing UI and noticed that appended icons current don't work for the `Input` component. They end up in the same position as the prepended icons, overlaid over each other. The solution is splitting out the prepended and appended icon classes as these shouldn't be applied to both icon slots equally.

### Example

```vue
<Input icon="search" placeholder="Search..." clearable="true" />
```

### Before

<img width="410" height="64" alt="Screenshot 2025-11-14 at 14 11 56" src="https://github.com/user-attachments/assets/d759926c-fac5-49bb-90a4-79fc84e9ff0c" />

### After

<img width="406" height="62" alt="Screenshot 2025-11-14 at 14 03 50" src="https://github.com/user-attachments/assets/5b55134a-0a78-4ed3-9377-46fdf1ed07b3" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Split icon class logic into separate prepended/appended variants and update template bindings to correctly position input icons.
> 
> - **UI Input (`packages/ui/src/Input/Input.vue`)**
>   - **Icon classes**:
>     - Remove position-specific compound variants from `iconClasses` and keep only shared styling.
>     - Add `prependedIconClasses` (`start-0` with size-based padding) and `appendedIconClasses` (`end-0` with size-based padding).
>   - **Template**:
>     - Use `prependedIconClasses` for the prepend slot and `appendedIconClasses` for the append slot to position icons correctly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d59924be36c987b782517fc690c51a8b7f15842a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->