### PR TITLE
[6.x] Improve header layout for mobile

### DIFF
--- a/resources/js/components/ui/Header.vue
+++ b/resources/js/components/ui/Header.vue
@@ -8,8 +8,8 @@ const props = defineProps({
 </script>
 
 <template>
-    <header class="flex flex-wrap items-center justify-between gap-4 px-2 sm:px-0 py-4 md:py-8" data-ui-header>
-        <h1 class="text-[25px] leading-[1.25] st-text-legibility font-medium antialiased flex items-center gap-2.5 flex-1">
+    <header class="flex flex-wrap items-center justify-between gap-4 px-2 sm:px-0 py-6 max-md:pb-8 md:py-8" data-ui-header>
+        <h1 class="text-[25px] leading-[1.25] st-text-legibility font-medium antialiased flex items-center gap-2.5 md:flex-1">
             <!-- Wrap icon in a fixed size div (the same size as the icon) to prevent layout shift once it loads -->
             <div v-if="icon" class="size-5 relative">
                 <Icon :name="icon" class="size-5 text-gray-500"></Icon>


### PR DESCRIPTION
This improves the mobile layout for headers, especially when you have longer titles

## Before

![2025-12-03 at 11 22 37@2x](https://github.com/user-attachments/assets/da38fd40-9f13-4e98-9a44-181b37f4ba0e)


## After

![2025-12-03 at 11 22 29@2x](https://github.com/user-attachments/assets/b007aaf1-de54-452b-809a-966524fd77e8)
