### PR TITLE
[6.x] Fix stacks closing immediately after opening

### DIFF
--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -7,7 +7,8 @@ import {
     useSlots,
     watch,
     onBeforeUnmount,
-    provide
+    provide,
+    onMounted,
 } from 'vue';
 import { stacks, events, keys, config } from '@/api';
 import wait from '@/util/wait.js';
@@ -173,8 +174,11 @@ function cleanup() {
 watch(
     () => props.open,
     (value) => value ? open() : close(),
-    { immediate: true }
 );
+
+onMounted(() => {
+	if (props.open) open();
+});
 
 onBeforeUnmount(() => {
     cleanup();


### PR DESCRIPTION
This pull request fixes an issue where some stacks would close immediately after opening. This was caused by the immediate watcher, which is called _before_ the component has finished mounting. 

I've fixed it by removing the `immediate` option from the watcher and checking the open state in `onMounted()` instead, which is what we do in the `Modal` component.

Fixes #13508