### PR TITLE
[6.x] Translate breadcrumb string

### DIFF
--- a/resources/js/components/global-header/Breadcrumbs.vue
+++ b/resources/js/components/global-header/Breadcrumbs.vue
@@ -104,7 +104,7 @@ function setDropdownItemActive(breadcrumbIndex, linkIndex, breadcrumb) {
                     <Link
                         :href="breadcrumb.url"
                         :aria-label="`${__('Navigate to')} ${__(breadcrumb.display)}`"
-                        v-text="breadcrumb.display"
+                        v-text="__(breadcrumb.display)"
                         @click="setBreadcrumbActive(breadcrumbIndex)"
                     />
                 </ui-dropdown-header>


### PR DESCRIPTION

<img width="360" height="270" alt="CleanShot 2025-12-09 at 09 47 06" src="https://github.com/user-attachments/assets/23512291-7835-4c3a-a098-b6b4420116b8" />


Fixes #13287