### PR TITLE
[6.x] Allow custom widgets without min-height

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -51,7 +51,7 @@ function tailwindWidthClass(width) {
         <div class="widgets @container/widgets flex flex-wrap gap-y-6 -mx-2 sm:-mx-3">
             <div
                 v-for="widget in widgets"
-                class="min-h-54 px-3 starting-style-transition starting-style-transition--siblings"
+                class="px-3 starting-style-transition starting-style-transition--siblings"
                 :class="classes(widget)"
             >
                 <component v-if="widget.component" :is="widget.component.name" v-bind="widget.component.props" />


### PR DESCRIPTION
The dashboard currently applies a min-height of 220px to each item. This makes it impossible to create single-line custom widgets without extraneous whitespace below. This PR removes the min-height from the **wrappers** of widgets. It does leave the min-height on the **widget** itself — using the `<ui-widget>` component will still apply the min-height as visible in the screenshots below. It's just the "chromeless" widget on top that gets to define (or not define) its min-height on its own now.

### Before

<img width="813" height="834" alt="Screenshot 2025-11-26 at 12 50 03" src="https://github.com/user-attachments/assets/56333333-b818-4ca0-a78d-5f57840180b0" />

### After

<img width="811" height="647" alt="Screenshot 2025-11-26 at 12 49 15" src="https://github.com/user-attachments/assets/2d125a78-e1db-4f3e-b661-e050133f10c7" />