### PR TITLE
[6.x] Floating toolbar pointer improvements

### DIFF
--- a/resources/js/components/ui/Listing/BulkActions.vue
+++ b/resources/js/components/ui/Listing/BulkActions.vue
@@ -57,12 +57,12 @@ function actionFailed(response) {
             v-if="visible"
             layout
             data-floating-toolbar
-            class="sticky inset-x-0 bottom-1 sm:bottom-6 z-(--z-index-above) flex w-full max-w-[95vw] mx-auto justify-center "
+            class="pointer-events-none sticky inset-x-0 bottom-1 sm:bottom-6 z-(--z-index-above) flex w-full max-w-[95vw] mx-auto justify-center"
             :initial="{ y: 100, opacity: 0 }"
             :animate="{ y: 0, opacity: 1 }"
             :transition="{ duration: 0.2, ease: 'easeInOut' }"
         >
-            <div class="space-y-3 rounded-xl border border-gray-300/60 dark:border-gray-700 p-1 bg-gray-200/55 shadow-[0_1px_16px_-2px_rgba(63,63,71,0.2)] dark:bg-gray-800 dark:shadow-[0_10px_15px_rgba(0,0,0,.5)] dark:inset-shadow-2xs dark:inset-shadow-white/10">
+            <div class="pointer-events-auto space-y-3 rounded-xl border border-gray-300/60 dark:border-gray-700 p-1 bg-gray-200/55 shadow-[0_1px_16px_-2px_rgba(63,63,71,0.2)] dark:bg-gray-800 dark:shadow-[0_10px_15px_rgba(0,0,0,.5)] dark:inset-shadow-2xs dark:inset-shadow-white/10">
             <ButtonGroup>
                 <Button
                     class="text-blue-500!"

--- a/resources/js/components/ui/Listing/BulkActions.vue
+++ b/resources/js/components/ui/Listing/BulkActions.vue
@@ -57,7 +57,7 @@ function actionFailed(response) {
             v-if="visible"
             layout
             data-floating-toolbar
-            class="sticky inset-x-0 bottom-1 sm:bottom-6 z-100 flex w-full max-w-[95vw] mx-auto justify-center "
+            class="sticky inset-x-0 bottom-1 sm:bottom-6 z-(--z-index-above) flex w-full max-w-[95vw] mx-auto justify-center "
             :initial="{ y: 100, opacity: 0 }"
             :animate="{ y: 0, opacity: 1 }"
             :transition="{ duration: 0.2, ease: 'easeInOut' }"


### PR DESCRIPTION
## Description of the Problem

I noticed that the floating toolbar blocks pointer events underneath it's invisible parent container

Here, for example, you cannot click "Whistler's Mother and more"; the invisible horizontal container of the toolbar is blocking it

![2026-01-28 at 15 19 16@2x](https://github.com/user-attachments/assets/b7282ac4-9c77-4b16-8b72-ac031029ccd5)

## What this PR Does

- Unblocks pointer events on the parent, re-adding them to the inside container
- Replace a hard-coded z-index while I'm here

## How to Reproduce

1. Try selecting something underneath the toolbar
2. Experience not being able to select anything