### PR TITLE
[6.x] Wrap `STATAMIC_REVISIONS_PATH` env value in `base_path()`

### DIFF
--- a/config/stache.php
+++ b/config/stache.php
@@ -107,7 +107,9 @@ return [
 
         'revisions' => [
             'class' => Stores\RevisionsStore::class,
-            'directory' => env('STATAMIC_REVISIONS_PATH', config('statamic.revisions.path', storage_path('statamic/revisions'))),
+            'directory' => env('STATAMIC_REVISIONS_PATH')
+                ? base_path(env('STATAMIC_REVISIONS_PATH'))
+                : config('statamic.revisions.path', storage_path('statamic/revisions')),
         ],
 
     ],


### PR DESCRIPTION
This PR fixes an issue with the `STATAMIC_REVISIONS_PATH` environment variable, where it wasn't an absolute path, unlike the old config option.

You can save revisions correctly (because they'll stick around in the Stache), but as soon as you clear the cache, they'll disappear because the Stache won't be able to find the files.

This PR fixes it by wrapping the env variable in the `base_path()` helper.

Fixes #13623