### PR TITLE
[6.x] Avoid squashed Combobox options near viewport edge

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -427,7 +427,7 @@ defineExpose({
                         align="start"
                         :class="[
                             'shadow-ui-sm z-(--z-index-above) rounded-lg border border-gray-200 bg-white p-2 dark:border-white/10 dark:bg-gray-800',
-                            'max-h-[var(--reka-combobox-content-available-height)] min-w-[var(--reka-combobox-trigger-width)]',
+                            'min-h-[10rem] max-h-[var(--reka-combobox-content-available-height)] min-w-[var(--reka-combobox-trigger-width)]',
                             'overflow-hidden'
                         ]"
                         :style="optionWidth ? { width: `${optionWidth}px` } : {}"


### PR DESCRIPTION
This pull request attempts to fix an issue with the Combobox dropdown where it could be squashed the near the viewport edge, instead of alternating to the opposite position.

This PR fixes it by adding a `min-height` to the dropdown's content and reducing the spacing between the top/bottom of the dropdown and the edge of the viewport.

Fixes #13365

## Before


https://github.com/user-attachments/assets/64db99b2-3fd5-4c50-bad0-51314b4c9c56



## After

https://github.com/user-attachments/assets/486b80c5-8a52-43da-a4b9-212e815725ca

