### PR TITLE
[6.x] Delete duplicate table border radius rule

### DIFF
--- a/resources/css/components/fieldtypes/table.css
+++ b/resources/css/components/fieldtypes/table.css
@@ -84,10 +84,10 @@ Table Fieldtype
             &:last-child td {
                 @apply border-b-0 overflow-hidden;
                 &:first-child {
-                    @apply rounded-bl-lg;
+                    @apply rounded-bl-[calc(var(--radius-lg)-1px)];
                 }
                 &:last-child {
-                    @apply rounded-br-lg;
+                    @apply rounded-br-[calc(var(--radius-lg)-1px)];
                 }
             }
 


### PR DESCRIPTION
There were a couple of rules that were essentially doing the same thing, but one was much better/more specific than the other.

The rule I deleted was causing issues because it was mistakenly targeting the first `tr` when a `thead` was present, e.g. when configuring Radio field options. You can see here we don't want this:

![2025-11-17 at 14 41 07@2x](https://github.com/user-attachments/assets/784cf9d4-76b3-42f2-bbd1-16fbbfedaf8a)

The rule that's the same but better is a few lines up:

```
/* If the table has no header, top left and top right corners of the first row should be rounded. E.g. a list fieldtype but not a table fieldtype. */
&:not(:has(th)) tbody tr:first-child td {
    &:first-child {
        @apply rounded-tl-[calc(var(--radius-lg)-1px)];
    }
    &:last-child {
        @apply rounded-tr-[calc(var(--radius-lg)-1px)];
    }
}
```