### PR TITLE
[6.x] Fix Markdown buttons config field

### DIFF
--- a/resources/js/components/fieldtypes/markdown/MarkdownButtonsSettingFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownButtonsSettingFieldtype.vue
@@ -1,15 +1,15 @@
 <template>
     <div class="relative">
         <div class="bard-fixed-toolbar bard-toolbar-setting dark" ref="buttons">
-            <ui-button
+            <button
                 v-for="button in buttons"
-                :class="{ active: enabled(button.name) }"
-                :icon="button.svg"
                 :key="button.name"
-                @click="toggleButton(button.name)"
                 v-tooltip="button.text"
-                variant="ghost"
-            />
+                :class="{ active: enabled(button.name) }"
+                @click="toggleButton(button.name)"
+            >
+                <ui-icon :name="button.svg" />
+            </button>
         </div>
     </div>
 </template>


### PR DESCRIPTION
This PR fixes an issue where it wasn't possible to tell if a button was selected or not. This PR also updates the Markdown buttons component so it looks more like the Bard equivalent.

## Before

<img width="454" height="68" alt="CleanShot 2026-01-07 at 14 42 27" src="https://github.com/user-attachments/assets/ae89347a-43ef-4fae-9272-665c06b4ff25" />


## After

<img width="454" height="68" alt="CleanShot 2026-01-07 at 14 42 07" src="https://github.com/user-attachments/assets/e4bebd04-d497-4b13-a914-681f4f7a69af" />
