### PR TITLE
[6.x] Bump description contrast up one level

### DIFF
--- a/packages/ui/src/Description.vue
+++ b/packages/ui/src/Description.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 </script>
 
 <template>
-    <div class="text-sm font-normal text-gray-500 dark:text-gray-400 st-text-trim-start [[data-ui-panel-header]_&]:text-gray-600 dark:[[data-ui-panel-header]_&]:text-gray-400 [&_a]:underline [&_a:hover]:text-gray-700 dark:[&_a:hover]:text-gray-300 [&_code]:px-0.5 [&_code]:rounded-sm" data-ui-description>
+    <div class="text-sm font-normal text-gray-600 dark:text-gray-400 st-text-trim-start [&_a]:underline [&_a:hover]:text-gray-700 dark:[&_a:hover]:text-gray-300 [&_code]:px-0.5 [&_code]:rounded-sm" data-ui-description>
         <slot v-if="hasDefaultSlot" />
         <span v-else v-html="text" />
     </div>


### PR DESCRIPTION
I think the description contrast could do with coming down an extra 100 in light mode. It feels much more readable for me without impacting the aesthetic of v6.

Dark mode is fine as it is.

This is used throughout the CP but is most noticeable in areas where long descriptions are used, such as the Blueprint area

## Before

(the description underneath Title and Hidden, which strains my eyes a touch with the surrounding white behind)

![2025-11-18 at 14 39 35@2x](https://github.com/user-attachments/assets/d1114c08-f637-4e3b-9339-3df4dba5adc8)

## After

(the description underneath Title and Hidden, which now feels more comfortable to read)

![2025-11-18 at 14 38 43@2x](https://github.com/user-attachments/assets/d312ef93-9df4-4240-b243-b68cc80e4423)
