### PR TITLE
[6.x] Hide add set bar at the top of Replicator fields when `max_sets` has been reached

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -52,7 +52,7 @@
                                     @duplicated="duplicateSet(set._id)"
                                     @removed="removed(set, index)"
                                 >
-                                    <template v-slot:picker>
+                                    <template v-if="canAddSet" v-slot:picker>
                                         <add-set-button
                                             variant="between"
                                             :groups="groupConfigs"


### PR DESCRIPTION
This pull request ensures that the "add set bar" at the top of Replicator fields is hidden when the `max_sets` limit has been reached.

Fixes #13398

## Before

<img width="785" height="215" alt="CleanShot 2026-01-05 at 10 35 06" src="https://github.com/user-attachments/assets/310b1abd-f0d4-44d1-adb2-fd2fb0c4c072" />


## After

<img width="783" height="193" alt="CleanShot 2026-01-05 at 10 34 39" src="https://github.com/user-attachments/assets/95f05490-0d0a-4439-8ede-096e43c6f275" />