### PR TITLE
[6.x] Prevent setting active tab from hash in inline publish forms

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -74,7 +74,6 @@
             ref="container"
             :name="publishContainer"
             :reference="initialReference"
-            :is-inline="isInline"
             :blueprint="fieldset"
             v-model="values"
             :extra-values="extraValues"
@@ -86,6 +85,7 @@
             v-model:modified-fields="localizedFields"
             :track-dirty-state="trackDirtyState"
             :sync-field-confirmation-text="syncFieldConfirmationText"
+            :remember-tab="!isInline"
         >
             <LivePreview
                 :enabled="isPreviewing"

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -57,7 +57,6 @@
             ref="container"
             :name="publishContainer"
             :reference="initialReference"
-            :is-inline="isInline"
             :blueprint="fieldset"
             v-model="values"
             :meta="meta"
@@ -67,6 +66,7 @@
             :site="site"
             :localized-fields="localizedFields"
             :sync-field-confirmation-text="syncFieldConfirmationText"
+            :remember-tab="!isInline"
         >
             <LivePreview
                 :enabled="isPreviewing"

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -69,7 +69,7 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
-    isInline: {
+    rememberTab: {
         type: Boolean,
         default: false,
     },
@@ -234,7 +234,7 @@ const provided = {
     desyncField,
     components,
     asConfig: toRef(() => props.asConfig),
-    isInline: toRef(() => props.isInline),
+    rememberTab: toRef(() => props.rememberTab),
     isTrackingOriginValues: computed(() => !!props.originValues),
     setValues,
     setFieldValue,

--- a/resources/js/components/ui/Publish/Form.vue
+++ b/resources/js/components/ui/Publish/Form.vue
@@ -44,6 +44,10 @@ const props = defineProps({
     asConfig: {
         type: Boolean,
         default: false,
+    },
+    rememberTab: {
+        type: Boolean,
+        default: true,
     }
 });
 
@@ -95,6 +99,7 @@ onUnmounted(() => saveKeyBinding.destroy());
         :errors="errors"
         :read-only="readOnly"
         :as-config="asConfig"
+        :remember-tab="rememberTab"
         v-model="values"
     >
         <Tabs />

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -13,7 +13,7 @@ import ElementContainer from '@/components/ElementContainer.vue';
 import ShowField from '@/components/field-conditions/ShowField.js';
 
 const slots = useSlots();
-const { blueprint, visibleValues, extraValues, revealerValues, errors, hiddenFields, setHiddenField, container, isInline } = injectContainerContext();
+const { blueprint, visibleValues, extraValues, revealerValues, errors, hiddenFields, setHiddenField, container, rememberTab } = injectContainerContext();
 const tabs = ref(blueprint.value.tabs);
 const width = ref(null);
 const sidebarTab = computed(() => tabs.value.find((tab) => tab.handle === 'sidebar'));
@@ -52,7 +52,8 @@ function setActive(tab) {
 }
 
 function setActiveTabFromHash() {
-    if (isInline.value) return;
+    if (!rememberTab.value) return;
+
     if (window.location.hash.length === 0) return;
 
     setActive(window.location.hash.substr(1));
@@ -60,7 +61,9 @@ function setActiveTabFromHash() {
 
 watch(
     () => activeTab.value,
-    (tab) => window.location.hash = tab,
+    (tab) => {
+        if (rememberTab.value) window.location.hash = tab
+    }
 );
 
 const fieldTabMap = computed(() => {


### PR DESCRIPTION
This pull request prevents the active tab being set based off the URL hash in inline publish forms (eg. via relationship fieldtypes).

Fixes #13166