### PR TITLE
[5.x] Fix: Prevent 304 responses without client cache headers

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -235,9 +235,18 @@ class Cache
     private function addEtagToResponse($request, $response)
     {
         if (! $response->isRedirect() && $content = $response->getContent()) {
-            $response
-                ->setEtag(md5($content))
-                ->isNotModified($request);
+            // Clear any potentially stale cache-related headers that might interfere
+            $response->headers->remove('ETag');
+            $response->headers->remove('Last-Modified');
+
+            // Set fresh ETag based on current content
+            $response->setEtag(md5($content));
+
+            // Only call isNotModified() if request has cache validation headers
+            // This prevents 304 responses to clients that haven't sent If-None-Match or If-Modified-Since
+            if ($request->headers->has('If-None-Match') || $request->headers->has('If-Modified-Since')) {
+                $response->isNotModified($request);
+            }
         }
 
         return $response;


### PR DESCRIPTION
Fixes #13652

## Problem

The static caching middleware was unconditionally calling `isNotModified()` on every cached response, which could incorrectly return HTTP 304 to clients that didn't send cache validation headers (`If-None-Match` or `If-Modified-Since`). This caused browsers like Safari to download 0-byte files instead of rendering pages.

## Root Cause

1. `ApplicationCacher` may cache responses with `ETag`/`Last-Modified` headers from previous requests
2. When serving cached responses, these stale headers interfere with fresh ETag generation
3. `isNotModified()` evaluates these cached headers and incorrectly returns true even without client validation headers

## Solution

This PR updates `src/StaticCaching/Middleware/Cache.php` to:

1. **Clear stale headers**: Remove any existing `ETag`/`Last-Modified` headers before setting a fresh ETag
2. **Conditional check**: Only call `isNotModified()` when the request contains cache validation headers (`If-None-Match` or `If-Modified-Since`)

This preserves ETag functionality for legitimate conditional requests while preventing inappropriate 304 responses.

## Testing

- ✅ Request without cache headers → HTTP 200 OK (bug fixed)
- ✅ Request with `If-None-Match` → HTTP 304 Not Modified (ETag functionality preserved)
- ✅ No breaking changes to existing functionality

## Related

This is related to the ETag support feature introduced in v5.68 (PR #11441), which has had one previous bug fix in v5.70 (#13425).