### PR TITLE
[6.x] Fix "Create Entry" button on collection widget

### DIFF
--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -34,12 +34,10 @@ class Collection extends Widget
         $blueprints = $collection
             ->entryBlueprints()
             ->reject->hidden()
-            ->map(function ($blueprint) {
-                return [
-                    'handle' => $blueprint->handle(),
-                    'title' => __($blueprint->title()),
-                ];
-            })->values();
+            ->map(fn ($blueprint) => [
+                'handle' => $blueprint->handle(),
+                'title' => __($blueprint->title()),
+            ])->values();
 
         $blueprint = $collection->entryBlueprint();
 


### PR DESCRIPTION
This pull request fixes the "Create Entry" button on the collection widget, which wasn't working due to the lack of `createEntryUrl` in the blueprints array.

Fixes #13071