### PR TITLE
[6.x] Confirmation Modals

### DIFF
--- a/packages/cms/src/temporary.js
+++ b/packages/cms/src/temporary.js
@@ -2,7 +2,6 @@ export const {
     HasInputOptions,
     InlineEditForm,
     RelatedItem,
-    ConfirmationModal,
     RevisionHistory,
     RestoreRevision,
     RevisionPreview,

--- a/packages/cms/src/ui.js
+++ b/packages/cms/src/ui.js
@@ -15,6 +15,7 @@ export const {
     CodeEditor,
     Combobox,
     CommandPaletteItem,
+    ConfirmationModal,
     Context,
     ContextFooter,
     ContextHeader,

--- a/resources/js/bootstrap/cms/temporary.js
+++ b/resources/js/bootstrap/cms/temporary.js
@@ -1,7 +1,6 @@
 export { default as HasInputOptions } from '../../components/fieldtypes/HasInputOptions.js';
 export { default as InlineEditForm } from '../../components/inputs/relationship/InlineEditForm.vue';
 export { default as RelatedItem } from '../../components/inputs/relationship/Item.vue';
-export { default as ConfirmationModal } from '../../components/modals/ConfirmationModal.vue';
 export { default as RevisionHistory } from '../../components/revision-history/History.vue';
 export { default as RestoreRevision } from '../../components/revision-history/Restore.vue';
 export { default as RevisionPreview } from '../../components/revision-history/Preview.vue';

--- a/resources/js/bootstrap/cms/ui.js
+++ b/resources/js/bootstrap/cms/ui.js
@@ -15,6 +15,7 @@ export {
     CodeEditor,
     Combobox,
     CommandPaletteItem,
+    ConfirmationModal,
     Context,
     ContextFooter,
     ContextHeader,

--- a/resources/js/bootstrap/components.js
+++ b/resources/js/bootstrap/components.js
@@ -14,7 +14,7 @@ import Slugify from '../components/slugs/Slugify.vue';
 import ElementContainer from '../components/ElementContainer.vue';
 import CreateEntryButton from '../components/entries/CreateEntryButton.vue';
 import Portal from '../components/portals/Portal.vue';
-import ConfirmationModal from '../components/modals/ConfirmationModal.vue';
+import ConfirmationModal from '../components/ui/Modal/ConfirmationModal.vue';
 import FieldActionModal from '../components/field-actions/FieldActionModal.vue';
 import ElevatedSessionModal from '../components/modals/ElevatedSessionModal.vue';
 import ResourceDeleter from '../components/ResourceDeleter.vue';

--- a/resources/js/components/ResourceDeleter.vue
+++ b/resources/js/components/ResourceDeleter.vue
@@ -1,6 +1,6 @@
 <template>
     <confirmation-modal
-        v-if="deleting"
+        :open="deleting"
         :title="modalTitle"
         :bodyText="modalBody"
         :buttonText="__('Delete')"

--- a/resources/js/components/actions/ConfirmableAction.vue
+++ b/resources/js/components/actions/ConfirmableAction.vue
@@ -87,7 +87,7 @@ defineExpose({
 
 <template>
     <confirmation-modal
-        v-if="confirming"
+        v-model:open="confirming"
         :title="action.title"
         :danger="action.dangerous"
         :submittable="action.runnable"

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -168,7 +168,7 @@
             />
 
         <confirmation-modal
-            v-if="closingWithChanges"
+            v-model:open="closingWithChanges"
             :title="__('Unsaved Changes')"
             :body-text="__('Are you sure? Unsaved changes will be lost.')"
             :button-text="__('Discard Changes')"

--- a/resources/js/components/assets/Upload.vue
+++ b/resources/js/components/assets/Upload.vue
@@ -32,7 +32,7 @@
 
 
         <confirmation-modal
-            v-if="showNewFilenameModal"
+            :open="showNewFilenameModal"
             :title="__('New Filename')"
             @cancel="showNewFilenameModal = false"
             @confirm="confirmNewFilename"

--- a/resources/js/components/blueprints/BlueprintResetter.vue
+++ b/resources/js/components/blueprints/BlueprintResetter.vue
@@ -1,6 +1,6 @@
 <template>
     <confirmation-modal
-        v-if="resetting"
+        :open="resetting"
         :title="modalTitle"
         :bodyText="modalBody"
         :buttonText="__('Reset')"

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -220,7 +220,7 @@
         />
 
         <confirmation-modal
-            v-if="selectingOrigin"
+            :open="selectingOrigin"
             :title="__('Create Localization')"
             :buttonText="__('Create')"
             @cancel="cancelLocalization()"
@@ -234,7 +234,7 @@
         </confirmation-modal>
 
         <confirmation-modal
-            v-if="pendingLocalization"
+            :open="pendingLocalization"
             :title="__('Unsaved Changes')"
             :body-text="__('Are you sure? Unsaved changes will be lost.')"
             :button-text="__('Continue')"

--- a/resources/js/components/field-actions/FieldActionModal.vue
+++ b/resources/js/components/field-actions/FieldActionModal.vue
@@ -1,6 +1,7 @@
 <template>
     <div>
         <confirmation-modal
+            open
             :title="title"
             :danger="dangerous"
             :buttonText="buttonText"

--- a/resources/js/components/fieldsets/FieldsetDeleter.vue
+++ b/resources/js/components/fieldsets/FieldsetDeleter.vue
@@ -1,6 +1,6 @@
 <template>
     <confirmation-modal
-        v-if="deleting"
+        :open="deleting"
         :title="modalTitle"
         :buttonText="__('Delete')"
         :danger="true"

--- a/resources/js/components/fieldsets/FieldsetResetter.vue
+++ b/resources/js/components/fieldsets/FieldsetResetter.vue
@@ -1,6 +1,6 @@
 <template>
     <confirmation-modal
-        v-if="resetting"
+        :open="resetting"
         :title="modalTitle"
         :bodyText="modalBody"
         :buttonText="__('Reset')"

--- a/resources/js/components/fieldtypes/ArrayFieldtype.vue
+++ b/resources/js/components/fieldtypes/ArrayFieldtype.vue
@@ -92,7 +92,7 @@
         </div>
 
         <confirmation-modal
-            v-if="deleting !== false"
+            :open="deleting !== false"
             :title="__('Delete Row')"
             :bodyText="__('Are you sure you want to delete this row?')"
             :buttonText="__('Delete')"

--- a/resources/js/components/fieldtypes/TableFieldtype.vue
+++ b/resources/js/components/fieldtypes/TableFieldtype.vue
@@ -61,7 +61,7 @@
             </section>
 
             <confirmation-modal
-                v-if="deletingRow !== false"
+                :open="deletingRow !== false"
                 :title="__('Delete Row')"
                 :bodyText="__('Are you sure you want to delete this row?')"
                 :buttonText="__('Delete')"
@@ -72,7 +72,7 @@
             </confirmation-modal>
 
             <confirmation-modal
-                v-if="deletingColumn !== false"
+                :open="deletingColumn !== false"
                 :title="__('Delete Column')"
                 :bodyText="__('Are you sure you want to delete this column?')"
                 :buttonText="__('Delete')"

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -41,7 +41,7 @@
         </element-container>
 
         <confirmation-modal
-            v-if="deletingRow !== null"
+            :open="deletingRow !== null"
             :title="__('Delete Row')"
             :body-text="__('Are you sure?')"
             :button-text="__('Delete')"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -235,7 +235,7 @@ function onAnimationComplete() {
         </div>
 
         <confirmation-modal
-            v-if="deletingSet"
+            :open="deletingSet"
             :title="__('Delete Set')"
             :body-text="__('Are you sure?')"
             :button-text="__('Delete')"

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -85,7 +85,7 @@
         />
 
         <confirmation-modal
-            v-if="pendingLocalization"
+            :open="pendingLocalization"
             :title="__('Unsaved Changes')"
             :body-text="__('Are you sure? Unsaved changes will be lost.')"
             :button-text="__('Continue')"

--- a/resources/js/components/inputs/relationship/InlinePublishForm.vue
+++ b/resources/js/components/inputs/relationship/InlinePublishForm.vue
@@ -33,7 +33,7 @@
         </Stack>
 
         <confirmation-modal
-            v-if="closingWithChanges"
+            :open="closingWithChanges"
             :title="__('Unsaved Changes')"
             :body-text="__('Are you sure? Unsaved changes will be lost.')"
             :button-text="__('Discard Changes')"

--- a/resources/js/components/revision-history/Restore.vue
+++ b/resources/js/components/revision-history/Restore.vue
@@ -3,7 +3,7 @@
         <Button @click="confirming = true" :text="__('Restore')" />
 
         <confirmation-modal
-            v-if="confirming"
+            :open="confirming"
             :title="__('Restore Revision')"
             :buttonText="__('Restore')"
             @confirm="restore"

--- a/resources/js/components/structures/PageEditor.vue
+++ b/resources/js/components/structures/PageEditor.vue
@@ -55,7 +55,7 @@
         </div>
 
         <confirmation-modal
-            v-if="closingWithChanges"
+            :open="closingWithChanges"
             :title="__('Unsaved Changes')"
             :body-text="__('Are you sure? Unsaved changes will be lost.')"
             :button-text="__('Discard Changes')"

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -77,7 +77,7 @@
         </ui-panel>
 
         <confirmation-modal
-            v-if="discardingChanges"
+            :open="discardingChanges"
             :title="__('Discard Changes')"
             :body-text="__('Are you sure?')"
             :button-text="__('Discard Changes')"

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -111,7 +111,7 @@
         </PublishContainer>
 
         <confirmation-modal
-            v-if="pendingLocalization"
+            :open="pendingLocalization"
             :title="__('Unsaved Changes')"
             :body-text="__('Are you sure? Unsaved changes will be lost.')"
             :button-text="__('Continue')"

--- a/resources/js/components/two-factor/RecoveryCodesModal.vue
+++ b/resources/js/components/two-factor/RecoveryCodesModal.vue
@@ -87,7 +87,7 @@ function copyToClipboard() {
     </Modal>
 
     <confirmation-modal
-        v-if="confirming"
+        :open="confirming"
         :danger="true"
         :title="__('Are you sure?')"
         @cancel="confirming = false"

--- a/resources/js/components/two-factor/TwoFactor.vue
+++ b/resources/js/components/two-factor/TwoFactor.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, watch } from 'vue';
-import ConfirmationModal from '@/components/modals/ConfirmationModal.vue';
+import { ConfirmationModal } from '@ui';
 import TwoFactorSetup from './Setup.vue';
 import TwoFactorRecoveryCodesModal from './RecoveryCodesModal.vue';
 import { requireElevatedSession } from '@/components/elevated-sessions';

--- a/resources/js/components/ui/Listing/Presets.vue
+++ b/resources/js/components/ui/Listing/Presets.vue
@@ -207,7 +207,7 @@ function deletePreset() {
     </div>
 
     <confirmation-modal
-        v-if="isCreating"
+        :open="isCreating"
         :title="__('Create New View')"
         :buttonText="__('Create')"
         @cancel="isCreating = false"
@@ -222,7 +222,7 @@ function deletePreset() {
     </confirmation-modal>
 
     <confirmation-modal
-        v-if="isRenaming"
+        :open="isRenaming"
         :title="__('Rename View')"
         :buttonText="__('Rename')"
         @cancel="isRenaming = false"
@@ -242,7 +242,7 @@ function deletePreset() {
     </confirmation-modal>
 
     <confirmation-modal
-        v-if="isConfirmingDeletion"
+        :open="isConfirmingDeletion"
         :title="__('Delete View')"
         :bodyText="__('Are you sure you want to delete this view?')"
         :buttonText="__('Delete')"

--- a/resources/js/components/ui/index.js
+++ b/resources/js/components/ui/index.js
@@ -12,6 +12,7 @@ export { default as Checkbox } from './Checkbox/Item.vue';
 export { default as CheckboxGroup } from './Checkbox/Group.vue';
 export { default as CodeEditor } from './CodeEditor.vue';
 export { default as Combobox } from './Combobox/Combobox.vue';
+export { default as ConfirmationModal } from './Modal/ConfirmationModal.vue';
 export { default as Context } from './Context/Context.vue';
 export { default as ContextFooter } from './Context/Footer.vue';
 export { default as ContextHeader } from './Context/Header.vue';

--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -49,7 +49,7 @@ provide('layout', {
         />
 
         <confirmation-modal
-            v-if="$root.copyToClipboardModalUrl"
+            :open="$root.copyToClipboardModalUrl !== null"
             :cancellable="false"
             :button-text="__('OK')"
             :title="__('Copy to clipboard')"

--- a/resources/js/pages/preferences/nav/Edit.vue
+++ b/resources/js/pages/preferences/nav/Edit.vue
@@ -179,7 +179,7 @@
         />
 
         <confirmation-modal
-            v-if="confirmingReset"
+            :open="confirmingReset"
             :title="__('Reset')"
             :bodyText="__('Are you sure you want to reset nav customizations?')"
             :buttonText="__('Reset')"
@@ -189,7 +189,7 @@
         />
 
         <confirmation-modal
-            v-if="confirmingRemoval"
+            :open="confirmingRemoval"
             :title="__('Remove')"
             :bodyText="__('Are you sure you want to remove this section and all of its children?')"
             :buttonText="__('Remove')"

--- a/resources/js/pages/users/Passkeys.vue
+++ b/resources/js/pages/users/Passkeys.vue
@@ -4,8 +4,7 @@ import { startRegistration, browserSupportsWebAuthn } from '@simplewebauthn/brow
 import { router } from '@inertiajs/vue3';
 import axios from 'axios'
 import Head from '@/pages/layout/Head.vue';
-import { Header, Button, EmptyStateMenu, EmptyStateItem, Listing, DropdownItem, Modal, Input, ModalClose, Field } from '@ui';
-import ConfirmationModal from '@/components/modals/ConfirmationModal.vue';
+import { Header, Button, EmptyStateMenu, EmptyStateItem, Listing, DropdownItem, Modal, ConfirmationModal, Input, ModalClose, Field } from '@ui';
 import { toggleArchitecturalBackground } from '@/pages/layout/architectural-background.js';
 
 const props = defineProps([

--- a/resources/js/stories/ConfirmationModal.stories.ts
+++ b/resources/js/stories/ConfirmationModal.stories.ts
@@ -1,0 +1,127 @@
+import type {Meta, StoryObj} from '@storybook/vue3';
+import { Button, Badge, ConfirmationModal, Icon } from '@ui';
+
+const meta = {
+    title: 'Overlays/ConfirmationModal',
+    component: ConfirmationModal,
+} satisfies Meta<typeof ConfirmationModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const _DocsIntro: Story = {
+    tags: ['!dev'],
+    parameters: {
+        docs: {
+            source: {
+                code: `
+                    <ConfirmationModal
+                        v-model:open="isConfirming"
+                        body-text="Do you really want to do that?"
+                        @confirm="hasConfirmed = true"
+                    />
+                `
+            }
+        }
+    },
+    render: () => ({
+        components: { ConfirmationModal, Button, Badge },
+        data: () => ({
+            isConfirming: false,
+            hasConfirmed: false,
+        }),
+        template: `
+            <div class="flex items-center gap-2">
+                <Button text="Confirm" @click="isConfirming = true" />
+                <Badge color="green" text="Confirmed" icon="checkmark" v-if="hasConfirmed" />
+                <ConfirmationModal
+                    v-model:open="isConfirming"
+                    body-text="Do you really want to do that?"
+                    @confirm="hasConfirmed = true"
+                />
+            </div>
+        `,
+    }),
+};
+
+
+export const ViaProp: Story = {
+    render: () => ({
+        components: { ConfirmationModal, Button, Icon },
+        data: () => ({
+            isOpen: false,
+            isConfirmed: false,
+        }),
+        template: `
+            <div class="flex items-center gap-2">
+                <Button
+                    :text="isConfirmed ? 'Confirmed' : 'Confirm'"
+                    :disabled="isConfirmed"
+                    :icon="isConfirmed ? 'checkmark' : null"
+                    @click="isOpen = true"
+                />
+
+                <Button
+                    v-if="isConfirmed"
+                    icon="x"
+                    text="Reset"
+                    variant="ghost"
+                    @click="isConfirmed = false"
+                />
+            </div>
+
+            <ConfirmationModal
+                v-model:open="isOpen"
+                @confirm="isConfirmed = true"
+            />
+        `
+    }),
+};
+
+
+
+export const Busy: Story = {
+    render: () => ({
+        components: { ConfirmationModal, Button, Icon },
+        data: () => ({
+            isOpen: false,
+            isConfirmed: false,
+            isBusy: false,
+        }),
+        methods: {
+            confirm() {
+                this.isBusy = true;
+                setTimeout(() => {
+                    this.isConfirmed = true;
+                    this.isBusy = false;
+                    this.isOpen = false;
+                }, 1000);
+            }
+        },
+        template: `
+            <div class="flex items-center gap-2">
+                <Button
+                    :text="isConfirmed ? 'Confirmed' : 'Confirm'"
+                    :disabled="isConfirmed"
+                    :icon="isConfirmed ? 'checkmark' : null"
+                    :loading="isBusy"
+                    @click="isOpen = true"
+                />
+
+                <Button
+                    v-if="isConfirmed"
+                    icon="x"
+                    text="Reset"
+                    variant="ghost"
+                    @click="isConfirmed = false"
+                />
+            </div>
+
+            <ConfirmationModal
+                v-model:open="isOpen"
+                :busy="isBusy"
+                @confirm="confirm"
+            />
+        `
+    }),
+};

--- a/resources/js/stories/docs/ConfirmationModal.mdx
+++ b/resources/js/stories/docs/ConfirmationModal.mdx
@@ -1,0 +1,12 @@
+import { Canvas, Meta, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as ConfirmationModalStories from '../ConfirmationModal.stories';
+
+<Meta of={ConfirmationModalStories} />
+
+# Confirmation Modal
+A wrapper around the [Modal](?path=/docs/overlays-modal--docs) component for simple confirmation dialogs.
+
+<Canvas of={ConfirmationModalStories._DocsIntro} sourceState={'shown'} />
+
+## Arguments
+<ArgTypes of={ConfirmationModalStories} />

--- a/resources/js/stories/docs/Modal.mdx
+++ b/resources/js/stories/docs/Modal.mdx
@@ -6,6 +6,8 @@ import * as ModalStories from '../Modal.stories';
 # Modal
 Display content in a layer above the main page. Ideal for confirmations, alerts, and forms.
 
+> For simple confirmations, there is a [Confirmation Modal](?path=/docs/overlays-confirmationmodal--docs) component that wraps this component.
+
 <Canvas of={ModalStories._DocsIntro} sourceState={'shown'} />
 
 ## Title

--- a/resources/js/tests/Package.test.js
+++ b/resources/js/tests/Package.test.js
@@ -121,6 +121,7 @@ it('exports ui', async () => {
         'CheckboxGroup',
         'CodeEditor',
         'Combobox',
+        'ConfirmationModal',
         'Context',
         'ContextFooter',
         'ContextHeader',


### PR DESCRIPTION
Line up confirmation modals with standard modals. Makes a few tweaks too.

## Open State

The open state is now controlled the same way as modals.

```html
<!-- Using v-model -->
<ConfirmationModal v-model:open="isOpen">

<!-- Using a prop & event listener -->
<ConfirmationModal :open="isOpen" @update:open="openUpdated">
```

## Close on confirm

Upon confirmation, the modal will close. Previously you had to listen for `@confirm` and update the condition yourself.

If you use the `busy` prop, automatic closing will **not** happen.

## Breaking change

This is a breaking change. To upgrade:

- Adjust component name. It was <stack>, but now it's either:
  - `<ui-confirmation-modal>` or
  - `import { ConfirmationModal } from '@statamic/cms/ui'` and `<ConfirmationModal>`
- Adjust the open state logic from the previous `v-if` to the new `v-model:open` or `:open`.

```diff
-<confirmation-modal v-if="isConfirming" ...>
+<ui-confirmation-modal v-model:open="isConfirming" ...>
```