### PR TITLE
[6.x] Use min-width on field comparison operator dropdown

### DIFF
--- a/resources/js/components/field-conditions/Condition.vue
+++ b/resources/js/components/field-conditions/Condition.vue
@@ -29,7 +29,7 @@
             </Combobox>
         </div>
 
-        <div class="w-32">
+        <div class="w-auto min-w-32">
             <Select
                 class="w-full"
                 :model-value="condition.operator"


### PR DESCRIPTION
I applied the same changes as in #13289 for the operator dropdown.

## Before (English and German)
<img width="1312" height="709" alt="Bildschirmfoto 2025-12-10 um 15 40 30" src="https://github.com/user-attachments/assets/c91b3128-9690-427e-8f8c-4e1fec8d373e" />
<img width="1269" height="347" alt="Bildschirmfoto 2025-12-10 um 15 46 38" src="https://github.com/user-attachments/assets/0b3d462b-4192-4684-8532-20896e39cd7e" />

## After (English and German)
<img width="1325" height="714" alt="Bildschirmfoto 2025-12-10 um 15 42 09" src="https://github.com/user-attachments/assets/b04447e7-72b7-4216-b0f2-e612859dd577" />
<img width="1267" height="349" alt="Bildschirmfoto 2025-12-10 um 15 46 02" src="https://github.com/user-attachments/assets/f2271028-98d6-47b9-bcf4-9a6999acf684" />
