### PR TITLE
[6.x] Collapse nav on window shrink

### DIFF
--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -10,15 +10,32 @@ const localStorageKey = 'statamic.nav';
 const isOpen = ref(localStorage.getItem(localStorageKey) !== 'closed');
 const navRef = ref(null);
 const isMobile = ref(false);
+const collapsedByViewport = ref(false);
 let clickListenerActive = false;
 
 onMounted(() => {
     // Check if screen is less than lg breakpoint (1024px)
     const mediaQuery = window.matchMedia('(width < 1024px)');
     isMobile.value = mediaQuery.matches;
-    
+
     const handleMediaChange = (e) => {
         isMobile.value = e.matches;
+        // Collapse nav when viewport shrinks to mobile size
+        if (e.matches && isOpen.value) {
+            isOpen.value = false;
+            collapsedByViewport.value = true;
+            localStorage.setItem(localStorageKey, 'closed');
+        }
+        // Expand nav when viewport grows back to desktop size (only if it was collapsed by viewport. If the user explicitly set the nav to collapse, we don't want to expand it.)
+        if (!e.matches && !isOpen.value && collapsedByViewport.value) {
+            isOpen.value = true;
+            collapsedByViewport.value = false;
+            localStorage.setItem(localStorageKey, 'open');
+        }
+        // Reset the flag if we're on desktop
+        if (!e.matches) {
+            collapsedByViewport.value = false;
+        }
     };
     
     mediaQuery.addEventListener('change', handleMediaChange);
@@ -69,6 +86,9 @@ function handleClickOutside(event) {
 
 function toggle() {
     isOpen.value = !isOpen.value;
+    // Reset viewport flag since user is explicitly toggling, so we should respect their preference
+    // even when viewport size changes (don't auto-expand if user manually closed it)
+    collapsedByViewport.value = false;
     localStorage.setItem(localStorageKey, isOpen.value ? 'open' : 'closed');
 }
 


### PR DESCRIPTION
This closes #13322

By default, the nav should collapse when we get to lower viewports.

It should also expand again when the window is dragged out to a higher viewport, unless the user has set a preference for a collapsed nav.