### PR TITLE
[6.x] Nav tag: `is_parent` shouldn't be true when URL is `#`

### DIFF
--- a/src/Tags/Structure.php
+++ b/src/Tags/Structure.php
@@ -154,7 +154,9 @@ class Structure extends Tags
             return false;
         }
 
-        // todo: just a fragment
+        if ($url === '#') {
+            return false;
+        }
 
         if ($this->siteAbsoluteUrl === $absoluteUrl) {
             return false;


### PR DESCRIPTION
This PR fixes an issue with the `is_parent` variable where it is incorrectly returning `true` when the page URL is `#`.

It looks like it was caused by some of the URL-reworkings in #11840. `URL::isAncestorOf()` now strips the fragment and any query parameters from the URL (which in this case would leave an empty string) and passes it to `URL::tidy()` which returns `/` (the actual parent).

Fixes #13226