### PR TITLE
[5.x] Add computed callable

### DIFF
--- a/src/Data/StoresScopedComputedFieldCallbacks.php
+++ b/src/Data/StoresScopedComputedFieldCallbacks.php
@@ -16,7 +16,7 @@ trait StoresScopedComputedFieldCallbacks
      * @param  string|array  $scopes
      * @param  string|array  $field
      */
-    public function computed($scopes, $field, ?Closure $callback = null)
+    public function computed($scopes, $field, ?callable $callback = null)
     {
         foreach (Arr::wrap($scopes) as $scope) {
             if (is_array($field)) {

--- a/tests/Data/StoresScopedComputedFieldCallbacksTest.php
+++ b/tests/Data/StoresScopedComputedFieldCallbacksTest.php
@@ -111,9 +111,104 @@ class StoresScopedComputedFieldCallbacksTest extends TestCase
             'another_field' => $closureB,
         ], $repository->getComputedCallbacks('articles')->all());
     }
+
+    #[Test]
+    function it_can_store_scoped_computed_invokables()
+    {
+        $repository = new FakeRepositoryWithScopedCallbacks;
+
+        $repository->computed('events', 'some_field', $invokableA = new FakeInvokable('A'));
+        $repository->computed('articles', 'some_field', $invokableB = new FakeInvokable('B'));
+        $repository->computed('articles', 'another_field', $invokableC = new FakeInvokable('C'));
+
+        $this->assertEquals([
+            'some_field' => $invokableA,
+        ], $repository->getComputedCallbacks('events')->all());
+
+        $this->assertEquals([
+            'some_field' => $invokableB,
+            'another_field' => $invokableC,
+        ], $repository->getComputedCallbacks('articles')->all());
+
+        $this->assertEquals([], $repository->getComputedCallbacks('products')->all());
+    }
+
+    public function it_can_store_scoped_computed_invokables_for_multiple_scopes()
+    {
+        $repository = new FakeRepositoryWithScopedCallbacks;
+
+        $repository->computed(['events', 'articles'], 'some_field', $invokable = new FakeInvokable('A'));
+
+        $this->assertEquals([
+            'some_field' => $invokable,
+        ], $repository->getComputedCallbacks('events')->all());
+
+        $this->assertEquals([
+            'some_field' => $invokable,
+        ], $repository->getComputedCallbacks('articles')->all());
+    }
+
+    #[Test]
+    public function it_can_store_multiple_scoped_computed_invokables()
+    {
+        $repository = new FakeRepositoryWithScopedCallbacks;
+
+        $repository->computed('events', [
+            'some_field' => $invokableA = new FakeInvokable('A')
+        ]);
+
+        $repository->computed('articles', [
+            'some_field' => $invokableB = new FakeInvokable('B'),
+            'another_field' => $invokableC = new FakeInvokable('C'),
+        ]);
+
+        $this->assertEquals([
+            'some_field' => $invokableA,
+        ], $repository->getComputedCallbacks('events')->all());
+
+        $this->assertEquals([
+            'some_field' => $invokableB,
+            'another_field' => $invokableC,
+        ], $repository->getComputedCallbacks('articles')->all());
+
+        $this->assertEquals([], $repository->getComputedCallbacks('products')->all());
+    }
+
+    #[Test]
+    public function it_can_store_multiple_scoped_computed_invokables_for_multiple_scopes()
+    {
+        $repository = new FakeRepositoryWithScopedCallbacks;
+
+        $repository->computed(['events', 'articles'], [
+            'some_field' => $invokableA = new FakeInvokable('A'),
+            'another_field' => $invokableB = new FakeInvokable('B'),
+        ]);
+
+        $this->assertEquals([
+            'some_field' => $invokableA,
+            'another_field' => $invokableB,
+        ], $repository->getComputedCallbacks('events')->all());
+
+        $this->assertEquals([
+            'some_field' => $invokableA,
+            'another_field' => $invokableB,
+        ], $repository->getComputedCallbacks('articles')->all());
+    }
 }
 
 class FakeRepositoryWithScopedCallbacks
 {
     use StoresScopedComputedFieldCallbacks;
+}
+
+class FakeInvokable
+{
+    public function __construct(private ?string $value = null)
+    {
+
+    }
+    public function __invoke($item, $value)
+    {
+
+    }
 }


### PR DESCRIPTION
Allow `callable` type for computed values.

When `\Closure` function bodies are taking up too much room within  a Service Provider, a callable can be used to abstract the computed method.

```
class TooterService
{
    public function __invoke($entry) {
        //
   }
}
....
Collection::computed(['articles', 'pages'], 'shares', (new TooterService));
```

**Notes**

- Am not sure if there are other `::computed` which need modifications.
- This does not enable dependency injection in the `callable`, I was cautious to add `app()->call(...)` to `Statamic\Data\ContainsComputedData` - but would be cool feature. 
