### PR TITLE
[6.x] Fix theme grid alignment

### DIFF
--- a/resources/js/components/themes/Themes.vue
+++ b/resources/js/components/themes/Themes.vue
@@ -102,7 +102,7 @@ defineExpose({
             />
         </div>
 
-        <div class="grid grid-cols-2 @lg/themes:grid-cols-3 @2xl/themes:grid-cols-4 gap-4">
+        <div class="grid items-start grid-cols-2 @lg/themes:grid-cols-3 @2xl/themes:grid-cols-4 gap-4">
             <button
                 v-for="theme in results"
                 :key="theme.id"


### PR DESCRIPTION
Fix the theme grid alignment when some theme titles take up multiple lines

## Before

![2026-01-12 at 13 34 49@2x](https://github.com/user-attachments/assets/c9f7b060-aa03-4bc5-b3a2-998fa3cdebe8)


## After

![2026-01-12 at 13 34 36@2x](https://github.com/user-attachments/assets/2927b373-ca40-4460-9120-085cf0acfcdb)
