### PR TITLE
[6.x] Fix modal mounting

### DIFF
--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -55,11 +55,11 @@ const escBinding = ref(null);
 const portal = computed(() => modal.value ? `#portal-target-${modal.value.id}` : null);
 
 function open() {
-	if (!modal.value) modal.value = portals.create('modal');
+    if (!modal.value) modal.value = portals.create('modal');
 
     escBinding.value = keys.bindGlobal('esc', dismiss);
 
-	nextTick(() => {
+    nextTick(() => {
         mounted.value = true;
 
         nextTick(() => visible.value = true);
@@ -69,39 +69,39 @@ function open() {
 function close() {
     visible.value = false;
 
-	wait(300).then(() => {
-		mounted.value = false;
-		updateOpen(false);
-	});
+    wait(300).then(() => {
+        mounted.value = false;
+        updateOpen(false);
+    });
 }
 
 function dismiss() {
-	if (!props.dismissible) return;
+    if (!props.dismissible) return;
 
-	emit('dismissed');
-	close();
+    emit('dismissed');
+    close();
 }
 
 provide('closeModal', close);
 
 function updateOpen(value) {
-	if (isUsingOpenProp.value) {
-		emit('update:open', value);
-	}
+    if (isUsingOpenProp.value) {
+        emit('update:open', value);
+    }
 }
 
 watch(
-	() => props.open,
-	(value) => value ? open() : close(),
+    () => props.open,
+    (value) => value ? open() : close(),
 );
 
 onMounted(() => {
-	if (props.open) open();
+    if (props.open) open();
 });
 
 onBeforeUnmount(() => {
-	modal.value?.destroy();
-	escBinding.value?.destroy();
+    modal.value?.destroy();
+    escBinding.value?.destroy();
 });
 
 defineExpose({


### PR DESCRIPTION
Continuing from #13202, I noticed some modals didn't work. It complained about the portal target not existing.

Not exactly sure why it works for some modals and not others. Maybe it was standalone modal vs confirmation modals?
e.g. the column customizer was broken but table row actions with confirmation modals were fine.

This PR fixes that by setting the `mounted` value to true on the next tick.

The visible still needs to be on the _next_ tick so that we get the nice transition. If they were on the same tick, the modal would just immediately pop in.

I also noticed tabs were used in here so I switched to spaces.
