### PR TITLE
[6.x] Use collection icon in widget

### DIFF
--- a/resources/js/components/entries/CollectionWidget.vue
+++ b/resources/js/components/entries/CollectionWidget.vue
@@ -15,6 +15,7 @@ import { Link } from '@inertiajs/vue3';
 const props = defineProps({
     additionalColumns: Array,
     collection: String,
+	icon: String,
     title: String,
     listingUrl: String,
     initialPerPage: {
@@ -38,7 +39,7 @@ const cols = computed(() => [{ label: 'Title', field: 'title', visible: true }, 
 
 const widgetProps = computed(() => ({
     title: props.title,
-    icon: 'collections',
+    icon: props.icon,
     href: props.listingUrl,
 }));
 

--- a/src/Widgets/Collection.php
+++ b/src/Widgets/Collection.php
@@ -54,6 +54,7 @@ class Collection extends Widget
 
         return VueComponent::render('collection-widget', [
             'collection' => $collection->handle(),
+            'icon' => $collection->icon(),
             'title' => $this->config('title', $collection->title()),
             'additionalColumns' => $columns,
             'filters' => Scope::filters('entries', [


### PR DESCRIPTION
This pull request ensures that a collection's icon is used in the widget, rather than the generic `collections` icon.

Closes #13367
