### PR TITLE
[5.x] Ensure field parent is set correctly

### DIFF
--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -31,6 +31,7 @@ trait ExtractsFromEntryFields
         }
 
         $fields = $blueprint
+            ->setParent($entry)
             ->fields()
             ->addValues($values)
             ->preProcess();


### PR DESCRIPTION
This PR closes #9630. We need to set the correct parent so that `$this->field->parent()` within a fieldtype always has the correct parent assigned.