### PR TITLE
[5.x] Fix blueprint cache

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -150,6 +150,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
 
         return $this
             ->normalizeTabs()
+            ->resetBlueprintCache()
             ->resetFieldsCache();
     }
 


### PR DESCRIPTION
I noticed that the blueprint fields don't contain new items after using `$blueprint->setContents()` in a listener. This PR ensures the blueprint cache is reset.

Left without PR. Right with PR. Notice the missing `text` field on the left.

<img width="1992" height="310" alt="CleanShot 2026-01-05 at 20 11 16@2x" src="https://github.com/user-attachments/assets/86507f98-a4f5-4720-ab44-e0feda9cdb77" />

You can reproduce the issue with this simple listener:

```php
<?php

namespace App\Listeners;

use Statamic\Events\EntryBlueprintFound;

class ExtendBlueprint
{
    public function handle(EntryBlueprintFound $event): void
    {
        $contents = collect($event->blueprint->contents())
            ->dot()
            ->merge([
                'tabs.main.sections.0.fields.4.handle' => 'text',
                'tabs.main.sections.0.fields.4.field.type' => 'text',
            ])
            ->undot()
            ->all();

        dd($event->blueprint->setContents($contents)->fields()->all()->all());
    }
}
```