### PR TITLE
[6.x] Tweak fullscreen header actions behaviour to match field-level actions behaviour

### DIFF
--- a/resources/js/components/publish/FullscreenHeader.vue
+++ b/resources/js/components/publish/FullscreenHeader.vue
@@ -5,14 +5,14 @@
             <slot />
         </div>
         <div class="flex items-center justify-end gap-2 py-2.5">
-            <Dropdown class="mr-2">
+            <Dropdown v-if="hasNonQuickActions" class="mr-2">
                 <template #trigger>
                     <Button icon="dots" variant="ghost" size="xs" :aria-label="__('Open dropdown menu')" />
                 </template>
                 <DropdownMenu>
                     <DropdownItem
                         v-if="fieldActions.length"
-                        v-for="action in fieldActions"
+                        v-for="action in fieldActions.filter((a) => !a.quick)"
                         :text="action.title"
                         :variant="action.dangerous ? 'destructive' : 'default'"
                         @click="action.run(action)"
@@ -26,6 +26,7 @@
                     v-tooltip="action.title"
                     @click="action.run()"
                     size="xs"
+                    :disabled="action.disabled"
                     :icon="action.icon"
                     :aria-label="action.title"
                     tabindex="-1"
@@ -57,5 +58,11 @@ export default {
             default: () => [],
         },
     },
+
+    computed: {
+        hasNonQuickActions() {
+            return this.fieldActions.filter((a) => !a.quick).length > 0;
+        },
+    }
 };
 </script>


### PR DESCRIPTION
The updates to the Quick Actions for fields (like Bard and Replicator) added some new things at the Field level:
- disabled quick actions have the correct state changes applied
- dropdown only shown if there are non-quick actions

This PR takes these same behaviours and adds them to the Fullscreen Header.

If there are no non-quick actions, the dropdown is no longer shown. 

If quick actions are disabled, their state is correctly reflected.

Before:
<img width="150" height="86" alt="image" src="https://github.com/user-attachments/assets/85e35b5e-92b4-4e40-9382-0c09d3d84a16" />

After:
<img width="162" height="90" alt="image" src="https://github.com/user-attachments/assets/5e8b31ec-3635-4c81-a56f-72520469f514" />
