### PR TITLE
[6.x] Update replicator previews after reordering sets

### DIFF
--- a/resources/js/components/fieldtypes/fieldtype.js
+++ b/resources/js/components/fieldtypes/fieldtype.js
@@ -90,6 +90,7 @@ const use = function(emit, props) {
         handle: props.handle,
         name,
         fieldActions,
+        replicatorPreview,
     };
 
     return {

--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -105,6 +105,12 @@ function replicatorPreviewUpdated(value) {
     setFieldPreviewValue(fullPath.value, value);
 }
 
+watch(
+    () => fullPath.value,
+    () => setFieldPreviewValue(fullPath.value, fieldtype.value?.replicatorPreview),
+    { immediate: true }
+);
+
 function focused() {
     // todo
 }


### PR DESCRIPTION
This pull request fixes an issue where replicator previews wouldn't be updated after reordering sets.

Fixes #13110
