### PR TITLE
[6.x] Fix side by side field layout from collapsing

### DIFF
--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -44,7 +44,7 @@ const rootClasses = computed(() =>
             variant: {
                 block: 'w-full',
                 inline: [
-                    'flex justify-between gap-x-7 gap-y-1.5',
+                    'flex justify-between [&>*:last-child]:flex-shrink-0 gap-x-7 gap-y-1.5',
                     'has-[[data-ui-label]~[data-ui-control]]:grid-cols-[1fr_auto]',
                     'has-[[data-ui-control]~[data-ui-label]]:grid-cols-[auto_1fr]',
                     '[&>[data-ui-control]~[data-ui-description]]:row-start-2 [&>[data-ui-control]~[data-ui-description]]:col-start-2',


### PR DESCRIPTION
If the side-by-side field layout is enabled with a long instructions, the field UI could collapse like this:

![2025-12-18 at 10 36 10@2x](https://github.com/user-attachments/assets/dcf233f7-0936-417f-bab2-639cda85de98)

This is due flexbox's default layout.

I've added `flex-shrink: 0` to the last child of inline field types, which contains the field UI

![2025-12-18 at 10 37 52@2x](https://github.com/user-attachments/assets/041b60e9-8bbf-447d-98f4-8571739d09a6)
