### PR TITLE
[6.x] Restoring a revision should force a hard-reload of the page

### DIFF
--- a/resources/js/components/revision-history/Restore.vue
+++ b/resources/js/components/revision-history/Restore.vue
@@ -17,7 +17,6 @@
 
 <script>
 import { Button } from '@/components/ui';
-import { router } from '@inertiajs/vue3';
 
 export default {
     components: {
@@ -45,7 +44,7 @@ export default {
             this.$axios.post(this.url, payload).then((response) => {
                 Statamic.$hooks.run('revision.restored', { reference: this.reference }).then(() => {
                     this.$dirty.disableWarning();
-                    router.reload();
+                    window.location.reload();
                 });
             });
         },


### PR DESCRIPTION
This pull request fixes an issue where the page wasn't being properly reloaded after restoring a revision, leading the stacks to remain open and the old values in the publish form.

I thought I had fixed this the other day in #13624 but obviously not, sorry! 😞

Fixes #13655