### PR TITLE
[6.x] Fix a few outdated asConfig field references

### DIFF
--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -18,10 +18,10 @@
 
         <ui-panel v-if="showTitle" :heading="__('Settings')">
             <ui-card class="p-0! divide-y divide-gray-200 dark:divide-gray-800">
-                <ui-field as-config :label="__('Title')" :instructions="__('messages.blueprints_title_instructions')" :errors="errors?.title">
+                <ui-field inline :label="__('Title')" :instructions="__('messages.blueprints_title_instructions')" :errors="errors?.title">
                     <ui-input v-model="blueprint.title" />
                 </ui-field>
-                <ui-field as-config :label="__('Hidden')" :instructions="__('messages.blueprints_hidden_instructions')" :error="errors?.hidden" variant="inline">
+                <ui-field inline :label="__('Hidden')" :instructions="__('messages.blueprints_hidden_instructions')" :error="errors?.hidden" variant="inline">
                     <ui-switch v-model="blueprint.hidden" />
                 </ui-field>
             </ui-card>

--- a/resources/js/components/roles/PublishForm.vue
+++ b/resources/js/components/roles/PublishForm.vue
@@ -16,7 +16,7 @@
         <Panel :heading="__('Settings')">
             <Card class="p-0! divide-y divide-gray-200 dark:divide-gray-800">
                 <Field
-                    as-config
+                    inline
                     :label="__('Title')"
                     :instructions="__('messages.role_title_instructions')"
                     :errors="errors.title"
@@ -26,7 +26,7 @@
                 </Field>
 
                 <Field
-                    as-config
+                    inline
                     :label="__('Handle')"
                     :instructions="__('messages.role_handle_instructions')"
                     :errors="handleErrors"
@@ -36,7 +36,7 @@
                 </Field>
 
                 <Field
-                    as-config
+                    inline
                     v-if="canAssignSuper"
                     :label="__('permissions.super')"
                     :instructions="__('permissions.super_desc')"

--- a/resources/js/stories/Field.stories.ts
+++ b/resources/js/stories/Field.stories.ts
@@ -116,8 +116,8 @@ export const _InlineVariant: Story = {
 };
 
 const instructionsBelowCode = `
-<Field 
-    label="Bio" 
+<Field
+    label="Bio"
     instructions="Tell us a bit about yourself. Markdown is supported."
     instructions-below
 >
@@ -160,29 +160,29 @@ export const _WithActionsSlot: Story = {
     }),
 };
 
-const asConfigCode = `
+const inlineCode = `
 <div class="bg-white dark:bg-gray-900 rounded-lg divide-y divide-gray-200 dark:divide-gray-800">
-    <Field label="Site Name" as-config>
+    <Field label="Site Name" inline>
         <Input value="My Awesome Site" />
     </Field>
-    <Field label="Tagline" as-config>
+    <Field label="Tagline" inline>
         <Input value="Just another Statamic site" />
     </Field>
-    <Field label="Description" as-config full-width-setting>
+    <Field label="Description" inline full-width-setting>
         <Textarea value="A brief description of my site" />
     </Field>
 </div>
 `;
 
-export const _AsConfig: Story = {
+export const _Inline: Story = {
     tags: ['!dev'],
     parameters: {
         docs: {
-            source: { code: asConfigCode }
+            source: { code: inlineCode }
         }
     },
     render: () => ({
         components: { Field, Input, Textarea },
-        template: asConfigCode,
+        template: inlineCode,
     }),
 };

--- a/resources/js/stories/docs/Field.mdx
+++ b/resources/js/stories/docs/Field.mdx
@@ -31,9 +31,9 @@ Position instructions below the control instead of below the label for better vi
 Add action buttons or controls next to the label using the `actions` slot.
 <Canvas of={FieldStories._WithActionsSlot} sourceState={'shown'} />
 
-## As Config
-Use the `asConfig` prop to style fields as configuration settings with a two-column layout. Use `fullWidthSetting` to override the two-column layout for specific fields.
-<Canvas of={FieldStories._AsConfig} sourceState={'shown'} />
+## Inline
+Use the `inline` prop to style fields as configuration settings with a two-column layout. Use `fullWidthSetting` to maintain the alternate padding of inline mode but span the full width of the container.
+<Canvas of={FieldStories._Inline} sourceState={'shown'} />
 
 ## Arguments
 <ArgTypes of={FieldStories} />


### PR DESCRIPTION
The Field component recently changed the asConfig prop to inline in #13384 but a few usages were missed.
