### PR TITLE
[6.x] Avoid making unnecessary requests in Relationship fieldtype

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -293,7 +293,6 @@ export default {
         },
 
         initializeData() {
-			// https://github.com/statamic/cms/pull/12042/commits/e048475232fe6874723de9269b10ba6918cebad1
             if (!this.data) {
                 return this.getDataForSelections(this.value);
             }

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -98,8 +98,6 @@ export default {
     },
 
     created() {
-        // Get the items via ajax.
-        // TODO: To save on requests, this should probably be done in the preload step and sent via meta.
         if (!this.typeahead) this.request();
 
 		watch(


### PR DESCRIPTION
This pull request aims to avoid making unnecessary requests in the Relationship fieldtype.

* Avoid making requests to fetch selections in `RelationshipInput` when nothing is selected.
    * This wasn't an issue in v5, but it was introduced (I _think_ accidentally) in https://github.com/statamic/cms/pull/12042/commits/e048475232fe6874723de9269b10ba6918cebad1 (likely accidentally.
* Added caching around requests in `RelationshipSelectField` to avoid making duplicate requests with the same parameters.
  * Borrowed the caching approach from #11523. 
  * I've also removed the TODO around moving items into the fieldtype's `preload` method - requests are _probably_ fine, especially now that they're cached. 

Related: #13385