### PR TITLE
[6.x] Fix `level` prop example on Heading docs

### DIFF
--- a/resources/js/stories/Heading.stories.ts
+++ b/resources/js/stories/Heading.stories.ts
@@ -65,7 +65,7 @@ export const _Sizes: Story = {
 };
 
 const levelCode = `
-<Heading level="3" size="xl">Create collection</Heading>
+<Heading :level="3" size="xl">Create collection</Heading>
 `;
 
 export const _HeadingLevel: Story = {


### PR DESCRIPTION
The example is missing a colon (`:`), meaning we were technically passing a string, rather than a number, which would cause a prop type warning in the console.

Related: #13552
