### PR TITLE
[6.x] Add "mod+s" shortcut to save blueprint order

### DIFF
--- a/resources/js/pages/blueprints/ScopedIndex.vue
+++ b/resources/js/pages/blueprints/ScopedIndex.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch } from 'vue';
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
 import { Link, router } from '@inertiajs/vue3';
 import Head from '@/pages/layout/Head.vue';
 import { Header, Button, DocsCallout, DropdownItem, Listing } from '@ui';
@@ -9,6 +9,7 @@ const props = defineProps(['blueprints', 'reorderUrl', 'createUrl']);
 
 const rows = ref(props.blueprints);
 const hasBeenReordered = ref(false);
+const saveKeyBinding = ref(null);
 
 const reorderable = computed(() => rows.value.length > 1);
 
@@ -42,6 +43,17 @@ function saveOrder() {
 }
 
 const reloadPage = () => router.reload();
+
+onMounted(() => {
+    saveKeyBinding.value = Statamic.$keys.bindGlobal(['mod+s'], (e) => {
+        if (hasBeenReordered.value) {
+            e.preventDefault();
+            saveOrder();
+        }
+    });
+});
+
+onBeforeUnmount(() => saveKeyBinding.value?.destroy());
 </script>
 
 <template>

--- a/resources/js/pages/blueprints/ScopedIndex.vue
+++ b/resources/js/pages/blueprints/ScopedIndex.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import { ref, computed, watch, onBeforeUnmount } from 'vue';
 import { Link, router } from '@inertiajs/vue3';
 import Head from '@/pages/layout/Head.vue';
 import { Header, Button, DocsCallout, DropdownItem, Listing } from '@ui';
@@ -9,7 +9,6 @@ const props = defineProps(['blueprints', 'reorderUrl', 'createUrl']);
 
 const rows = ref(props.blueprints);
 const hasBeenReordered = ref(false);
-const saveKeyBinding = ref(null);
 
 const reorderable = computed(() => rows.value.length > 1);
 
@@ -44,14 +43,12 @@ function saveOrder() {
 
 const reloadPage = () => router.reload();
 
-onMounted(() => {
-    saveKeyBinding.value = Statamic.$keys.bindGlobal(['mod+s'], (e) => {
-        if (hasBeenReordered.value) {
-            e.preventDefault();
-            saveOrder();
-        }
-    });
-});
+const saveKeyBinding = ref(Statamic.$keys.bindGlobal(['mod+s'], (e) => {
+    if (hasBeenReordered.value) {
+        e.preventDefault();
+        saveOrder();
+    }
+}));
 
 onBeforeUnmount(() => saveKeyBinding.value?.destroy());
 </script>


### PR DESCRIPTION
This pull request relates to #13724 

I found one more spot where no mod+s keybinding was set for reordering, the overview of all blueprints for a collection.