### PR TITLE
[6.x] Fix drag & dropping sets in Bard

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -739,6 +739,7 @@ export default {
                 enableInputRules: this.config.enable_input_rules,
                 enablePasteRules: this.config.enable_paste_rules,
                 editorProps: { attributes: { class: 'bard-content' } },
+	            onDrop: () => this.debounceNextUpdate = false,
                 onFocus: () => this.$emit('focus'),
                 onBlur: () => {
                     // Since clicking into a field inside a set would also trigger a blur, we can't just emit the


### PR DESCRIPTION
This pull request fixes an issue where dragging & dropping sets in Bard would cause an issue and potentially lead to data loss.

This was another of those timing issues where the TipTap document updates immediately, but the fieldtype's value is debounced. Similar to #13167 and #12963.

Fixes #13434