### PR TITLE
[6.x] Update usage of `:localized-fields` prop in terms publish form

### DIFF
--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -64,7 +64,7 @@
             :origin-meta="originMeta"
             :errors="errors"
             :site="site"
-            :localized-fields="localizedFields"
+            v-model:modified-fields="localizedFields"
             :sync-field-confirmation-text="syncFieldConfirmationText"
         >
             <LivePreview


### PR DESCRIPTION
You'll see a warning about the `:localized-fields` prop when you open a terms publish form:

<img width="1504" height="119" alt="CleanShot 2025-12-08 at 10 54 09" src="https://github.com/user-attachments/assets/74f5528d-4505-4c16-b244-5f8c2c8344f4" />


The prop has since been renamed to `modifiedFields` and has two-way data binding. This PR updates the usage.