### PR TITLE
[6.x] Calendar: Fix `number-of-months` prop

### DIFF
--- a/resources/js/components/ui/Calendar/Calendar.vue
+++ b/resources/js/components/ui/Calendar/Calendar.vue
@@ -85,7 +85,7 @@ const gridStyle = computed(() => {
         :maxValue="maxValue"
         :locale="$date.locale"
         fixed-weeks
-        :number-of-months="inline ? numberOfMonths : 1"
+        :number-of-months="numberOfMonths"
         @update:model-value="emit('update:modelValue', $event)"
     >
         <Component :is="components.CalendarHeader" class="flex items-center justify-between ps-3 pe-1 pb-3.5 -mt-1">
@@ -114,7 +114,7 @@ const gridStyle = computed(() => {
                 class="w-full border-collapse space-y-1 select-none"
             >
                 <Component :is="components.CalendarGridHead">
-                    <ui-badge class="mb-2" v-if="inline && numberOfMonths > 1">
+                    <ui-badge class="mb-2" v-if="numberOfMonths > 1">
                         {{ new Date(month.value.toString()).toLocaleString($date.locale, { month: 'long' }) }}
                     </ui-badge>
                     <Component :is="components.CalendarGridRow" class="mb-1 grid w-full grid-cols-7">


### PR DESCRIPTION
This pull request fixes an issue where the `number-of-months` prop on the `Calendar` component wasn't working correctly. The calendar has space for another month, but it's not actually showing it.

## Before

<img width="1036" height="592" alt="CleanShot 2026-01-07 at 12 56 33" src="https://github.com/user-attachments/assets/a0246cea-1e4f-4a90-9966-b7de7bfd9cd1" />


## After

<img width="1035" height="633" alt="CleanShot 2026-01-07 at 12 59 20" src="https://github.com/user-attachments/assets/e846a6ee-9a9b-45d5-937b-ce11fd4d2e09" />
