### PR TITLE
[6.x] Fix duplicating Bard sets

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -490,7 +490,7 @@ export default {
             });
         },
 
-        duplicateSet(old_id, attrs, pos) {
+        duplicateSet(old_id, attrs, getPos) {
             const id = uniqid();
             const enabled = attrs.enabled;
             const deepCopy = JSON.parse(JSON.stringify(attrs.values));
@@ -498,9 +498,14 @@ export default {
 
             this.updateSetMeta(id, this.meta.existing[old_id]);
 
+            this.debounceNextUpdate = false;
+
             // Perform this in nextTick because the meta data won't be ready until then.
             this.$nextTick(() => {
-                this.editor.commands.setAt({ attrs: { id, enabled, values }, pos });
+                const pos = getPos();
+                const node = this.editor.state.doc.nodeAt(pos);
+                const insertPos = pos + (node?.nodeSize || 0);
+                this.editor.commands.setAt({ attrs: { id, enabled, values }, pos: insertPos });
             });
         },
 

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -318,7 +318,7 @@ export default {
             this.extension.options.bard.duplicateSet(
                 this.node.attrs.id,
                 this.node.attrs,
-                this.getPos() + this.node.nodeSize,
+                this.getPos,
             );
         },
     },


### PR DESCRIPTION
This pull request attempts to fix an issue when duplicating the last set in Bard. 

TipTap was throwing a "RangeError: Position 9 out of range" error because the position we were passing to `setAt()` was larger than the number of nodes in the document. Calculating the position inside the `nextTick()` _right_ before we set it seems to work without any issues.

Fixes #13368
