### PR TITLE
[6.x] Don't redirect to referrer when 2FA challenge is required

### DIFF
--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -42,9 +42,11 @@ const submit = () => {
             errors.value = {};
         },
         onSuccess: (page) => {
-	        if (!page?.component && props.referer) {
-		        window.location.href = props.referer;
-	        }
+			if (page.component === 'auth/two-factor/Challenge') {
+				return;
+			}
+
+	        window.location.href = props.referer;
         },
         onError: () => processing.value = false
     });


### PR DESCRIPTION
This pull request fixes an issue when logging in with 2FA where you'd be redirected to the 2FA challenge back, then immediately back to the login page. 

This was due to us always redirecting to the referrer URL. I've added a conditional before redirecting to check if a 2FA challenge is required.
