### PR TITLE
[6.x] Remove custom Vue warnHandler

### DIFF
--- a/resources/js/bootstrap/statamic.js
+++ b/resources/js/bootstrap/statamic.js
@@ -311,14 +311,6 @@ export default {
         registerIconSets(this.initialConfig);
         components.boot(this.$app);
 
-        // Suppress the translation warnings
-        this.$app.config.warnHandler = (msg, vm, trace) => {
-            if (msg.includes('Property "__" should not start with _ which is a reserved prefix for Vue internals')) {
-                return;
-            }
-            console.warn(msg, vm, trace);
-        };
-
         axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
         axios.defaults.headers.common['X-CSRF-TOKEN'] = Statamic.$config.get('csrfToken');
 


### PR DESCRIPTION
We were overriding the warnHandler to avoid some warnings when using the `__` helper in props.
The downside was that you lose the nice stack trace in your console.

Removing the handler, I can't figure out how to even trigger those warnings anyway. Maybe something in Vue changed, or it was because of Inertia, or something else.

Even still, you don't get those warnings at all when compiled for production.
