### PR TITLE
[6.x] Fix StaticWarm to work being reverse proxy & add base_uri option

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -37,6 +37,7 @@ class StaticWarm extends Command
         {--queue : Queue the requests}
         {--u|user= : HTTP authentication user}
         {--p|password= : HTTP authentication password}
+        {--base_uri= : Base URI to use for all requests}
         {--insecure : Skip SSL verification}
         {--uncached : Only warm uncached URLs}
         {--max-depth= : Maximum depth of URLs to warm}
@@ -131,6 +132,7 @@ class StaticWarm extends Command
     private function clientConfig(): array
     {
         return [
+            'base_uri' => $this->option('base_uri') ?: config('app.url'),
             'verify' => $this->shouldVerifySsl(),
             'auth' => $this->option('user') && $this->option('password')
                 ? [$this->option('user'), $this->option('password')]


### PR DESCRIPTION
As stated in #13145, this PR fixes the StaticWarm command to work behind a reverse proxy by setting the Guzzle client to hit `config('app.url')` by default. This means that if laravel isn't exposed to the internet but instead is reverse proxied by nginx that passes back the requests to php-fpm, this will use the `config('app.url')` to hit nginx instead of `localhost` as it does currently.

This PR also adds a simple `base_uri` option to the command to override that `base_uri`. This can be useful if you wish laravel hits the other nginx docker service, for example by setting `--base_uri=http://nginx` for example. 

Fixes #13145