### PR TITLE
[6.x] Revert combobox squish fix

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -423,7 +423,7 @@ defineExpose({
                         align="start"
                         :class="[
                             'shadow-ui-sm z-(--z-index-above) rounded-lg border border-gray-200 bg-white p-2 dark:border-white/10 dark:bg-gray-800',
-                            'min-h-[10rem] max-h-[var(--reka-combobox-content-available-height)] min-w-[var(--reka-combobox-trigger-width)]',
+                            'max-h-[var(--reka-combobox-content-available-height)] min-w-[var(--reka-combobox-trigger-width)]',
                             'overflow-hidden'
                         ]"
                         :style="optionWidth ? { width: `${optionWidth}px` } : {}"
@@ -442,7 +442,7 @@ defineExpose({
                             <div class="relative">
                                 <ComboboxViewport
                                     ref="viewport"
-                                    class="max-h-[calc(var(--reka-combobox-content-available-height)-2rem)] overflow-y-scroll"
+                                    class="max-h-[calc(var(--reka-combobox-content-available-height)-5rem)] overflow-y-scroll"
                                     data-ui-combobox-viewport
                                 >
                                     <ComboboxEmpty class="p-2 text-sm" data-ui-combobox-empty>


### PR DESCRIPTION
This reverts #13452

The minimum height added is weird when there's fewer options. 

<img width="645" height="255" alt="CleanShot 2026-01-07 at 16 59 47" src="https://github.com/user-attachments/assets/39079f07-f12b-4d2a-863f-96f5c32b3d67" />
