### PR TITLE
[6.x] Support limit argument in explode modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -716,7 +716,7 @@ class CoreModifiers extends Modifier
      */
     public function explode($value, $params)
     {
-        return explode(Arr::get($params, 0), $value);
+        return explode(Arr::get($params, 0), $value, Arr::get($params, 1, PHP_INT_MAX));
     }
 
     /**

--- a/tests/Modifiers/ExplodeTest.php
+++ b/tests/Modifiers/ExplodeTest.php
@@ -28,6 +28,18 @@ class ExplodeTest extends TestCase
         $this->assertEquals($expected, $modified);
     }
 
+    #[Test]
+    public function it_breaks_a_string_into_an_array_of_strings_with_limit(): void
+    {
+        $places = 'Scotland, England, Switzerland, Italy';
+        $expected = [
+            'Scotland',
+            'England, Switzerland, Italy',
+        ];
+        $modified = $this->modify($places, [', ', 2]);
+        $this->assertEquals($expected, $modified);
+    }
+
     private function modify($value, array $params)
     {
         return Modify::value($value)->explode($params)->fetch();


### PR DESCRIPTION
This PR adds support for the `limit` arg in the explode modifier.