### PR TITLE
[6.x] Fix button group shadow extending beyond its buttons

### DIFF
--- a/resources/js/components/ui/Button/Group.vue
+++ b/resources/js/components/ui/Button/Group.vue
@@ -1,7 +1,7 @@
 <template>
     <div
         :class="[
-            'group/button flex flex-wrap [[data-floating-toolbar]_&]:justify-center [[data-floating-toolbar]_&]:gap-1 [[data-floating-toolbar]_&]:lg:gap-x-0',
+            'group/button inline-flex flex-wrap [[data-floating-toolbar]_&]:justify-center [[data-floating-toolbar]_&]:gap-1 [[data-floating-toolbar]_&]:lg:gap-x-0',
             '[&>[data-ui-group-target]:not(:first-child):not(:last-child)]:rounded-none',
             '[&>[data-ui-group-target]:first-child:not(:last-child)]:rounded-e-none',
             '[&>[data-ui-group-target]:last-child:not(:first-child)]:rounded-s-none',


### PR DESCRIPTION
A recent change moved the button group shadow to the wrapper itself, which looks nicer, but requires the wrapper to not grow in width, which the current `flex` style does. This PR changes it to `inline-flex` by default to avoid shadows growing beyond the width of its contents.

### Before

<img width="355" height="97" alt="Screenshot 2025-12-11 at 22 41 57" src="https://github.com/user-attachments/assets/9d9d132d-a78c-472d-b53a-b858a5069cce" />

### After

<img width="363" height="97" alt="Screenshot 2025-12-11 at 22 53 55" src="https://github.com/user-attachments/assets/a2f611e8-5517-4f1a-a072-59d88cce6d2b" />
