### PR TITLE
[6.x] Fix uploading design in Files fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -19,7 +19,7 @@
                     <div class="text-sm text-gray-600 dark:text-gray-400">{{ __('Drop to Upload') }}</div>
                 </div>
 
-                <div class="border border-gray-400 dark:border-gray-700 border-dashed rounded-xl p-4 flex flex-col @2xs:flex-row items-center gap-4" :class="{ 'rounded-b-none': value.length }">
+                <div class="border border-gray-400 dark:border-gray-700 border-dashed rounded-xl p-4 flex flex-col @2xs:flex-row items-center gap-4" :class="{ 'rounded-b-none': value.length || uploads.length }">
                     <div class="text-sm text-gray-600 dark:text-gray-400 flex items-center flex-1 justify-center">
                         <ui-icon name="upload-cloud" class="size-5 text-gray-500 me-2" />
                         <span v-text="`${__('Drag & drop here or')}&nbsp;`" />
@@ -30,7 +30,7 @@
                     </div>
                 </div>
 
-                <div v-if="uploads.length" class="border-gray-300 border-l border-r">
+                <div v-if="uploads.length" class="rounded-xl border border-gray-300 dark:border-gray-700 border-t-0 rounded-t-none divide-y" :class="{ 'rounded-b-none': value.length }">
                     <uploads :uploads="uploads" />
                 </div>
 


### PR DESCRIPTION
This pull request updates the design of in-progress uploads in the Files fieldtype so it matches that of the Assets fieldtype.

We use the Files fieldtype in the "Reupload Asset" action. You can slow down the upload for testing by adding a `sleep()` to the `FilesFieldtypeController`.

## Before

<img width="643" height="149" alt="CleanShot 2026-01-09 at 14 49 57" src="https://github.com/user-attachments/assets/a085999c-279d-43ba-97d2-c5c3a7247de1" />


## After

<img width="643" height="149" alt="CleanShot 2026-01-09 at 14 49 33" src="https://github.com/user-attachments/assets/e6223ac0-c4a6-4588-9d0f-47d88289a03f" />
