### PR TITLE
[6.x] Asset field listing preview improvements

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsIndexFieldtype.vue
@@ -1,13 +1,13 @@
 <template>
     <div class="flex text-2xs gap-2">
-        <a v-for="asset in value.slice(0, 5)" :key="asset.id" :href="asset.url" target="_blank">
+        <a v-for="asset in value.assets.splice(0, 5)" :key="asset.id" :href="asset.url" target="_blank">
             <asset-thumbnail :asset="asset" class="-my-1 h-8 max-w-3xs" />
         </a>
         <span
-            v-if="value.length > 5"
+            v-if="value.total > 6"
             class="-my-1 flex h-8 min-w-8 items-center justify-center px-1.5 font-mono text-gray-600 dark:text-gray-400"
         >
-            +&thinsp;{{ value.length - 5 }}
+            +&thinsp;{{ value.total - 5 }}
         </span>
     </div>
 </template>

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -438,7 +438,16 @@ class Assets extends Fieldtype
 
     public function preProcessIndex($data)
     {
-        return $this->getItemsForPreProcessIndex($data)->map(function ($asset) {
+        $total = $data === null
+            ? 0
+            : ($this->config('max_files') === 1 ? 1 : count($data));
+
+        // Since we only want to display a handful of thumbnails, we'll slice it up here so we don't perform more
+        // augmentation overhead than necessary. e.g. 5 thumbs then +remainder. If the remainder is 1, we may
+        // as well show all 6 since the +1 would almost take up the same amount of space.
+        $data = collect($data)->take(6)->all();
+
+        $assets = $this->getItemsForPreProcessIndex($data)->map(function ($asset) {
             $arr = [
                 'id' => $asset->id(),
                 'is_image' => $isImage = $asset->isImage(),
@@ -456,6 +465,8 @@ class Assets extends Fieldtype
 
             return $arr;
         });
+
+        return compact('total', 'assets');
     }
 
     protected function getItemsForPreProcessIndex($values): Collection


### PR DESCRIPTION
## Description of the Problem

When there are many images attached to an assets field, and they're shown in the preview listings it can be unwieldy, as per #13681 

<img width="1509" height="1193" alt="image" src="https://github.com/user-attachments/assets/6bea8030-f6bd-4200-a453-bd84e3ff792a" />

## What this PR Does

- Closes #13681 
- Adds a missing gap between the images
- Shows the first 5 by default
- Shows how many other images are attached to the field as `n +`
- If there are 6, show 6. Since the `+1` would take up about the same size as another thumbnail.

### Before

![2026-01-28 at 12 34 48@2x](https://github.com/user-attachments/assets/9f7c413a-2f1e-45e8-b61e-95b080e0e055)

### After

![2026-01-28 at 12 34 39@2x](https://github.com/user-attachments/assets/bc3da317-043d-4fcb-bc7d-f2e3ca3e490a)

## How to Reproduce

1. Add an assets field, load it up with images
2. Set it to "visible" on publish forms so it shows up in the listings