### PR TITLE
[6.x] Fix creating folders in empty asset container

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -88,7 +88,7 @@
                         </slot>
 
                         <div
-                            v-if="containerIsEmpty"
+                            v-if="containerIsEmpty && !creatingFolder"
                             class="rounded-lg border border-dashed border-gray-300 dark:border-gray-700 p-6 text-center text-gray-500"
                             v-text="__('No results')"
                         />

--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -1,7 +1,7 @@
 <template>
     <ui-card :class="{
-        'space-y-8': folders.length || assets.length,
-        '!p-0': folders.length === 0 && assets.length === 0
+        'space-y-8': folders.length || assets.length || creatingFolder,
+        '!p-0': folders.length === 0 && assets.length === 0 && !creatingFolder
     }">
         <!-- Folders -->
         <section class="folder-grid-listing" v-if="folders.length || creatingFolder">
@@ -170,7 +170,7 @@
         </section>
 
         <!-- Empty state -->
-        <div v-if="folders.length === 0 && assets.length === 0" class="text-center text-gray-500 text-sm py-4">
+        <div v-if="folders.length === 0 && assets.length === 0 && !creatingFolder" class="text-center text-gray-500 text-sm py-4">
             {{ __('No items found') }}
         </div>
     </ui-card>


### PR DESCRIPTION
This pull request fixes an issue where it wasn't possible to create folders in an empty asset container.

Fixes #12547
