### PR TITLE
[6.x] Fix alignment issue in `ContextHeader` component

### DIFF
--- a/resources/js/components/ui/Context/Header.vue
+++ b/resources/js/components/ui/Context/Header.vue
@@ -15,7 +15,7 @@ const slots = useSlots();
 const usingSlot = !!slots.default;
 
 const headerClasses = cva({
-    base: 'col-span-2 px-3.5 py-3 bg-white dark:bg-gray-900 font-medium border-b border-gray-200 dark:border-black text-sm text-gray-900 dark:text-gray-300',
+    base: 'col-span-2 flex items-center px-3.5 py-3 bg-white dark:bg-gray-900 font-medium border-b border-gray-200 dark:border-black text-sm text-gray-900 dark:text-gray-300',
     variants: {
         usingSlot: {
             true: 'grid grid-cols-[auto_1fr_auto]',


### PR DESCRIPTION
This pull request fixes an alignment issue in the `ContextHeader` component. This PR makes it consistent with the `DropdownHeader` component.

Noticed this while working on the Storybook docs.

## Before

<img width="347" height="340" alt="CleanShot 2025-12-19 at 14 09 29" src="https://github.com/user-attachments/assets/bf60f7e6-f23f-489d-a281-a68660181df8" />


## After

<img width="371" height="339" alt="CleanShot 2025-12-19 at 14 09 12" src="https://github.com/user-attachments/assets/ec50220d-9bd3-4e8b-a4be-38185748018c" />
