### PR TITLE
[6.x] Unset `image` key on sets unless preview image has been added

### DIFF
--- a/src/Fields/FieldTransformer.php
+++ b/src/Fields/FieldTransformer.php
@@ -78,6 +78,10 @@ class FieldTransformer
                                             unset($set['icon']);
                                         }
 
+                                        if (! Arr::get($set, 'image')) {
+                                            unset($set['image']);
+                                        }
+
                                         if (! Arr::get($set, 'hide')) {
                                             unset($set['hide']);
                                         }


### PR DESCRIPTION
This pull request fixes an issue where the `image` would be persisted to the blueprint's YAML file without a set preview image.
