### PR TITLE
[6.x] Bard: Avoid debouncing new or deleted nodes

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -745,7 +745,23 @@ export default {
                     }, 1);
                 },
                 onUpdate: () => {
-                    this.json = clone(this.editor.getJSON().content);
+                    const oldJson = this.json;
+                    const newJson = clone(this.editor.getJSON().content);
+
+                    const countNodes = (nodes) => {
+                        if (!nodes || !Array.isArray(nodes)) return 0;
+                        let count = nodes.length;
+                        nodes.forEach(node => {
+                            if (node.content) {
+                                count += countNodes(node.content);
+                            }
+                        });
+                        return count;
+                    };
+
+                    if (countNodes(oldJson) !== countNodes(newJson)) this.debounceNextUpdate = false;
+
+                    this.json = newJson;
                     this.html = this.editor.getHTML();
                 },
                 onCreate: ({ editor }) => {


### PR DESCRIPTION
This pull request fixes an issue when new TipTap nodes are created, where node indexes change before the publish container has been updated, causing errors within the `Set` component which relies on the container being correct.

We fixed a few similar issues in #12963. This PR addresses it by comparing the old & new JSON strings when updating state, and if the node count changes, we disable debouncing for the next update.

Fixes #13162