### PR TITLE
[6.x] Fix duplicate items in the Command Palette's "Recent" category

### DIFF
--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -102,7 +102,7 @@ const results = computed(() => {
         .map(category => {
             return {
                 text: __(category),
-	            items: grouped[category],
+                items: grouped[category],
             };
         })
         .filter(category => category.items);


### PR DESCRIPTION
This pull request fixes an issue where items under the "Recent" category may be duplicated.

When an item is added to the `recentItems` array, the code was mutating the original item object by setting `item.category = __('Recent')`. This caused the item's object in `serverItems` to have its category changed to "Recent", resulting in the duplicates.

This PR fixes it by cloning the item object when adding it to the `recentItems` array, so changing the category leave the original object intact.

Fixes #13466

## Before


https://github.com/user-attachments/assets/2ab0b61f-297a-4a63-b805-2ac24319f54a

## After


https://github.com/user-attachments/assets/3098b5d1-01a2-435c-85ea-b13dcb718f0e

