### PR TITLE
[6.x] Run update scripts when updating to `6.0.0-beta.4`

### DIFF
--- a/src/UpdateScripts/AddAddonSettingsToGitConfig.php
+++ b/src/UpdateScripts/AddAddonSettingsToGitConfig.php
@@ -9,7 +9,7 @@ class AddAddonSettingsToGitConfig extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return $this->isUpdatingTo('6.0.0');
+        return $this->isUpdatingTo('6.0.0-beta.4');
     }
 
     public function update()

--- a/src/UpdateScripts/AddTimezoneConfigOptions.php
+++ b/src/UpdateScripts/AddTimezoneConfigOptions.php
@@ -12,7 +12,7 @@ class AddTimezoneConfigOptions extends UpdateScript
 
     public function shouldUpdate($newVersion, $oldVersion): bool
     {
-        return $this->isUpdatingTo('6.0.0');
+        return $this->isUpdatingTo('6.0.0-beta.4');
     }
 
     public function update(): void

--- a/src/UpdateScripts/RemoveParentField.php
+++ b/src/UpdateScripts/RemoveParentField.php
@@ -8,7 +8,7 @@ class RemoveParentField extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return $this->isUpdatingTo('6.0.0');
+        return $this->isUpdatingTo('6.0.0-beta.4');
     }
 
     public function update()

--- a/src/UpdateScripts/UpdateGlobalVariables.php
+++ b/src/UpdateScripts/UpdateGlobalVariables.php
@@ -14,7 +14,7 @@ class UpdateGlobalVariables extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return $this->isUpdatingTo('6.0.0');
+        return $this->isUpdatingTo('6.0.0-beta.4');
     }
 
     public function update()


### PR DESCRIPTION
This pull request ensures that our v6 update scripts run when updating to `6.0.0-beta.4`, allowing us to iron out any issues with them before the stable release.

Only realised this the other day while building an update script for one of my addons. 