### PR TITLE
[6.x] Fix missing `fullscreen` config option for the fullscreen quick action in a replicator

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -172,6 +172,7 @@ export default {
                     title: __('Toggle Fullscreen Mode'),
                     icon: ({ vm }) => (vm.fullScreenMode ? 'fullscreen-close' : 'fullscreen-open'),
                     quick: true,
+                    visible: this.config.fullscreen,
                     visibleWhenReadOnly: true,
                     run: this.toggleFullscreen,
                 },


### PR DESCRIPTION
The full screen quick action for a replicator is always shown.

The field config's preference for the full screen action is not being utilised.

This PR fixes this.