### PR TITLE
[5.x] Enable `copy_reset_password_link` for users with `editPassword` permission

### DIFF
--- a/src/Actions/CopyPasswordResetLink.php
+++ b/src/Actions/CopyPasswordResetLink.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Actions;
 
-use Exception;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Contracts\Auth\User as UserContract;
 
@@ -17,7 +16,7 @@ class CopyPasswordResetLink extends Action
 
     public function visibleTo($item)
     {
-        return config('statamic.users.allow_copy_reset_password_link', false) && $item instanceof UserContract;
+        return $item instanceof UserContract;
     }
 
     public function visibleToBulk($items)
@@ -27,7 +26,7 @@ class CopyPasswordResetLink extends Action
 
     public function authorize($authed, $user)
     {
-        return $authed->can('sendPasswordReset', $user);
+        return $authed->can('editPassword', $user);
     }
 
     public function confirmationText()
@@ -44,10 +43,6 @@ class CopyPasswordResetLink extends Action
 
     public function run($items, $values)
     {
-        if (! config('statamic.users.allow_copy_reset_password_link', false)) {
-            throw new Exception('Copying password reset links is not allowed.');
-        }
-
         $user = $items->first();
 
         $passwordResetLink = $user->password()


### PR DESCRIPTION
I've discovered an undocumented and likely forgotten feature. Since it would be useful for a project of mine, I propose reactivating it.

I noticed it was disabled some time ago due to a security concern: https://github.com/statamic/cms/pull/9390.

I believe the security issue might have been that a user with the `sendPasswordReset` permission could elevate their privileges by copying the reset link from a higher-ranking user. However, I can't identify any functional difference for users with `editPassword` permissions, so I guess we can "safely" activate it for users with such permissions. It also arguably way safer, than sending one-time passwords around.