### PR TITLE
[6.x] Fix link toolbar top radius

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="bard-link-toolbar">
         <div>
-            <div class="border-b bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800 rounded-t-md">
+            <div class="border-b bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-800 rounded-t-xl">
                 <section class="flex gap-2 items-center p-4 border-b dark:border-gray-800">
                     <ui-select
                         v-model="linkType"


### PR DESCRIPTION
The top border radius was clipping on the link toolbar.

## Before

![2025-12-18 at 12 08 34@2x](https://github.com/user-attachments/assets/a384039d-5794-41b6-9845-aedada51877a)


## After

![2025-12-18 at 12 08 19@2x](https://github.com/user-attachments/assets/c7cdaee6-4680-4d5f-897b-f0dee831acca)
