### PR TITLE
[6.x] Fix `$fakeStacheDirectory` path when running addon tests on Windows

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -7,6 +7,7 @@ use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use ReflectionClass;
 use Statamic\Addons\Manifest;
 use Statamic\Console\Processes\Composer;
+use Statamic\Facades\Path;
 use Statamic\Providers\StatamicServiceProvider;
 use Statamic\Statamic;
 use Statamic\Testing\Concerns\PreventsSavingStacheItemsToDisk;
@@ -26,7 +27,7 @@ abstract class AddonTestCase extends OrchestraTestCase
 
         if (isset($uses[PreventsSavingStacheItemsToDisk::class])) {
             $reflector = new ReflectionClass($this->addonServiceProvider);
-            $this->fakeStacheDirectory = dirname($reflector->getFileName()).'/../tests/__fixtures__/dev-null';
+            $this->fakeStacheDirectory = Path::resolve(dirname($reflector->getFileName()).'/../tests/__fixtures__/dev-null');
 
             $this->preventSavingStacheItemsToDisk();
         }


### PR DESCRIPTION
This PR fixes an issue caused by the changes in #13640, where running addon tests on Windows would fail due to invalid paths:

Example failure:

```
1) Tests\Cart\Calculator\ApplyDiscountsTest::automatically_applies_discounts_without_codes
ErrorException: file_put_contents(D:/a/statamic-cargo/statamic-cargo/src/../tests/__fixtures__/dev-null/D:/a/statamic-cargo/statamic-cargo/tests/__fixtures__/content/collections/products.yaml): Failed to open stream: No such file or directory

D:\a\statamic-cargo\statamic-cargo\vendor\laravel\framework\src\Illuminate\Foundation\Bootstrap\HandleExceptions.php:258
D:\a\statamic-cargo\statamic-cargo\vendor\laravel\framework\src\Illuminate\Filesystem\Filesystem.php:204
D:\a\statamic-cargo\statamic-cargo\vendor\statamic\cms\src\Filesystem\AbstractAdapter.php:29
D:\a\statamic-cargo\statamic-cargo\vendor\statamic\cms\src\Filesystem\Manager.php:49
D:\a\statamic-cargo\statamic-cargo\vendor\laravel\framework\src\Illuminate\Support\Facades\Facade.php:363
D:\a\statamic-cargo\statamic-cargo\vendor\statamic\cms\src\Data\ExistsAsFile.php:94
D:\a\statamic-cargo\statamic-cargo\vendor\statamic\cms\src\Stache\Stores\BasicStore.php:142
D:\a\statamic-cargo\statamic-cargo\vendor\statamic\cms\src\Stache\Stores\BasicStore.php:114
D:\a\statamic-cargo\statamic-cargo\vendor\statamic\cms\src\Stache\Repositories\CollectionRepository.php:87
D:\a\statamic-cargo\statamic-cargo\vendor\laravel\framework\src\Illuminate\Support\Facades\Facade.php:363
D:\a\statamic-cargo\statamic-cargo\vendor\statamic\cms\src\Entries\Collection.php:505
D:\a\statamic-cargo\statamic-cargo\tests\Cart\Calculator\ApplyDiscountsTest.php:126
D:\a\statamic-cargo\statamic-cargo\tests\Cart\Calculator\ApplyDiscountsTest.php:21
```

This PR fixes the issue by wrapping the path in `Path::resolve()` to ensure the dots in the path are correctly resolved. I've tested this fix on one of my addons:

* Failing tests: https://github.com/duncanmcclean/statamic-cargo/actions/runs/21442231562/job/61748158259
* Commit between tests: https://github.com/duncanmcclean/statamic-cargo/pull/121/commits/377cc4cd81188c690b743aa62d4513727b0dd8c9
* Passing tests: https://github.com/duncanmcclean/statamic-cargo/actions/runs/21442316287/job/61748469285