### PR TITLE
[5.x] Revert "`AssetContainer::accessible()` should take filesystem visibility into account"

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -489,10 +489,7 @@ class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, 
      */
     public function accessible()
     {
-        $config = $this->disk()->filesystem()->getConfig();
-
-        return Arr::get($config, 'url') !== null
-            && Arr::get($config, 'visibility', 'public') === 'public';
+        return Arr::get($this->disk()->filesystem()->getConfig(), 'url') !== null;
     }
 
     /**


### PR DESCRIPTION
This PR reverts #13621.

The `visibility` option doesn't reliably indicate whether assets are web-accessible. It controls filesystem permissions (local) or object ACLs (S3), but doesn't account for setups where access is provided through other means (eg. a private S3 bucket frontend by CloudFront).

The presence of a configured URL is a clearer signal of intent: if a URL is configured, then we know the assets are accessible there, regardless of how that access is achieved.

Fixes #13667.