### PR TITLE
[6.x] Remove reka tabs outline

### DIFF
--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -62,6 +62,17 @@
     }
 }
 
+@layer ui {
+    /* Notes...
+        - Reka adds a container something like `<div id="reka-tabs-v-12-content-main" role="tabpanel" data-state="inactive" etc. />` around any tab panels such as "main" and "seo".
+        - If you click into an empty area of the tab, then use your keyboard to focus on a different window, it leaves a useless outline state. This component is not focusable.
+        - We can't edit this HTML so instead we'll target it with a selector
+    */
+    [id*="reka-tabs"][role="tabpanel"] {
+        outline: none;
+    }
+}
+
 /* Use a utility layer only when we need higher specificity */
 @layer utilities {
     /* When we have a focus state within a focus state, only the inner-most focused container should _have_ focus. e.g. if we're focusing on a Bard field within a Bard field, only the inner Bard field should receive the focus outline. */
@@ -70,7 +81,7 @@
     }
 
     /* Notes...
-    
+
         - Sometimes we want to show a focus outline on a container when it has focus-within, e.g. in Replicator sets where we want to show a focus outline on the set header when it has focus on the button inside the header, whose shape is not as neat.
 
         - Here we set a specific target for the focus outline


### PR DESCRIPTION
Under certain conditions, such as clicking an empty area of the tab and then using your keyboard to focus on a different window, Reka's tabpanels leave an outline state.

This is useless since this component is not focusable.

I've left a verbose comment here because this is one of those things someone will look at in future and think "what does this do?"

## Before

![2026-01-13 at 10 48 51@2x](https://github.com/user-attachments/assets/411e1323-9444-4d74-af16-8abd02c6d3fb)
![2026-01-13 at 10 49 09@2x](https://github.com/user-attachments/assets/1e3f59ee-97d7-443a-b1ca-360612bc528b)
