### PR TITLE
[5.x] Date modifiers shouldn't return anything when value is empty

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -3281,6 +3281,10 @@ class CoreModifiers extends Modifier
 
     private function carbon($value)
     {
+        if (! $value) {
+            return optional();
+        }
+
         if (! $value instanceof Carbon) {
             $value = (is_numeric($value)) ? Date::createFromTimestamp($value, config('app.timezone')) : Date::parse($value);
         }


### PR DESCRIPTION
This pull request fixes an issue with our date modifiers, where they would output the current date if the provided value is empty, rather than outputting nothing.

Fixes #13022