### PR TITLE
[5.x] Generate etag after nocache replacements

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -232,7 +232,7 @@ class Cache
         return response($html, 503, ['Retry-After' => 1]);
     }
 
-    private function addEtagToResponse($request, $response): Response
+    private function addEtagToResponse($request, $response)
     {
         if (! $response->isRedirect() && $content = $response->getContent()) {
             $response


### PR DESCRIPTION
This PR changes the generation of Etags. It is now performed after any NoCache replacements so that the Etag is determined correctly for responses with NoCache blocks.

Fixes #13425