### PR TITLE
[5.x] Prevent redirect when creating term via fieldtype

### DIFF
--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -504,7 +504,7 @@ export default {
                     }
 
                     // If the edit URL was changed (i.e. the term slug was updated), redirect them there.
-                    else if (window.location.href !== response.data.data.edit_url) {
+                    else if (!this.isInline && window.location.href !== response.data.data.edit_url) {
                         window.location = response.data.data.edit_url;
                     }
 


### PR DESCRIPTION
Backports the fix from #13150.

Fixes #13593