### PR TITLE
[6.x] Skip Laravel Herd test failure

### DIFF
--- a/tests/Support/Concerns/TestsIlluminateStr.php
+++ b/tests/Support/Concerns/TestsIlluminateStr.php
@@ -1370,6 +1370,12 @@ trait TestsIlluminateStr
 
     public function testWordCount()
     {
+        // Laravel Herd has an issue with locale handling on Mac.
+        // See: https://github.com/beyondcode/herd-community/issues/1282
+        if (str_word_count('мама') !== 0) {
+            $this->markTestSkipped();
+        }
+
         $this->assertEquals(2, Str::wordCount('Hello, world!'));
         $this->assertEquals(10, Str::wordCount('Hi, this is my first contribution to the Laravel framework.'));
 


### PR DESCRIPTION
Theres an issue with a particular test when using Laravel Herd on Mac.
I'm tired of seeing it fail locally so this'll skip it.
Context: https://github.com/beyondcode/herd-community/issues/1282
