### PR TITLE
[6.x] Fix conditional fields border

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -3,7 +3,7 @@
 /* Here we extend Tailwind's classes to add additional functionality where we're sure it won't break anything. */
 
 /* If the next sibling is hidden (by a Vue conditional), remove the bottom border. For example, /cp/asset-containers/assets/edit, the Image Manipulation toggle. */
-.divide-y > *:has(+[style*="display: none"]) {
+.divide-y > *:has(+[style*="display: none"]:last-child) {
     border-block-end: none;
 }
 


### PR DESCRIPTION
This fixes #13098 by adjusting removing the border if the next sibling is hidden (by a Vue conditional).

I've changed the selector to be more specific and also tested its original purpose to make sure that still works (for example, /cp/asset-containers/assets/edit, the Image Manipulation toggle)