### PR TITLE
[6.x] Reload actions after Publish/Unpublish in entry listing

### DIFF
--- a/resources/js/components/actions/ItemActions.vue
+++ b/resources/js/components/actions/ItemActions.vue
@@ -31,7 +31,13 @@ function runAction(action, values, onSuccess, onError) {
     emit('started');
 
     runServerAction({ action, values, onSuccess, onError, url: props.url, selections: [props.item] })
-        .then((data) => emit('completed', true, data))
+        .then((data) => {
+            if (props.actions === undefined) {
+                actionsLoaded.value = false;
+            }
+
+            emit('completed', true, data);
+        })
         .catch((data) => {
             errors.value = data.errors;
             emit('completed', false, data);


### PR DESCRIPTION
When using Publish/Unpublish from the row action dropdown in entry listings, the action executes correctly but the dropdown menu doesn't update to reflect the new state. For example, after clicking "Unpublish", the menu still shows "Unpublish" instead of "Publish". As seen here:

https://github.com/user-attachments/assets/6e4725e7-cb7e-4e7a-a11a-a577eb8c0f55

This pull request fixes this by resetting `actionsLoaded` after an action has been executed and forces a reload. This only applies to listings where the actions are fetched via API. (props.actions === undefined)

An alternative approach would be to load the actions directly in the [ListedEntry](https://github.com/statamic/cms/blob/master/src/Http/Resources/CP/Entries/ListedEntry.php) endpoint and combine this with a `watch` on `props.actions` in the Vue component. However, implementation using actionsLoaded requires way less code. And in my opinion, reloading actions is a good compromise.