### PR TITLE
[6.x] Markdown cheatsheet double close button

### DIFF
--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -144,13 +144,11 @@
                     />
                 </Stack>
 
-                <Stack size="narrow" v-model:open="showCheatsheet">
-                    <div class="relative h-full overflow-auto bg-white p-2 dark:bg-gray-800 rounded-l-2xl">
-                        <div class="prose prose-zinc prose-headings:font-medium prose-pre:prose-code:!text-white mx-auto max-w-3xl">
-                            <h2 v-text="__('Markdown Cheatsheet')"></h2>
-                            <div v-html="__('markdown.cheatsheet')"></div>
-                        </div>
-                    </div>
+                <Stack size="narrow" v-model:open="showCheatsheet" :title="__('Markdown Cheatsheet')">
+                    <div
+                        class="prose prose-zinc prose-headings:font-medium prose-pre:prose-code:!text-white mx-auto max-w-3xl [&>*:first-child]:![margin-block-start:0]"
+                        v-html="__('markdown.cheatsheet')"
+                    />
                 </Stack>
             </div>
         </div>


### PR DESCRIPTION
This PR fixes two close buttons inside the markdown cheatsheet.

## Before

with two close buttons

![2026-01-09 at 14 42 27@2x](https://github.com/user-attachments/assets/d95a493b-d86a-4392-92fe-33547b7e7318)

## After

![2026-01-09 at 14 42 14@2x](https://github.com/user-attachments/assets/fe862550-db6a-41c3-b10f-ef9c7f5e0552)
