### PR TITLE
[6.x] Prevent inline bard images from flickering when adding nodes

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -220,6 +220,7 @@ export default {
             errorsById: {},
             debounceNextUpdate: true,
             setsCache: {},
+            assetsCache: {},
             loadingSet: null,
         };
     },

--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -170,6 +170,13 @@ export default {
         },
 
         loadAsset(id) {
+            const cache = this.extension.options.bard.assetsCache;
+
+            if (cache[id]) {
+                this.setAsset(cache[id]);
+                return;
+            }
+
             this.$axios
                 .post(cp_url('assets-fieldtype'), {
                     assets: [id],
@@ -180,6 +187,7 @@ export default {
         },
 
         setAsset(asset) {
+            this.extension.options.bard.assetsCache[asset.id] = asset;
             this.editorAsset = asset;
             this.assetId = asset.id;
             this.assetAlt = asset.values.alt;


### PR DESCRIPTION
This pull request fixes an issue where inline bard images would visibly flicker when adding nodes (like hitting enter to add a paragraph).

This is happening because TipTap's `VueNodeViewRenderer` recreates inline node view components when the document structure changes. Each time the `Image` component is recreated, it calls `loadAsset` which makes an API request, causing the image to flicker as it reloads.

This PR works around the issue by caching the loaded asset data in the parent `BardFieldtype` component, then retrieves 
the data from there when re-creating the component in order to avoid unnecessary API requests.

Fixes #13682
