### PR TITLE
[5.x] Abort 404 when asset is not found in AssetsController

### DIFF
--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -38,6 +38,8 @@ class AssetsController extends CpController
     {
         $asset = Asset::find(base64_decode($asset));
 
+        abort_if(! $asset, 404);
+
         // TODO: Auth
 
         return new AssetResource($asset);
@@ -128,6 +130,8 @@ class AssetsController extends CpController
     public function download($asset)
     {
         $asset = Asset::find(base64_decode($asset));
+
+        abort_if(! $asset, 404);
 
         // TODO: Auth
 


### PR DESCRIPTION
## Summary
- Add `abort_if(! $asset, 404)` null guard after `Asset::find()` in `show()` and `download()` methods of `AssetsController`
- Prevents 500 errors when an asset cannot be found, returning a proper 404 instead

## Test plan
- [ ] Verify requesting a non-existent asset via `show()` returns 404
- [ ] Verify requesting a non-existent asset via `download()` returns 404
- [ ] Verify existing asset requests still work normally

Fixes #13739