### PR TITLE
[6.x] Laravel Boost Guidelines

### DIFF
--- a/resources/boost/guidelines/core.blade.php
+++ b/resources/boost/guidelines/core.blade.php
@@ -94,5 +94,5 @@ Most of the folder structure will feel familiar to Laravel developers. However, 
     - For more information on Statamic's UI Components, please visit our Storybook docs: https://ui.statamic.dev
 
 ### Additional Context
-- Statamic Documentation: https://statamic.dev
+- Statamic Documentation: https://statamic.dev/llms.txt
 - GitHub Issues: https://github.com/statamic/cms/issues


### PR DESCRIPTION
This pull request adds Laravel Boost guidelines to Statamic, as per [the Boost documentation](https://github.com/laravel/boost?tab=readme-ov-file#third-party-package-ai-guidelines).

After this PR has been merged and tagged, developers will be able to run `php artisan boost:install` to add Statamic's guidelines to their project's AI guidelines file (eg. `CLAUDE.md`, `AGENTS.md`, etc).

Closes https://github.com/statamic/ideas/issues/1354