### PR TITLE
[6.x] Pull bard floating toolbar above theads

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -196,7 +196,7 @@
 @layer ui {
     .bard-floating-toolbar {
         /* We need to pull this above other things such as theads, e.g. Grid fieldtype > Bard fieldtype > floating toolbar. */
-        @apply flex rounded-full bg-black px-2 shadow-lg whitespace-nowrap z-(--z-index-max) relative;
+        @apply flex rounded-full bg-black px-2 shadow-lg whitespace-nowrap z-(--z-index-draggable) relative;
 
         &:before {
             @apply border-t-black top-full start-1/2 absolute -ml-[3px] content-none border-6 border-transparent;


### PR DESCRIPTION
This PR closes #13372 by pulling floating Bard toolbars to the same z-index as `thead`s