### PR TITLE
[6.x] Hash URLs when saving nocache regions in database

### DIFF
--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -252,7 +252,6 @@ class ExtensionServiceProvider extends ServiceProvider
         Updates\AddTimezoneConfigOptions::class,
         Updates\RemoveParentField::class,
         Updates\UpdateGlobalVariables::class,
-        Updates\PublishMigrationForNocacheUrlColumn::class,
         Updates\PublishMigrationForTwoFactorColumns::class,
         Updates\PublishMigrationForWebauthnTable::class,
         Updates\AddAddonSettingsToGitConfig::class,


### PR DESCRIPTION
Right now, when you store nocache regions in the database, visiting pages with long URLs can result in errors because of the max length of the column in the database.

You can workaround it by upping the column size, but that doesn't really "fix" the problem, just gets rid of it for now.

This pull request implements a suggestion (statamic/ideas#1329) where page URLs are MD5 hashed, resulting in a fixed length in the database.

~~I've also added an update script which publishes a migration converting URLs to MD5 hashes. Although, we could probably get away without this migration by telling folks to clear the static cache when deploying the v6 upgrade?~~

Fixes #11034
Closes statamic/ideas#1329