### PR TITLE
[6.x] Fix JsDriver::addToFormData call to match interface signature

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -84,7 +84,7 @@ class Tags extends BaseTags
         if ($jsDriver) {
             $data['js_driver'] = $jsDriver->handle();
             $data['show_field'] = $jsDriver->copyShowFieldToFormData($data['fields']);
-            $data = array_merge($data, $jsDriver->addToFormData($form, $data));
+            $data = array_merge($data, $jsDriver->addToFormData($data));
         }
 
         $this->addToDebugBar($data, $formHandle);


### PR DESCRIPTION
The method `$jsDriver->addToFormData() `was being called with two arguments `($form, $data)`, while the [JsDriver](https://github.com/statamic/cms/blob/5.x/src/Forms/JsDrivers/JsDriver.php) interface defines it to accept only one parameter:
```php
public function addToFormData($data)
```

This commit aligns the method call with the interface contract, preventing signature mismatch and potential runtime errors.

PR similar to PR  [[5.x]](https://github.com/statamic/cms/pull/13463)