### PR TITLE
[6.x] Menu icons

### DIFF
--- a/resources/js/components/ui/Context/Item.vue
+++ b/resources/js/components/ui/Context/Item.vue
@@ -31,7 +31,7 @@ const tag = computed(() => {
 const classes = cva({
     base: [
         'col-span-2 grid grid-cols-subgrid items-center',
-        'rounded-lg px-1 py-1.25 text-sm antialiased',
+        'rounded-lg px-1 py-1.5 text-sm antialiased',
         'text-gray-700 dark:text-gray-300',
         'not-data-disabled:cursor-pointer data-disabled:opacity-50',
         'hover:not-data-disabled:bg-gray-50 dark:hover:not-data-disabled:bg-gray-950 outline-hidden',

--- a/resources/js/components/ui/Dropdown/Item.vue
+++ b/resources/js/components/ui/Dropdown/Item.vue
@@ -29,7 +29,7 @@ const tag = computed(() => {
 });
 
 const classes = cva({
-    base: 'col-span-2 grid grid-cols-subgrid items-center rounded-lg px-1 py-1.25 text-sm antialiased text-gray-900 dark:text-gray-300 not-data-disabled:cursor-pointer data-disabled:opacity-50 hover:not-data-disabled:bg-gray-100 dark:hover:not-data-disabled:bg-gray-800 outline-hidden',
+    base: 'col-span-2 grid grid-cols-subgrid items-center rounded-lg px-1 py-1.5 text-sm antialiased text-gray-900 dark:text-gray-300 not-data-disabled:cursor-pointer data-disabled:opacity-50 hover:not-data-disabled:bg-gray-100 dark:hover:not-data-disabled:bg-gray-800 outline-hidden',
     variants: {
         variant: {
             default: 'text-gray-700 dark:text-gray-300',


### PR DESCRIPTION
Well, I guess the actual delta here is only one character, haha!

But this PR explored removing icons in light of [this article about Tahoe](https://tonsky.me/blog/tahoe-icons/).

It was concluded that removing icons from our smaller dropdown menus did not have the same effect as in a larger app or OS, and that it looks better as is.

However, we decided to tighten up the menu slightly, which is what this change effectively does.