### PR TITLE
[6.x] Fix console error when icon is missing from nav item

### DIFF
--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -129,7 +129,7 @@ Statamic.$events.$on('nav.toggle', toggle);
                             :class="{ 'active': item.active }"
                             @click="handleParentClick($event, item)"
                         >
-                            <Icon v-if="item.icon" :name="item.icon" />
+                            <Icon :name="item.icon ?? 'fieldtype-spacer'" />
                             <span v-text="__(item.display)" />
                         </component>
                         <ul v-if="item.children.length && item.active">


### PR DESCRIPTION
This pull request fixes a console error when an icon is missing from a nav item. 

<img width="806" height="282" alt="CleanShot 2025-12-11 at 10 13 26" src="https://github.com/user-attachments/assets/aa69e93b-f4e4-4c0f-9ffa-a0937dbeb26d" />
