### PR TITLE
[6.x] Run migration update scripts when updating to `6.0.0-beta.4`

### DIFF
--- a/src/UpdateScripts/PublishMigrationForTwoFactorColumns.php
+++ b/src/UpdateScripts/PublishMigrationForTwoFactorColumns.php
@@ -10,7 +10,7 @@ class PublishMigrationForTwoFactorColumns extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return $this->isUpdatingTo('6.0.0')
+        return $this->isUpdatingTo('6.0.0-beta.4')
             && config('statamic.users.repository', 'file') === 'eloquent';
     }
 

--- a/src/UpdateScripts/PublishMigrationForWebauthnTable.php
+++ b/src/UpdateScripts/PublishMigrationForWebauthnTable.php
@@ -9,7 +9,7 @@ class PublishMigrationForWebauthnTable extends UpdateScript
 {
     public function shouldUpdate($newVersion, $oldVersion)
     {
-        return $this->isUpdatingTo('6.0.0')
+        return $this->isUpdatingTo('6.0.0-beta.4')
             && config('statamic.users.repository', 'file') === 'eloquent';
     }
 


### PR DESCRIPTION
Looks like I missed a few in #13594. Sorry!

I was probably searching for `6.0.0');`, which wouldn't have caught these two. 😬