### PR TITLE
[5.x] Fix nocache tag not replacing element correctly

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -251,6 +251,19 @@ class FileCacher extends AbstractCacher
         return map;
     }
 
+    function replaceElement(el, html) {
+        const tmp = document.createElement('div');
+        const fragment = document.createDocumentFragment();
+
+        tmp.setHTMLUnsafe(html);
+
+        while (tmp.firstChild) {
+            fragment.appendChild(tmp.firstChild);
+        }
+
+        el.replaceWith(fragment);
+    }
+
     var map = createMap();
 
     fetch('/!/nocache', {
@@ -267,7 +280,7 @@ class FileCacher extends AbstractCacher
 
         const regions = data.regions;
         for (var key in regions) {
-            if (map[key]) map[key].setHTMLUnsafe(regions[key]);
+            if (map[key]) replaceElement(map[key], regions[key]);
         }
 
         for (const input of document.querySelectorAll('input[value="$csrfPlaceholder"]')) {


### PR DESCRIPTION
This pull request fixes an issue caused by #12929, where the nocache tag wasn't replacing the `<span class="nocache">` element as expected.

In my testing, this PR seems to fix both issues, in addition to supporting shadow root elements (which the previous PR added support for).

This is the template I was testing with:

```antlers
{{ nocache }}
    <p class="mb-6">only element</p>
{{ /nocache }}

<ul class="flex items-center mb-6">
    {{ nocache }}
        {{ nav:header }}
            <li>
                <a class="py-1.5 px-3 rounded-md {{ if is_current }} bg-white font-medium {{ else }} text-blue-600 hover:bg-white {{ /if }}" href="{{ url }}">{{ title }}</a>
            </li>
        {{ /nav:header }}
    {{ /nocache }}
</ul>

{{ nocache }}
    <div>
        <template shadowrootmode="open">...</template>
    </div>
{{ /nocache }}
```

Fixes #13114
Fixes #13141