### PR TITLE
[6.x] Add missing `chevron-up` icon

### DIFF
--- a/resources/svg/icons/chevron-up.svg
+++ b/resources/svg/icons/chevron-up.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M14.78 11.78a.75.75 0 0 1-1.06 0L10 8.06l-3.72 3.72a.75.75 0 1 1-1.06-1.06l4.25-4.25a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06Z" clip-rule="evenodd"/></svg>


### PR DESCRIPTION
We have `chevron-down`, `chevron-left`, and `chevron-right`, but no `chevron-up`. 

Similar to #12954