### PR TITLE
[6.x] Fix dark switch border

### DIFF
--- a/resources/js/components/ui/Switch.vue
+++ b/resources/js/components/ui/Switch.vue
@@ -17,7 +17,7 @@ const switchRootClasses = cva({
         'relative flex rounded-full shrink-0 border-2',
         'transition-colors cursor-pointer',
         'data-[state=checked]:shadow-inner data-[state=checked]:border-switch-bg data-[state=checked]:bg-switch-bg',
-        'data-[state=unchecked]:border-transparent dark:[.publish-fields_&]:data-[state=checked]:border-gray-800',
+        'data-[state=unchecked]:border-transparent',
         'data-[state=unchecked]:bg-gray-200 dark:data-[state=unchecked]:bg-gray-700'
     ],
     variants: {


### PR DESCRIPTION
There was a stray border in dark mode that was applied just on publish field switches, which shouldn't be there anymore now that we're using switch theme variables

## Before

Here you can see the white circle is flush/the same height as the green background 

![2025-11-21 at 14 55 01@2x](https://github.com/user-attachments/assets/a451e93e-d0f3-42e6-b3bd-2dd425a5939f)

## after

There is now a small background border to show the switch is housed

![2025-11-21 at 14 21 03@2x](https://github.com/user-attachments/assets/eba3c51c-8629-43ca-a96d-0f204342d82d)
