### PR TITLE
[6.x] Use min-width on field condition dropdowns

### DIFF
--- a/resources/js/components/field-conditions/Builder.vue
+++ b/resources/js/components/field-conditions/Builder.vue
@@ -5,8 +5,8 @@
             :instructions="__('messages.field_conditions_instructions')"
         >
             <div class="mb-6 flex items-center gap-x-4">
-                <Select v-model="when" :options="whenOptions" class="w-40" />
-                <Select v-if="hasConditions" v-model="type" :options="typeOptions" class="w-80" />
+                <Select v-model="when" :options="whenOptions" class="w-auto min-w-40" />
+                <Select v-if="hasConditions" v-model="type" :options="typeOptions" class="w-auto min-w-80" />
                 <Input v-if="hasConditions && isCustom" v-model="customMethod" class="flex-1" />
             </div>
         </Field>


### PR DESCRIPTION
This pull request sets a min-width on the field condition dropdowns in order to account for internationalisation. 

Fixes #13281

## Before


https://github.com/user-attachments/assets/57efe43a-dc57-459d-a443-5545bea7597b



## After


https://github.com/user-attachments/assets/49deb992-0c84-4117-a001-448c932f56ba

