### PR TITLE
[6.x] After creating the assets folder, it keeps the last folder name

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -121,6 +121,7 @@
                             />
 
                             <Table
+                                ref="table"
                                 v-if="mode === 'table'"
                                 :assets="items"
                                 :folders="folders"
@@ -132,6 +133,7 @@
                             />
 
                             <Grid
+                                ref="grid"
                                 v-if="mode === 'grid'"
                                 :assets="items"
                                 :action-url="actionUrl"


### PR DESCRIPTION
When creating multiple asset folders, it shows the last one used in the new input field.

### How to reproduce

1. Go to `/cp/assets/browse/assets`
2. Create a new folder
3. Click on `Create folder` again
4. It will show the last created folder name.

https://github.com/user-attachments/assets/c17fe45c-d7ee-4c8a-80f1-47ceff563ff9

### What this PR Does

Fixes the new folder input to show the placeholder without carrying the previous folder name.