### PR TITLE
[6.x] Fix values being lost when reordering sets

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -327,6 +327,8 @@ export default {
         watch(
             () => data_get(this.publishContainer.values.value, this.fieldPathPrefix),
             (values) => {
+				if (! values) return;
+
                 this.updateAttributes({ values });
             },
             { deep: true }


### PR DESCRIPTION
This pull request fixes an issue where set values might be lost when reordering sets.

When you drag a set, TipTap temporarily removes it from the fieldtype's value, which triggers the `watch()` inside the `Set.vue` component to overwrite the set's values with `undefined`, which ultimately causes the set's values to be emptied.

By adding a guard inside the watcher, we're keeping the original values intact until TipTap has finished updating the document.

Fixes #13539