### PR TITLE
[6.x] Add file icon extensions

### DIFF
--- a/resources/js/components/FileIcon.vue
+++ b/resources/js/components/FileIcon.vue
@@ -86,12 +86,17 @@ export default {
                 case 'avif':
                 case 'bmp':
                 case 'gif':
+                case 'heic':
+                case 'heif':
                 case 'ico':
                 case 'jpg':
                 case 'jpeg':
                 case 'png':
+                case 'apng':
                 case 'raw':
+                case 'dng':
                 case 'nef':
+                case 'tif':
                 case 'tiff':
                 case 'webp':
                     return 'image';


### PR DESCRIPTION
Add a few more file extensions we've encountered in the wild to use for selecting asset file icons.

- `gz` instead of `tar.zg` (the value of the `extension` key is just the last segment)
- Design document types for Affinity (`af`), Indesign (`indd`), and Photoshop Large Format (`psb`)
- Image types for iOS (`heif`/`heic`), APNG, RAW (`dng`) and a common variant of TIFF (`tif`)