### PR TITLE
[6.x] More obvious active subnav

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -38,24 +38,28 @@
 
     ul li ul li a.active {
         @apply text-black dark:text-white font-medium bg-transparent;
-        &::before {
-            content: '';
-            position: absolute;
-            left: -1px;
-            @apply h-4 border-s border-s-black;
-        }
-        :where(.dark) &::before {
-            @apply border-s-gray-400;
-        }
     }
-
-/* Less distracting for single-subnav items */
-    ul li ul li:only-child a.active {
-        &::before {
-            @apply border-s-gray-400;
+    ul li ul li {
+        a.active {
+            /* [1] Add a little vertical line to indicate the "active" subnav item */
+            &::before {
+                content: '';
+                position: absolute;
+                left: -1px;
+                @apply h-4 border-s border-s-black;
+            }
+            :where(.dark) &::before {
+                @apply border-s-gray-400;
+            }
         }
-        :where(.dark) &::before {
-            @apply border-s-gray-500;
+        &:only-child a.active {
+            /* [/2] Make the "active" subnav item less distracting for single-subnav items such as Assets/assets */
+            &::before {
+                @apply border-s-gray-400;
+            }
+            :where(.dark) &::before {
+                @apply border-s-gray-500;
+            }
         }
     }
 


### PR DESCRIPTION
This PR makes it easier to see where you are in the subnav at a glance.

![2025-12-18 at 22 44 28@2x](https://github.com/user-attachments/assets/58cd8703-33ff-4413-b8ea-54f5df116f6b)

This is similar to active tabs such as "All, Published, Test" here

![2025-12-18 at 22 58 02@2x](https://github.com/user-attachments/assets/c9464c14-0a33-4241-aba7-977563ea6dd0)
