### PR TITLE
[6.x] Fix blueprint focus tabindex

### DIFF
--- a/resources/js/components/blueprints/Fields.vue
+++ b/resources/js/components/blueprints/Fields.vue
@@ -4,6 +4,7 @@
             class="blueprint-section-draggable-zone field-grid gap-2! mb-4 starting-style-transition-children"
             :data-tab="tabId"
             :data-section="sectionId"
+            tabindex="-1"
         >
             <slot name="empty-state" v-if="!fields.length" />
 

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="blueprint-section min-h-40 w-full outline-hidden @container">
+    <div class="blueprint-section min-h-40 w-full outline-hidden @container" tabindex="-1">
         <ui-panel>
             <ui-panel-header class="flex items-center justify-between pl-2.75! pr-3.25!">
                 <div class="flex items-center gap-2 flex-1">

--- a/resources/js/components/blueprints/Sections.vue
+++ b/resources/js/components/blueprints/Sections.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div ref="sections" class="blueprint-sections flex flex-wrap outline-hidden" :data-tab="tabId">
+        <div ref="sections" class="blueprint-sections flex flex-wrap outline-hidden" :data-tab="tabId" tabindex="-1">
             <BlueprintSection
                 ref="section"
                 v-for="(section, i) in sections"


### PR DESCRIPTION
This PR closes #13451 by removing certain tab indexes.

It appears that Shopify's draggable package adds many `tabindex: 0`s to divs, which causes some unwanted focus points on the divs.