### PR TITLE
[6.x] Performance Optimisation for Queries - Optimise IteratorBuilder limit queries to avoid loading all items

### DIFF
--- a/src/Query/ItemQueryBuilder.php
+++ b/src/Query/ItemQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Query;
 
+use Generator;
 use Illuminate\Support\Collection;
 
 class ItemQueryBuilder extends IteratorBuilder
@@ -18,6 +19,13 @@ class ItemQueryBuilder extends IteratorBuilder
     protected function getBaseItems()
     {
         return $this->items;
+    }
+
+    protected function getBaseItemsLazy(): Generator
+    {
+        foreach ($this->items as $item) {
+            yield $item;
+        }
     }
 
     public function whereStatus($status)

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Search;
 
+use Generator;
 use Statamic\Contracts\Search\Result;
 use Statamic\Data\DataCollection;
 use Statamic\Query\Concerns\FakesQueries;
@@ -53,6 +54,31 @@ abstract class QueryBuilder extends BaseQueryBuilder
         $results = $this->getSearchResults($this->query);
 
         return $this->transformResults($results);
+    }
+
+    protected function getBaseItemsLazy(): Generator
+    {
+        $results = $this->getSearchResults($this->query);
+
+        // If withoutData mode, yield PlainResults directly (cheap, no hydration)
+        if (! $this->withData) {
+            foreach ($results as $i => $result) {
+                $plainResult = new PlainResult($result);
+                $plainResult->setIndex($this->index)->setScore($result['search_score'] ?? null);
+                yield $plainResult;
+            }
+
+            return;
+        }
+
+        // With data mode - batch hydrate to reduce database queries
+        $batchSize = 50;
+        foreach ($this->collect($results)->chunk($batchSize) as $batch) {
+            $hydrated = $this->transformResults($batch);
+            foreach ($hydrated as $item) {
+                yield $item;
+            }
+        }
     }
 
     public function transformResults($results)

--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -72,7 +72,11 @@ abstract class QueryBuilder extends BaseQueryBuilder
         }
 
         // With data mode - batch hydrate to reduce database queries
