### PR TITLE
[6.x] Fix background gradient color in field settings

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -4,7 +4,7 @@
             <Icon name="loading" />
         </div>
 
-        <header v-if="!loading" class="flex flex-wrap items-center justify-between pl-3 pt-3 pb-4 -mb-4 sticky top-0 z-(--z-index-modal) bg-gradient-to-b from-white from-75% dark:from-gray-800">
+        <header v-if="!loading" class="flex flex-wrap items-center justify-between pl-3 pt-3 pb-4 -mb-4 sticky top-0 z-(--z-index-modal) bg-gradient-to-b from-content-bg from-75% dark:from-dark-content-bg">
             <Heading :text=" __(fieldtype.title + ' ' + 'Field')" size="lg" :icon="fieldtype.icon" />
             <div class="flex items-center gap-3">
                 <Button variant="ghost" :text="__('Cancel')" @click.prevent="close" />


### PR DESCRIPTION
This PR sets the correct header background color for the field settings stack.

In field settings, the sticky header has a gradient as background. And the colors of said gradient were hard-coded to `white` and `gray-800`.

This was not noticeable with the standard theme. However, if a theme had a different color as `content-bg`, the gradient became visible.

Dark Mode before:
<img width="1226" height="370" alt="dark-before" src="https://github.com/user-attachments/assets/3d2276d3-d8b1-4a0d-95d3-e23235d54efb" />

Dark Mode after:
<img width="1226" height="370" alt="dark-after" src="https://github.com/user-attachments/assets/f60e7dff-2f46-495a-b31e-fb2b70aee8ad" />

Light Mode before:
<img width="1226" height="370" alt="light-before" src="https://github.com/user-attachments/assets/36d30c81-016a-4f89-8ca7-2d5f90405cb2" />

Light Mode after:
<img width="1226" height="370" alt="light-after" src="https://github.com/user-attachments/assets/96866fde-eb61-4e67-8e85-5fefd7caeee9" />