### PR TITLE
[5.x] Fix filterWhere with arrays

### DIFF
--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -160,7 +160,7 @@ abstract class Builder extends BaseBuilder
         $lookup = array_flip(array_map(fn ($v) => $v ?? '__NULL__', $where['values']));
 
         return $values->filter(
-            fn ($value) => isset($lookup[$value ?? '__NULL__'])
+            fn ($value) => ! is_array($value) && isset($lookup[$value ?? '__NULL__'])
         );
     }
 
@@ -169,7 +169,7 @@ abstract class Builder extends BaseBuilder
         $lookup = array_flip(array_map(fn ($v) => $v ?? '__NULL__', $where['values']));
 
         return $values->filter(
-            fn ($value) => ! isset($lookup[$value ?? '__NULL__'])
+            fn ($value) => is_array($value) || ! isset($lookup[$value ?? '__NULL__'])
         );
     }
 


### PR DESCRIPTION
This PR fixes a `Cannot access offset of type array in isset or empty` exception that was likely introduced with https://github.com/statamic/cms/pull/12894 or https://github.com/statamic/cms/pull/13266.

I ran into it because of PR https://github.com/statamic/cms/pull/11870. The exception was caused by the following query in https://github.com/statamic/cms/pull/11870/commits/75d76d02e0435f52235d411840ac74c173a19b07:

```php
$query->whereIn('author', [User::current()->id()]);
```

I've removed this query in favor of the new `whereHas()` as seen in the commit. This resolves the issue in that particular PR.

I thought it was worth raising the issue anyway and providing a fix for it.