### PR TITLE
[6.x] Fix edit link to additional blueprints

### DIFF
--- a/resources/js/pages/blueprints/Index.vue
+++ b/resources/js/pages/blueprints/Index.vue
@@ -246,7 +246,7 @@ const resetters = ref({});
                             <td>
                                 <div class="flex items-center gap-2">
                                     <Icon name="blueprints" class="text-gray-500 me-1" />
-                                    <Link :href="cp_url(`blueprints/additional/${blueprint.namespace}/${blueprint.handle}/edit`)" v-text="__(blueprint.title)" />
+                                    <Link :href="blueprint.edit_url" v-text="__(blueprint.title)" />
                                 </div>
                             </td>
                             <td class="actions-column">

--- a/src/Fields/BlueprintRepository.php
+++ b/src/Fields/BlueprintRepository.php
@@ -275,6 +275,7 @@ class BlueprintRepository
                             'handle' => $blueprint->handle(),
                             'namespace' => $blueprint->namespace(),
                             'title' => $blueprint->title(),
+                            'edit_url' => $blueprint->editAdditionalBlueprintUrl(),
                             'reset_url' => $blueprint->resetAdditionalBlueprintUrl(),
                             'is_resettable' => $blueprint->isResettable(),
                             'command_palette_link' => $blueprint->commandPaletteLink($type, $blueprint->editAdditionalBlueprintUrl()),


### PR DESCRIPTION
This pull request fixes the edit link to additional blueprint on the blueprint index page.
