### PR TITLE
[6.x] Fix nav breakpoint being off by 1px

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -47,7 +47,7 @@
 
 
 /* Mobile nav behavior */
-@media (max-width: theme(--breakpoint-lg)) {
+@media (width < theme(--breakpoint-lg)) {
     .nav-main {
         /* Always visible but off-screen by default */
         @apply flex;


### PR DESCRIPTION
The nav sidebar breakpoint should essentially be `max-width: 1023px` rather than `max-width: 1024px`.

Before this fix if you set the viewport width to exactly `1024px` you'd see an in-between state for the nav like this:

## Before

With a viewport exactly 1024px wide you'd see an "in-between" state

![2025-12-10 at 16 21 46@2x](https://github.com/user-attachments/assets/fcc213a2-3113-45ba-b108-a764742b4e5c)


## After

With a viewport exactly 1024px wide the desktop state is now fully there

![2025-12-10 at 16 21 11@2x](https://github.com/user-attachments/assets/2c669746-cdff-4622-8980-1c7a8242af2c)
