### PR TITLE
[6.x] Avoid Bard image alt input being focused on page load

### DIFF
--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -28,8 +28,8 @@
                 @paste.stop
             >
                 <Input
+	                ref="alt"
                     name="alt"
-                    :focus="showingAltEdit"
                     v-model="alt"
                     :placeholder="assetAlt"
                     :prepend="__('Alt Text')"
@@ -156,6 +156,12 @@ export default {
         alt(alt) {
             this.updateAttributes({ alt });
         },
+
+	    showingAltEdit(showingAltEdit) {
+		    if (showingAltEdit) {
+				this.$nextTick(() => this.$refs.alt.focus());
+		    }
+	    },
     },
 
     methods: {


### PR DESCRIPTION
This pull request fixes an issue where the alt input on a Bard image would be focused when editing an entry, rather than the page title.

This PR fixes it by only focusing the alt input after clicking the "Override Alt" button.

Fixes #13683