### PR TITLE
[6.x] Hide clear button on date filters

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -13,6 +13,7 @@
             :model-value="datePickerValue"
             :number-of-months="config.number_of_months"
             :read-only="isReadOnly"
+            :clearable="config.clearable"
             @update:model-value="datePickerUpdated"
         />
     </div>

--- a/src/Query/Scopes/Filters/Fields/Date.php
+++ b/src/Query/Scopes/Filters/Fields/Date.php
@@ -24,6 +24,7 @@ class Date extends FieldtypeFilter
             'value' => [
                 'type' => 'date',
                 'full_width' => true,
+                'clearable' => false,
                 'if' => [
                     'operator' => 'contains_any >, <',
                 ],
@@ -32,6 +33,7 @@ class Date extends FieldtypeFilter
                 'type' => 'date',
                 'mode' => 'range',
                 'full_width' => true,
+                'clearable' => false,
                 'if' => [
                     'operator' => 'between',
                 ],


### PR DESCRIPTION
This pull request hides the clear button on Date filter fields, because the clear button for the row is shown right next to it.