### PR TITLE
[5.x] Fix uninitialized property error from `HandleEntrySchedule` job

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -104,7 +104,7 @@ class AppServiceProvider extends ServiceProvider
 
         $this->addAboutCommandInfo();
 
-        $this->app->make(Schedule::class)->job(new HandleEntrySchedule)->everyMinute();
+        $this->app->make(Schedule::class)->job(HandleEntrySchedule::class)->everyMinute();
     }
 
     public function register()


### PR DESCRIPTION
This pull request attempts to fix the uninitialized property error from the `HandleEntrySchedule` job.

When we were registering the schedule job, we were passing an instance of the job which meant the constructor was only called once (when we new'd up the instance).

This PR passes the class name instead, forcing Laravel to get a new instance from the container every time, ensuring the job's constructor gets called.

Fixes #13590