### PR TITLE
[6.x] Show sidebar when `actions` tab is provided

### DIFF
--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -38,7 +38,7 @@ const visibleMainTabs = computed(() => {
     });
 });
 const hasMultipleVisibleMainTabs = computed(() => visibleMainTabs.value.length > 1);
-const shouldShowSidebar = computed(() => (slots.sidebar || sidebarTab.value) && width.value > 920);
+const shouldShowSidebar = computed(() => (slots.actions || sidebarTab.value) && width.value > 920);
 const activeTab = ref(visibleMainTabs.value[0].handle);
 
 onMounted(() => setActiveTabFromHash());


### PR DESCRIPTION
This pull request fixes an issue where the sidebar wouldn't be rendered when there's no "Sidebar" tab but there is an `actions` slot.

Fixes #13176