### PR TITLE
[6.x] Fix Livewire CSRF token replacement

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -274,8 +274,12 @@ class FileCacher extends AbstractCacher
             window.livewire_token = data.csrf
         }
 
-        if (window.hasOwnProperty('livewireScriptConfig')) {
-            window.livewireScriptConfig.csrf = data.csrf
+        if (window.livewireScriptConfig) {
+            // Replaces token if Livewire is already available. Usually on fast networks.
+            window.livewireScriptConfig.csrf = data.csrf;
+        } else {
+            // Delays replacing the token until Livewire is initialized. Usually on slow networks.
+            document.addEventListener('livewire:init', () => window.livewireScriptConfig.csrf = data.csrf);
         }
 
         document.dispatchEvent(new CustomEvent('statamic:csrf.replaced', { detail: data }));


### PR DESCRIPTION
This PR fixes a race condition that caused the Livewire CSRF token to not be replaced at the appropriate time. I never noticed this issue until @robdekort reached out. I was able to reproduce it by throttling the network speed. Fortunately, it was a simple fix.

This implementation has one small catch, though. If the token is replaced on `livewire:init`, the `statamic:csrf.replaced` event is dispatched before the `window.livewireScriptConfig.csrf` is assigned. I don't think this is a big deal but maybe worth mentioning in the docs.