### PR TITLE
[5.x] Terms fieldtype: Only show "Allow Creating" option when using stack selector

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -88,6 +88,9 @@ class Terms extends Relationship
                         'instructions' => __('statamic::fieldtypes.terms.config.create'),
                         'type' => 'toggle',
                         'default' => true,
+                        'if' => [
+                            'mode' => 'default',
+                        ],
                     ],
                     'taxonomies' => [
                         'display' => __('Taxonomies'),


### PR DESCRIPTION
Right now, the "Allow Creating" option is only available in the stack selector mode, as you can't create terms in the select/typeahead modes.

To avoid confusion, this pull request hides the option in the blueprint builder _unless_ the stack selector mode is configured.

Related: #11816