### PR TITLE
[5.x] Fix existing field validation with prefixed fieldset imports

### DIFF
--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -76,7 +76,7 @@ class FieldsController extends CpController
                             if ($field['type'] === 'import') {
                                 return Fieldset::find($field['fieldset'])
                                     ->fields()->all()
-                                    ->map(fn ($importedField) => ($field['prefix'] ?? '') . $importedField->handle())
+                                    ->map(fn ($importedField) => ($field['prefix'] ?? '').$importedField->handle())
                                     ->values()
                                     ->toArray();
                             }


### PR DESCRIPTION
This pull request fixes an issue where you'd get a validation error when a field handle matches that of an imported field w/ a prefix.

Fixes #10857
