### PR TITLE
[6.x] Fix bard graphql test

### DIFF
--- a/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/BardFieldtypeTest.php
@@ -294,17 +294,17 @@ GQL;
         EntryFactory::collection('blog')->id('1')->data([
             'title' => 'Main Post',
             'things' => [
-                ['type' => 'text', 'text' => 'first text'],
-                ['type' => 'meal', 'food' => 'burger', 'drink' => 'coke', 'extras' => [
-                    ['type' => 'food', 'item' => 'fries'],
-                    ['type' => 'food', 'item' => 'ketchup'],
-                ]],
-                ['type' => 'text', 'text' => 'second text'],
-                ['type' => 'car', 'make' => 'toyota', 'model' => 'corolla'],
-                ['type' => 'meal', 'food' => 'salad', 'drink' => 'water', 'extras' => [
-                    ['type' => 'food', 'item' => 'dressing'],
-                ]],
-                ['type' => 'text', 'text' => 'last text'],
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'first text']]],
+                ['type' => 'set', 'attrs' => ['id' => '1', 'values' => ['type' => 'meal', 'food' => 'burger', 'drink' => 'coke', 'extras' => [
+                    ['type' => 'set', 'attrs' => ['id' => '1a', 'values' => ['type' => 'food', 'item' => 'fries']]],
+                    ['type' => 'set', 'attrs' => ['id' => '1b', 'values' => ['type' => 'food', 'item' => 'ketchup']]],
+                ]]]],
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'second text']]],
+                ['type' => 'set', 'attrs' => ['id' => '2', 'values' => ['type' => 'car', 'make' => 'toyota', 'model' => 'corolla']]],
+                ['type' => 'set', 'attrs' => ['id' => '3', 'values' => ['type' => 'meal', 'food' => 'salad', 'drink' => 'water', 'extras' => [
+                    ['type' => 'set', 'attrs' => ['id' => '3a', 'values' => ['type' => 'food', 'item' => 'dressing']]],
+                ]]]],
+                ['type' => 'paragraph', 'content' => [['type' => 'text', 'text' => 'last text']]],
             ],
         ])->create();
 


### PR DESCRIPTION
This test was failing for me locally. Strange because it passes on GitHub Actions.

Not exactly sure of the reason, but if we switch to prosemirror content like the other tests do anyway, it fixes it. This test isn't concerned with the legacy data structure so it doesn't matter.
