### PR TITLE
[6.x] Register `statamic.web` middleware group before booted callbacks

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -35,9 +35,9 @@ class AppServiceProvider extends ServiceProvider
     public function boot()
     {
         $this->app->booted(function () {
+            $this->registerMiddlewareGroup();
             Statamic::runBootedCallbacks();
             $this->loadRoutesFrom("{$this->root}/routes/routes.php");
-            $this->registerMiddlewareGroup();
         });
 
         $this->app[\Illuminate\Contracts\Http\Kernel::class]


### PR DESCRIPTION
Closes https://github.com/statamic/ideas/issues/1384

This PR moves the `registerMiddlewareGroup` call before the `runBootedCallbacks` call in the app service provider. This allows middleware to be pushed to the end of the `statamic.web` middleware group in booted callbacks.

This should not affect https://github.com/statamic/cms/issues/8453.

Given these calls:

```php
return Application::configure(...)
    ->withMiddleware(function (Middleware $middleware): void {
        $middleware->appendToGroup('statamic.web', [
            \App\MyBootstrapMiddleware::class,
        ]);
    })
```
```php
Statamic::booted(function () {
    Route::prependMiddlewareToGroup('statamic.web', \App\MyFirstMiddleware::class);
    Route::pushMiddlewareToGroup('statamic.web', \App\MyLastMiddleware::class);
});
```

The group would previously result in this:

```
App\MyFirstMiddleware
App\MyBootstrapMiddleware
App\MyLastMiddleware
Statamic\Http\Middleware\StacheLock
Statamic\...
Statamic\StaticCaching\Middleware\Cache
```

Now it results in this:

```
App\MyFirstMiddleware
App\MyBootstrapMiddleware
Statamic\Http\Middleware\StacheLock
Statamic\...
Statamic\StaticCaching\Middleware\Cache
App\MyLastMiddleware
```

In testing this I also discovered that `prependMiddlewareToGroup` does nothing if the middleware group doesn't exist yet (which it wouldn't previously), so this also fixes that issue.

There is a potential breaking change with this, if someone is currently using `pushMiddlewareToGroup` it will be getting added at the start, with this change it will be added at the end. The fix is to explicitly use `prependMiddlewareToGroup` if it needs  to be at the start. Given that prepend didn't work before it's very possible people might be using push.