### PR TITLE
[6.x] Define styles for large icon-only button variant

### DIFF
--- a/packages/ui/src/Button/Button.vue
+++ b/packages/ui/src/Button/Button.vue
@@ -72,6 +72,7 @@ const buttonClasses = computed(() => {
             round: { true: 'rounded-full' },
         },
         compoundVariants: [
+            { iconOnly: true, size: 'lg', class: 'w-12 [&_svg]:size-5' },
             { iconOnly: true, size: 'base', class: 'w-10 [&_svg]:size-4.5' },
             { iconOnly: true, size: 'sm', class: 'w-8 [&_svg]:size-3.5' },
             { iconOnly: true, size: 'xs', class: 'w-6.5 h-6.5 [&_svg]:size-3' },


### PR DESCRIPTION
Setting a button's size to `lg` and enabling the `icon-only` option will squish the icon since that particular variant is undefined and thus missing a set width like the other variants. This adds a new variant that accounts for the combination of `lg` and `icon-only`.

```vue
<Button icon="trash" :icon-only="true" size="lg" />
```

### Before

<img width="45" height="64" alt="Screenshot 2025-11-17 at 11 03 16" src="https://github.com/user-attachments/assets/202bee45-e9c2-4acc-8a1f-98a19d07f903" />

### After

<img width="69" height="65" alt="Screenshot 2025-11-17 at 11 05 09" src="https://github.com/user-attachments/assets/a8d3ee61-a263-4c4a-a16c-76927500f747" />
