### PR TITLE
[6.x] Add a little top margin to the `header-actions` slot

### DIFF
--- a/resources/js/components/ui/Panel/Panel.vue
+++ b/resources/js/components/ui/Panel/Panel.vue
@@ -22,7 +22,9 @@ const props = defineProps({
         <PanelHeader v-if="heading">
             <Heading v-html="heading" />
             <Subheading v-if="subheading" v-html="subheading" />
-            <slot name="header-actions" />
+	        <div v-if="!!$slots['header-actions']" class="mt-1">
+		        <slot name="header-actions" />
+	        </div>
         </PanelHeader>
         <slot />
     </div>


### PR DESCRIPTION
This one might be subjective, but I feel like the `header-actions` slot in the `Panel` component could do with a little top margin to introduce some breathing space between the heading and the button.

## Before

<img width="698" height="262" alt="CleanShot 2026-01-09 at 14 31 57" src="https://github.com/user-attachments/assets/e2b1bda9-cb77-4f81-b30e-19e92a695166" />

## After

<img width="695" height="261" alt="CleanShot 2026-01-09 at 14 32 09" src="https://github.com/user-attachments/assets/adbb35ef-f700-4142-aaee-14070cabee40" />
