### PR TITLE
[6.x] Prevent redirect when creating term via fieldtype

### DIFF
--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -369,7 +369,7 @@ export default {
                     }
 
                     // If the edit URL was changed (i.e. the term slug was updated), redirect them there.
-                    else if (window.location.href !== response.data.data.edit_url) {
+                    else if (!this.isInline && window.location.href !== response.data.data.edit_url) {
                         this.redirectTo(response.data.data.edit_url);
                     }
 


### PR DESCRIPTION
This pull request fixes an issue when creating terms via the fieldtype, where the user would be redirected to the newly created term instead of staying on the current page.
