### PR TITLE
[6.x] Update `orchestra/testbench` constraint in `make:addon` stub

### DIFF
--- a/src/Console/Commands/stubs/addon/composer.json.stub
+++ b/src/Console/Commands/stubs/addon/composer.json.stub
@@ -14,7 +14,7 @@
         "statamic/cms": "^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.2 || ^10.0"
+        "orchestra/testbench": "^10.8"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
A very minor thing, but I realised our `composer.json` stub was requiring Testbench 9 which isn't necessary because v6 only supports Laravel 12.

I've also bumped the minimum version of Testbench 10 to the version with PHP 8.5 compatibility.