### PR TITLE
[6.x] Underline publish section instruction links

### DIFF
--- a/packages/ui/src/Subheading.vue
+++ b/packages/ui/src/Subheading.vue
@@ -8,7 +8,7 @@ const props = defineProps({
 });
 
 const classes = cva({
-    base: 'flex items-center gap-2 text-gray-600 text-pretty tracking-tight dark:text-gray-400 [&_code]:text-xs [&_code]:bg-gray-600/10 [&_code]:rounded-sm [&_code]:px-1 [&_code]:py-0.5',
+    base: 'flex items-center gap-2 text-gray-600 text-pretty tracking-tight dark:text-gray-400 [&_a]:underline [&_a:hover]:text-gray-800 dark:[&_a:hover]:text-gray-200 [&_code]:text-xs [&_code]:bg-gray-600/10 [&_code]:rounded-sm [&_code]:px-1 [&_code]:py-0.5',
     variants: {
         size: {
             sm: 'text-xs',


### PR DESCRIPTION
Make it so links in publish section instructions are underlined like links in field instructions.

### Before

<img width="756" height="224" alt="Screenshot 2025-11-15 at 14 16 52" src="https://github.com/user-attachments/assets/a9d99ce8-7cfd-4a6c-bcc8-c8d3e12d92ff" />

### After

<img width="758" height="227" alt="Screenshot 2025-11-15 at 14 17 12" src="https://github.com/user-attachments/assets/d385e2dc-fa56-4a17-935a-8050ecb8ee96" />

### Dark

<img width="760" height="222" alt="Screenshot 2025-11-15 at 14 17 31" src="https://github.com/user-attachments/assets/e1547b2a-625c-461a-9994-9910787901d9" />
