### PR TITLE
[6.x] Remove keybindings when CreateForm component is unmounted

### DIFF
--- a/resources/js/components/ui/CreateForm.vue
+++ b/resources/js/components/ui/CreateForm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, onMounted, getCurrentInstance } from 'vue';
+import { ref, computed, watch, onMounted, onBeforeUnmount, getCurrentInstance } from 'vue';
 import { router } from '@inertiajs/vue3';
 
 const props = defineProps({
@@ -21,6 +21,7 @@ const title = ref(null);
 const handle = ref(null);
 const slug = $slug.separatedBy('_');
 const errors = ref({});
+const saveBinding = ref(null);
 
 const canSubmit = computed(() => {
     return title.value && (props.withoutHandle || handle.value);
@@ -51,7 +52,7 @@ const submit = () => {
 };
 
 onMounted(() => {
-    $keys.bindGlobal(['return', 'mod+s'], (e) => {
+    saveBinding.value = $keys.bindGlobal(['return', 'mod+s'], (e) => {
         e.preventDefault();
 
         if (canSubmit.value) {
@@ -59,6 +60,8 @@ onMounted(() => {
         }
     });
 });
+
+onBeforeUnmount(() => saveBinding.value?.destroy());
 </script>
 
 <template>


### PR DESCRIPTION
This pull request fixes an issue where pressing "enter" after creating something (eg. a nav, a collection) would result in an error due to the CreateForm trying to submit its form, even though its no longer visible.

Fixes #13232.