### PR TITLE
[6.x] Escape command palette when navigating

### DIFF
--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -271,7 +271,10 @@ const modalClasses = cva({
     ],
 })({});
 
-router.on('start', () => Statamic.$commandPalette.clear());
+router.on('start', () => {
+    Statamic.$commandPalette.clear();
+    open.value = false;
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Description of the Problem

- The current command palette behaviour is to escape/close when navigating to a chosen page
- However, I found this doesn't happen when choosing the command to edit a blueprint. Instead the command palette stays up and focused, which is undesirable
- It could be this happens with other command palette actions, but I've only seen it when editing the blueprint in my limited usage.

<img width="1708" height="1027" alt="image" src="https://github.com/user-attachments/assets/55281bb9-6151-4b7a-8018-f676fcc4696b" />

## What this PR Does

Forcibly closes the command palette when navigating

## How to Reproduce

1. Go to any entry
2. Invoke the command palette with `cmd + k`
3. Type "eb" to edit the blueprint and hit enter
4. See how the page navigates in the background but the command palette remains active