### PR TITLE
[6.x] Anchor positioned nav marker

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -87,7 +87,7 @@
                 left: calc(anchor(left) + 0.25rem);
                 top: anchor(top);
                 transition-property: top, left;
-                transition-duration: 0.15s;
+                transition-duration: 0.2s;
                 transition-timing-function: cubic-bezier(0.215, 0.610, 0.355, 1);
             }
             :where(.dark) &::before {


### PR DESCRIPTION
The nav marker for the main nav is now controlled via CSS "anchor positioning" for browsers that support it (currently has good "baseline" support).

The nav marker now animates between items, e.g. from `Collections > Pages` to `Collections > Blog`