### PR TITLE
[6.x] Show proper 404 pages instead of plain text

### DIFF
--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -9,6 +9,7 @@ use Statamic\Assets\AssetFolder;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\CP\Column;
 use Statamic\Exceptions\AuthorizationException;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\Scope;
 use Statamic\Facades\User;
@@ -54,7 +55,7 @@ class BrowserController extends CpController
 
         $asset = Asset::find("{$containerHandle}::{$path}");
 
-        abort_unless($container && $asset, 404);
+        throw_unless($container && $asset, new NotFoundHttpException);
 
         $this->authorize('view', $asset);
 

--- a/src/Http/Controllers/CP/Preferences/Nav/RoleNavController.php
+++ b/src/Http/Controllers/CP/Preferences/Nav/RoleNavController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Preferences\Nav;
 
 use Illuminate\Http\Request;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Preference;
 use Statamic\Facades\Role;
@@ -23,7 +24,7 @@ class RoleNavController extends Controller
 
     public function edit($handle)
     {
-        abort_unless($role = Role::find($handle), 404);
+        throw_unless($role = Role::find($handle), new NotFoundHttpException);
 
         $this->currentHandle = $handle;
 
@@ -43,7 +44,7 @@ class RoleNavController extends Controller
 
     public function update(Request $request, $handle)
     {
-        abort_unless($role = Role::find($handle), 404);
+        throw_unless($role = Role::find($handle), new NotFoundHttpException);
 
         $nav = $this->getUpdatedNav($request);
 
@@ -58,7 +59,7 @@ class RoleNavController extends Controller
 
     public function destroy($handle)
     {
-        abort_unless($role = Role::find($handle), 404);
+        throw_unless($role = Role::find($handle), new NotFoundHttpException);
 
         $role->removePreference('nav')->save();
 


### PR DESCRIPTION
Similar to #13041, this pull request ensures the "proper" 404 pages is shown instead of plain text.