### PR TITLE
[6.x] Fix error when adding nested replicator set

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -214,9 +214,10 @@ export default {
 
             this.updateSetMeta(set._id, this.meta.new[handle]);
 
-            this.update([...this.value.slice(0, index), set, ...this.value.slice(index)]);
-
-            this.expandSet(set._id);
+			this.$nextTick(() => {
+				this.update([...this.value.slice(0, index), set, ...this.value.slice(index)]);
+				this.expandSet(set._id);
+			});
         },
 
         duplicateSet(old_id) {


### PR DESCRIPTION
This pull request avoids errors when adding a new set in a nested Replicator field (replicator -> bard -> replicator). 

The errors mentioned in #13611 were coming from fieldtypes which were expecting metadata which hasn't yet been set on the container. 

Wrapping the `update()` in a `$nextTick` callback resolves the issue, giving Vue time to do whatever it needs to do.

Fixes #13611