### PR TITLE
[6.x] Fix separator on video fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/VideoFieldtype.vue
+++ b/resources/js/components/fieldtypes/VideoFieldtype.vue
@@ -10,7 +10,7 @@
                 @update:model-value="update"
                 @focus="$emit('focus')"
                 @blur="$emit('blur')"
-                class="border-s-0"
+                input-class="border-s-0"
             />
         </ui-input-group>
         <ui-description v-if="isInvalid" class="text-red-600">{{ __('statamic::validation.url') }}</ui-description>


### PR DESCRIPTION
Fix the prepend separator on the video fieldtype by targeting the input.

I noticed that border-s-0 was broken so I target the input instead

## Before

(the border between the prepend "URL" and the placeholder is double-parked)

![2025-11-21 at 15 40 09@2x](https://github.com/user-attachments/assets/71b10b28-9f6a-43b0-a91c-26d095238dd8)

## After

(hairline border, like it should be)

![2025-11-21 at 15 39 56@2x](https://github.com/user-attachments/assets/fb9dee2f-0bcf-488d-945d-7f4ec4cb3ed9)
