### PR TITLE
[6.x] Fix bard full screen styles

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -275,9 +275,9 @@
             min-height: calc(100vh - 120px);
         }
 
-        .bard-content:not(.bard-set *) > {
-            p > code,
-            pre code {
+        .bard-content:not(.bard-set *) {
+            > p > code,
+            > pre code {
                 @apply bg-purple-100;
             }
         }


### PR DESCRIPTION
This closes #13358.

The CSS compiler was having trouble figuring out the nesting. Making it a bit more verbose fixed things.