### PR TITLE
[6.x] Customize colums border fixes

### DIFF
--- a/resources/js/components/ui/Listing/CustomizeColumns.vue
+++ b/resources/js/components/ui/Listing/CustomizeColumns.vue
@@ -77,7 +77,7 @@ function reset() {
                     <!-- Available Columns -->
                     <div class="flex w-1/2 flex-col text-start">
                         <ui-heading :text="__('Available Columns')" class="py-2 px-3 border-b dark:border-gray-700" />
-                        <div class="flex flex-1 flex-col space-y-1 overflow-y-auto h-full px-3 py-2 select-none bg-gray-100 dark:bg-gray-900 rounded-bl-[calc(var(--radius-lg)-1px)]">
+                        <div class="flex flex-1 flex-col space-y-1 overflow-y-auto h-full px-3 py-2 select-none bg-gray-100 dark:bg-gray-900 rounded-es-[calc(var(--radius-lg)-1px)]">
                             <ui-checkbox
                                 v-model="column.visible"
                                 :label="column.label"
@@ -91,7 +91,7 @@ function reset() {
                     <!-- Displayed Columns -->
                     <div class="flex w-1/2 flex-col text-start border-l dark:border-gray-700">
                         <ui-heading :text="__('Displayed Columns')" class="py-2 px-3 border-b dark:border-gray-700" />
-                        <div class="overflow-y-auto bg-gray-100 dark:bg-gray-900 rounded-br-[calc(var(--radius-lg)-1px)] h-full">
+                        <div class="overflow-y-auto bg-gray-100 dark:bg-gray-900 rounded-ee-[calc(var(--radius-lg)-1px)] h-full">
                             <sortable-list
                                 v-model="selectedColumns"
                                 :distance="5"


### PR DESCRIPTION
A couple of fixes for "Customize Columns", including:

- Dark borders
- Border-radii. It seems like Tailwind doesn't natively support logical properties for border-radius. I think left and right are fine here? I've minused 1px to account for the parent border