### PR TITLE
[6.x] Collapse empty publish sections

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -882,3 +882,10 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+    /* Collapse the section when it has no fields */
+    [class*=space-y]:empty {
+        margin: 0;
+    }
+</style>


### PR DESCRIPTION
This PR collapses the publish section margin when it has no fields. It closes #13373

A CSS solution was simpler here than a Vue one.

P.S. I thought about adding this CSS rule globally, but data may be loading in dynamically such as the grid view on /cp/collections, which loads in entries _after_ the page has initiated—so in this case it would flip-flop between an empty/not empty state. So it's probably best to scope this selector.