### PR TITLE
[6.x] Fix field conditions & validation rules not being persisted

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -41,7 +41,7 @@
                     <TabContent name="conditions">
                         <CardPanel :heading="__('Conditions')">
                             <FieldConditionsBuilder
-                                :config="config"
+                                :config="values"
                                 :suggestable-fields="suggestableConditionFields"
                                 @updated="updateFieldConditions"
                                 @updated-always-save="updateAlwaysSave"
@@ -51,7 +51,7 @@
 
                     <TabContent name="validation">
                         <CardPanel :heading="__('Validation')">
-                            <FieldValidationBuilder :config="config" @updated="updateField('validate', $event)" />
+                            <FieldValidationBuilder :config="values" @updated="updateField('validate', $event)" />
                         </CardPanel>
                     </TabContent>
                 </div>


### PR DESCRIPTION
This pull request fixes an issue where changes to Field Conditions or Validation Rules would be lost after switching tabs. 

It seems to be related to the fact that the field config was coming from `config` (a prop) rather than `values` (the "live" version of the config).

Fixes #13346