### PR TITLE
[6.x] Improve group button shadows

### DIFF
--- a/resources/js/components/ui/Button/Group.vue
+++ b/resources/js/components/ui/Button/Group.vue
@@ -10,7 +10,7 @@
             '[&>*:last-child:not(:first-child)_[data-ui-group-target]]:rounded-s-none',
             'dark:[&_button]:ring-0',
             'max-lg:[[data-floating-toolbar]_&_button]:rounded-md!',
-            'shadow-ui-sm'
+            'shadow-ui-sm rounded-lg'
         ]"
         data-ui-button-group
     >


### PR DESCRIPTION
When buttons are in a group, apply the shadow to the whole group rather than individual buttons.

## Before

Here is a zoomed image of the button group. Because each button has an individual shadow, you get these white shadow gaps, which are distracting.

![2025-12-03 at 11 01 01@2x](https://github.com/user-attachments/assets/d0724730-309e-4335-b098-b500b1e8656e)

## After

There is now a uniform shadow around the group

![2025-12-03 at 10 59 55@2x](https://github.com/user-attachments/assets/3a6461d3-c7b2-4071-9f7d-bb5c11d6dc3f)
