### PR TITLE
[6.x] Improve the Fullscreen experiences for Bard, Replicator, Code, and Markdown.

### DIFF
--- a/resources/css/components/fieldtypes/markdown.css
+++ b/resources/css/components/fieldtypes/markdown.css
@@ -51,13 +51,7 @@
 ========================================================================== */
 [data-markdown-toolbar] {
     @apply flex items-center justify-between rounded-t-[calc(var(--radius-lg)-1px)] bg-gray-50 px-2 py-1 overflow-x-auto;
-    @apply sticky z-(--z-index-global-header) -top-2 border-b border-gray-300 dark:border-white/20 dark:border-b-white/10 dark:bg-gray-925;
-    /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
-    margin-block-end: 8px;
-    /* Pull the subsequent element up to compensate for this */
-    ~ * {
-        margin-block-start: -8px;
-    }
+    @apply border-b border-gray-300 dark:border-white/20 dark:border-b-white/10 dark:bg-gray-925;
 }
 
 .grid-cell [data-markdown-toolbar] {
@@ -95,7 +89,7 @@
 }
 
 .markdown-fullscreen {
-    @apply fixed inset-0 min-h-screen overflow-scroll rounded-none border-0 bg-gray-100 pt-14;
+    @apply fixed inset-0 min-h-screen overflow-scroll rounded-none border-0 bg-gray-100 pt-12;
     will-change: transform;
 
     .mode-wrap {

--- a/resources/css/components/fieldtypes/markdown.css
+++ b/resources/css/components/fieldtypes/markdown.css
@@ -93,11 +93,11 @@
     will-change: transform;
 
     .mode-wrap {
-        height: calc(100vh - 88px); /*  sans toolbars */
+        height: calc(100vh - 80px); /*  sans toolbars */
         overflow-y: scroll;
         cursor: text;
         &.mode-preview {
-            height: calc(100vh - 52px); /*  no footer toolbar */
+            height: calc(100vh - 44px); /*  no footer toolbar */
         }
     }
 

--- a/resources/js/components/fieldtypes/CodeFieldtype.vue
+++ b/resources/js/components/fieldtypes/CodeFieldtype.vue
@@ -30,6 +30,12 @@ export default {
 
     components: { CodeEditor },
 
+    data() {
+        return {
+            escBinding: null,
+        };
+    },
+
     computed: {
         mode() {
             return this.value.mode || this.config.mode;
@@ -48,13 +54,27 @@ export default {
                     icon: ({ vm }) => (vm.$refs.codeEditor.fullScreenMode ? 'fullscreen-close' : 'fullscreen-open'),
                     quick: true,
                     visibleWhenReadOnly: true,
-                    run: ({ vm }) => vm.$refs.codeEditor.toggleFullscreen(),
+                    run: ({ vm }) => vm.toggleFullscreen(),
                 },
             ];
         },
     },
 
     methods: {
+        toggleFullscreen() {
+            const wasFullscreen = this.$refs.codeEditor.fullScreenMode;
+            this.$refs.codeEditor.toggleFullscreen();
+
+            if (wasFullscreen) {
+                if (this.escBinding) {
+                    this.escBinding.destroy();
+                    this.escBinding = null;
+                }
+            } else {
+                this.escBinding = this.$keys.bindGlobal('esc', this.toggleFullscreen);
+            }
+        },
+
         modeUpdated(mode) {
             this.updateDebounced({ code: this.value.code, mode });
         },

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -54,7 +54,7 @@
                             :is-fullscreen="false"
                             @toggle-dark-mode="toggleDarkMode"
                             @button-click="handleButtonClick"
-                            class="mb-2 [&~*]:-mt-2'"
+                            class="mb-2 [&~*]:-mt-2"
                         />
 
                         <div class="drag-notification" v-show="dragging">

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -40,6 +40,7 @@
                                 :is-fullscreen="true"
                                 @toggle-dark-mode="toggleDarkMode"
                                 @button-click="handleButtonClick"
+                                :class="fullScreenMode ? 'sticky z-(--z-index-global-header) -top-2' : 'mb-2 [&~*]:-mt-2'"
                             />
                         </publish-field-fullscreen-header>
 
@@ -95,7 +96,7 @@
                                 <!-- Hidden input for label association -->
                                 <input v-if="id" :id="id" type="text" class="sr-only" @focus="focusCodeMirror" tabindex="-1" />
 
-                                <footer class="flex items-center justify-between bg-gray-50 dark:bg-gray-900 rounded-b-[calc(var(--radius-lg)-1px)] border-t border-gray-300 dark:border-white/10 p-1 text-sm w-full" :class="{ 'absolute inset-x-0 bottom-0 rounded-': fullScreenMode }">
+                                <footer class="flex items-center justify-between bg-gray-50 dark:bg-gray-900 rounded-b-[calc(var(--radius-lg)-1px)] border-t border-gray-300 dark:border-white/10 p-1 text-sm w-full" :class="{ 'absolute inset-x-0 bottom-0 rounded-none z-(--z-index-global-header)': fullScreenMode }">
                                     <div class="markdown-cheatsheet-helper">
                                         <Button
                                             icon="markdown"

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -329,8 +329,11 @@ export default {
         },
 
         toggleFullscreen() {
-            this.fullScreenMode = !this.fullScreenMode;
-            this.trackHeightUpdates();
+            if (this.fullScreenMode) {
+                this.closeFullScreen();
+            } else {
+                this.openFullScreen();
+            }
         },
 
         toggleDarkMode() {

--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -40,7 +40,7 @@
                                 :is-fullscreen="true"
                                 @toggle-dark-mode="toggleDarkMode"
                                 @button-click="handleButtonClick"
-                                :class="fullScreenMode ? 'sticky z-(--z-index-global-header) -top-2' : 'mb-2 [&~*]:-mt-2'"
+                                class="sticky z-(--z-index-global-header) -top-2"
                             />
                         </publish-field-fullscreen-header>
 
@@ -54,6 +54,7 @@
                             :is-fullscreen="false"
                             @toggle-dark-mode="toggleDarkMode"
                             @button-click="handleButtonClick"
+                            class="mb-2 [&~*]:-mt-2'"
                         />
 
                         <div class="drag-notification" v-show="dragging">

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -16,7 +16,7 @@
                         @close="toggleFullscreen"
                     />
 
-                    <section :class="{ 'mt-8 p-4': fullScreenMode }">
+                    <section :class="{ 'mt-12 p-4': fullScreenMode }">
                         <sortable-list
                             :model-value="value"
                             :vertical="true"

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -105,6 +105,7 @@ export default {
             focused: false,
             collapsed: clone(this.meta.collapsed),
             fullScreenMode: false,
+            escBinding: null,
             provide: {
                 replicatorSets: this.config.sets,
                 showReplicatorFieldPreviews: this.config.previews,
@@ -256,6 +257,15 @@ export default {
 
         toggleFullscreen() {
             this.fullScreenMode = !this.fullScreenMode;
+
+            if (this.fullScreenMode) {
+                this.escBinding = this.$keys.bindGlobal('esc', this.toggleFullscreen);
+            } else {
+                if (this.escBinding) {
+                    this.escBinding.destroy();
+                    this.escBinding = null;
+                }
+            }
         },
 
         blurred() {

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -7,7 +7,7 @@
             <div :class="{ wrapperClasses: fullScreenMode }">
                 <div
                     class="replicator-fieldtype-container"
-                    :class="{ 'replicator-fullscreen fixed inset-0 min-h-screen overflow-scroll rounded-none bg-gray-200 dark:bg-gray-800': fullScreenMode }"
+                    :class="{ 'replicator-fullscreen fixed inset-0 min-h-screen overflow-scroll rounded-none bg-gray-100 dark:bg-gray-800': fullScreenMode }"
                 >
                     <publish-field-fullscreen-header
                         v-if="fullScreenMode"
@@ -16,7 +16,7 @@
                         @close="toggleFullscreen"
                     />
 
-                    <section :class="{ 'dark:bg-gray-850 mt-14 bg-gray-200 p-4': fullScreenMode }">
+                    <section :class="{ 'mt-8 p-4': fullScreenMode }">
                         <sortable-list
                             :model-value="value"
                             :vertical="true"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -128,7 +128,8 @@ reveal.use(rootEl, () => emit('expanded'));
         <slot name="picker" />
         <div
             layout
-            class="relative z-2 w-full rounded-lg border border-gray-300 text-base dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black shadow-ui-sm dark:[&_[data-ui-switch]]:border-gray-600 dark:[&_[data-ui-switch]]:border-1"
+            data-replicator-set
+            class="relative z-2 w-full rounded-lg border border-gray-300 text-base dark:border-white/10 bg-white dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black shadow-ui-sm dark:[&_[data-ui-switch]]:border-gray-600 dark:[&_[data-ui-switch]]:border-1"
             :class="{
                 'border-red-500': hasError
             }"

--- a/resources/js/components/publish/FullscreenHeader.vue
+++ b/resources/js/components/publish/FullscreenHeader.vue
@@ -1,5 +1,5 @@
 <template>
-    <header class="fixed inset-x-0 top-0 z-max flex items-center justify-between bg-gray-50 dark:bg-gray-900 px-4 shadow-ui-lg">
+    <header class="fixed h-12 inset-x-0 top-0 z-max flex items-center justify-between bg-gray-50 dark:bg-gray-900 px-4 shadow-ui-lg">
         <ui-heading class="shrink-0" :text="__(title)" />
         <div class="flex min-w-max items-center gap-4">
             <slot />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds ESC-to-exit for Code/Replicator fullscreen and tightens fullscreen header/toolbar spacing with visual tweaks across Markdown/Replicator.
> 
> - **Fullscreen UX**
>   - **ESC to exit**: Bind/unbind global `esc` in `CodeFieldtype.vue` and `replicator/Replicator.vue` when toggling fullscreen.
>   - **Header sizing**: `publish/FullscreenHeader.vue` gets fixed height (`h-12`); related paddings/heights updated in Markdown CSS.
> - **Markdown editor**
>   - Toolbar behavior/layout: remove default sticky CSS; add sticky only in fullscreen and spacing adjustments for fixed toolbar; footer gains `z-(--z-index-global-header)` in fullscreen.
>   - Fullscreen layout: reduce top padding and computed heights; keep toolbar non-bordered in fullscreen; minor z-index tweaks.
> - **Replicator**
>   - Fullscreen visuals: lighter background (`bg-gray-100`), remove dark bg from section; adjust top margin to match new header (`mt-12`).
>   - Set card: ensure white bg in light mode and add `data-replicator-set` attribute.
> - **Code editor**
>   - Field action delegates to component `toggleFullscreen`; manage ESC binding on enter/exit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fa40c8bd3d02a6b64c8c7d5e0d3d519548685e08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->