### PR TITLE
[6.x] Fix incorrect index name passed to `InsertMultipleJob` job

### DIFF
--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -91,7 +91,7 @@ abstract class Index
         $documents
             ->chunk(config('statamic.search.chunk_size'))
             ->each(fn ($documents) => InsertMultipleJob::dispatch(
-                name: Str::beforeLast($this->name, '_'),
+                name: $this->locale ? Str::before($this->name, "_{$this->locale}") : $this->name,
                 locale: $this->locale,
                 documents: $documents
             ));


### PR DESCRIPTION
This PR fixes an issue where an incorrect index name was being passed to the `InsertMultipleJob` if the index name contained an underscore.

We only need to split the index name when the `$locale` property is set in order to get the name without the locale/site (eg. `articles_default` -> `articles`).