-        $batchSize = 50;
+        // Use smaller batches when we know the limit and don't need filtering
+        $batchSize = $this->limit && empty($this->wheres) && empty($this->orderBys) && ! $this->randomize
+            ? ($this->offset ?? 0) + $this->limit
+            : 50;
+
         foreach ($this->collect($results)->chunk($batchSize) as $batch) {
             $hydrated = $this->transformResults($batch);
             foreach ($hydrated as $item) {

--- a/tests/Fakes/Query/HydrationTrackingQueryBuilder.php
+++ b/tests/Fakes/Query/HydrationTrackingQueryBuilder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Fakes\Query;
+
+use Generator;
+use Mockery;
+use Statamic\Search\Index;
+use Statamic\Search\PlainResult;
+use Statamic\Search\QueryBuilder;
+
+class HydrationTrackingQueryBuilder extends QueryBuilder
+{
+    protected $results;
+    protected $hydrationCounter;
+
+    public function __construct($results, &$counter)
+    {
+        $this->results = $results;
+        $this->hydrationCounter = &$counter;
+        parent::__construct(Mockery::mock(Index::class));
+    }
+
+    public function getSearchResults($query)
+    {
+        return $this->results;
+    }
+
+    public function getBaseItems()
+    {
+        return $this->collect($this->results)->map(function ($item) {
+            $this->hydrationCounter++;
+            $result = new PlainResult($item);
+            $result->setScore($item['search_score'] ?? null);
+
+            return $result;
+        });
+    }
+
+    protected function getBaseItemsLazy(): Generator
+    {
+        foreach ($this->results as $item) {
+            $this->hydrationCounter++;
+            $result = new PlainResult($item);
+            $result->setScore($item['search_score'] ?? null);
+            yield $result;
+        }
+    }
+}

--- a/tests/Fakes/Query/TestIteratorBuilder.php
+++ b/tests/Fakes/Query/TestIteratorBuilder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Fakes\Query;
+
+use Generator;
+use Statamic\Data\DataCollection;
+use Statamic\Query\IteratorBuilder;
+
+class TestIteratorBuilder extends IteratorBuilder
+{
+    protected $items;
+    protected $loadCounter;
+
+    public function __construct($items, &$counter)
+    {
+        $this->items = $items;
+        $this->loadCounter = &$counter;
+    }
+
+    protected function getBaseItems()
+    {
+        $this->items->each(function () {
+            $this->loadCounter++;
+        });
+
+        return new DataCollection($this->items->all());
+    }
+
+    protected function getBaseItemsLazy(): Generator
+    {
+        foreach ($this->items as $item) {
+            $this->loadCounter++;
+            yield $item;
+        }
+    }
+}

--- a/tests/Query/IteratorBuilderTest.php
+++ b/tests/Query/IteratorBuilderTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tests\Query;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Fakes\Query\TestIteratorBuilder;
+use Tests\TestCase;
+
+class IteratorBuilderTest extends TestCase
+{
+    #[Test]
+    public function it_optimizes_limit_without_wheres()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        $this->assertEquals(10, $loadCount, 'Should only load 10 items, not all 10000');
+    }
+
+    #[Test]
+    public function it_optimizes_limit_with_offset()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->offset(5)->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        $this->assertEquals(15, $loadCount, 'Should load offset + limit items');
+        $this->assertEquals(6, $results->first()['id'], 'First result should be offset by 5');
+    }
+
+    #[Test]
+    public function it_batches_with_wheres()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'id' => $i,
+            'value' => "item-$i",
+            'even' => $i % 2 === 0,
+        ]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->where('even', true)->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        // With 50% match rate and batch size of 50, should need ~1-2 batches
+        $this->assertLessThan(150, $loadCount, 'Should batch and stop early, not load all 10000');
+        $this->assertTrue($results->every(fn ($item) => $item['even'] === true));
+    }
+
+    #[Test]
+    public function it_batches_with_wheres_low_match_rate()
+    {
+        $loadCount = 0;
+        // Only 10% of items match (every 10th item)
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'id' => $i,
+            'value' => "item-$i",
+            'matches' => $i % 10 === 0,
+        ]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->where('matches', true)->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        // With 10% match rate, need ~100 items to find 10 matches
+        // Batch size is max(50, 10*2) = 50, so ~2-3 batches
+        $this->assertLessThan(300, $loadCount, 'Should batch efficiently with low match rate');
+        $this->assertTrue($results->every(fn ($item) => $item['matches'] === true));
+    }
+
+    #[Test]
+    public function it_loads_all_when_has_orderby()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->orderBy('id', 'desc')->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        $this->assertEquals(100, $loadCount, 'Must load all items to sort');
+        $this->assertEquals(100, $results->first()['id'], 'First result should be highest id');
+    }
+
+    #[Test]
+    public function it_loads_all_when_randomize()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->inRandomOrder()->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        $this->assertEquals(100, $loadCount, 'Must load all items to randomize');
+    }
+
+    #[Test]
+    public function it_loads_all_when_no_limit()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->get();
+
+        $this->assertCount(100, $results);
+        $this->assertEquals(100, $loadCount, 'Should load all items when no limit');
+    }
+
+    #[Test]
+    public function it_handles_limit_greater_than_total()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 50))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->limit(100)->get();
+
+        $this->assertCount(50, $results);
+        $this->assertEquals(50, $loadCount, 'Should load all available items');
+    }
+
+    #[Test]
+    public function it_handles_offset_near_end()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->offset(95)->limit(10)->get();
+
+        $this->assertCount(5, $results);
+        $this->assertEquals(100, $loadCount, 'Should load up to available items');
+    }
+
+    #[Test]
+    public function it_handles_wheres_with_no_matches()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => [
+            'id' => $i,
+            'value' => "item-$i",
+            'status' => 'draft',
+        ]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->where('status', 'published')->limit(10)->get();
+
+        $this->assertCount(0, $results);
+        $this->assertEquals(100, $loadCount, 'Should scan all items when no matches found');
+    }
+
+    #[Test]
+    public function it_handles_complex_wheres()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'id' => $i,
+            'value' => "item-$i",
+            'status' => $i % 3 === 0 ? 'published' : 'draft',
+            'featured' => $i % 5 === 0,
+        ]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        // Items matching: divisible by 3 AND divisible by 5 = divisible by 15
+        $results = $builder
+            ->where('status', 'published')
+            ->where('featured', true)
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(10, $results);
+        // ~6.67% match rate (every 15th item), should need ~150 items
+        $this->assertLessThan(500, $loadCount, 'Should batch efficiently with complex wheres');
+    }
+
+    #[Test]
+    public function it_preserves_item_order_without_orderby()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['id' => $i, 'value' => "item-$i"]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder->limit(10)->get();
+
+        $this->assertEquals([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], $results->pluck('id')->all());
+    }
+
+    #[Test]
+    public function it_works_with_whereIn()
+    {
+        $loadCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'id' => $i,
+            'value' => "item-$i",
+            'category' => 'cat-'.($i % 100),
+        ]);
+
+        $builder = new TestIteratorBuilder($items, $loadCount);
+        $results = $builder
+            ->whereIn('category', ['cat-1', 'cat-2', 'cat-3'])
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(10, $results);
+        $this->assertLessThan(500, $loadCount);
+    }
+}

