### PR TITLE
[6.x] Fix append prepend border in dark mode

### DIFF
--- a/resources/js/components/ui/Input/GroupAppend.vue
+++ b/resources/js/components/ui/Input/GroupAppend.vue
@@ -9,7 +9,7 @@ const props = defineProps({
         :class="[
             'flex items-center justify-center',
             'shadow-ui-sm disabled:shadow-none',
-            'border border-gray-300 bg-gray-50 text-gray-600 antialiased dark:border-white/10 dark:bg-gray-925 dark:text-gray-300',
+            'border border-gray-300 bg-gray-50 text-gray-600 antialiased dark:border-gray-700 dark:bg-gray-925 dark:text-gray-300',
             'rounded-e-lg px-3 text-sm leading-[1.375rem] shrink-0',
         ]"
         data-ui-input-group-append

--- a/resources/js/components/ui/Input/GroupPrepend.vue
+++ b/resources/js/components/ui/Input/GroupPrepend.vue
@@ -9,7 +9,7 @@ const props = defineProps({
         :class="[
             'flex items-center justify-center',
             'shadow-ui-sm disabled:shadow-none',
-            'border border-gray-300 bg-gray-50 text-gray-600 antialiased dark:border-white/10 dark:bg-gray-950 dark:text-gray-300',
+            'border border-gray-300 bg-gray-50 text-gray-600 antialiased dark:border-gray-700 dark:bg-gray-950 dark:text-gray-300',
             'rounded-s-lg px-3 text-sm leading-[1.375rem] shrink-0',
         ]"
         data-ui-input-group-prepend


### PR DESCRIPTION
These should be the same value as the input border…

## Before

![2025-11-21 at 15 57 11@2x](https://github.com/user-attachments/assets/ea45928f-89e8-4e4b-931c-47c7a992c706)

## After

![2025-11-21 at 15 56 49@2x](https://github.com/user-attachments/assets/ec308191-3d97-4842-9b25-18aaf379efca)
