### PR TITLE
[6.x] Add layout actions to Command Palette on collection show page

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -283,7 +283,7 @@ export default {
 
             Statamic.$commandPalette.add({
                 category: Statamic.$commandPalette.category.Actions,
-                text: __('Toggle Grid Layout'),
+                text: __('Switch to Grid Layout'),
                 icon: 'layout-grid',
                 when: () => this.mode === 'list',
                 action: () => this.mode = 'grid',
@@ -291,7 +291,7 @@ export default {
 
             Statamic.$commandPalette.add({
                 category: Statamic.$commandPalette.category.Actions,
-                text: __('Toggle List Layout'),
+                text: __('Switch to List Layout'),
                 icon: 'layout-list',
                 when: () => this.mode === 'grid',
                 action: () => this.mode = 'list',

--- a/resources/js/pages/collections/Show.vue
+++ b/resources/js/pages/collections/Show.vue
@@ -437,7 +437,7 @@ export default {
 
             Statamic.$commandPalette.add({
                 category: Statamic.$commandPalette.category.Actions,
-                text: __('Toggle List Layout'),
+                text: __('Switch to List Layout'),
                 icon: 'layout-list',
                 when: () => this.view !== 'list',
                 action: () => this.view = 'list',
@@ -445,7 +445,7 @@ export default {
 
             Statamic.$commandPalette.add({
                 category: Statamic.$commandPalette.category.Actions,
-                text: __('Toggle Calendar Layout'),
+                text: __('Switch to Calendar Layout'),
                 icon: 'calendar',
                 when: () => this.canUseCalendar && this.view !== 'calendar',
                 action: () => this.view = 'calendar',
@@ -453,7 +453,7 @@ export default {
 
             Statamic.$commandPalette.add({
                 category: Statamic.$commandPalette.category.Actions,
-                text: __('Toggle Tree Layout'),
+                text: __('Switch to Tree Layout'),
                 icon: 'navigation',
                 when: () => this.canUseStructureTree && this.view !== 'tree',
                 action: () => this.view = 'tree',


### PR DESCRIPTION
The collections index page has Command Palette actions for switching between the list & grid layouts, so I thought I'd add similar actions for the collection show page so you can switch between list/tree/calendar.