### PR TITLE
[6.x] Increase toggle area of collapsible publish sections

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -58,15 +58,15 @@ function toggleSection(id) {
                 { 'pb-0': section.collapsed }
             ]"
         >
-            <PanelHeader v-if="section.display || section.collapsible" class="flex items-center justify-between">
-                <div>
+            <PanelHeader v-if="section.display || section.collapsible" class="relative flex items-center justify-between">
+                <div class="[&_a]:relative [&_a]:z-(--z-index-above)">
                     <Heading :text="__(section.display)" />
                     <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
                 </div>
                 <Button
                     @click="toggleSection(i)"
                     v-if="section.collapsible"
-                    class="[&_svg]:size-5 rounded-xl"
+                    class="static! [&_svg]:size-5 rounded-xl after:content-[''] after:absolute after:inset-0"
                     icon="chevron-down"
                     size="sm"
                     variant="ghost"


### PR DESCRIPTION
Working with the amazing new collapsible sections, I found myself trying over and over to click the section title, wishing the whole header was clickable instead of just the small toggle all the way to the right.

This PR expands the toggle button's clickable area to cover the whole header. The z-index stuff above makes sure any links in instructions are still clickable. If having the instructions text selectable is important, one could expand the clickable area only in the collapsed state, but having it expanded in general felt more natural for now.

### Before

![Screen Recording 2025-11-15 at 14 43 46](https://github.com/user-attachments/assets/ee4ea1a0-066b-44d7-8a34-cbe17bf4934a)

### After

![Screen Recording 2025-11-15 at 14 42 20](https://github.com/user-attachments/assets/0f96a5fa-3dd7-45dc-b495-cf5cbaccb21a)
