### PR TITLE
[6.x] Display error when `npm install` fails in `setup-cp-vite` command

### DIFF
--- a/src/Console/Commands/SetupCpVite.php
+++ b/src/Console/Commands/SetupCpVite.php
@@ -46,7 +46,7 @@ class SetupCpVite extends Command
 
     private function installDependencies(): self
     {
-        spin(
+        $result = spin(
             callback: function () {
                 $packageJsonPath = base_path('package.json');
                 $contents = File::json($packageJsonPath);
@@ -63,12 +63,17 @@ class SetupCpVite extends Command
 
                 File::put($packageJsonPath, json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
-                Process::path(base_path())->run('npm install', function (string $type, string $buffer) {
-                    echo $buffer;
-                });
+                return Process::path(base_path())->run('npm install');
             },
             message: 'Installing dependencies...'
         );
+
+        if ($result->failed()) {
+            $this->line($result->errorOutput() ?: $result->output());
+            $this->components->error('Failed to install dependencies. You need to run "npm install" manually.');
+
+            return $this;
+        }
 
         $this->components->info('Installed dependencies');
 

--- a/tests/Console/Commands/SetupCpViteTest.php
+++ b/tests/Console/Commands/SetupCpViteTest.php
@@ -174,6 +174,24 @@ JSON, $this->files->get(base_path('package.json')));
 PHP, $this->files->get(app_path('Providers/AppServiceProvider.php')));
     }
 
+    #[Test]
+    public function it_shows_error_when_npm_install_fails_but_continues()
+    {
+        Process::fake([
+            '*' => Process::result(
+                output: '',
+                errorOutput: 'npm ERR! code ERESOLVE',
+                exitCode: 1,
+            ),
+        ]);
+
+        $this
+            ->artisan('statamic:setup-cp-vite')
+            ->expectsOutputToContain('Failed to install dependencies')
+            ->expectsOutputToContain('npm ERR! code ERESOLVE')
+            ->expectsOutputToContain('Added cp:dev and cp:build scripts to package.json');
+    }
+
     private function makeNecessaryFiles(): void
     {
         $this->files->put(app_path('Providers/AppServiceProvider.php'), <<<'PHP'


### PR DESCRIPTION
Currently, the `npm install` command fails silently. Its output may show for a split second before the spinner finishes and cleans up the output.

This PR fixes it by catching any failures and throwing an error message telling the user to run `npm install` themselves.

Fixes #13697
