### PR TITLE
[6.x] Fix passkey error modal not closing

### DIFF
--- a/resources/js/pages/users/Passkeys.vue
+++ b/resources/js/pages/users/Passkeys.vue
@@ -131,11 +131,12 @@ function handleAxiosError(e) {
     </EmptyStateMenu>
 
     <ConfirmationModal
-        v-model:open="showErrorModal"
+        :open="showErrorModal"
         :title="__('There was an error creating your passkey')"
         :body-text="error"
         :cancellable="false"
         :button-text="__('OK')"
+        @update:open="error = null"
     />
 
     <Modal


### PR DESCRIPTION
This pull request fixes an issue where clicking "OK" in the passkey error modal wasn't closing it, due to `showErrorModal` being a computed property.

When closing the modal, we need to clear the errors.