### PR TITLE
[6.x] Sort global sets by title

### DIFF
--- a/src/Http/Controllers/CP/Globals/GlobalsController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalsController.php
@@ -39,7 +39,7 @@ class GlobalsController extends CpController
                 'configure_url' => $set->editUrl(),
                 'delete_url' => $set->deleteUrl(),
             ];
-        })->filter()->values();
+        })->filter()->sortBy('title')->values();
 
         return Inertia::render('globals/Index', [
             'globals' => $globals,


### PR DESCRIPTION
This pull request adds sorting to the global set index, matching the order of globals in the nav.

Fixes #13091