### PR TITLE
[6.x] Add `default` config option to Date fieldtype

### DIFF
--- a/resources/lang/en/fieldtypes.php
+++ b/resources/lang/en/fieldtypes.php
@@ -78,6 +78,7 @@ return [
     'date.config.number_of_months' => 'Control how many months are shown at one time.',
     'date.config.time_enabled' => 'Enable the timepicker.',
     'date.config.time_seconds_enabled' => 'Show seconds in the timepicker.',
+    'date.config.default' => 'You may specify a date using `YYYY-MM-DD`, or `now`.',
     'date.title' => 'Date',
     'dictionary.config.dictionary' => 'The dictionary you wish to pull options from.',
     'dictionary.file.config.filename' => 'The filename containing your options, relative to the `resources/dictionaries` directory.',

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -115,6 +115,11 @@ class Date extends Fieldtype
                         'instructions' => __('statamic::fieldtypes.date.config.format'),
                         'type' => 'text',
                     ],
+                    'default' => [
+                        'display' => __('Default Value'),
+                        'instructions' => __('statamic::fieldtypes.date.config.default'),
+                        'type' => 'text',
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
This pull request adds a `default` config field to the Date fieldtype. We can't use the Date fieldtype for it as we need to support `now`.

Closes #13530