### PR TITLE
[6.x] Table checkbox alignment

### DIFF
--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -130,7 +130,8 @@
     }
 
     thead th.checkbox-column {
-        @apply sticky z-1 ps-3 w-8;
+        /* We need calc on the padding-start to account for the border of the table */
+        @apply sticky z-1 ps-[calc(0.75rem+1px)] w-8;
         .data-table--contained & {
             @apply sticky ps-4;
         }


### PR DESCRIPTION
This closes #13449 by accounting for the table border for the `padding-inline-start` value

<img width="559" height="394" alt="image" src="https://github.com/user-attachments/assets/6dae1f39-95cc-4c43-8ec3-4b032df12b46" />
