### PR TITLE
[6.x] Merge extra form data recursively

### DIFF
--- a/src/Forms/JsDrivers/Alpine.php
+++ b/src/Forms/JsDrivers/Alpine.php
@@ -35,7 +35,7 @@ class Alpine extends AbstractJsDriver
         }
 
         return [
-            'x-data' => $this->renderAlpineXData(collect($this->getInitialFormData())->merge($extraData)->all(), $this->scope),
+            'x-data' => $this->renderAlpineXData(collect($this->getInitialFormData())->mergeRecursive($extraData)->all(), $this->scope),
         ];
     }
 


### PR DESCRIPTION
When passing data into a form:create tag through x-data, the group field's nested values are lost because the extra data replaces the entire group key during the merge. Using a recursive merge preserves the existing nested values and resolves the issue.
