### PR TITLE
[6.x] Remove background from main header icon

### DIFF
--- a/resources/js/components/ui/Header.vue
+++ b/resources/js/components/ui/Header.vue
@@ -11,7 +11,7 @@ const props = defineProps({
     <header class="flex flex-wrap items-center justify-between gap-4 px-2 sm:px-0 py-4 md:py-8" data-ui-header>
         <h1 class="text-[25px] leading-[1.25] st-text-legibility font-medium antialiased flex items-center gap-2.5 flex-1">
             <!-- Wrap icon in a fixed size div (the same size as the icon) to prevent layout shift once it loads -->
-            <div v-if="icon" class="size-5 relative bg-white dark:bg-gray-900">
+            <div v-if="icon" class="size-5 relative">
                 <Icon :name="icon" class="size-5 text-gray-500"></Icon>
             </div>
             <slot name="title">{{ title }}</slot>


### PR DESCRIPTION
Remove the white background from the main header icon, which becomes visible if you change the `content-bg` theme variable to something other than white. Since it has no visual effect when using the default theme values, I'm assuming nothing (aka transparent) is a good replacement here.

### Before

<img width="445" height="241" alt="Screenshot 2025-11-28 at 11 33 58" src="https://github.com/user-attachments/assets/d5471fde-78ed-4a64-a6ce-3b8f140144aa" />

### After

<img width="445" height="237" alt="Screenshot 2025-11-28 at 11 34 18" src="https://github.com/user-attachments/assets/434c0727-4b5e-4bd7-94c8-a207a9c4bbe5" />
