### PR TITLE
[5.x] Avoid hardcoded nocache url in js

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -55,7 +55,8 @@ Route::name('statamic.')->group(function () {
     Route::prefix(config('statamic.routes.action'))
         ->post('nocache', NoCacheController::class)
         ->middleware(NoCacheLocalize::class)
-        ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken']);
+        ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken'])
+        ->name('nocache');
 
     if (OAuth::enabled()) {
         Route::get(config('statamic.oauth.routes.login'), [OAuthController::class, 'redirectToProvider'])->name('oauth.login');

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -239,7 +239,7 @@ class FileCacher extends AbstractCacher
     public function getNocacheJs(): string
     {
         $csrfPlaceholder = CsrfTokenReplacer::REPLACEMENT;
-        $nocacheUrl = URL::prependSiteUrl(config('statamic.routes.action').'/nocache');
+        $nocacheUrl = URL::makeRelative(route('statamic.nocache'));
 
         $default = <<<EOT
 (function() {


### PR DESCRIPTION
This PR modifies the `/!/nocache` URL in the NoCache JavaScript to utilize `URL::prependSiteUrl()`, thereby ensuring that it uses to the site’s `APP_URL` configuration. This aligns with the behavior of other action routes, such as forms and authentication.

Sites running on a subdirectory (e.g., https://domain.com/subsite) now have their NoCache AJAX requests sent to https://domain.com/!/nocache instead of https://domain.com/subsite/!/nocache.