### PR TITLE
[6.x] Performance Optimisation for Stache - Stache Batch Get Items for Redis/Memcached/DynamoDB - Reduce Network Overhead

### DIFF
--- a/tests/Stache/AggregateStoreTest.php
+++ b/tests/Stache/AggregateStoreTest.php
@@ -34,6 +34,54 @@ class AggregateStoreTest extends TestCase
         $this->assertInstanceOf(ChildStore::class, $childOne);
         $this->assertEquals(['one' => $childOne, 'two' => $childTwo], $this->store->stores()->all());
     }
+
+    #[Test]
+    public function it_gets_items_from_multiple_child_stores()
+    {
+        $this->store->store('one')->setItems([
+            'a' => ['id' => 'a', 'title' => 'Item A'],
+            'b' => ['id' => 'b', 'title' => 'Item B'],
+        ]);
+
+        $this->store->store('two')->setItems([
+            'c' => ['id' => 'c', 'title' => 'Item C'],
+            'd' => ['id' => 'd', 'title' => 'Item D'],
+        ]);
+
+        $items = $this->store->getItems(['one::a', 'two::c', 'one::b']);
+
+        $this->assertCount(3, $items);
+        $this->assertEquals('a', $items[0]['id']);
+        $this->assertEquals('c', $items[1]['id']);
+        $this->assertEquals('b', $items[2]['id']);
+    }
+
+    #[Test]
+    public function it_gets_items_preserving_order_across_stores()
+    {
+        $this->store->store('one')->setItems([
+            'a' => ['id' => 'a'],
+            'b' => ['id' => 'b'],
+        ]);
+
+        $this->store->store('two')->setItems([
+            'c' => ['id' => 'c'],
+            'd' => ['id' => 'd'],
+        ]);
+
+        // Request in mixed order
+        $items = $this->store->getItems(['two::d', 'one::a', 'two::c', 'one::b']);
+
+        $this->assertEquals(['d', 'a', 'c', 'b'], $items->pluck('id')->all());
+    }
+
+    #[Test]
+    public function it_returns_empty_collection_for_empty_keys()
+    {
+        $items = $this->store->getItems([]);
+
+        $this->assertCount(0, $items);
+    }
 }
 
 class TestAggregateStore extends AggregateStore
@@ -53,4 +101,20 @@ class TestAggregateStore extends AggregateStore
 
 class TestChildStore extends ChildStore
 {
+    protected $items = [];
+
+    public function setItems(array $items)
+    {
+        $this->items = $items;
+    }
+
+    public function getItem($key)
+    {
+        return $this->items[$key] ?? null;
+    }
+
+    public function getItems($keys)
+    {
+        return collect($keys)->map(fn ($key) => $this->getItem($key));
+    }
 }

--- a/tests/Stache/BasicStoreTest.php
+++ b/tests/Stache/BasicStoreTest.php
@@ -54,6 +54,45 @@ class BasicStoreTest extends TestCase
     }
 
     #[Test]
+    public function it_gets_multiple_items_by_keys()
+    {
+        file_put_contents($this->tempDir.'/foo.yaml', '');
+        file_put_contents($this->tempDir.'/bar.yaml', '');
+        file_put_contents($this->tempDir.'/baz.yaml', '');
+
+        $items = $this->store->getItems(['foo', 'bar', 'baz']);
+
+        $this->assertCount(3, $items);
+        $this->assertEquals('foo', $items[0]->id());
+        $this->assertEquals('bar', $items[1]->id());
+        $this->assertEquals('baz', $items[2]->id());
+    }
+
+    #[Test]
+    public function it_gets_multiple_items_preserving_order()
+    {
+        file_put_contents($this->tempDir.'/foo.yaml', '');
+        file_put_contents($this->tempDir.'/bar.yaml', '');
+        file_put_contents($this->tempDir.'/baz.yaml', '');
+
+        // Request in different order than created
+        $items = $this->store->getItems(['baz', 'foo', 'bar']);
+
+        $this->assertCount(3, $items);
+        $this->assertEquals('baz', $items[0]->id());
+        $this->assertEquals('foo', $items[1]->id());
+        $this->assertEquals('bar', $items[2]->id());
+    }
+
+    #[Test]
+    public function it_returns_empty_collection_for_empty_keys()
+    {
+        $items = $this->store->getItems([]);
+
+        $this->assertCount(0, $items);
+    }
+
+    #[Test]
     public function it_gets_an_item_by_path()
     {
         $this->markTestIncomplete();


### PR DESCRIPTION
### Description

Optimises Stache store item retrieval by using batch cache operations for Redis, Memcached, and DynamoDB users.

- Adds `getItems()` method to `BasicStore` that fetches multiple items efficiently
- Groups keys by child store in `AggregateStore` before delegating
- Uses `cache()->many()` for batch fetching (single MGET for Redis)
- Only enables batch mode for network-based cache drivers (Redis, Memcached, DynamoDB)
- File/Array cache users continue using individual lookups (due to no network overhead)

### Performance Impact

For Redis/Memcached users fetching many items (eg. search results). I wrote a little benchmark tool and this is more or less the summary of the speed improvements. I have only benchmarked using Redis but given they're all in-memory stores, it should be roughly the same for Dynamo/Memcached:

| Items | Batch (new) | Individual (old) | Improvement | Speedup |
|-------|-------------|------------------|-------------|---------|
| 100   | 0.38 ms     | 4.61 ms          | 91.8%       | 12x     |
| 1000  | 2.42 ms     | 27.76 ms         | 91.3%       | 11.5x   |
| 5000  | 11.54 ms    | 134.52 ms        | 91.4%       | 11.7x   |

Approx 12x speedup for Redis users. The batch approach using MGET is much faster than N individual GET calls.

For File/Array cache users: no change (driver detection skips batch mode). With in-memory Array cache, the improvement is minimal because there's no network latency to optimise. The overhead of building the batch request can even make it slightly slower for small datasets, so it's skipped.

### Use Cases

This improvement benefits any code path that retrieves multiple Stache items at once such as:

- Search results hydration
- Entry queries returning many results
- Bulk operations on entries/terms/assets