### PR TITLE
[6.x] Preference connectors

### DIFF
--- a/resources/js/pages/preferences/Index.vue
+++ b/resources/js/pages/preferences/Index.vue
@@ -19,7 +19,7 @@ defineProps([
         <Header :title="__('Preferences')" icon="preferences" />
 
         <section class="relative flex flex-col gap-8">
-            <div class="absolute top-0 start-8 border-s w-px border-gray-400 dark:border-gray-600 h-[calc(100%-1.25rem)] border-dashed"></div>
+            <div class="absolute top-0 start-8 border-s w-px border-gray-300 dark:border-gray-700 h-[calc(100%-1.25rem)] border-dashed"></div>
             <CardPanel class="mb-0!" :heading="__('Global Preferences')" :subheading="__('Applied to all users by default.')">
                 <div class="flex items-center justify-between">
                     <div class="flex items-center gap-2 sm:gap-3">


### PR DESCRIPTION
Make preference connectors on /cp/preferences consistent with the color of other connectors

## Before
Barely visible

![2026-01-05 at 11 20 54@2x](https://github.com/user-attachments/assets/edac31bf-efe2-4d35-be40-4e1099ec02a0)


## After
![2026-01-05 at 11 20 25@2x](https://github.com/user-attachments/assets/f980ec8d-2494-4b83-ab78-8b15e19f178b)
