### PR TITLE
[6.x] Avoid setting active nav item when click event is cancelled

### DIFF
--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -73,6 +73,8 @@ function toggle() {
 }
 
 function handleParentClick(event, item) {
+	if (event.defaultPrevented) return;
+
     // Prevent opening in a new tab from updating the active state.
     if (event.ctrlKey || event.metaKey || event.which === 2) return;
 
@@ -86,6 +88,8 @@ function handleParentClick(event, item) {
 }
 
 function handleChildClick(event, item, child) {
+	if (event.defaultPrevented) return;
+
     // Prevent opening in a new tab from updating the active state.
     if (event.ctrlKey || event.metaKey || event.which === 2) return;
 


### PR DESCRIPTION
This pull request fixes an issue where the active nav item would be set when the triggering click event is cancelled (eg. by cancelling out of a dirty state warning).