### PR TITLE
[6.x] Ensure theme color for progress bar is applied

### DIFF
--- a/resources/css/components/progress.css
+++ b/resources/css/components/progress.css
@@ -3,9 +3,9 @@
     pointer-events: none;
 }
 
-#nprogress .bar {
+#nprogress .bar.bar {
     @apply fixed top-0 w-full bg-progress-bar start-0;
-    height: 1px;
+    height: 2px;
     /* above global-header */
     z-index: var(--z-index-portal);
 }


### PR DESCRIPTION
The current theme config for the progress bar (indigo-700) is not applied. That's because the progress bar styles are overwritten by `style` attributes set on the element itself. This PR increases the specificity so the styles are applied. I changed it from 1px to 2px since that's what's currently being applied anyway.