### PR TITLE
[6.x] Add `as` prop to `ContextItem` component

### DIFF
--- a/resources/js/components/ui/Context/Item.vue
+++ b/resources/js/components/ui/Context/Item.vue
@@ -1,12 +1,13 @@
 <script setup>
 import { ContextMenuItem } from 'reka-ui';
-import {computed, useSlots} from 'vue';
+import { computed, useSlots } from 'vue';
 import Icon from '../Icon/Icon.vue';
 import { cva } from 'cva';
-import {Link} from "@inertiajs/vue3";
+import { Link } from "@inertiajs/vue3";
 
 const props = defineProps({
-	as: { type: String, default: null },
+    /** The element or component this component should render as */
+    as: { type: String, default: null },
     /** The URL to link to */
     href: { type: String, default: null },
     /** When `href` is provided, this prop controls the link's `target` attribute */
@@ -22,9 +23,9 @@ const props = defineProps({
 const slots = useSlots();
 const hasDefaultSlot = !!slots.default;
 const tag = computed(() => {
-	if (props.as) return props.as;
-	if (! props.href) return 'div';
-	return props.target === '_blank' ? 'a' : Link;
+    if (props.as) return props.as;
+    if (! props.href) return 'div';
+    return props.target === '_blank' ? 'a' : Link;
 });
 
 const classes = cva({


### PR DESCRIPTION
This pull request adds an `as` prop to the `ContextItem` component, making it consistent with the `DropdownItem` component.

I noticed the inconsistency while working on the Storybook docs.