### PR TITLE
[6.x] Prevent linebreak for selected assets message

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -52,7 +52,7 @@
                             <button type="button" class="text-left underline underline-offset-2 cursor-pointer hover:text-gray-925 dark:hover:text-gray-200" @click.prevent="uploadFile">
                                 {{ __('choose a file') }}
                             </button>.
-                            <span class="leading-tight" v-if="selectedFilesText" v-text="selectedFilesText" />
+                            <span class="leading-tight whitespace-nowrap" v-if="selectedFilesText" v-text="selectedFilesText" />
                         </div>
                     </div>
 


### PR DESCRIPTION
## Description of the Problem

It is possible that the expression “1/1 selected” will be written on two lines like this

<img width="954" height="726" alt="image" src="https://github.com/user-attachments/assets/9a6f8d1d-76aa-4490-9e18-6a8d78eec620" />

## What this PR Does

This closes #13559, preventing whitespace for the selected assets message

## How to Reproduce

1. Asset fieldtype with max_files