### PR TITLE
[6.x] Fix pasted content disappearing in Bard

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -823,7 +823,13 @@ export default {
                 editable: !this.readOnly,
                 enableInputRules: this.config.enable_input_rules,
                 enablePasteRules: this.config.enable_paste_rules,
-                editorProps: { attributes: { class: 'bard-content' } },
+                editorProps: {
+                    attributes: { class: 'bard-content' },
+                    handlePaste: () => {
+                        this.debounceNextUpdate = false;
+                        return false;
+                    },
+                },
                 onDrop: () => this.debounceNextUpdate = false,
                 onFocus: () => {
                     this.hasBeenFocused = true;


### PR DESCRIPTION
This pull request attempts to fix an issue where pasted text disappears almost instantly after removing characters and pasting.

I was able to reproduce the issue originally and confirmed this fixed it, however, then I switched back to `master` to record a video and wasn't able to reproduce it anymore. Hopefully this fix still works! 😅

Fixes #13698