### PR TITLE
[6.x] Text wrap balance error messages

### DIFF
--- a/packages/ui/src/ErrorMessage.vue
+++ b/packages/ui/src/ErrorMessage.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-    <div class="text-sm font-normal text-red-600 st-text-trim-start text-balance [[data-ui-panel-header]_&]:text-red-600 [&_a]:underline [&_a:hover]:text-red-700 dark:[&_a:hover]:text-red-300" data-ui-error-message>
+    <div class="text-sm font-normal text-red-600 st-text-trim-start text-pretty @5xl/panel:text-balance [[data-ui-panel-header]_&]:text-red-600 [&_a]:underline [&_a:hover]:text-red-700 dark:[&_a:hover]:text-red-300" data-ui-error-message>
         <slot v-if="hasDefaultSlot" />
         <span v-else v-html="text" />
     </div>


### PR DESCRIPTION
This adds `text-wrap: balance` to error messages to improve readability on larger container viewports when they're more than one line.

At narrower container viewports we use `text-wrap: pretty` to simply avoid widows.

## Before

Text is awkwardly long
![2025-11-18 at 11 21 22@2x](https://github.com/user-attachments/assets/99654cc6-eea1-42fc-802a-31229d0b2f85)

With an undesirable widow
![2025-11-18 at 11 20 51@2x](https://github.com/user-attachments/assets/390c35ff-01ee-4595-93ce-788260e5ef21)

## After

Text is balanced and the error is easier to read
![2025-11-18 at 10 47 11@2x](https://github.com/user-attachments/assets/84323e19-ec06-44b0-beae-d972b6b0cda3)

Avoiding Widows
![2025-11-18 at 11 20 24@2x](https://github.com/user-attachments/assets/e03f8ac4-d0f2-4362-85b7-82fc3a264500) 
