### PR TITLE
[6.x] Avoid generating slug for localization when field isn't localizable

### DIFF
--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -110,7 +110,7 @@ export default {
         handleLocalizationCreated({ container }) {
             // Only reset for the "slug" field in the matching container.
             // Other slug fields that aren't named "slug" should be left alone.
-            if (this.handle === 'slug' && container.name === this.publishContainer.name) {
+            if (this.handle === 'slug' && container.name === this.publishContainer.name && this.config.localizable) {
                 this.$refs.slugify.reset();
             }
         },


### PR DESCRIPTION
Fixes #4727

## Before


https://github.com/user-attachments/assets/2c831148-b1b2-43fc-aebf-f32fd8a88150



## After


https://github.com/user-attachments/assets/b75142d5-8f34-4523-be4a-d4e7b5a325c8

