### PR TITLE
[6.x] Improve assets without filenames

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -18,7 +18,7 @@
         >
         </asset-editor>
 
-        <div class="flex h-full rounded-b-md relative" :class="{ 'bg-checkerboard rounded-lg': canBeTransparent, 'border-b dark:border-gray-700': showFilename }">
+        <div class="flex h-full rounded-b-md relative" :class="{ 'bg-checkerboard rounded-lg!': canBeTransparent, 'border-b dark:border-gray-700': showFilename }">
             <div class="p-1 flex flex-col items-center justify-center h-full">
                 <!-- Solo Bard -->
                 <template v-if="isImage && isInBardField && !isInAssetBrowser">


### PR DESCRIPTION
## Description of the Problem

There were some hover state gaps for the "Set Alt" badge as described in https://github.com/statamic/cms/issues/13558
If you carefully hover very slowly between the alt badge and the outer edges of the asset tile, you can experience this.

## What this PR Does

- Prevent hover gaps using margin

### Prevent duplicate borders by only showing them when the filename is present

#### Before, with duplicate borders

![2026-01-16 at 11 19 21@2x](https://github.com/user-attachments/assets/0e9d4d59-d293-436c-bad0-de54f2f8cbae)

### Prevent clipped corners caused by a combination of the checkerboard background and incorrect radius specificity

#### Before, with clipped corners

![2026-01-16 at 11 20 37@2x](https://github.com/user-attachments/assets/e2af6837-ac06-4397-b845-4c263813d8ec)

### After, without duplicate borders and clipped corners fixed

![2026-01-16 at 11 25 18@2x](https://github.com/user-attachments/assets/4e5c5919-5049-499a-9492-ed0e50aba115)

## How to Reproduce

1. Asset fieldtype with grid view and show_filename turned off.