### PR TITLE
[6.x] Fix stack focus trap height

### DIFF
--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -31,7 +31,7 @@
                             { '-translate-x-4 rtl:translate-x-4': isHovering }
                         ]"
                     >
-                        <FocusScope trapped loop class="h-full">
+                        <FocusScope trapped loop as-child>
                             <slot name="default" :depth="depth" :close="close" />
                         </FocusScope>
                     </div>


### PR DESCRIPTION
This PR fixes the inner stack height.

I noticed this  issue with the Asset fieldtype where the "action" row was not being forced to the bottom of the stack correctly.

Adding a height of 100% to the inner container fixed this

## Before

Notice the "action" bar containing Select and Cancel is not positioned at the bottom of the stack here.

![2026-01-05 at 15 06 29@2x](https://github.com/user-attachments/assets/ab1bc767-fb4e-4eaa-8a81-ed451a8571a7)


## After

![2026-01-05 at 15 05 54@2x](https://github.com/user-attachments/assets/e1cc429b-8752-4798-841c-d5bd1aa04d01)
