### PR TITLE
[6.x] Bard image button defaults

### DIFF
--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -7,6 +7,7 @@ use Facades\Statamic\Fieldtypes\RowId;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Statamic\Facades\Asset;
+use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
@@ -47,6 +48,14 @@ class Bard extends Replicator
 
     protected function configFieldItems(): array
     {
+        $containers = AssetContainer::all();
+
+        $defaultButtons = $containers->isEmpty()
+            ? collect(static::$defaultButtons)
+                ->reject(fn ($value) => $value === 'image')
+                ->values()->all()
+            : static::$defaultButtons;
+
         return [
             [
                 'display' => __('Editor Settings'),
@@ -57,7 +66,7 @@ class Bard extends Replicator
                         'instructions' => __('statamic::fieldtypes.bard.config.buttons'),
                         'type' => 'bard_buttons_setting',
                         'full_width_setting' => true,
-                        'default' => static::$defaultButtons,
+                        'default' => $defaultButtons,
                     ],
                     'toolbar_mode' => [
                         'display' => __('Toolbar Mode'),
@@ -180,6 +189,8 @@ class Bard extends Replicator
                             'buttons' => 'contains_any anchor, image',
                         ],
                         'width' => 50,
+                        'default' => $containers->count() == 1 ? $containers->first()->handle() : null,
+                        'force_in_config' => true,
                         'validate' => [
                             $this->containerRequiredRule(),
                         ],


### PR DESCRIPTION
To reduce confusion around the Image button being enabled but not visible in the UI, we started requiring that an asset container be selected whenever the Image button is enabled (https://github.com/statamic/cms/pull/12238).

However, because the Image button is enabled by default, this meant that creating a Bard field forced you to select an asset container before you could save the field.

This PR adjusts the default behavior of the buttons and container config fields based on how many asset containers you have configured.

### No containers:
- Button bar **excludes** the image button
- Container field is blank. But, no validation would kick in because the image button isnt selected.

### One container:
- Button bar has the image button selected
- Container field defaults to the sole container
- This is the most common situation since Statamic ships with one container.
- Fixes #13601

### More than one container:
- Button bar has the image button selected
- Container field defaults to blank. This causes the same validation that currently happens, forcing you to pick a container.

Replaces #13607 - We'd prefer to keep the image button enabled by default where possible.
Replaces #13609 - Giving the asset container fieldtype a default value means it can never be null.

This follows the approach we already take for the container config field inside the assets fieldtype.