### PR TITLE
[6.x] Collection widget fixes

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -17,7 +17,7 @@
                 <ui-panel-header class="flex items-center justify-between">
                     <div class="flex items-center gap-1.5">
                         <ui-heading size="lg" :text="__(collection.title)" :href="collection.available_in_selected_site ? collection.entries_url : collection.edit_url" />
-                        <span v-if="collection.available_in_selected_site" class="text-sm text-gray-600">
+                        <span v-if="collection.available_in_selected_site" class="text-sm text-gray-600 dark:text-gray-400">
                             ({{ __n('messages.entry_count', collection.entries_count, { count: collection.entries_count }) }})
                         </span>
                     </div>
@@ -105,17 +105,17 @@
                     </div>
                 </ui-card>
 
-                <ui-panel-footer v-if="collection.available_in_selected_site" class="flex items-center gap-6 text-sm text-gray-600">
-                    <div class="flex items-center gap-2">
-                        <ui-badge :text="String(collection.published_entries_count)" pill class="bg-gray-200 dark:bg-gray-700" />
+                <ui-panel-footer v-if="collection.available_in_selected_site" class="flex items-center gap-6 text-sm text-gray-600 dark:text-gray-400">
+                    <div class="flex items-center gap-1.5">
+                        <ui-badge :text="String(collection.published_entries_count)" pill class="bg-white! dark:bg-gray-700! [&_span]:st-text-trim-cap" />
                         <span>{{ __('Published') }}</span>
                     </div>
-                    <div class="flex items-center gap-2 text-sm" v-if="collection.scheduled_entries_count > 0">
-                        <ui-badge :text="String(collection.scheduled_entries_count)" pill class="bg-gray-200 dark:" />
+                    <div class="flex items-center gap-1.5" v-if="collection.scheduled_entries_count > 0">
+                        <ui-badge :text="String(collection.scheduled_entries_count)" pill class="bg-white! dark:bg-gray-700! [&_span]:st-text-trim-cap" />
                         <span>{{ __('Scheduled') }}</span>
                     </div>
-                    <div class="flex items-center gap-2 text-sm" v-if="collection.draft_entries_count > 0">
-                        <ui-badge :text="String(collection.draft_entries_count)" pill class="bg-gray-200 dark:" />
+                    <div class="flex items-center gap-1.5" v-if="collection.draft_entries_count > 0">
+                        <ui-badge :text="String(collection.draft_entries_count)" pill class="bg-white! dark:bg-gray-700! [&_span]:st-text-trim-cap" />
                         <span>{{ __('Drafts') }}</span>
                     </div>
                 </ui-panel-footer>
@@ -304,3 +304,11 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+    @supports(text-box: cap alphabetic) {
+        [data-ui-badge] {
+            padding-block: calc(var(--spacing) * 1.5);
+        }
+    }
+</style>


### PR DESCRIPTION
A few fixes and improvements to collection widgets…

- Correct colors so it's easier to see badges and text, especially in dark mode
- Tightened up badge spacing a touch
- Improve vertical spacing for the badges

## Before

Text surrounding the widget is too dark

![2025-11-27 at 15 11 37@2x](https://github.com/user-attachments/assets/6b7b4872-00f0-49ba-bcf1-2e0caa6db13f)

Badges difficult to read

![2025-11-27 at 15 12 32@2x](https://github.com/user-attachments/assets/ffed2bf0-c24e-424d-bff2-4e042c67377e)


## After
![2025-11-27 at 15 11 27@2x](https://github.com/user-attachments/assets/22ac310e-ff21-47fd-a021-36d1d07f7172)

![2025-11-27 at 15 11 19@2x](https://github.com/user-attachments/assets/b1a6a47c-bd27-4a9b-a12e-cc80c8c21b30)
