### PR TITLE
[6.x] Asset modal with checkerboard pattern

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -39,6 +39,7 @@
                                 v-slot="{ actions }"
                             >
                                 <ui-button inset size="sm" v-if="isImage && isFocalPointEditorEnabled" @click.prevent="openFocalPointEditor" icon="focus" variant="ghost" class="[&_svg]:!opacity-45" :text="__('Focal Point')" />
+                                <ui-button inset size="sm" v-if="isImage && asset && asset.can_be_transparent" @click="showCheckerboard = !showCheckerboard" icon="eye" variant="ghost" :class="[showCheckerboard ? '[&_svg]:!opacity-100' : '[&_svg]:!opacity-45']" :text="__('Transparency')" />
                                 <ui-button inset size="sm" v-if="canRunAction('rename_asset')" @click.prevent="runAction(actions, 'rename_asset')" icon="rename" variant="ghost" class="[&_svg]:!opacity-45" :text="__('Rename')" />
                                 <ui-button inset size="sm" v-if="canRunAction('move_asset')" @click.prevent="runAction(actions, 'move_asset')" icon="move-folder" variant="ghost" class="[&_svg]:!opacity-45" :text="__('Move to Folder')" />
                                 <ui-button inset size="sm" v-if="canRunAction('replace_asset')" @click.prevent="runAction(actions, 'replace_asset')" icon="replace" variant="ghost" class="[&_svg]:!opacity-45" :text="__('Replace')" />
@@ -67,7 +68,7 @@
                             class="flex flex-1 flex-col justify-center items-center p-8 h-full min-h-0"
                         >
                             <!-- Image -->
-                            <div v-if="asset.isImage" class="hover:bg-checkerboard max-w-full max-h-full">
+                            <div v-if="asset.isImage" class="max-w-full max-h-full" :class="{ 'bg-checkerboard before:opacity-100': asset.can_be_transparent && showCheckerboard }">
                                 <img :src="asset.preview" class="relative asset-thumb shadow-ui-xl max-w-full max-h-full object-contain" />
                             </div>
 
@@ -238,6 +239,7 @@ export default {
             fields: null,
             fieldset: null,
             showFocalPointEditor: false,
+            showCheckerboard: false,
             error: null,
             errors: {},
             actions: [],


### PR DESCRIPTION
This closes #13436 by adding the checkerboard to the asset modal on hover.

A few considerations:

- I believe the checkerboard was designed to _not_ be present so that you can see a clean view of the image
- This can cause problems with certain images, as reported in #13436
- Therefore, the checkerboard now shows on hover, similar to the thumbnail. This is likely how you'll see it when you first open the modal, since the hover target is so large—I think this works well. It's more like: if you move your mouse away, you see a clean image without a background.

FWIW, I tried playing with hover transitions here, but they don't work well when the background is initially transparent, like it is here, because the checkerboard effect is layered. I think this is fine—it can just be utilitarian, without a transition.