### PR TITLE
[6.x] Make "Emails" field on configure forms page full-width

### DIFF
--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -257,6 +257,7 @@ class FormsController extends CpController
                     'email' => [
                         'type' => 'grid',
                         'mode' => 'stacked',
+                        'full_width_setting' => true,
                         'add_row' => __('Add Email'),
                         'instructions' => __('statamic::messages.form_configure_email_instructions'),
                         'fields' => [


### PR DESCRIPTION
Fixes #13520

## Before

<img width="1006" height="1377" alt="CleanShot 2026-01-13 at 09 12 41" src="https://github.com/user-attachments/assets/82507ae6-aa5a-4fc6-a9a6-8e5adb6ea51f" />


## After

<img width="997" height="1359" alt="CleanShot 2026-01-13 at 09 12 22" src="https://github.com/user-attachments/assets/2cd1dd6d-b0d3-4992-b359-4d6e01bc960b" />
