### PR TITLE
[5.x] Add `Nav::clearCachedUrls` expectation to `AddonTestCase`

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -36,7 +36,8 @@ abstract class AddonTestCase extends OrchestraTestCase
         $this->addToAssertionCount(-1);
 
         \Statamic\Facades\CP\Nav::shouldReceive('build')->zeroOrMoreTimes()->andReturn(collect());
-        $this->addToAssertionCount(-1); // Dont want to assert this
+        \Statamic\Facades\CP\Nav::shouldReceive('clearCachedUrls')->zeroOrMoreTimes();
+        $this->addToAssertionCount(-2); // Dont want to assert this
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
We added it to our `TestCase` in #13297, but it needs adding to the `AddonTestCase` as well. 