### PR TITLE
[6.x] Fix passkeys differently

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/yaml": "^7.0.3",
         "ueberdosis/tiptap-php": "^2.0",
         "voku/portable-ascii": "^2.0.2",
-        "web-auth/webauthn-lib": "^5.3@dev",
+        "web-auth/webauthn-lib": "^5.2",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "symfony/yaml": "^7.0.3",
         "ueberdosis/tiptap-php": "^2.0",
         "voku/portable-ascii": "^2.0.2",
-        "web-auth/webauthn-lib": "^5.2",
+        "web-auth/webauthn-lib": "~5.2.0",
         "wilderborn/partyline": "^1.0"
     },
     "require-dev": {

--- a/src/Auth/WebAuthn/Passkey.php
+++ b/src/Auth/WebAuthn/Passkey.php
@@ -7,13 +7,13 @@ use ParagonIE\ConstantTime\Base64UrlSafe;
 use Statamic\Contracts\Auth\Passkey as Contract;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\User;
-use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 
 abstract class Passkey implements Contract
 {
     private string $name;
     private string $user;
-    private CredentialRecord $credential;
+    private PublicKeyCredentialSource $credential;
     private ?Carbon $lastLogin = null;
 
     public function id(): string
@@ -45,14 +45,14 @@ abstract class Passkey implements Contract
         return User::find($this->user);
     }
 
-    public function credential(): CredentialRecord
+    public function credential(): PublicKeyCredentialSource
     {
         return $this->credential;
     }
 
-    public function setCredential(array|CredentialRecord $credential): Contract
+    public function setCredential(array|PublicKeyCredentialSource $credential): Contract
     {
-        $this->credential = $credential instanceof CredentialRecord
+        $this->credential = $credential instanceof PublicKeyCredentialSource
             ? $credential
             : $this->credentialFromArray($credential);
 
@@ -95,15 +95,15 @@ abstract class Passkey implements Contract
         $this->lastLogin = $data['last_login'] ? Carbon::createFromTimestamp($data['last_login']) : null;
     }
 
-    private function credentialToArray(CredentialRecord $credential): array
+    private function credentialToArray(PublicKeyCredentialSource $credential): array
     {
         $json = app(Serializer::class)->serialize($credential, 'json');
 
         return json_decode($json, true);
     }
 
-    private function credentialFromArray(array $array): CredentialRecord
+    private function credentialFromArray(array $array): PublicKeyCredentialSource
     {
-        return app(Serializer::class)->deserialize(json_encode($array), CredentialRecord::class, 'json');
+        return app(Serializer::class)->deserialize(json_encode($array), PublicKeyCredentialSource::class, 'json');
     }
 }

--- a/src/Auth/WebAuthn/WebAuthn.php
+++ b/src/Auth/WebAuthn/WebAuthn.php
@@ -44,7 +44,7 @@ class WebAuthn
 
         $options = $this->getRequestOptions(session()->pull('webauthn.challenge'));
 
