### PR TITLE
[5.x] Ensure updated_at and updated_by is not null in TracksLastModified

### DIFF
--- a/src/Data/TracksLastModified.php
+++ b/src/Data/TracksLastModified.php
@@ -9,14 +9,14 @@ trait TracksLastModified
 {
     public function lastModified()
     {
-        return ($this->has('updated_at') && ! is_null($this->get('updated_at')))
+        return $this->get('updated_at')
             ? Carbon::createFromTimestamp($this->get('updated_at'), config('app.timezone'))
             : $this->fileLastModified();
     }
 
     public function lastModifiedBy()
     {
-        return ($this->has('updated_by') && ! is_null($this->get('updated_by')))
+        return $this->get('updated_by')
             ? User::find($this->get('updated_by'))
             : null;
     }


### PR DESCRIPTION
In one of our customer projects that we finally were allowed to update to v5 we encountered an error when saving certain entries:

```
Carbon\Carbon::createFromTimestamp(): Argument #1 ($timestamp) must be of type string|int|float, null given, called in /var/www/html/vendor/statamic/cms/src/Data/TracksLastModified.php on line 15
```

On closer inspection it turned out that the affected entries have `updated_at: null` in their data. I currently can't quite figure out _why_ that is the case, but this causes a problem in `TracksLastModified::lastModified()`:

```php
public function lastModified()
{
    return $this->has('updated_at')
        ? Carbon::createFromTimestamp($this->get('updated_at'), config('app.timezone'))
        : $this->fileLastModified();
}
```

The entry _has_ `updated_at`, but it is `null`, causing the Carbon error.

This PR simply changes the `lastModified()` function (and `lastModifiedBy()` too, for good measure) to not just check if the key is there, but also if its truthy.