### PR TITLE
[6.x] Increase contrast between pressed and unpressed button variants

### DIFF
--- a/packages/ui/src/Button/Button.vue
+++ b/packages/ui/src/Button/Button.vue
@@ -75,7 +75,7 @@ const buttonClasses = computed(() => {
             { iconOnly: true, size: 'base', class: 'w-10 [&_svg]:size-4.5' },
             { iconOnly: true, size: 'sm', class: 'w-8 [&_svg]:size-3.5' },
             { iconOnly: true, size: 'xs', class: 'w-6.5 h-6.5 [&_svg]:size-3' },
-            { iconOnly: true, variant: 'pressed', class: '[&_svg]:!opacity-80 dark:[&_svg]:!opacity-100' },
+            { iconOnly: true, variant: 'pressed', class: '[&_svg]:!opacity-70 dark:[&_svg]:!opacity-100' },
             { iconOnly: false, iconAppend: true, class: '[&_svg]:-me-1' },
             { iconOnly: false, iconPrepend: true, class: '[&_svg]:-ms-0.5' },
             { inset: true, size: 'lg', class: '-m-1.5' },


### PR DESCRIPTION
 This is rather subjective, but I figured I'd suggest the change and let you guys decide whether you agree or not.

We're currently developing [a few custom fieldtypes](https://statamic.com/addons/daun/icon-group-fieldtype) to extend the native ones with icon-only button versions. Easy going so far. Looking at these for a while made me realize they could do with a bit more contrast in the pressed state to allow faster scanning for editors, especially on their not-so-great screens that swallow light grays.

~~Another option would be to increase the contrast of the icons themselves. But that's probably another PR.~~ I also went ahead and slightly increased the contrast of the icons themselves. That seems to help especially in dark mode.

### Before 

<img width="936" height="429" alt="Screenshot 2025-11-17 at 23 20 55" src="https://github.com/user-attachments/assets/06fd25b0-04ca-436f-8aa7-b39f9ffe0e80" />

### After

<img width="935" height="428" alt="Screenshot 2025-11-17 at 23 27 20" src="https://github.com/user-attachments/assets/2d600d68-8203-40b4-8386-0c935396effc" />

## Dark mode

Even with these changes, the dark mode version isn't amazing as far as contrast goes, but it doesn't get any darker than black. The only way to improve contrast from here would be to lighten the default button variant, but I didn't want to go too far with this.

### Before

<img width="934" height="425" alt="Screenshot 2025-11-17 at 23 20 46" src="https://github.com/user-attachments/assets/814edbd4-6fda-4e2d-b809-68e12e0e503e" />

### After

<img width="932" height="423" alt="Screenshot 2025-11-17 at 23 16 24" src="https://github.com/user-attachments/assets/1a409cb6-b436-4228-b9ab-9aa68d236989" />
