### PR TITLE
[6.x] Vertically center combobox tags

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -42,6 +42,9 @@
     /* =Jay. Sometimes this is handy e.g. the text inside the command palette searchbox */
     text-box: cap alphabetic;
 }
+@utility st-text-trim-ex-alphabetic {
+    text-box: ex alphabetic;
+}
 
 @utility placeholder-xs {
     /* =Jay. The default of 1em on field inputs feels a bit clumsy/big */

--- a/resources/js/components/ui/Combobox.vue
+++ b/resources/js/components/ui/Combobox.vue
@@ -410,7 +410,7 @@ defineExpose({
                         :key="getOptionValue(option)"
                         class="sortable-item mt-2"
                     >
-                        <Badge pill size="lg">
+                        <Badge pill size="lg" class="[&>*]:st-text-trim-ex-alphabetic">
                             <div v-if="labelHtml" v-html="getOptionLabel(option)"></div>
                             <div v-else>{{ __(getOptionLabel(option)) }}</div>
 
@@ -438,6 +438,12 @@ defineExpose({
     /* Override the hardcoded z-index of Reka's popper content wrapper. We can't use a direct descendant selector because the stack is inside a portal, so instead we'll check to see if there is a stack present. */
     body:has(.stack, .live-preview) [data-reka-popper-content-wrapper] {
         z-index: var(--z-index-portal)!important;
+    }
+
+    @supports(text-box: ex alphabetic) {
+        [data-ui-badge] {
+            padding-block: 0.65rem;
+        }
     }
 
     /* Override the hardcoded z-index of Reka's popper content wrapper. When there's a modal present, we need to ensure the popper content is above it. We can't use a direct descendant selector because the modal is inside a portal, so instead we'll check to see if there is modal content present. */


### PR DESCRIPTION
More accurately vertically center combobox badges, using progressive enhancement.

## The Issue

Currently, the badges have uneven space due to the way browsers trim text (or _don't_ trim, rather).

## Solution

We can fix that with progressive enhancement using the new `text-box` property, which snips the top and bottom of text. We need to apply padding when this happens, which is why I've wrapped the padding in an `@supports` rule. 

## Before

Look at the tags carefully and notice how the words are not perfectly in the middle of the badge, vertically.
It's difficult to unsee this—it almost looks like there is larger top padding than bottom padding.

![2025-11-21 at 17 53 51@2x](https://github.com/user-attachments/assets/bd01f0f7-b246-4fc8-a4d2-9a846acdca7c)

## After

The tag text is vertically centered

![2025-11-21 at 17 53 35@2x](https://github.com/user-attachments/assets/12614cbe-7044-420b-bc8a-52805b11363c)
