### PR TITLE
[6.x] Only add "Browse the Marketplace" action to command palette for public addons

### DIFF
--- a/resources/js/pages/addons/Index.vue
+++ b/resources/js/pages/addons/Index.vue
@@ -12,13 +12,15 @@ const rows = ref(props.addons);
 
 onMounted(() => {
     props.addons.forEach(addon => {
-        Statamic.$commandPalette.add({
-            category: Statamic.$commandPalette.category.Actions,
-            text: [__('Browse the Marketplace'), addon.name],
-            icon: 'external-link',
-            url: addon.marketplace_url,
-            openNewTab: true,
-        });
+		if (addon.marketplace_url) {
+			Statamic.$commandPalette.add({
+				category: Statamic.$commandPalette.category.Actions,
+				text: [__('Browse the Marketplace'), addon.name],
+				icon: 'external-link',
+				url: addon.marketplace_url,
+				openNewTab: true,
+			});
+		}
     });
 });
 </script>


### PR DESCRIPTION
This pull request adds a conditional around the "Browse the Marketplace" command palette action on the addons index page. The action should only be registered for public addons.

<img width="854" height="58" alt="CleanShot 2025-11-27 at 10 53 47" src="https://github.com/user-attachments/assets/c826428c-d14e-45c4-95ad-b3b3e6a02084" />
