### PR TITLE
[6.x] Make PreventsSavingStacheItemsToDisk work with Pest PHP

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -3,7 +3,6 @@
 namespace Statamic\Testing;
 
 use Facades\Statamic\Version;
-use Illuminate\Support\Str;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use ReflectionClass;
 use Statamic\Addons\Manifest;
@@ -26,8 +25,8 @@ abstract class AddonTestCase extends OrchestraTestCase
         $uses = array_flip(class_uses_recursive(static::class));
 
         if (isset($uses[PreventsSavingStacheItemsToDisk::class])) {
-            $reflection = new ReflectionClass($this);
-            $this->fakeStacheDirectory = Str::before(dirname($reflection->getFileName()), DIRECTORY_SEPARATOR.'tests').'/tests/__fixtures__/dev-null';
+            $reflector = new ReflectionClass($this->addonServiceProvider);
+            $this->fakeStacheDirectory = dirname($reflector->getFileName()).'/../tests/__fixtures__/dev-null';
 
             $this->preventSavingStacheItemsToDisk();
         }


### PR DESCRIPTION
This PR fixes the `PreventsSavingStacheItemsToDisk` trait with Pest PHP. The `fakeStacheDirectory` path is incorrectly calculated, causing test fixtures to be saved to the wrong location. 

## Root Cause

In `AddonTestCase::setUp()`, the current code uses reflection on `$this` to determine the test file path:

```php
$reflection = new ReflectionClass($this);
$this->fakeStacheDirectory = Str::before(dirname($reflection->getFileName()), DIRECTORY_SEPARATOR.'tests').'/tests/__fixtures__/dev-null';
```

### PHPUnit
In PHPUnit tests, `$this` refers to the actual test class (e.g., `MyAddonTest`), so `$reflection->getFileName()` correctly returns the test file path like `/path/to/addon/tests/Feature/MyAddonTest.php`.

### Pest PHP
In Pest PHP tests, `$this` refers to a dynamically generated class created by Pest internally. As a result, `$reflection->getFileName()` returns a path inside `vendor/pestphp/pest/src/Factories/`, causing the `fakeStacheDirectory` to be set to an incorrect location like `vendor/pestphp/pest/src/Factories/tests/__fixtures__/dev-null`.

## Solution

Use reflection on `$this->addonServiceProvider` instead of `$this`. This provides a reliable reference point regardless of whether Pest or PHPUnit is being used, and is consistent with the existing approach in `getEnvironmentSetUp()`:

```php
protected function setUp(): void
    // ...
    $reflector = new ReflectionClass($this->addonServiceProvider);
    $this->fakeStacheDirectory = dirname($reflector->getFileName()).'/../tests/__fixtures__/dev-null';
    // ...
}
```

```php
protected function getEnvironmentSetUp($app)
{
    // ...
    $reflector = new ReflectionClass($this->addonServiceProvider);
    $directory = dirname($reflector->getFileName());
    // ...
    $app['config']->set('statamic.stache.stores.collections.directory', $directory.'/../tests/__fixtures__/content/collections');
    // ...
}
```