### PR TITLE
[6.x] Improve Combobox performance

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -421,8 +421,8 @@ defineExpose({
 
                 <ComboboxPortal>
                     <ComboboxContent
-                        :force-mount="options.length > 50"
-                        :hidden="options.length > 50 && !dropdownOpen"
+                        :force-mount="true"
+                        :hidden="!dropdownOpen"
                         position="popper"
                         :side-offset="5"
                         align="start"


### PR DESCRIPTION
This pull request aims to improve the performance of the Combobox component, specifically when opening/closing the dropdown and searching through lots of options.

Improvements:

* Refactored `isSelected` method to use `.some()` instead of `.filter()` to avoid unnecessary comparisons.
* Removed the deep cloning of options in `filteredOptions`
  * I can't seem to figure out _why_ I added this in the first place, but everything seems to work fine without it. 
* The `measureOptionWidths` method now only measures the width of the three options with the longest labels, not _every_ option.
* Enabled the `force-mount` prop for longer dropdowns, allowing options to be rendered & measurements to happen _before_ the user clicks to open the dropdown.
  * This change seems to have the biggest impact of them all. The Icon fieldtype opens almost instantly, compared to waiting 400(ish) ms before this PR.
* Fixed an issue where the dropdown's `min-height` was dependant on the `options` prop, not `filteredOptions`.
  * This meant that if you had 10 options, but filtered down via search to just 1, the min-height for 3 and above would remain applied.

Closes #13615