### PR TITLE
[6.x] Disable image button in Bard by default

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -37,7 +37,6 @@ class Bard extends Replicator
         'removeformat',
         'quote',
         'anchor',
-        'image',
         'table',
     ];
 


### PR DESCRIPTION
To reduce confusion around the Image button being enabled but not visible in the UI, we started requiring that an asset container be selected whenever the Image button is enabled (#12238).

However, because the Image button is enabled by default, this meant that creating a Bard field forced you to select an asset container before you could save the field. 

This PR disables the Image button by default, making it (and selecting a container) opt-in.

Fixes #13601