### PR TITLE
[6.x] Fix error when restoring revision

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -821,13 +821,15 @@ export default {
                 prioritize: true,
             });
 
-            Statamic.$commandPalette.add({
-                category: Statamic.$commandPalette.category.Actions,
-                text: __('Edit Blueprint'),
-                icon: 'blueprint-edit',
-                when: () => this.canEditBlueprint,
-                url: this.actions.editBlueprint,
-            });
+			if (this.actions.editBlueprint) {
+				Statamic.$commandPalette.add({
+					category: Statamic.$commandPalette.category.Actions,
+					text: __('Edit Blueprint'),
+					icon: 'blueprint-edit',
+					when: () => this.canEditBlueprint,
+					url: this.actions.editBlueprint,
+				});
+			}
 
             this.$refs.actions?.preparedActions.forEach(action => Statamic.$commandPalette.add({
                 category: Statamic.$commandPalette.category.Actions,


### PR DESCRIPTION
This pull request fixes an error that'd occur when viewing a revision, and would prevent stacks from closing properly when restoring a revision.

Fixes #13624