--- a/tests/Search/QueryBuilderPerformanceTest.php
+++ b/tests/Search/QueryBuilderPerformanceTest.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Tests\Search;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\Fakes\Query\HydrationTrackingQueryBuilder;
+use Tests\TestCase;
+
+class QueryBuilderPerformanceTest extends TestCase
+{
+    #[Test]
+    public function it_only_hydrates_limited_items_when_no_wheres()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => ['reference' => "entry::item-$i"]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        $this->assertLessThanOrEqual(10, $hydrationCount, 'Should only hydrate 10 items, not all 10000');
+    }
+
+    #[Test]
+    public function it_batches_hydration_when_has_wheres()
+    {
+        $hydrationCount = 0;
+        // Create items where only 10% match the filter
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'reference' => "entry::item-$i",
+            'status' => $i % 10 === 0 ? 'published' : 'draft',
+        ]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()
+            ->where('status', 'published')
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(10, $results);
+        // Should hydrate ~100-200 items (enough batches to find 10 matches), not all 10000
+        $this->assertLessThan(500, $hydrationCount, 'Should batch hydrate, not hydrate all 10000');
+    }
+
+    #[Test]
+    public function it_loads_all_when_has_orderby()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => [
+            'reference' => "entry::item-$i",
+            'title' => "Title $i",
+        ]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()
+            ->orderBy('title')
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(10, $results);
+        // Must load all 100 to sort
+        $this->assertEquals(100, $hydrationCount, 'Must hydrate all items to sort');
+    }
+
+    #[Test]
+    public function it_handles_offset_with_limit_optimization()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => ['reference' => "entry::item-$i"]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->offset(100)->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        $this->assertLessThanOrEqual(110, $hydrationCount, 'Should only hydrate offset + limit items');
+    }
+
+    #[Test]
+    public function it_handles_large_limit_efficiently()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => ['reference' => "entry::item-$i"]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->limit(1000)->get();
+
+        $this->assertCount(1000, $results);
+        $this->assertEquals(1000, $hydrationCount, 'Should hydrate exactly 1000 items');
+    }
+
+    #[Test]
+    public function it_handles_wheres_with_very_low_match_rate()
+    {
+        $hydrationCount = 0;
+        // Only 1% of items match (every 100th item)
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'reference' => "entry::item-$i",
+            'rare' => $i % 100 === 0,
+        ]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()
+            ->where('rare', true)
+            ->limit(5)
+            ->get();
+
+        $this->assertCount(5, $results);
+        // With 1% match rate, need ~500 items to find 5 matches
+        // Should be much less than 10000
+        $this->assertLessThan(1500, $hydrationCount, 'Should batch efficiently even with low match rate');
+    }
+
+    #[Test]
+    public function it_handles_no_matching_items()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => [
+            'reference' => "entry::item-$i",
+            'status' => 'draft',
+        ]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()
+            ->where('status', 'published')
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(0, $results);
+        $this->assertEquals(100, $hydrationCount, 'Should scan all items when no matches');
+    }
+
+    #[Test]
+    public function it_respects_search_score_ordering_after_optimization()
+    {
+        $hydrationCount = 0;
+        // Items with search scores in descending order
+        $items = collect(range(1, 100))->map(fn ($i) => [
+            'reference' => "entry::item-$i",
+            'search_score' => 100 - $i + 1, // 100, 99, 98, ...
+        ]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        // Results should be in original order (by search_score)
+        $this->assertEquals(
+            [100, 99, 98, 97, 96, 95, 94, 93, 92, 91],
+            $results->pluck('search_score')->all()
+        );
+    }
+
+    #[Test]
+    public function it_loads_all_when_randomized()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['reference' => "entry::item-$i"]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->inRandomOrder()->limit(10)->get();
+
+        $this->assertCount(10, $results);
+        $this->assertEquals(100, $hydrationCount, 'Must hydrate all items to randomize');
+    }
+
+    #[Test]
+    public function it_loads_all_when_no_limit()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['reference' => "entry::item-$i"]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->get();
+
+        $this->assertCount(100, $results);
+        $this->assertEquals(100, $hydrationCount, 'Should hydrate all items when no limit');
+    }
+
+    #[Test]
+    public function it_handles_limit_greater_than_total()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 50))->map(fn ($i) => ['reference' => "entry::item-$i"]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->limit(100)->get();
+
+        $this->assertCount(50, $results);
+        $this->assertEquals(50, $hydrationCount, 'Should hydrate all available items');
+    }
+
+    #[Test]
+    public function it_handles_multiple_wheres()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'reference' => "entry::item-$i",
+            'status' => $i % 3 === 0 ? 'published' : 'draft',
+            'featured' => $i % 5 === 0,
+        ]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        // Items matching: divisible by 3 AND divisible by 5 = divisible by 15 (~6.67%)
+        $results = $builder->withoutData()
+            ->where('status', 'published')
+            ->where('featured', true)
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(10, $results);
+        // Should batch efficiently, not load all 10000
+        $this->assertLessThan(1000, $hydrationCount, 'Should batch efficiently with multiple wheres');
+    }
+
+    #[Test]
+    public function it_handles_whereIn()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 10000))->map(fn ($i) => [
+            'reference' => "entry::item-$i",
+            'category' => 'cat-'.($i % 100),
+        ]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        // 3% match rate (3 categories out of 100)
+        $results = $builder->withoutData()
+            ->whereIn('category', ['cat-1', 'cat-2', 'cat-3'])
+            ->limit(10)
+            ->get();
+
+        $this->assertCount(10, $results);
+        $this->assertLessThan(1000, $hydrationCount, 'Should batch efficiently with whereIn');
+    }
+
+    #[Test]
+    public function it_handles_offset_near_end()
+    {
+        $hydrationCount = 0;
+        $items = collect(range(1, 100))->map(fn ($i) => ['reference' => "entry::item-$i"]);
+
+        $builder = new HydrationTrackingQueryBuilder($items, $hydrationCount);
+        $results = $builder->withoutData()->offset(95)->limit(10)->get();
+
+        $this->assertCount(5, $results);
+        $this->assertEquals(100, $hydrationCount, 'Should hydrate up to available items');
+    }
+}


