### PR TITLE
[6.x] Fix missing "Create Folder" button in asset fieldtype selector

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -210,6 +210,7 @@ class Assets extends Fieldtype
                 'can_upload' => User::current()->can('store', [\Statamic\Contracts\Assets\Asset::class, $container]),
                 'can_edit' => User::current()->can('edit', $container),
                 'can_delete' => User::current()->can('delete', $container),
+                'can_create_folders' => User::current()->can('create', [\Statamic\Contracts\Assets\AssetFolder::class, $container]),
                 'sort_field' => $container->sortField(),
                 'sort_direction' => $container->sortDirection(),
             ],


### PR DESCRIPTION
This pull request fixes an issue where the "Create Folder" button wasn't showing in the Asset Fieldtype selector because the container passed into it by the fieldtype was missing the `can_create_folders` key.

Related: #12281
Fixes #13093
