### PR TITLE
[6.x] Remove the spinner from the loading bulk actions state

### DIFF
--- a/resources/js/components/ui/Listing/BulkActions.vue
+++ b/resources/js/components/ui/Listing/BulkActions.vue
@@ -51,7 +51,7 @@ function actionFailed(response) {
         :context="actionContext"
         @started="actionStarted"
         @completed="actionCompleted"
-        v-slot="{ actions, loading }"
+        v-slot="{ actions }"
     >
         <Motion
             v-if="visible"
@@ -66,7 +66,6 @@ function actionFailed(response) {
             <ButtonGroup>
                 <Button
                     class="text-blue-500!"
-                    :disabled="loading"
                     :text="__n(`Deselect :count item|Deselect all :count items`, selections.length)"
                     @click="clearSelections"
                 />


### PR DESCRIPTION
## Description of the Problem

- #13450 added a check to the bulk actions to wait for the data response before showing the floating toolbar.
- Jason added a loading spinner to that rather than waiting for the full data response.
  - However, the loading spinner appears every time you select/deselect anything and causes frequent layout shifts to the floating toolbar (see below)

![2026-01-28 at 13 12 39](https://github.com/user-attachments/assets/b0c5a2af-5830-4201-837a-298a54556325)

## What this PR Does

The delay of 300ms before showing the bar is enough to fix the original issue (https://github.com/statamic/cms/issues/13444) so I've just removed the loading icon

## How to Reproduce

1. Bulk select items and see the loading spinner cause layout shifts as shown in the GIF above