### PR TITLE
[6.x] Prevent "Type / to insert a set" clashing with nodes

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -105,7 +105,7 @@
                                             v-tooltip="__('Add Set')"
                                         />
                                         <ui-description
-                                            v-if="!$refs.setPicker?.isOpen"
+                                            v-show="shouldShowAddSetHelperText"
                                             :text="__('Type \'/\' to insert a set')"
                                             :class="{'ps-9': fullScreenMode}"
                                         />
@@ -360,6 +360,10 @@ export default {
                     visible: this.config.fullscreen,
                 },
             ];
+        },
+
+        shouldShowAddSetHelperText() {
+            return !this.$refs.setPicker?.isOpen && this.suitableToShowSetButton(this.editor);
         },
     },
 


### PR DESCRIPTION
This pull request fixes an issue where the "Type / to insert a set" text was clashing with nodes - especially noticeable when `always_show_set_button: true`.

This PR aims to fix it by only showing the text when the current node is empty. 

Fixes #13577
