### PR TITLE
[6.x] Make dots consistent

### DIFF
--- a/resources/css/components/metrics.css
+++ b/resources/css/components/metrics.css
@@ -29,10 +29,10 @@
         @apply bg-blue;
     }
     &.green {
-        @apply bg-green-600;
+        @apply bg-green-500;
     }
     &.red {
-        @apply bg-red-600;
+        @apply bg-red-500;
     }
 }
 

--- a/resources/js/components/blueprints/Listing.vue
+++ b/resources/js/components/blueprints/Listing.vue
@@ -38,7 +38,7 @@ const reloadPage = () => router.reload();
     >
         <template #cell-title="{ row: blueprint }">
             <div class="flex items-center">
-                <div class="little-dot me-2" :class="[blueprint.hidden ? 'hollow' : 'bg-green-600']" />
+                <div class="little-dot me-2" :class="[blueprint.hidden ? 'hollow' : 'bg-green-500']" />
                 <a :href="blueprint.edit_url">{{ __(blueprint.title) }}</a>
 
                 <resource-deleter

--- a/resources/js/components/ui/Calendar/Calendar.vue
+++ b/resources/js/components/ui/Calendar/Calendar.vue
@@ -151,7 +151,7 @@ const gridStyle = computed(() => {
                                     'data-disabled:text-gray-400 dark:data-disabled:text-gray-600',
                                     'data-unavailable:pointer-events-none data-unavailable:text-black/30 data-unavailable:line-through',
                                     'before:absolute before:top-[3px] before:hidden before:h-1 before:w-1 before:rounded-lg before:bg-white',
-                                    'data-today:before:block data-today:before:bg-green-600',
+                                    'data-today:before:block data-today:before:bg-green-500',
                                 ]"
                             />
                         </Component>

--- a/resources/js/components/ui/Publish/Localization.vue
+++ b/resources/js/components/ui/Publish/Localization.vue
@@ -21,7 +21,7 @@ defineProps({
                 :class="{
                     'bg-green-600': localization.published,
                      'bg-gray-500': !localization.published,
-                     'bg-red-600': !localization.exists,
+                     'bg-red-500': !localization.exists,
                 }"
             />
             {{ __(localization.name) }}

--- a/resources/js/pages/blueprints/ScopedIndex.vue
+++ b/resources/js/pages/blueprints/ScopedIndex.vue
@@ -69,7 +69,7 @@ const reloadPage = () => router.reload();
         >
             <template #cell-title="{ row: blueprint }">
                 <div class="flex items-center">
-                    <div class="little-dot me-2" :class="[blueprint.hidden ? 'hollow' : 'bg-green-600']" />
+                    <div class="little-dot me-2" :class="[blueprint.hidden ? 'hollow' : 'bg-green-500']" />
                     <Link :href="blueprint.edit_url" v-text="__(blueprint.title)" />
 
                     <resource-deleter

--- a/resources/js/pages/utilities/Licensing.vue
+++ b/resources/js/pages/utilities/Licensing.vue
@@ -61,7 +61,7 @@ const props = defineProps([
                         <TableRow>
                             <TableCell class="w-64 font-bold">
                                 <div class="flex gap-2 sm:gap-3">
-                                    <span class="little-dot mt-[0.45rem]" :class="site.valid ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600'" />
+                                    <span class="little-dot mt-[0.45rem]" :class="site.valid ? 'bg-green-500' : 'bg-red-500 dark:bg-red-600'" />
                                     {{ site.key ?? __('No license key') }}
                                 </div>
                             </TableCell>
@@ -87,7 +87,7 @@ const props = defineProps([
                         <TableRow>
                             <TableCell class="w-64 font-bold">
                                 <div class="flex gap-2 sm:gap-3">
-                                    <span class="little-dot mt-[0.45rem]" :class="statamic.valid ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600'" />
+                                    <span class="little-dot mt-[0.45rem]" :class="statamic.valid ? 'bg-green-500' : 'bg-red-500'" />
                                     <span>
                                     {{ __('Statamic') }}
                                     <span v-if="statamic.pro" class="text-pink">{{ __('Pro') }}</span>
@@ -112,7 +112,7 @@ const props = defineProps([
                         <TableRow v-for="addon in addons" :key="addon.name">
                             <TableCell class="w-64">
                                 <div class="flex gap-2 sm:gap-3">
-                                    <span class="little-dot mt-[0.45rem]" :class="addon.valid ? 'bg-green-500 dark:bg-green-600' : 'bg-red-500 dark:bg-red-600'" />
+                                    <span class="little-dot mt-[0.45rem]" :class="addon.valid ? 'bg-green-' : 'bg-red-500'" />
                                     <span class="font-bold">
                                     <a :href="addon.marketplaceUrl" class="underline">{{ addon.name }}</a>
                                 </span>
@@ -134,7 +134,7 @@ const props = defineProps([
                         <TableRow v-for="addon in unlistedAddons" :key="addon.name">
                             <TableCell class="w-64">
                                 <div class="flex gap-2 sm:gap-3">
-                                    <span class="little-dot mt-[0.45rem] bg-green-500 dark:bg-green-600" />
+                                    <span class="little-dot mt-[0.45rem] bg-green-500" />
                                     {{ addon.name }}
                                 </div>
                             </TableCell>


### PR DESCRIPTION
I noticed there were a couple of different green/red shades across the "dots" such as statuses.

I've opted for the brighter shade here. I think it feels a bit more modern, and vibes better with the new indigo primary color. It's not used as a background to text so accessibility should be good here.

I think the same shade works well across both dark and light modes, so I've removed dark variants.