### PR TITLE
[6.x] Filter should focus on field after its been selected

### DIFF
--- a/resources/js/components/ui/Listing/FieldFilterRow.vue
+++ b/resources/js/components/ui/Listing/FieldFilterRow.vue
@@ -18,15 +18,12 @@ const props = defineProps({
 
 const fieldContainer = ref(null);
 
-const focusFirstField = async () => {
-    await nextTick();
-    if (fieldContainer.value) {
-        // Look for the first input, textarea, or select element
+const focusFirstField = () => {
+    setTimeout(() => {
         const firstInput = fieldContainer.value.querySelector('input:not([readonly]), textarea, select, [contenteditable="true"]');
-        if (firstInput) {
-            firstInput.focus();
-        }
-    }
+
+        firstInput?.focus();
+    }, 10);
 };
 
 const handleKeydown = (event) => {


### PR DESCRIPTION
This pull request fixes an issue with field filters where the input wasn't being focused as intended after adding a new filter. The "Add Field" dropdown was being focused instead.

This PR fixes it by swapping `nextTick()` for `setTimeout()`.