### PR TITLE
[6.x] Fix error when calculating stack depth for non-existent stack

### DIFF
--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -57,7 +57,7 @@ const hasStackHeaderComponent = hasComponent('StackHeader', slotProps);
 const hasStackContentComponent = hasComponent('StackContent', slotProps);
 const isUsingOpenProp = computed(() => instance?.vnode.props?.hasOwnProperty('open'));
 const portal = computed(() => stack.value ? `#portal-target-${stack.value.id}` : null);
-const depth = computed(() => stacks.stacks().findIndex(s => s.id === stack.value.id) + 1);
+const depth = computed(() => stacks.stacks().findIndex(s => s.id === stack.value?.id) + 1);
 const isTopStack = computed(() => stacks.count() === depth.value);
 
 const shouldAddHeader = computed(() => !!(props.title || props.icon) && !hasStackHeaderComponent.value);


### PR DESCRIPTION
This pull request fixes an error when calculating the stack depth for a non-existent stack.

You can reproduce this by editing a Bard/Replicator field. The "Sets" fieldtype contains components with stacks. When you switch to the "Conditions" tab, those stacks are removed from the `stacks.stacks()` array. This causes the error in the depth calculation.

Fixes #13600