### PR TITLE
[6.x] Pressing "esc" should blur CodeMirror inputs

### DIFF
--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -537,6 +537,13 @@ export default {
          * Execute a keyboard shortcut, when applicable
          */
         shortcut(e) {
+	        // Handle ESC to blur/unfocus the editor
+	        if (e.keyCode === 27) {
+		        e.preventDefault();
+		        this.codemirror.getInputField().blur();
+		        return;
+	        }
+
             const mod = e.metaKey || e.ctrlKey;
             if (!mod) return;
 

--- a/resources/js/components/ui/CodeEditor.vue
+++ b/resources/js/components/ui/CodeEditor.vue
@@ -139,6 +139,14 @@ function initCodeMirror() {
 
     codemirror.value.on('focus', () => emit('focus'));
     codemirror.value.on('blur', () => emit('blur'));
+
+    codemirror.value.on('keydown', (cm, e) => {
+	    // Handle ESC to blur/unfocus the editor
+        if (e.keyCode === 27) {
+            e.preventDefault();
+            codemirror.value.getInputField().blur();
+        }
+    });
 }
 
 watch(


### PR DESCRIPTION
This pull request allows you to press `esc` to blur (unfocus) the CodeMirror input in the Code & Markdown fieldtypes.

Fixes #13035
