### PR TITLE
[6.x] Focusable quick actions

### DIFF
--- a/resources/js/components/field-actions/FieldActions.vue
+++ b/resources/js/components/field-actions/FieldActions.vue
@@ -25,7 +25,6 @@
                 :disabled="action.disabled"
                 :icon-only="true"
                 :aria-label="action.title"
-                tabindex="-1"
             >
                 <ui-icon :name="action.icon" class="size-3.5" />
             </Button>


### PR DESCRIPTION
Closes #13296.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make quick action buttons focusable by removing `tabindex="-1"` in `resources/js/components/field-actions/FieldActions.vue`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 151d369ed94dfcf1a57e18148d8f0dc67a4a165c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->