### PR TITLE
[6.x] Fix scrolled bard toolbar z index

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -990,6 +990,7 @@ export default {
                 &::after {
                     content: '';
                     position: absolute;
+                    z-index: var(--z-index-below);
                     inset: -4px -8px;
                     box-shadow:
                         /* Left Mask */


### PR DESCRIPTION
This fixes the z-index of a scrolled Bard field pseudo elements so that you can click toolbar buttons and closes #13197 