### PR TITLE
[6.x] Fix error when searching assets via the Command Palette

### DIFF
--- a/src/Http/Controllers/CP/CommandPaletteController.php
+++ b/src/Http/Controllers/CP/CommandPaletteController.php
@@ -47,7 +47,7 @@ class CommandPaletteController extends CpController
     {
         $badge = $result->getCpBadge();
 
-        if (! Arr::has($index->config(), 'sites')) {
+        if (! Arr::has($index->config(), 'sites') && method_exists($result->getSearchable(), 'site')) {
             $badge = $result->getSearchable()->site()->name().' - '.$badge;
         }
 


### PR DESCRIPTION
This pull request fixes an error when searching assets via the Command Palette after #13650. We need to check that the `site()` method exists on the searchable before calling it.