### PR TITLE
[6.x] Fix nested permissions in permission tree

### DIFF
--- a/resources/js/components/roles/PermissionTree.vue
+++ b/resources/js/components/roles/PermissionTree.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :style="`padding-left: ${12 * depth - 12}px`">
+    <div :style="`padding-inline-start: ${12 * depth - 12}px`">
         <template v-for="permission in permissions" :key="permission.value">
             <ui-checkbox
                 :class="[


### PR DESCRIPTION
This pull request fixes an issue where nested permissions weren't being shown as such in the permission tree.

Fixes #13521

## Before

<img width="1043" height="1241" alt="CleanShot 2026-01-13 at 09 17 40" src="https://github.com/user-attachments/assets/29c2cffd-0e81-475d-ba57-5055394d46a4" />


## After

<img width="1043" height="1241" alt="CleanShot 2026-01-13 at 09 17 29" src="https://github.com/user-attachments/assets/b1d7fbf8-d6b4-43d3-9029-4fff5e251510" />