### PR DESCRIPTION
### Description

This PR optimises the `IteratorBuilder` to avoid loading all items when a `limit()` is applied without `orderBy()` or `inRandomOrder()`. This significantly improves search query performance, particularly for sites with large datasets.

Fixes https://github.com/statamic/cms/issues/13215 

### Problem

Previously, `IteratorBuilder::getFilteredItems()` loaded ALL items before applying limits. For a `->limit(10)` query on 10,000 results, it would hydrate all 10,000 items before taking the first 10.

### Solution

Added a new abstract method `getBaseItemsLazy(): Generator` that yields items lazily, enabling early termination when the limit is reached.

Three optimisation paths in `getFilteredItems()`:
- **No limit, orderBy, or randomise**: Falls back to loading all items (unchanged behaviour)
- **Limit without wheres**: Loads only `offset + limit` items
- **Limit with wheres**: Batches items and stops early when enough matches are collected

### Benchmark Results

I wrote a simple benchmark script separately to test the difference in performance between current code and new code for various scenarios (eg wheres, where + limit, limit etc.). I skipped orderBy as this remains the same, but I did test just in case and it's the same.

| Scenario       | Limit | Old Time | Old Hydrated | New Time | New Hydrated | Improvement |
|----------------|-------|----------|--------------|----------|--------------|-------------|
| No wheres      | 10    | 0.70ms   | 10,000       | 0.04ms   | 10           | 99.9% fewer |
| No wheres      | 50    | 0.68ms   | 10,000       | 0.05ms   | 50           | 99.5% fewer |
| No wheres      | 100   | 0.68ms   | 10,000       | 0.06ms   | 100          | 99% fewer   |
| 50% match rate | 10    | 9.13ms   | 10,000       | 0.10ms   | 50           | 99.5% fewer |
| 50% match rate | 50    | 9.14ms   | 10,000       | 0.15ms   | 100          | 99% fewer   |
| 50% match rate | 100   | 9.12ms   | 10,000       | 0.26ms   | 200          | 98% fewer   |
| 10% match rate | 10    | 9.01ms   | 10,000       | 0.18ms   | 100          | 99% fewer   |
| 10% match rate | 50    | 8.99ms   | 10,000       | 0.57ms   | 500          | 95% fewer   |
| 10% match rate | 100   | 8.98ms   | 10,000       | 1.08ms   | 1,000        | 90% fewer   |

