### PR TITLE
[5.x] Fix add set button not overlap content on small container

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -163,7 +163,7 @@
 }
 
 .bard-add-set-button {
-    @apply flex items-center justify-center absolute rtl:-right-4 ltr:-left-4 top-[-6px] z-1;
+    @apply flex items-center justify-center absolute rtl:-right-6 ltr:-left-6 @lg/bard:rtl:-right-4 @lg/bard:ltr:-left-4 top-[-6px] z-1;
 }
 
 .bard-footer-toolbar {


### PR DESCRIPTION
This PR resolves: https://github.com/statamic/cms/issues/13270

When the bard field is less then 32 rem wide the content has reduced padding, resulting in the bard add set button overlapping with the content.
https://github.com/statamic/cms/blob/566eb8ba117d15e471ba48a0424a7332cb9f359d/resources/css/components/fieldtypes/bard.css#L11-L14

This PR resolves this by moving the button when the width is smaller.

Currently overlapping:

<img width="83" height="110" alt="Image" src="https://github.com/user-attachments/assets/626492de-0a8b-4f03-bf86-20228a355464" />

What this PR resolves:

<img width="76" height="121" alt="Image" src="https://github.com/user-attachments/assets/9db2a16e-313b-4154-83e5-3ebee1460d72" />