### PR TITLE
[6.x] Adds "Set Alt" button in assets grid view

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -36,7 +36,7 @@
                 </template>
 
             </div>
-            <div class="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-100 duration-100 gap-2">
+            <div class="absolute inset-0 flex items-center justify-center opacity-0 hover:opacity-100 duration-100">
                 <div class="flex items-center justify-center gap-2">
                     <template v-if="!readOnly">
                         <ui-button size="sm" @click="editOrOpen" :icon="asset.isEditable ? 'pencil' : 'eye'" aria-label="__('Edit')" v-if="asset.isViewable" />


### PR DESCRIPTION
This closes #12592 and #13483

Added the "Set Alt" button for Assets fields when "Show filename" is disabled and UI mode is set to grid.
~I removed the checkerboard background to make it easier to see the blue-colored button.~
The icon buttons have also been reduced from 'sm' -> 'xs' to make space for the button

Alt-text has been changed from 'blue' -> 'sky' in Assets grid view to maintain consistency.


**Before**
<img width="150" height="150" alt="Skjermbilde 2026-01-08 kl  21 58 17" src="https://github.com/user-attachments/assets/7549da67-08fb-4a01-92b7-acb3da321a02" />

**After**
<img width="150" height="150" alt="Skjermbilde 2026-01-08 kl  21 52 00" src="https://github.com/user-attachments/assets/c1209c10-bb4d-4e67-9bdf-33ba22508091" />