### PR TITLE
[6.x] Fix display of taxonomy preview targets

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -306,6 +306,7 @@ class TaxonomiesController extends CpController
                         'display' => __('Preview Targets'),
                         'instructions' => __('statamic::messages.taxonomies_preview_targets_instructions'),
                         'type' => 'grid',
+                        'full_width_setting' => true,
                         'fields' => [
                             [
                                 'handle' => 'label',


### PR DESCRIPTION
This pull request fixes how the "Preview Targets" field is displayed on the configure taxonomy page, matching the configure collection page.

## Before

<img width="836" height="515" alt="CleanShot 2025-11-18 at 17 32 14" src="https://github.com/user-attachments/assets/46dbe355-bb83-4064-bfa2-4839be929f1f" />


## After

<img width="833" height="321" alt="CleanShot 2025-11-18 at 17 32 01" src="https://github.com/user-attachments/assets/983a0e11-d961-4942-acfe-36ebe259f148" />
