### PR TITLE
[6.x] Delete Blade `docs-callout` component

### DIFF
--- a/resources/views/components/docs-callout.blade.php
+++ b/resources/views/components/docs-callout.blade.php
@@ -1,1 +1,0 @@
-<ui-docs-callout topic="{{ $topic }}" url="{{ $url }}" />


### PR DESCRIPTION
This pull request deletes the Blade `docs-callout` component, in favour of using the Vue component directly. 

It used to live in the `partials` directory in v5, but it was moved to `components` in v6 before the Inertia migration, meaning developers would already need to update their code when upgrading to v6.

