### PR TITLE
[6.x] Enforce 4 digit years

### DIFF
--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -159,6 +159,7 @@ const getInputLabel = (part) => {
                                     v-if="item.part === 'literal'"
                                     :part="item.part"
                                     :class="{ 'text-sm text-gray-600 dark:text-gray-400 antialiased': !item.contenteditable }"
+                                    v-on="inputEvents"
                                 >
                                     {{ item.value }}
                                 </DatePickerInput>


### PR DESCRIPTION
This pull request ensures that years always have 4 digits: 

https://github.com/user-attachments/assets/56c2d919-4cb5-41d1-8941-60160e8204eb

