### PR TITLE
[6.x] Prevent revealer fields from showing in replicator previews

### DIFF
--- a/resources/js/components/fieldtypes/RevealerFieldtype.vue
+++ b/resources/js/components/fieldtypes/RevealerFieldtype.vue
@@ -23,7 +23,7 @@ import { onMounted, onBeforeUnmount, watch, nextTick, computed } from 'vue';
 
 const emit = defineEmits(Fieldtype.emits);
 const props = defineProps(Fieldtype.props);
-const { update, expose, isReadOnly } = Fieldtype.use(emit, props);
+const { update, expose, isReadOnly, defineReplicatorPreview } = Fieldtype.use(emit, props);
 defineExpose(expose);
 
 const { setRevealerField, unsetRevealerField, setHiddenField } = injectContainerContext();
@@ -50,4 +50,6 @@ function buttonReveal() {
 
     update(true);
 }
+
+defineReplicatorPreview(() => null);
 </script>


### PR DESCRIPTION
This pull request prevents the `true`/`false` value of the Revealer fieldtype from showing in Bard/Replicator set previews.

Fixes #13399