### PR TITLE
[6.x] Panel: Show `header-actions` slot in the right of the header

### DIFF
--- a/resources/js/components/ui/Panel/Panel.vue
+++ b/resources/js/components/ui/Panel/Panel.vue
@@ -19,10 +19,14 @@ const props = defineProps({
         ]"
         data-ui-panel
     >
-        <PanelHeader v-if="heading">
-            <Heading v-html="heading" />
-            <Subheading v-if="subheading" v-html="subheading" />
-            <slot name="header-actions" />
+        <PanelHeader v-if="heading" class="flex items-center justify-between">
+	        <div>
+		        <Heading v-html="heading" />
+		        <Subheading v-if="subheading" v-html="subheading" />
+	        </div>
+	        <div v-if="$slots['header-actions']" class="flex flex-wrap items-center gap-2 sm:gap-3">
+                <slot name="header-actions" />
+	        </div>
         </PanelHeader>
         <slot />
     </div>


### PR DESCRIPTION
This pull request moves the panel's `header-actions` slot to the right of the header, rather than directly below the heading & subheading.

Replaces #13494

## Before

<img width="810" height="254" alt="CleanShot 2026-01-13 at 09 26 04" src="https://github.com/user-attachments/assets/c57bb4ed-90aa-4933-99b5-9391a441e230" />


## After

<img width="812" height="226" alt="CleanShot 2026-01-13 at 09 25 51" src="https://github.com/user-attachments/assets/a3908193-8762-4187-8ea6-da7db3f8c244" />
