### PR TITLE
[6.x] Remove unnecessary padding from Dictionary Fields fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/DictionaryFields.vue
+++ b/resources/js/components/fieldtypes/DictionaryFields.vue
@@ -84,3 +84,9 @@ export default {
     },
 };
 </script>
+
+<style>
+.dictionary_fields-fieldtype {
+    padding: 0;
+}
+</style>


### PR DESCRIPTION
This pull request removes unnecessary padding padding from the Dictionary Fields fieldtype. The nested fields should look like they're normal/inline fields.

## Before

<img width="882" height="337" alt="CleanShot 2025-11-14 at 17 02 12" src="https://github.com/user-attachments/assets/0ea8269f-785d-4e1d-81e7-bbc6cc475472" />


## After

<img width="882" height="306" alt="CleanShot 2025-11-14 at 17 01 58" src="https://github.com/user-attachments/assets/6990f4a5-7132-4ef4-9f5c-c134b17b587f" />
