### PR TITLE
[6.x] Fix nocache URL not being interpolated in static cache JavaScript

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -249,7 +249,6 @@ class FileCacher extends AbstractCacher
     public function getCsrfTokenJs(): string
     {
         $csrfPlaceholder = CsrfTokenReplacer::REPLACEMENT;
-        $nocacheUrl = URL::makeRelative(route('statamic.nocache'));
 
         $default = <<<EOT
 (function() {
@@ -289,7 +288,9 @@ EOT;
 
     public function getNocacheJs(): string
     {
-        $default = <<<'EOT'
+        $nocacheUrl = URL::makeRelative(route('statamic.nocache'));
+
+        $default = <<<EOT
 (function() {
     function createMap() {
         var map = {};


### PR DESCRIPTION
This fixes a bug, introduded via b91e52016fd57a7fab0df512ce81860c3ab2ffc0