### PR TITLE
[6.x] Clear command palette actions when navigating between pages

### DIFF
--- a/resources/js/components/CommandPalette.js
+++ b/resources/js/components/CommandPalette.js
@@ -17,6 +17,7 @@ class Command {
         this.keys = command.keys;
         this.prioritize = command.prioritize ?? false;
         this.trackRecent = command.trackRecent ?? false;
+        this.persist = command.persist ?? false;
 
         this.#validate();
     }
@@ -47,6 +48,10 @@ export default class CommandPalette {
         commands.value[command.key] = command;
 
         return command;
+    }
+
+    clear() {
+        commands.value = Object.fromEntries(Object.entries(commands.value).filter(([key, command]) => command.persist));
     }
 
     actions() {

--- a/resources/js/components/Theme.js
+++ b/resources/js/components/Theme.js
@@ -82,6 +82,7 @@ export default class Theme {
             action: () => {
                 this.preference = 'light';
             },
+            persist: true,
         });
 
         Statamic.$commandPalette.add({
@@ -90,6 +91,7 @@ export default class Theme {
             action: () => {
                 this.preference = 'dark';
             },
+            persist: true,
         });
 
         Statamic.$commandPalette.add({
@@ -98,6 +100,7 @@ export default class Theme {
             action: () => {
                 this.preference = 'auto';
             },
+            persist: true,
         });
     }
 }

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -11,6 +11,7 @@ import { each, groupBy, orderBy, find, uniq } from 'lodash-es';
 import { motion } from 'motion-v';
 import { cva } from 'cva';
 import { Icon, Subheading } from '@/components/ui';
+import { router } from '@inertiajs/vue3';
 
 let metaPressed = ref(false);
 let open = ref(false);
@@ -269,6 +270,8 @@ const modalClasses = cva({
         'slide-in-from-top-2',
     ],
 })({});
+
+router.on('start', () => Statamic.$commandPalette.clear());
 </script>
 
 <template>


### PR DESCRIPTION
This pull request fixes an issue where Command Palette actions added via the JS API were being kept around after navigating to a different page.

This PR fixes it by listening to Inertia's `start` event and clearing the `commands` object. Some actions, like "Toggle Dark Mode" should be persisted between pages, so I've added a `persist` option for that.