### PR TITLE
[6.x] Starting & ending impersonation should trigger full page refreshes

### DIFF
--- a/resources/js/components/actions/Actions.js
+++ b/resources/js/components/actions/Actions.js
@@ -63,6 +63,12 @@ export default function useActions() {
 
             if (data.redirect) {
                 if (data.bypassesDirtyWarning) Statamic.$dirty.disableWarning();
+
+                if (data.triggersFullPageRefresh) {
+                    window.location = data.redirect;
+                    return;
+                }
+
                 router.get(data.redirect);
             }
 

--- a/src/Actions/Action.php
+++ b/src/Actions/Action.php
@@ -136,6 +136,11 @@ abstract class Action implements Arrayable
         return false;
     }
 
+    public function triggersFullPageRefresh(): bool
+    {
+        return false;
+    }
+
     public function requiresElevatedSession(): bool
     {
         return false;

--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -73,6 +73,11 @@ class Impersonate extends Action
         return $users->first()->can('access cp') ? cp_route('index') : '/';
     }
 
+    public function triggersFullPageRefresh(): bool
+    {
+        return true;
+    }
+
     public function confirmationText()
     {
         /** @translation */

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -53,6 +53,7 @@ abstract class ActionController extends CpController
             return [
                 'redirect' => $redirect,
                 'bypassesDirtyWarning' => $action->bypassesDirtyWarning(),
+                'triggersFullPageRefresh' => $action->triggersFullPageRefresh(),
             ];
         } elseif ($download = $action->download($items, $values)) {
             return $download instanceof Response ? $download : response()->download($download);

--- a/src/Http/Controllers/CP/Auth/ImpersonationController.php
+++ b/src/Http/Controllers/CP/Auth/ImpersonationController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Auth;
 
 use Illuminate\Events\NullDispatcher;
 use Illuminate\Support\Facades\Auth;
+use Inertia\Inertia;
 use Statamic\Events\ImpersonationEnded;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\Controller;
@@ -41,6 +42,6 @@ class ImpersonationController extends Controller
             ImpersonationEnded::dispatch($originalUser, $impersonatedUser);
         }
 
-        return redirect()->route('statamic.cp.users.index');
+        return Inertia::location(route('statamic.cp.users.index'));
     }
 }


### PR DESCRIPTION
This pull request ensures that a full-page refresh is done whenever starting or ending impersonation. 