### PR TITLE
[6.x] Prevent console warning about prop type in listing search

### DIFF
--- a/resources/js/components/ui/Listing/Search.vue
+++ b/resources/js/components/ui/Listing/Search.vue
@@ -22,7 +22,7 @@ defineExpose({ focus });
             icon="magnifying-glass"
             id="listings-search"
             variant="light"
-            :clearable="true"
+            clearable
             :placeholder="__('Search...')"
             :model-value="searchQuery"
             :disabled="reorderable"


### PR DESCRIPTION
Currently, when you visit any listing page w/ search enabled, you'll see this warning:

<img width="1105" height="138" alt="CleanShot 2025-11-24 at 12 37 51" src="https://github.com/user-attachments/assets/592d7735-f00d-499b-997c-1dc7a28fe566" />

This PR fixes it.

