### PR TITLE
[6.x] Bring back logo version tooltip

### DIFF
--- a/resources/js/components/global-header/Logo.vue
+++ b/resources/js/components/global-header/Logo.vue
@@ -6,7 +6,7 @@ import ProBadge from './ProBadge.vue';
 import { Link } from '@inertiajs/vue3';
 import useStatamicPageProps from '@/composables/page-props.js';
 
-const { logos, isPro, cmsName } = useStatamicPageProps();
+const { logos, isPro, cmsName, version } = useStatamicPageProps();
 const customLogoImage = computed(() => {
     if (! logos) return null
     return logos.dark.nav ?? logos.light.nav;
@@ -26,9 +26,9 @@ function toggleNav() {
                 <div class="p-1 max-sm:ps-2 mr-2 size-5 flex items-center justify-center lg:inset-0">
                     <Icon name="burger-menu-no-border" class="size-3.5! sm:size-3.25! opacity-75 hover:opacity-100" />
                 </div>
-                <img v-if="customLogoImage" :src="customLogoImage" :alt="cmsName" class="w-full max-w-[260px] max-h-7">
+                <img v-if="customLogoImage" :src="customLogoImage" :alt="cmsName" class="w-full max-w-[260px] max-h-7" v-tooltip="version">
             </button>
-            <Link v-if="customLogoText && !customLogoImage" :href="cp_url('/')" class="mr-2 font-medium text-white whitespace-nowrap" style="--focus-outline-offset: var(--outline-offset-button);">
+            <Link v-if="customLogoText && !customLogoImage" :href="cp_url('/')" class="mr-2 font-medium text-white whitespace-nowrap" v-tooltip="version" style="--focus-outline-offset: var(--outline-offset-button);">
                 {{ customLogoText }}
             </Link>
         </div>
@@ -39,7 +39,7 @@ function toggleNav() {
                 <div class="p-1 max-sm:ps-2 mr-2 size-5 flex items-center justify-center lg:inset-0">
                     <Icon name="burger-menu-no-border" class="size-3.5! sm:size-3.25! opacity-75 hover:opacity-100" />
                 </div>
-                <StatamicLogo class="size-7" />
+                <StatamicLogo class="size-7" v-tooltip="version" />
             </button>
             <Link :href="cp_url('/')" class="max-[350px]:hidden text-white/85 rounded-xs whitespace-nowrap" style="--focus-outline-offset: var(--outline-offset-button);">
                 {{ logos.text ?? logos.siteName }}

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -26,6 +26,7 @@ class HandleInertiaRequests extends Middleware
         return array_filter([
             ...parent::share($request),
             '_statamic' => [
+                'version' => Statamic::version(),
                 'cmsName' => __(Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic'),
                 'logos' => $this->logos(),
             ],


### PR DESCRIPTION
This pull request brings back the version tooltip on the logo - making it easy to determine which version of Statamic you're using. We had this in v5.

<img width="176" height="101" alt="CleanShot 2026-01-13 at 10 36 38" src="https://github.com/user-attachments/assets/71140671-4da8-49eb-8f18-001cd1e5470c" />


Closes #13526
