### PR TITLE
[5.x] Support custom validation rules for asset containers

### DIFF
--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -122,7 +122,7 @@ class Validator
         }, collect())->all();
     }
 
-    private function parse($rule)
+    public function parse($rule)
     {
         if (is_string($rule) && Str::startsWith($rule, 'new ')) {
             return $this->parseClassBasedRule($rule);

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Controllers\CP\Assets;
 
+use Facades\Statamic\Fields\Validator as FieldValidator;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
@@ -81,8 +82,12 @@ class AssetsController extends CpController
         abort_unless($container->allowUploads(), 403);
         $this->authorize('store', [AssetContract::class, $container]);
 
+        $validationRules = collect($container->validationRules())
+            ->map(fn ($rule) => FieldValidator::parse($rule))
+            ->all();
+
         $request->validate([
-            'file' => array_merge(['file', new AllowedFile], $container->validationRules()),
+            'file' => array_merge(['file', new AllowedFile], $validationRules),
         ]);
 
         $file = $request->file('file');


### PR DESCRIPTION
Currently, if you add a [custom validation rule](https://statamic.dev/validation#custom-rules) to an asset container, you'll run into an error:

```
[2025-12-30 10:56:52] local.ERROR: Method Illuminate\Validation\Validator::validateNewApp\Rules\NotMimes('gif') does not exist. {"userId":"77191f11-a000-41ed-bc9c-61334dbc188d","exception":"[object] (BadMethodCallException(code: 0): Method Illuminate\\Validation\\Validator::validateNewApp\\Rules\\NotMimes('gif') does not exist. at /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Validation/Validator.php:1692)
[stacktrace]
#0 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Validation/Validator.php(686): Illuminate\\Validation\\Validator->__call('validateNewApp\\\\...', Array)
#1 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Validation/Validator.php(481): Illuminate\\Validation\\Validator->validateAttribute('file', 'NewApp\\\\Rules\\\\No...')
#2 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Validation/Validator.php(516): Illuminate\\Validation\\Validator->passes()
#3 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Validation/Validator.php(558): Illuminate\\Validation\\Validator->fails()
#4 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Foundation/Providers/FoundationServiceProvider.php(156): Illuminate\\Validation\\Validator->validate()
#5 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Macroable/Traits/Macroable.php(126): Illuminate\\Http\\Request->Illuminate\\Foundation\\Providers\\{closure}(Array)
#6 /Users/aaron/Code/redacted/vendor/statamic/cms/src/Http/Controllers/CP/Assets/AssetsController.php(84): Illuminate\\Http\\Request->__call('validate', Array)
#7 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Routing/Controller.php(54): Statamic\\Http\\Controllers\\CP\\Assets\\AssetsController->store(Object(Illuminate\\Http\\Request))
#8 /Users/aaron/Code/redacted/vendor/laravel/framework/src/Illuminate/Routing/ControllerDispatcher.php(43): Illuminate\\Routing\\Controller->callAction('store', Array)
```

The error is happening because we're not transforming the `new App\Rules\CustomRule()` string from the container's YAML file, like we do with blueprint fields.

This PR fixes it by making the `Validator::parse()` method public and mapping through the validation rules and parsing them when uploading an asset.

Fixes #13407
