### PR TITLE
[6.x] Fix reorderable listings where items come from URL

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -580,6 +580,10 @@ function autoApplyFilters() {
 }
 
 function reordered(order) {
+	if (! props.items) {
+		items.value = order;
+	}
+
     emit('reordered', order);
 }
 


### PR DESCRIPTION
This pull request fixes an issue where reordered items in a listing wouldn't be persisted properly.

This issue only affects listings where items come from a URL (eg. entries listing) because the `Listing` component maintains its own `items` state rather than relying on the `items` prop.

Fixes #13482
