### PR TITLE
[5.x] Fix add set button not overlap content on small container

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -163,7 +163,7 @@
 }
 
 .bard-add-set-button {
-    @apply flex items-center justify-center absolute rtl:-right-4 ltr:-left-4 top-[-6px] z-1;
+    @apply flex items-center justify-center absolute rtl:-right-6 ltr:-left-6 @lg/bard:rtl:-right-4 @lg/bard:ltr:-left-4 top-[-6px] z-1;
 }
 
 .bard-footer-toolbar {


### PR DESCRIPTION

When the bard field is less then 32 rem wide the content has reduced padding, resulting in the bard add set button overlapping with the content. This PR resolves this by moving the button when the width is smaller.