### PR TITLE
[6.x] Show media dimensions for all filetypes

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -139,7 +139,7 @@
 
                 <div class="flex w-full items-center justify-end rounded-b border-t dark:border-gray-700 bg-gray-100 dark:bg-gray-900 px-4 py-3">
                     <div class="hidden h-full flex-1 gap-2 sm:gap-3 py-1 sm:flex">
-                        <ui-badge pill v-if="isImage" icon="assets" :text="__('messages.width_x_height', { width: asset.width, height: asset.height })" />
+                        <ui-badge pill v-if="asset.width && asset.height" icon="assets" :text="__('messages.width_x_height', { width: asset.width, height: asset.height })" />
                         <ui-badge pill icon="memory" :text="asset.size" />
                         <ui-badge pill icon="fingerprint">
                             <time


### PR DESCRIPTION
Always display available media dimensions in the asset editor, regardless of type. Very useful for videos, but this should kick in whenever any of the builtin metadata extractors finds width and height.

<img width="384" height="56" alt="Screenshot 2025-11-30 at 15 42 43" src="https://github.com/user-attachments/assets/d978aaa1-ee91-4183-94bf-aaac45c26704" />
