### PR TITLE
[6.x] Fix markdown text color in dark mode

### DIFF
--- a/resources/css/vendors/codemirror.css
+++ b/resources/css/vendors/codemirror.css
@@ -99,7 +99,7 @@
     /* Explicitly set some colors rather than inherit from the body, because we could have a dark cp > light code field, which would result in pale text on a white background, etc. */
     &.CodeMirror pre.CodeMirror-line,
     &.CodeMirror pre.CodeMirror-line-like {
-        @apply text-gray-900;
+        @apply text-gray-900 dark:text-gray-300;
     }
 
     .CodeMirror-gutters {


### PR DESCRIPTION
While using dark mode and a markdown field, the text is not visible.
I set the text to gray-300 as that's what I found the other fields to use in dark mode.


**Before**

<img width="720" height="190" alt="Skjermbilde 2026-01-08 kl  22 14 54" src="https://github.com/user-attachments/assets/6b477617-658b-4bff-8517-c97b61451e95" />

**After**

<img width="720" height="190" alt="Skjermbilde 2026-01-08 kl  22 15 09" src="https://github.com/user-attachments/assets/562ca940-0926-43cf-9a6b-427af9844427" />
