### PR TITLE
[6.x] Asset Replicator preview tweaks

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -372,7 +372,7 @@ export default {
                 this.assets
                     .map((asset) => {
                         return asset.isImage || asset.isSvg
-                            ? `<img src="${asset.thumbnail}" width="20" class="max-w-5 max-h-5 rounded-sm mr-1" height="20" title="${asset.basename}" />`
+                            ? `<img src="${asset.thumbnail}" width="20" class="max-w-5 max-h-5 rounded-sm mr-1 object-cover" height="20" title="${asset.basename}" />`
                             : asset.basename;
                     })
                     .join(' '),


### PR DESCRIPTION
Some small tweaks

- Remove the comma joining the preview items in favour of a space (as suggested by Jason)
- Add a small gap to compensate for losing the comma
- Round the asset previews slightly to match the rest of the UI

## Before
![2025-11-19 at 16 37 19@2x](https://github.com/user-attachments/assets/6584db05-6b01-4a3e-9ebd-43e32cac40a7)

## After
![2025-11-19 at 16 37 10@2x](https://github.com/user-attachments/assets/937aee79-795a-44b1-a488-cf4c59973662)
