### PR TITLE
[6.x] Prevent force mounting combobox to improve scroll performance

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -427,7 +427,6 @@ defineExpose({
 
                 <ComboboxPortal>
                     <ComboboxContent
-                        :force-mount="true"
                         :hidden="!dropdownOpen"
                         position="popper"
                         :side-offset="5"


### PR DESCRIPTION
This reverts the force-mount added in #13625 which aimed to improve the performance when opening the combobox. However this makes scroll event listener consistent so scroll performance suffers.

I believe the main issue was for comboboxes with lots of options like the icon fieldtype. This issue would come back, but we'll tweak that later.

Related #13689 
