### PR TITLE
[6.x] Filter out invalid vue export keys

### DIFF
--- a/packages/cms/src/vite-plugin/externals.js
+++ b/packages/cms/src/vite-plugin/externals.js
@@ -2,7 +2,7 @@ import * as Vue from 'vue';
 
 export default function() {
     const RESOLVED_VIRTUAL_MODULE_ID = '\0vue-external';
-    const vueExports = Object.keys(Vue).filter(key => key !== 'default');
+    const vueExports = Object.keys(Vue).filter(key => key !== 'default' && /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key));
 
     return {
         name: 'statamic-externals',


### PR DESCRIPTION
When attempting to compile an addon's js, it would fail on certain keys like `module.exports`.

```
error during build:
vue-external (4:1284): Expected ',', got '.' (Note that you need plugins to import files that are not JavaScript)
file: vue-external:4:1284
```

`Object.keys(Vue)` contained `module.exports` for the user who reported this issue. They are using Node 24. I'm using Node 22 and it doesn't contain module.exports. I don't have Node 24 to confirm that is exactly the issue, but this regex addition will filter out invalid keys regardless.
