### PR TITLE
[6.x] Add max files count

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -417,7 +417,7 @@ export default {
 
         selectedFilesText() {
             if (this.maxFiles !== Infinity) {
-                return `(${this.assets.length}/${this.maxFiles} ${__('selected')})`;
+                return __n(':count\/:max selected', this.assets.length, { max: this.maxFiles });
             }
         },
 


### PR DESCRIPTION
This should close #12593, improving the UX when only 1/1 assets are selectable.

The asset browser already shows that only 1 asset is selectable on the bottom info bar, so I think that initial UX is fine…

![2026-01-08 at 17 13 39@2x](https://github.com/user-attachments/assets/2026c5cc-3dcb-4510-82e6-b20c8f5b75b1)

But once you max-out the "Browse Assets" button now disappears

![2026-01-08 at 17 20 22@2x](https://github.com/user-attachments/assets/d45d4573-ff88-4a15-b7f0-9678c1d0f6f9)
