### PR TITLE
[6.x] Fix round button examples to stories

### DIFF
--- a/resources/js/stories/Button.stories.ts
+++ b/resources/js/stories/Button.stories.ts
@@ -171,10 +171,9 @@ export const Round: Story = {
         docs: {
             source: {
                 code: `
-                    <Button size="lg" text="Large" />
-                    <Button size="base" text="Base" />
-                    <Button size="sm" text="Small" />
-                    <Button size="xs" text="Extra Small" />
+                    <Button round icon="plus" />
+                    <Button round icon="plus" text="Add" />
+                    <Button round text="Add" />
                 `,
             },
         },


### PR DESCRIPTION
Fix rounded Button example in the new storybook.

Here how it currently looks like:

<img width="1035" height="384" alt="Screenshot 2025-12-07 at 11 51 10" src="https://github.com/user-attachments/assets/f78bfa8d-36ea-405b-934d-d78bb58be8fc" />