### PR TITLE
[6.x] Focus the "Display" input when opening section edit stack

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -37,7 +37,7 @@
         <stack
             narrow
             v-if="editingSection"
-            @opened="$refs.displayInput?.select()"
+            @opened="() => $nextTick(() => $refs.displayInput.focus())"
             @closed="editCancelled"
         >
             <div class="h-full overflow-scroll overflow-x-auto bg-white px-6 dark:bg-dark-800">

--- a/resources/js/components/stacks/Stack.vue
+++ b/resources/js/components/stacks/Stack.vue
@@ -41,7 +41,7 @@
 
 <script>
 export default {
-    emits: ['closed'],
+    emits: ['closed', 'opened'],
 
     props: {
         name: {
@@ -192,6 +192,7 @@ export default {
         this.mounted = true;
         this.$nextTick(() => {
             this.visible = true;
+            this.$emit('opened');
         });
     },
 };


### PR DESCRIPTION
This pull request fixes an issue where the "Display" input wasn't being properly focused when opening the blueprint section edit stack.