### PR TITLE
[6.x] Fix missing preset tab container border under "New View" button

### DIFF
--- a/resources/js/components/ui/Listing/Presets.vue
+++ b/resources/js/components/ui/Listing/Presets.vue
@@ -174,7 +174,7 @@ function deletePreset() {
 <template>
     <Tabs v-model:modelValue="currentTab">
         <div class="relative flex shrink-0 items-center space-x-2.5 px-2 -mt-2 sm:px-0 starting-style-transition">
-            <TabList class="flex-1 space-x-2.5 border-gray-200 !dark:border-gray-800">
+            <TabList class="flex-1 space-x-2.5">
                 <PresetTrigger name="all" :text="__('All')" />
                 <PresetTrigger
                     v-for="(preset, handle) in presets"


### PR DESCRIPTION
Before: 
<img width="1638" height="182" alt="image" src="https://github.com/user-attachments/assets/c3bdac3f-a94d-40ad-8dc7-9ff467bfe844" />

After:
<img width="2080" height="314" alt="CleanShot 2026-01-19 at 15 27 30@2x" src="https://github.com/user-attachments/assets/d709e0c3-c6cd-4dcb-b4b0-f81b33da7ee1" />

And on Hover it removes the border with a nice clean gap.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves visual consistency of the Presets tab header.
> 
> - Removes `border-...` styling from `TabList` and adjusts spacing
> - Wraps the "New View" `Button` in a bordered container (`border-b`, dark mode variant, slight negative top offset) that hides on hover for a clean gap
> - No logic changes; only template/class tweaks in `Presets.vue`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b8a947d20235af91a5f80ff0c9b1eb81fb3fb39. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->