### PR TITLE
[5.x] Terms Filter: Use `terms` fieldtype instead of `select`

### DIFF
--- a/src/Query/Scopes/Filters/Fields/Terms.php
+++ b/src/Query/Scopes/Filters/Fields/Terms.php
@@ -20,10 +20,12 @@ class Terms extends FieldtypeFilter
                 'default' => 'like',
             ],
             'term' => [
-                'type' => 'select',
-                'options' => $this->options()->all(),
+                'type' => 'terms',
                 'placeholder' => __('Term'),
                 'clearable' => true,
+                'mode' => 'select',
+                'max_items' => 1,
+                'taxonomies' => $this->fieldtype->taxonomies(),
                 'if' => [
                     'operator' => 'contains_any like',
                 ],
@@ -62,22 +64,5 @@ class Terms extends FieldtypeFilter
         $term = Facades\Term::find($id)->title();
 
         return $field.': '.$term;
-    }
-
-    protected function options()
-    {
-        return collect($this->fieldtype->taxonomies())
-            ->map(function ($handle) {
-                return Facades\Taxonomy::find($handle);
-            })
-            ->filter()
-            ->flatMap(function ($taxonomy) {
-                return $taxonomy->queryTerms()->get();
-            })
-            ->mapWithKeys(function ($term) {
-                $value = $this->fieldtype->usingSingleTaxonomy() ? $term->slug() : $term->id();
-
-                return [$value => $term->title()];
-            });
     }
 }


### PR DESCRIPTION
This pull request ensures that the Terms filter uses the `terms` fieldtype (which loads items via AJAX) rather than the `select` fieldtype (which requires that options are queried during the listing request).

This PR should improve the performance of listings when entries have taxonomy term fields _and_ have a lot of terms.

Fixes #13378
Fixes #10599