### PR TITLE
[6.x] Search instructions when searching sets

### DIFF
--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -263,8 +263,7 @@ export default {
                   }, []);
 
             if (this.search) {
-                return sets
-                    .filter((set) => !set.hide)
+                sets = sets
                     .filter((set) => {
                         return (
                             __(set.display).toLowerCase().includes(this.search.toLowerCase()) ||

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -263,14 +263,7 @@ export default {
                   }, []);
 
             if (this.search) {
-                sets = sets
-                    .filter((set) => {
-                        return (
-                            __(set.display).toLowerCase().includes(this.search.toLowerCase()) ||
-	                        __(set.instructions)?.toLowerCase().includes(this.search.toLowerCase()) ||
-                            set.handle.toLowerCase().includes(this.search.toLowerCase())
-                        );
-                    });
+                sets = this.filterSetsBySearch(sets);
             }
 
             return sets.filter((set) => !set.hide);
@@ -317,13 +310,7 @@ export default {
 
                 // Apply search filter if there's a search term
                 if (this.search) {
-                    filteredSets = filteredSets.filter(set => {
-                        return (
-                            __(set.display).toLowerCase().includes(this.search.toLowerCase()) ||
-                            __(set.instructions)?.toLowerCase().includes(this.search.toLowerCase()) ||
-                            set.handle.toLowerCase().includes(this.search.toLowerCase())
-                        );
-                    });
+                    filteredSets = this.filterSetsBySearch(filteredSets);
                 }
 
                 groups[group.handle] = {
@@ -480,6 +467,16 @@ export default {
         isSetLoading(handle) {
             return this.loadingSet === handle;
         },
+
+        filterSetsBySearch(sets) {
+            return sets.filter(set => {
+                return (
+                    __(set.display).toLowerCase().includes(this.search.toLowerCase()) ||
+                    __(set.instructions)?.toLowerCase().includes(this.search.toLowerCase()) ||
+                    set.handle.toLowerCase().includes(this.search.toLowerCase())
+                );
+            });
+        }
     },
 };
 </script>

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -268,6 +268,7 @@ export default {
                     .filter((set) => {
                         return (
                             __(set.display).toLowerCase().includes(this.search.toLowerCase()) ||
+	                        __(set.instructions)?.toLowerCase().includes(this.search.toLowerCase()) ||
                             set.handle.toLowerCase().includes(this.search.toLowerCase())
                         );
                     });

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -321,6 +321,7 @@ export default {
                     filteredSets = filteredSets.filter(set => {
                         return (
                             __(set.display).toLowerCase().includes(this.search.toLowerCase()) ||
+                            __(set.instructions)?.toLowerCase().includes(this.search.toLowerCase()) ||
                             set.handle.toLowerCase().includes(this.search.toLowerCase())
                         );
                     });


### PR DESCRIPTION
Currently, searching sets only looks at the set's display name & handle. This PR makes it so the set's instruction text is also searched.

Closes #13725
