### PR TITLE
[6.x] Show collection tree in navigation page selector

### DIFF
--- a/resources/js/components/structures/PageSelector.vue
+++ b/resources/js/components/structures/PageSelector.vue
@@ -14,6 +14,7 @@
         :can-create="false"
         :can-reorder="false"
         :max-items="maxItems"
+        :tree="tree"
         @item-data-updated="itemDataUpdated"
     />
 </template>
@@ -34,6 +35,10 @@ export default {
             type: Number,
             required: false,
         },
+	    tree: {
+			type: Object,
+		    required: false,
+	    },
     },
 
     data() {

--- a/resources/js/pages/navigation/Show.vue
+++ b/resources/js/pages/navigation/Show.vue
@@ -51,6 +51,7 @@ export default {
         canSelectAcrossSites: { type: Boolean, required: true },
         canEditBlueprint: { type: Boolean, required: true },
         entryQueryScopes: { type: Array, default: () => [] },
+	    collectionTree: { type: Object, required: false },
     },
 
     data() {
@@ -540,6 +541,7 @@ export default {
             :query-scopes="entryQueryScopes"
             :max-items="maxPagesSelection"
             :can-select-across-sites="canSelectAcrossSites"
+            :tree="collectionTree"
             @selected="entriesSelected"
         />
 

--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -93,6 +93,30 @@ class NavigationController extends CpController
 
         $this->authorize('view', $nav->in($site), __('You are not authorized to view navs.'));
 
+        $collectionTree = null;
+
+        if ($nav->collections()->count() === 1 && $nav->collections()->first()->hasStructure()) {
+            $collection = $nav->collections()->first();
+
+            $collectionBlueprints = $collection
+                ->entryBlueprints()
+                ->reject->hidden()
+                ->map(function ($blueprint) {
+                    return [
+                        'handle' => $blueprint->handle(),
+                        'title' => $blueprint->title(),
+                    ];
+                })->values();
+
+            $collectionTree = [
+                'title' => $collection->title(),
+                'url' => cp_route('collections.tree.index', $collection),
+                'showSlugs' => $collection->structure()->showSlugs(),
+                'expectsRoot' => $collection->structure()->expectsRoot(),
+                'blueprints' => $collectionBlueprints,
+            ];
+        }
+
         return Inertia::render('navigation/Show', [
             'title' => $nav->title(),
             'handle' => $nav->handle(),
@@ -118,6 +142,7 @@ class NavigationController extends CpController
             'canEdit' => User::current()->can('edit', $nav),
             'canSelectAcrossSites' => $nav->canSelectAcrossSites(),
             'canEditBlueprint' => User::current()->can('configure fields'),
+            'collectionTree' => $collectionTree,
         ]);
     }
 


### PR DESCRIPTION
This pull request adds a "Tree" view to the navigation page selector. The entry fieldtype supports it, but we never wired it up to the nav page selector.

Closes #13635