### PR TITLE
[6.x] Fix assets checkerboard border radius

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -18,7 +18,7 @@
         >
         </asset-editor>
 
-        <div class="flex h-full border-b dark:border-gray-700 rounded-b-md relative" :class="{ 'bg-checkerboard rounded-md': canBeTransparent }">
+        <div class="flex h-full border-b dark:border-gray-700 rounded-b-md relative" :class="{ 'bg-checkerboard rounded-lg': canBeTransparent }">
             <div class="p-1 flex flex-col items-center justify-center h-full">
                 <!-- Solo Bard -->
                 <template v-if="isImage && isInBardField && !isInAssetBrowser">


### PR DESCRIPTION
## Description of the Problem

The checkerboard radius was incorrect

![2026-01-15 at 13 28 58@2x](https://github.com/user-attachments/assets/483c03ca-2712-4979-989d-d233c6924112)


## What this PR Does

Corrects the value

![2026-01-15 at 13 28 39@2x](https://github.com/user-attachments/assets/ce630762-ce85-40ad-9ed6-f71c916915b7)

## How to Reproduce

1. Add an assets fieldtype in grid mode, where you'll see transparent images, which have a hidden checkerboard background, popping over the border