### PR TITLE
[6.x] Fix checkbox indeterminate state

### DIFF
--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -118,7 +118,7 @@ const conditionalProps = computed(() => {
                 <svg v-else viewBox="0 0 10 2" fill="none" xmlns="http://www.w3.org/2000/svg" class="size-2.5 shrink-0" aria-hidden="true"><path d="M2 1H8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" /></svg>
             </CheckboxIndicator>
             <span class="sr-only">
-                {{ indeterminate ? 'Indeterminate' : (modelValue ? 'Checked' : 'Unchecked') }}
+                {{ indeterminate ? __('Indeterminate') : (modelValue ? __('Checked') : __('Unchecked')) }}
             </span>
         </CheckboxRoot>
         <div class="flex flex-col" v-if="!solo">


### PR DESCRIPTION
This PR closes #13445 and closes #12979 by showing an "indeterminate" dash when only some, but not all, entries are selected

## Before

![2026-01-07 at 10 10 26@2x](https://github.com/user-attachments/assets/f192299b-c86c-4d2b-b21f-8136e9706e68)


## After

![2026-01-07 at 10 09 59@2x](https://github.com/user-attachments/assets/20c1f50b-ef61-45c0-84c1-04d4303de66c)
