### PR TITLE
[6.x] Initialize translations before color mode

### DIFF
--- a/resources/js/bootstrap/statamic.js
+++ b/resources/js/bootstrap/statamic.js
@@ -163,6 +163,9 @@ export default {
     },
 
     async start() {
+        setTranslations(this.initialConfig.translations);
+        setLocale(this.initialConfig.translationLocale);
+
         config.initialize(this.initialConfig);
         colorMode.initialize(this.initialConfig.user?.color_mode);
         contrast.initialize(this.initialConfig.user?.preferences?.strict_accessibility);
@@ -244,9 +247,6 @@ export default {
         this.$app.use(FloatingVue, { disposeTimeout: 30000, distance: 10 });
         this.$app.use(VueComponentDebug, { enabled: import.meta.env.VITE_VUE_COMPONENT_DEBUG === 'true' });
         toast.initialize(this.$app);
-
-        setTranslations(this.initialConfig.translations);
-        setLocale(this.initialConfig.translationLocale);
 
         Object.assign(this.$app.config.globalProperties, {
             $config: config,


### PR DESCRIPTION
This pull request fixes an issue where the translation for "Toggle Color Mode" (previously "Toggle Theme") wouldn't be used, due to the Command Palette commands being registered _before_ the app's translations.

This PR moves the setting of translations & the user's locale to before the color mode is initialized. Hopefully I've not overlooked something 😬

Fixes #13311