### PR TITLE
[6.x] Fix architectural lines missing horizontal

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -270,7 +270,8 @@
                 position: absolute;
                 inset: 0;
                 height: var(--height);
-                border-image: conic-gradient(var(--line-color) 0 0) fill 0/ /**/0 100vw;
+                /* Bust out of the container to create a full-width horizontal line, ref https://www.smashingmagazine.com/2024/01/css-border-image-property/#full-width-backgrounds */
+                border-image: conic-gradient(var(--line-color) 0 0) fill 0//0 100vw;
                 top: calc(50% - var(--height));
             }
             .dark &::after {


### PR DESCRIPTION
This fixes a missing horizontal line on the "architectural" backgrounds that appears when creating a new collection on the "wizard screen".

## Before

![2025-12-19 at 11 10 14@2x](https://github.com/user-attachments/assets/1f798cbe-3e0b-46ca-ac88-6bed2af5af9d)

## After

There is an additional horizontal line that runs across the background

![2025-12-19 at 11 10 46@2x](https://github.com/user-attachments/assets/765dbcce-c6d5-4f69-9e42-c1ecf5243bbb)

This was initially present, but this commit broke it https://github.com/statamic/cms/commit/3257369f36728fe6541f6d521fdfef49715eb19b.

I think Jack was trying to fix the compilation being broken, e.g. in the few commits before this like 72048bc84ceec61769ecd338b3a89914353cd9d3 —where there was simply a grey background on the wizard like this:

![2025-12-19 at 11 07 59@2x](https://github.com/user-attachments/assets/52216b48-afd1-4773-8fbe-a74bb952e0a7)

Jack's fix did the compilation_ but at the same time broke the line.

This PR doesn't seem to break the compiler 🤞