### PR TITLE
[6.x] Description contrast half way house

### DIFF
--- a/packages/ui/src/Description.vue
+++ b/packages/ui/src/Description.vue
@@ -11,7 +11,7 @@ const props = defineProps({
 </script>
 
 <template>
-    <div class="text-sm font-normal text-gray-600 dark:text-gray-400 st-text-trim-start [&_a]:underline [&_a:hover]:text-gray-700 dark:[&_a:hover]:text-gray-300 [&_code]:px-0.5 [&_code]:rounded-sm" data-ui-description>
+    <div class="text-sm font-normal text-gray-600/90 dark:text-gray-400 st-text-trim-start [&_a]:underline [&_a:hover]:text-gray-700 dark:[&_a:hover]:text-gray-300 [&_code]:px-0.5 [&_code]:rounded-sm" data-ui-description>
         <slot v-if="hasDefaultSlot" />
         <span v-else v-html="text" />
     </div>


### PR DESCRIPTION
Related to https://github.com/statamic/cms/pull/13090

I've taken the edge off gray-600 because the contrast of a label felt a bit too close to the description when you see a long list of'em—for example when editing field details like this.

Splitting hairs, I know, but hopefully the best of both worlds

![2025-11-18 at 16 22 07@2x](https://github.com/user-attachments/assets/84b3687d-02ed-4613-8c71-967f4ac612a8)

