### PR TITLE
[6.x] Fix focus trapping issue with `DatePicker` component

### DIFF
--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -155,26 +155,28 @@ const getInputLabel = (part) => {
                         </DatePickerTrigger>
                         <div class="flex items-center flex-1">
                             <template v-for="item in segments" :key="item.part">
-                                <DatePickerInput
-                                    v-if="item.part === 'literal'"
-                                    :part="item.part"
-                                    :class="{ 'text-sm text-gray-600 dark:text-gray-400 antialiased': !item.contenteditable }"
-                                    v-on="inputEvents"
-                                >
-                                    {{ item.value }}
-                                </DatePickerInput>
-                                <DatePickerInput
-                                    v-else
-                                    :part="item.part"
-                                    class="rounded-sm px-0.25 py-0.5 focus:bg-blue-100 focus:outline-hidden data-placeholder:text-gray-600 dark:focus:bg-blue-900 dark:data-placeholder:text-gray-400"
-                                    :class="{
-                                        'px-0.5!': item.part === 'month' || item.part === 'year' || item.part === 'day',
-                                    }"
-                                    :aria-label="getInputLabel(item.part)"
-                                    v-on="inputEvents"
-                                >
-                                    {{ item.value }}
-                                </DatePickerInput>
+	                            <div v-if="item.part === 'literal'">
+	                                <DatePickerInput
+	                                    :part="item.part"
+	                                    :class="{ 'text-sm text-gray-600 dark:text-gray-400 antialiased': !item.contenteditable }"
+	                                    v-on="inputEvents"
+	                                >
+	                                    {{ item.value }}
+	                                </DatePickerInput>
+	                            </div>
+	                            <div v-else>
+		                            <DatePickerInput
+			                            :part="item.part"
+			                            class="rounded-sm px-0.25 py-0.5 focus:bg-blue-100 focus:outline-hidden data-placeholder:text-gray-600 dark:focus:bg-blue-900 dark:data-placeholder:text-gray-400"
+			                            :class="{
+	                                        'px-0.5!': item.part === 'month' || item.part === 'year' || item.part === 'day',
+	                                    }"
+			                            :aria-label="getInputLabel(item.part)"
+			                            v-on="inputEvents"
+		                            >
+			                            {{ item.value }}
+		                            </DatePickerInput>
+	                            </div>
                             </template>
                         </div>
                         <Button


### PR DESCRIPTION
This pull request fixes a weird focus trapping issue with the `DatePicker` component, where clicking underneath the inputs incorrectly focuses the inputs.

I opened an issue on the Reka UI repository (https://github.com/unovue/reka-ui/issues/2310) and it turns out it is a quirk with `contenteditable`. Wrapping the inputs in divs fixes the issue 🤷‍♂️

## Before

https://github.com/user-attachments/assets/9ff44bd2-1251-417d-a924-3701db43c1b2


## After


https://github.com/user-attachments/assets/08984a80-16ba-48a6-b3ca-d41d99ecaf88

