### PR TITLE
[6.x] Change table select decoration

### DIFF
--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -154,8 +154,8 @@
 
 /* Row Selection */
 .data-table[data-has-selections] {
-    tbody tr[data-row="unselected"] td {
-        @apply text-gray-500! dark:text-gray-400!;
+    tbody tr[data-row="selected"] td {
+        @apply bg-gray-100 dark:bg-gray-950;
     }
 }
 


### PR DESCRIPTION
This closes #13327, highlighting selections with the background instead of the text colour.

This is essentially the same as the v5 behaviour.

I vaguely remember the reason for the v6 design change was to try and keep the background hover effect when items were selected—but I guess all considered, changing the background is more standard and advantageous. This is also how popular interfaces such as Fastmail and Gmail do it.