### PR TITLE
[5.x] Handle null value gracefully

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -181,7 +181,7 @@ trait HasSelectOptions
             'resolve' => function ($item, $args, $context, $info) {
                 $resolved = $item->resolveGqlValue($info->fieldName);
 
-                return is_null($resolved->value()) ? null : $resolved;
+                return is_null($resolved?->value()) ? null : $resolved;
             },
         ];
     }


### PR DESCRIPTION
I've encountered a scenario where `$resolved` is `null`. Resulting in `Call to a member function value() on null`. This can happen when `$value->value()` in `resolveGqlValue()` is `null`.

https://github.com/statamic/cms/blob/eaa66b5aeba364059132d1ae4b131ac9fb8f01e6/src/GraphQL/ResolvesValues.php#L12-L16