### PR TITLE
[6.x] Make the Structure fieldtype consistent with other relationship fieldtypes

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -1,10 +1,10 @@
 <template>
     <div
-        class="shadow-ui-sm relative z-2 flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-x-0 dark:border-t-0 dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
+        class="shadow-ui-sm relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-x-0 dark:border-t-0 dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
         :class="{ invalid: item.invalid }"
     >
         <ui-icon name="handles" class="item-move sortable-handle size-4 cursor-grab text-gray-300 dark:text-gray-600" v-if="sortable" />
-        <div class="flex flex-1 items-center">
+        <div class="flex flex-1 items-center line-clamp-1 text-sm text-gray-600 dark:text-gray-300">
             <ui-status-indicator v-if="item.status" :status="item.status" class="me-2" />
 
             <div


### PR DESCRIPTION
I noticed the "Structures" fieldtype was inconsistent with the other relationship-type fieldtypes, such as Terms, so I fixed that:

## Before

Different sizes and colors

![2025-11-20 at 17 04 51@2x](https://github.com/user-attachments/assets/d41bf249-3793-4417-aa86-aeb0a16670c0)

## After

A river of calm

![2025-11-20 at 17 05 35@2x](https://github.com/user-attachments/assets/7d03bf05-b672-44c4-8257-df3bc2f39060)
