### PR TITLE
[6.x] Fix collapsing sections with field conditions

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -42,10 +42,8 @@ function renderInstructions(instructions) {
 }
 
 function toggleSection(section) {
-	let index = sections.findIndex((s) => s === section);
-
-    if (sections[index].collapsible) {
-        sections[index].collapsed = !sections[index].collapsed;
+    if (section.collapsible) {
+        section.collapsed = !section.collapsed;
     }
 }
 </script>


### PR DESCRIPTION
This pull request fixes an issue with the collapsing sections feature, where it'd get out of sync if the "visible sections" state changed.

When the section's index is passed to `toggleSection`, it's the index of the section in the `visibleSections` array. However, the `toggleSection` method is using that index on the `sections` array.

This PR fixes it by passing the entire section to the `toggleSection` function, then leaving it to figure out the section's index in the `sections` array.

Fixes #13320
