### PR TITLE
[6.x] Fix prop type warning from `replicator/Set.vue`

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -151,7 +151,7 @@ reveal.use(rootEl, () => emit('expanded'));
                     v-if="!readOnly"
                 />
                 <button type="button" class="flex flex-1 items-center gap-4 p-2 py-1.75 min-w-0 cursor-pointer" @click="toggleCollapsedState">
-                    <Badge size="lg" :pill="true" color="white" class="px-3">
+                    <Badge size="lg" pill color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}
                             <Icon name="chevron-right" class="relative top-px size-3" />


### PR DESCRIPTION
This pull request ensures that the `pill` prop is a boolean, vs a literal string, to avoid this warning:

<img width="919" height="390" alt="CleanShot 2025-12-05 at 09 59 50" src="https://github.com/user-attachments/assets/115ddcef-5303-4c99-95fd-5a45441978de" />
