### PR TITLE
[6.x] Avoid squashed Combobox options near viewport edge

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -443,6 +443,12 @@ defineExpose({
                                 <ComboboxViewport
                                     ref="viewport"
                                     class="max-h-[calc(var(--reka-combobox-content-available-height)-2rem)] overflow-y-scroll"
+                                    :class="{
+										'min-h-[2.25px]': options.length === 0,
+										'min-h-[2.5rem]': options.length === 1,
+										'min-h-[5rem]': options.length === 2,
+										'min-h-[7.5rem]': options.length >= 3,
+                                    }"
                                     data-ui-combobox-viewport
                                 >
                                     <ComboboxEmpty class="p-2 text-sm" data-ui-combobox-empty>


### PR DESCRIPTION
This pull request brings back #13452, but uses different `min-height` values depending on the number of options to avoid the awkward whitespace issue seen in #13461.

Reka relies on the `min-height` property to determine when it needs to flip the options. 

Fixes #13365

## Before

https://github.com/user-attachments/assets/f0f4fb3a-c04e-4feb-bf0a-9aa634a72c57


## After


https://github.com/user-attachments/assets/c4b2725b-b815-4ed5-b6b3-c2d6dcf4bb2c

