### PR TITLE
[6.x] Only run lint workflow if php files have been changed

### DIFF
--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -11,7 +11,15 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            **.php
+
       - name: Check PHP code style issues
+        if: steps.changed-files.outputs.any_modified == 'true'
         uses: aglipanci/laravel-pint-action@v2
         with:
           testMode: true


### PR DESCRIPTION
Pint doesnt need to run if only non-PHP files have changed in the PR.

i.e. If the PR is just JS, we don't need to sit and wait for pint to finish. That step seems to take longer than the entire js test suite.