-        $credentialRecord = $this->assertionResponseValidator->check(
+        $publicKeyCredentialSource = $this->assertionResponseValidator->check(
             $passkey->credential(),
             $publicKeyCredential->response,
             $options,
@@ -53,7 +53,7 @@ class WebAuthn
         );
 
         $passkey
-            ->setCredential($credentialRecord)
+            ->setCredential($publicKeyCredentialSource)
             ->setLastLogin(now())
             ->save();
 
@@ -94,7 +94,7 @@ class WebAuthn
 
         $options = $this->getCreationOptions($user, session()->pull('webauthn.challenge'));
 
-        $credentialRecord = $this->attestationResponseValidator->check(
+        $publicKeyCredentialSource = $this->attestationResponseValidator->check(
             $publicKeyCredential->response,
             $options,
             request()->getHost()
@@ -103,7 +103,7 @@ class WebAuthn
         $passkey = app(Passkey::class)
             ->setUser($user)
             ->setName($name)
-            ->setCredential($credentialRecord);
+            ->setCredential($publicKeyCredentialSource);
 
         $passkey->save();
 

--- a/src/Contracts/Auth/Passkey.php
+++ b/src/Contracts/Auth/Passkey.php
@@ -3,7 +3,7 @@
 namespace Statamic\Contracts\Auth;
 
 use Carbon\Carbon;
-use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 
 interface Passkey
 {
@@ -17,9 +17,9 @@ interface Passkey
 
     public function setUser(string|User $user): self;
 
-    public function credential(): CredentialRecord;
+    public function credential(): PublicKeyCredentialSource;
 
-    public function setCredential(array|CredentialRecord $credential): self;
+    public function setCredential(array|PublicKeyCredentialSource $credential): self;
 
     public function lastLogin(): ?Carbon;
 

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -23,7 +23,7 @@ use Tests\Auth\PermissibleContractTests;
 use Tests\Auth\UserContractTests;
 use Tests\Preferences\HasPreferencesTests;
 use Tests\TestCase;
-use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 
 #[Group('2fa')]
 class EloquentUserTest extends TestCase
@@ -342,11 +342,11 @@ class EloquentUserTest extends TestCase
         $user = $this->user();
         $this->assertCount(0, $user->passkeys());
 
-        $mockCredentialA = \Mockery::mock(CredentialRecord::class);
+        $mockCredentialA = \Mockery::mock(PublicKeyCredentialSource::class);
         $mockCredentialA->publicKeyCredentialId = 'key-a';
-        $mockCredentialB = \Mockery::mock(CredentialRecord::class);
+        $mockCredentialB = \Mockery::mock(PublicKeyCredentialSource::class);
         $mockCredentialB->publicKeyCredentialId = 'key-b';
-        $mockCredentialC = \Mockery::mock(CredentialRecord::class);
+        $mockCredentialC = \Mockery::mock(PublicKeyCredentialSource::class);
         $mockCredentialC->publicKeyCredentialId = 'key-c';
 
         app()->instance(Serializer::class, new class($mockCredentialA, $mockCredentialB, $mockCredentialC)

--- a/tests/Auth/FileUserTest.php
+++ b/tests/Auth/FileUserTest.php
@@ -17,7 +17,7 @@ use Statamic\Facades\UserGroup as UserGroupAPI;
 use Statamic\Support\Arr;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
-use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 
 #[Group('user')]
 #[Group('2fa')]
@@ -198,9 +198,9 @@ class FileUserTest extends TestCase
         $user = $this->user();
         $this->assertCount(0, $user->passkeys());
 
-        $mockCredentialA = \Mockery::mock(CredentialRecord::class);
+        $mockCredentialA = \Mockery::mock(PublicKeyCredentialSource::class);
         $mockCredentialA->publicKeyCredentialId = 'key-a';
-        $mockCredentialB = \Mockery::mock(CredentialRecord::class);
+        $mockCredentialB = \Mockery::mock(PublicKeyCredentialSource::class);
         $mockCredentialB->publicKeyCredentialId = 'key-b';
 
         $user->setPasskeys(collect([

--- a/tests/Auth/WebAuthn/EloquentPasskeyTest.php
+++ b/tests/Auth/WebAuthn/EloquentPasskeyTest.php
@@ -13,7 +13,7 @@ use Statamic\Auth\Eloquent\WebAuthnModel;
 use Statamic\Facades\User;
 use Symfony\Component\Uid\Uuid;
 use Tests\TestCase;
-use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 use Webauthn\TrustPath\EmptyTrustPath;
 
 #[Group('passkeys')]
@@ -66,9 +66,9 @@ class EloquentPasskeyTest extends TestCase
         parent::tearDownAfterClass();
     }
 
-    private function createTestCredential(string $id = 'test-credential-id-123'): CredentialRecord
+    private function createTestCredential(string $id = 'test-credential-id-123'): PublicKeyCredentialSource
     {
-        return CredentialRecord::create(
+        return PublicKeyCredentialSource::create(
             publicKeyCredentialId: $id,
             type: 'public-key',
             transports: ['usb', 'nfc'],

--- a/tests/Auth/WebAuthn/FilePasskeyTest.php
+++ b/tests/Auth/WebAuthn/FilePasskeyTest.php
@@ -10,7 +10,7 @@ use Statamic\Facades\User;
 use Symfony\Component\Uid\Uuid;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
-use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 use Webauthn\TrustPath\EmptyTrustPath;
 
 #[Group('passkeys')]
@@ -18,9 +18,9 @@ class FilePasskeyTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
-    private function createTestCredential(string $id = 'test-credential-id-123'): CredentialRecord
+    private function createTestCredential(string $id = 'test-credential-id-123'): PublicKeyCredentialSource
     {
-        return CredentialRecord::create(
+        return PublicKeyCredentialSource::create(
             publicKeyCredentialId: $id,
             type: 'public-key',
             transports: ['usb', 'nfc'],

--- a/tests/Auth/WebAuthn/PasskeyTest.php
+++ b/tests/Auth/WebAuthn/PasskeyTest.php
@@ -11,7 +11,7 @@ use Statamic\Facades\User;
 use Symfony\Component\Uid\Uuid;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
-use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredentialSource;
 use Webauthn\TrustPath\EmptyTrustPath;
 
 #[Group('passkeys')]
@@ -19,9 +19,9 @@ class PasskeyTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
-    private function createTestCredential(): CredentialRecord
+    private function createTestCredential(): PublicKeyCredentialSource
     {
-        return CredentialRecord::create(
+        return PublicKeyCredentialSource::create(
             publicKeyCredentialId: 'test-credential-id-123',
             type: 'public-key',
             transports: ['usb', 'nfc'],
@@ -45,7 +45,7 @@ class PasskeyTest extends TestCase
             ->setUser($user)
             ->setCredential($credential);
 
-        $this->assertInstanceOf(CredentialRecord::class, $passkey->credential());
+        $this->assertInstanceOf(PublicKeyCredentialSource::class, $passkey->credential());
         $this->assertEquals('test-credential-id-123', $passkey->credential()->publicKeyCredentialId);
         $this->assertEquals('public-key', $passkey->credential()->type);
     }
@@ -183,7 +183,7 @@ class PasskeyTest extends TestCase
         $this->assertInstanceOf(Passkey::class, $unserialized);
         $this->assertEquals('My Passkey', $unserialized->name());
         $this->assertEquals('test-user', $unserialized->user()->id());
-        $this->assertInstanceOf(CredentialRecord::class, $unserialized->credential());
+        $this->assertInstanceOf(PublicKeyCredentialSource::class, $unserialized->credential());
         $this->assertEquals('test-credential-id-123', $unserialized->credential()->publicKeyCredentialId);
         $this->assertEquals('2024-01-15 10:30:00', $unserialized->lastLogin()->format('Y-m-d H:i:s'));
     }

--- a/tests/Auth/WebAuthn/WebAuthnTest.php
+++ b/tests/Auth/WebAuthn/WebAuthnTest.php
@@ -15,10 +15,10 @@ use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\AuthenticatorData;
 use Webauthn\CollectedClientData;
-use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialSource;
 
 #[Group('passkeys')]
 class WebAuthnTest extends TestCase
@@ -195,7 +195,7 @@ class WebAuthnTest extends TestCase
         );
 
         // Mock the passkey
-        $mockPasskeyCredential = Mockery::mock(CredentialRecord::class);
+        $mockPasskeyCredential = Mockery::mock(PublicKeyCredentialSource::class);
         $mockPasskeyCredential->publicKeyCredentialId = 'test-raw-id';
 
         $mockPasskey = Mockery::mock(Passkey::class);
@@ -209,7 +209,7 @@ class WebAuthnTest extends TestCase
         $mockUser->shouldReceive('id')->andReturn('test-user');
         $mockUser->shouldReceive('passkeys->first')->andReturn($mockPasskey);
 
-        $updatedCredentialRecord = Mockery::mock(CredentialRecord::class);
+        $updatedCredentialSource = Mockery::mock(PublicKeyCredentialSource::class);
 
         $this->mockSerializer
             ->shouldReceive('deserialize')
@@ -219,7 +219,7 @@ class WebAuthnTest extends TestCase
         $this->mockAssertionValidator
             ->shouldReceive('check')
             ->once()
-            ->andReturn($updatedCredentialRecord);
+            ->andReturn($updatedCredentialSource);
 
         $result = $this->webauthn->validateAssertion($mockUser, $credentials);
 


### PR DESCRIPTION
This reverts #13566

Fixes #13561 differently.

When someone has `"minimum-stability": "dev"`, they would've had the unreleased `5.3` version of `webauth-lib` installed, which had a breaking change.

In #13566 I decided to optimistically code as if 5.3 would be available by the time we want to release v6. That doesn't look likely.

This PR reverts #13566 because the webauth-lib will now be backwards compatible as per https://github.com/web-auth/webauthn-framework/pull/804. This results in no changes on our end.

This PR also changes the constraint from `^5.2` to `~5.2.0` so that 5.3 cannot be installed for people that still have their minimum stability set to dev.

When the mentioned PR is merged and 5.3 is released, we can switch the constraint back.