### PR TITLE
[6.x] Use collection icon on empty state page

### DIFF
--- a/resources/js/pages/collections/Empty.vue
+++ b/resources/js/pages/collections/Empty.vue
@@ -5,6 +5,7 @@ import useArchitecturalBackground from '@/pages/layout/architectural-background.
 useArchitecturalBackground();
 
 const props = defineProps([
+	'icon',
     'title',
     'blueprints',
     'canEdit',
@@ -23,7 +24,7 @@ const props = defineProps([
 
     <header class="py-8 mt-8 text-center starting-style-transition" v-cloak>
         <h1 class="text-[25px] font-medium antialiased flex justify-center items-center gap-2 sm:gap-3">
-            <ui-icon name="collections" class="size-5 text-gray-500"></ui-icon>
+            <ui-icon :name="icon" class="size-5 text-gray-500"></ui-icon>
             <span v-text="__(title)" />
         </h1>
     </header>

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -202,6 +202,7 @@ class CollectionsController extends CpController
         if ($collection->queryEntries()->count() === 0) {
             return Inertia::render('collections/Empty', [
                 ...Arr::only($props, [
+                    'icon',
                     'title',
                     'blueprints',
                     'canEdit',


### PR DESCRIPTION
This pull request fixes an issue where the configured collection icon wasn't being used on the collection empty state page.

Fixes #13371

## Before

<img width="520" height="723" alt="CleanShot 2025-12-19 at 14 19 22" src="https://github.com/user-attachments/assets/9ae8767e-8443-4a4f-9633-f828fbd50ff7" />


## After

<img width="520" height="723" alt="CleanShot 2025-12-19 at 14 19 07" src="https://github.com/user-attachments/assets/55936ece-5084-40a8-bbf1-ce9af6ef1c69" />
