### PR TITLE
[6.x] Export `architectural-background` for addons

### DIFF
--- a/packages/cms/src/inertia.js
+++ b/packages/cms/src/inertia.js
@@ -3,6 +3,8 @@ export const {
     Head,
     Link,
     router,
+    toggleArchitecturalBackground,
+    useArchitecturalBackground,
     useForm,
     usePoll,
 } = __STATAMIC__.inertia;

--- a/resources/js/bootstrap/cms/inertia.js
+++ b/resources/js/bootstrap/cms/inertia.js
@@ -7,3 +7,5 @@ export {
 } from '@inertiajs/vue3';
 
 export { default as Head } from '../../pages/layout/Head.vue';
+
+export { useArchitecturalBackground, toggleArchitecturalBackground } from '../../pages/layout/architectural-background.js';

--- a/resources/js/tests/Package.test.js
+++ b/resources/js/tests/Package.test.js
@@ -70,6 +70,8 @@ it('exports inertia', async () => {
         'Head',
         'Link',
         'router',
+        'toggleArchitecturalBackground',
+        'useArchitecturalBackground',
         'useForm',
         'usePoll',
     ];


### PR DESCRIPTION
This pull request exports the `architectural-background` composable under the `@statamic/cms/inertia` namespace, allowing it to be imported by addons.