### PR TITLE
[6.x] Fix bard sets being a higher z index than the fixed bard toolbar

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -2,7 +2,7 @@
     <node-view-wrapper class="my-4">
         <div
             ref="container"
-            class="shadow-ui-sm relative z-2 w-full rounded-lg border border-gray-300 bg-white text-base dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
+            class="shadow-ui-sm relative w-full rounded-lg border border-gray-300 bg-white text-base dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
             :class="{
                 // We’re styling a Set so that it shows a “selection outline” when selected with the mouse or keyboard.
                 // The extra `&:not(:has(:focus-within))` rule turns that outline off if any element inside the Set has focus (e.g. when editing inside a Bard field).


### PR DESCRIPTION
This PR closes #13394, and bard sets no longer appear higher than the Bard toolbar.

I can't see a reason for a hardcoded z-index here on sets.

I tried do understand why it might have been originally added…
It was added sporadically in May 2025 as part of a lot of publish form changes, so it may no longer be needed.