### PR TITLE
[6.x] Apply collection widget badge styling fixes to panel footer only

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -307,7 +307,7 @@ export default {
 
 <style scoped>
     @supports(text-box: cap alphabetic) {
-        [data-ui-badge] {
+        [data-ui-panel-footer] [data-ui-badge] {
             padding-block: calc(var(--spacing) * 1.5);
         }
     }


### PR DESCRIPTION
In #13200 the css added need to be more specific. It leaked to the listing view.

It caused these badges:
<img width="587" height="173" alt="CleanShot 2025-11-30 at 18 27 34" src="https://github.com/user-attachments/assets/509da5cc-66ce-43a1-b276-b2567e479442" />
to turn into these:
<img width="568" height="195" alt="CleanShot 2025-11-30 at 18 27 56" src="https://github.com/user-attachments/assets/2b9606f0-20ec-4588-a52e-2b8c25e40e6c" />

cc @JayGeorge 