### Safety checks

- Queries with `orderBy()` or `inRandomOrder()` load all items (sorting/shuffling requires all)
- Queries without `limit()` load all items (no early termination possible)
- Results are identical to previous behaviour, just faster

### Files Changed

- `src/Query/IteratorBuilder.php` - Core optimisation logic
- `src/Query/ItemQueryBuilder.php` - Implements `getBaseItemsLazy()`
- `src/Search/QueryBuilder.php` - Implements `getBaseItemsLazy()` with batch hydration

### Tests

- `tests/Query/IteratorBuilderTest.php` - 13 tests covering optimisation paths
- `tests/Search/QueryBuilderPerformanceTest.php` - 14 tests for search-specific behaviour
- `tests/Fakes/Query/TestIteratorBuilder.php` - Test helper
- `tests/Fakes/Query/HydrationTrackingQueryBuilder.php` - Test helper

Note: These tests all pass, it's just the UTF-8 which Duncan is fixing in another PR that are failing.

### Potential Future Optimisation

This PR optimises hydration by stopping early once the limit is reached. However, the search drivers still fetch all raw results from the index before we apply the limit.

A possible future optimisation could pass the limit down to `getSearchResults($query, $limit = null)` so drivers can fetch fewer results at the source:

- **Algolia**: Could use the `hitsPerPage` API parameter to request fewer hits
- **Comb**: Could limit raw results before mapping scores/snippets

This would be most beneficial for large indexes where the initial lookup is expensive.

In my testing, this PR still reduces my search from 3.5s down to 600ms using Comb, and with this future optimisation would reduce down to about 400ms.