### PR TITLE
[6.x] Remove collapsed publish section contents from tab order

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -77,7 +77,7 @@ function toggleSection(id) {
             <div
                 style="--tw-ease: ease;"
                 class="h-auto visible transition-[height,visibility] duration-[250ms,2s]"
-                :class="{ 'h-0! visibility-hidden overflow-clip': section.collapsed }"
+                :class="{ 'h-0! invisible! overflow-clip': section.collapsed }"
             >
                 <Card :class="{ 'p-0!': asConfig }">
                     <FieldsProvider :fields="section.fields">


### PR DESCRIPTION
Ensure that fields inside a collapsed publish section cannot be reached via keyboard. I assume the intention has been for it to behave like that, it's just that a different tailwind class is required to actually hide them (`invisible` instead of `visibility-hidden`).

Notice how the next focussable element after the Settings section toggle is the Images field's action button.

![Screen Recording 2025-11-15 at 14 07 22](https://github.com/user-attachments/assets/efe01a9b-ef19-43e5-9c3b-fc380b1ac8be)
