### PR TITLE
[6.x] Automatically close date picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6997,9 +6997,9 @@
       }
     },
     "node_modules/reka-ui": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.3.2.tgz",
-      "integrity": "sha512-lCysSCILH2uqShEnt93/qzlXnB7ySvK7scR0Q5C+a2iXwFVzHhvZQsMaSnbQYueoCihx6yyUZTYECepnmKrbRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/reka-ui/-/reka-ui-2.6.1.tgz",
+      "integrity": "sha512-XK7cJDQoNuGXfCNzBBo/81Yg/OgjPwvbabnlzXG2VsdSgNsT6iIkuPBPr+C0Shs+3bb0x0lbPvgQAhMSCKm5Ww==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.6.13",

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import {
     DatePickerAnchor,
     DatePickerContent,
@@ -26,6 +26,8 @@ import Calendar from '../Calendar/Calendar.vue';
 import Icon from '../Icon/Icon.vue';
 
 const emit = defineEmits(['update:modelValue']);
+
+const open = ref(false);
 
 const props = defineProps({
     date: { type: String, default: null },
@@ -82,6 +84,11 @@ const calendarEvents = computed(() => ({
             event.minute = 0;
             event.second = 0;
             event.millisecond = 0;
+            
+            // Close the popup when a date is selected
+            if (!props.inline) {
+                open.value = false;
+            }
         }
 
         emit('update:modelValue', event);
@@ -122,6 +129,8 @@ const getInputLabel = (part) => {
             :granularity="granularity"
             :locale="$date.locale"
             :disabled="disabled || readOnly"
+            :open="open"
+            @update:open="open = $event"
             @update:model-value="emit('update:modelValue', $event)"
             v-bind="$attrs"
             prevent-deselect

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -129,6 +129,7 @@ const getInputLabel = (part) => {
             role="group"
             :aria-label="__('Date picker')"
             :aria-required="required"
+            close-on-select
         >
             <DatePickerField v-slot="{ segments }" class="w-full">
                 <DatePickerAnchor as-child>

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import {
     DatePickerAnchor,
     DatePickerContent,
@@ -26,8 +26,6 @@ import Calendar from '../Calendar/Calendar.vue';
 import Icon from '../Icon/Icon.vue';
 
 const emit = defineEmits(['update:modelValue']);
-
-const open = ref(false);
 
 const props = defineProps({
     date: { type: String, default: null },
@@ -84,11 +82,6 @@ const calendarEvents = computed(() => ({
             event.minute = 0;
             event.second = 0;
             event.millisecond = 0;
-            
-            // Close the popup when a date is selected
-            if (!props.inline) {
-                open.value = false;
-            }
         }
 
         emit('update:modelValue', event);
@@ -129,8 +122,6 @@ const getInputLabel = (part) => {
             :granularity="granularity"
             :locale="$date.locale"
             :disabled="disabled || readOnly"
-            :open="open"
-            @update:open="open = $event"
             @update:model-value="emit('update:modelValue', $event)"
             v-bind="$attrs"
             prevent-deselect

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import {
     DateRangePickerCalendar,
     DateRangePickerCell,
@@ -26,6 +26,8 @@ import Icon from '../Icon/Icon.vue';
 import { parseAbsoluteToLocal } from '@internationalized/date';
 
 const emit = defineEmits(['update:modelValue']);
+
+const open = ref(false);
 
 const props = defineProps({
     date: { type: String, default: null },
@@ -79,6 +81,11 @@ const calendarEvents = computed(() => ({
             event.end.minute = 0;
             event.end.second = 0;
             event.end.millisecond = 0;
+            
+            // Close the popup when both start and end dates are selected
+            if (!props.inline && event.start && event.end) {
+                open.value = false;
+            }
         }
 
         emit('update:modelValue', event)
@@ -93,6 +100,8 @@ const calendarEvents = computed(() => ({
             :granularity="granularity"
             :locale="$date.locale"
             :disabled="disabled || readOnly"
+            :open="open"
+            @update:open="open = $event"
             @update:model-value="emit('update:modelValue', $event)"
             v-bind="$attrs"
             prevent-deselect

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import {
     DateRangePickerCalendar,
     DateRangePickerCell,
@@ -26,8 +26,6 @@ import Icon from '../Icon/Icon.vue';
 import { parseAbsoluteToLocal } from '@internationalized/date';
 
 const emit = defineEmits(['update:modelValue']);
-
-const open = ref(false);
 
 const props = defineProps({
     date: { type: String, default: null },
@@ -81,11 +79,6 @@ const calendarEvents = computed(() => ({
             event.end.minute = 0;
             event.end.second = 0;
             event.end.millisecond = 0;
-            
-            // Close the popup when both start and end dates are selected
-            if (!props.inline && event.start && event.end) {
-                open.value = false;
-            }
         }
 
         emit('update:modelValue', event)
@@ -100,8 +93,6 @@ const calendarEvents = computed(() => ({
             :granularity="granularity"
             :locale="$date.locale"
             :disabled="disabled || readOnly"
-            :open="open"
-            @update:open="open = $event"
             @update:model-value="emit('update:modelValue', $event)"
             v-bind="$attrs"
             prevent-deselect

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -98,6 +98,7 @@ const calendarEvents = computed(() => ({
             prevent-deselect
             hide-time-zone
             :placeholder="placeholder"
+            close-on-select
         >
             <DateRangePickerField v-slot="{ segments }" class="w-full">
                 <div


### PR DESCRIPTION
This PR closes #13374

The single date picker will close when you select a date, and the ranged date picker will close when you select the last date in the range.

This seems like standard behaviour, e.g. Fastmail Cal / Gmail Cal