### PR TITLE
[5.x] Avoid updating Bard value unless content has actually changed

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -411,7 +411,7 @@ export default {
         json(json, oldJson) {
             if (!this.mounted) return;
                         
-            if (json === oldJson) return;
+            if (JSON.stringify(json) === JSON.stringify(oldJson)) return;
 
             this.updateDebounced(json);
         },


### PR DESCRIPTION
This PR fixes an issue where the Bard Fieldtype would emit an update even if the content is exactly the same as the current value.

This causes problems when localizing entries. When a localization is created, we make a request to the server to get the form's values. This subsequently leads to Bard's `value` prop being updated.

However, because the object reference has changed, the check in the `json` watcher considers the value to be different, which ultimately leads to the `localizedFields` array being incorrectly updated.

This PR fixes it by stringifying the two objects so we can compare contents, and not references.