### PR TITLE
[6.x] Ensure sidebar tab is only active when sidebar area is hidden

### DIFF
--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -60,6 +60,15 @@ function setActiveTabFromHash() {
 }
 
 watch(
+	() => shouldShowSidebar.value,
+	() => {
+		if (shouldShowSidebar.value && activeTab.value === 'sidebar') {
+			setActive(visibleMainTabs.value[0].handle);
+		}
+	}
+);
+
+watch(
     () => activeTab.value,
     (tab) => {
         if (rememberTab.value) window.location.hash = tab


### PR DESCRIPTION
The sidebar area is hidden on smaller windows and the "Sidebar" tab shows like any other.

If the "Sidebar" tab is active and you resize the window, the sidebar fields continue to show in the "main" area of the publish form, rather than moving back to the sidebar as they should.

This also applies to Live Preview.

Fixes #13498
