### PR TITLE
[6.x] Anchor nav marker position tweaks

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -80,11 +80,11 @@
                 content: '';
                 position: absolute;
                 width: anchor-size(height);
-                height: anchor-size(height);
-                @apply h-4 border-s border-s-black;
+                height: calc(anchor-size(height) + 0.5px);
+                @apply border-s border-s-black;
                 translate: -100% 0;
                 position-anchor: --active;
-                left: calc(anchor(left) + 0.25rem);
+                left: calc(anchor(left) + 0.25rem - 0.5px);
                 top: anchor(top);
                 transition-property: top, left;
                 transition-duration: 0.2s;


### PR DESCRIPTION
## Description of the Problem

The nav marker position wasn't quite accurate. This closes #13560

It's certainly a little fiddly since different browsers render this very very slightly differently (below)—but it's an improvement

### Safari (note horizontal alignment)

![2026-01-15 at 16 53 20@2x](https://github.com/user-attachments/assets/af77e243-0152-4df8-8a9d-4dbc9dfdd631)

### Chrome (slightly different)

![2026-01-15 at 16 54 36@2x](https://github.com/user-attachments/assets/452a06e3-2a5f-4c13-9268-f162efd45637)


## What this PR Does

Makes it more accurate

## How to Reproduce

1. Go to a collection so that the nav marker is showing in the sidebar
2. Zoom in quite a lot to see the finer details of the alignment