### PR TITLE
[6.x] Content overflows content card

### DIFF
--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -32,8 +32,10 @@ provide('layout', {
         <main id="main" class="flex bg-body-bg dark:border-t dark:border-body-border rounded-t-2xl fixed top-14 inset-x-0 bottom-0 min-h-[calc(100vh-3.5rem)]">
             <Nav />
             <div id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto rounded-t-2xl">
-                <div id="content-card" class="relative content-card grid [&>*]:w-full min-h-full">
-                    <slot />
+                <div id="content-card" class="relative content-card grid min-h-full">
+                    <div class="w-full">
+                        <slot />
+                    </div>
                 </div>
             </div>
         </main>


### PR DESCRIPTION
This closes #13393 and fixes a bug that was introduced in #13361 because we were trying to get the child of #main-content to take up the parent height. 

Setting the display model to `grid` fixes this without the side effect of the height not expanding correctly.

I've tested a load of pages and it seems to be fine.