### PR TITLE
[6.x] Nested bard fixed toolbars - remove sticky stacking approach

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -135,7 +135,7 @@
             }
         }
 
-        /* When there's a fixed toolbar the the bard editor should have square radius in the top corners to but up against the bottom of the toolbar */
+        /* When there's a fixed toolbar the bard editor should have square radius in the top corners to but up against the bottom of the toolbar */
         .bard-fieldtype:has(> &) {
             .bard-editor:focus-within {
                 border-top-left-radius: 0!important;
@@ -174,7 +174,7 @@
         top: -24px;
     }
 
-    /*  Responive Wangjangling */
+    /* Responsive Wangjangling */
     @media (width >= theme(--breakpoint-md)) {
         /*  Fixed toolbar below fixed global header */
         .bard-fixed-toolbar {

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -154,7 +154,7 @@
     .bard-fixed-toolbar {
         z-index: var(--z-index-portal);
         position: sticky;
-        @apply -top-2;
+        @apply sm:-top-2;
         /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
         margin-block-end: 8px;
         /* Pull the subsequent element up to compensate for this. The focus ring adjustment here keeps the focus ring from disappearing into the toolbar, which would make the focus ring appear bottom heavy. */

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -164,6 +164,17 @@
         }
     }
 
+    /* Where a Bard fieldtype with a fixed toolbar... */
+    .bard-fieldtype:has(> .bard-fixed-toolbar) {
+        /* has a nested Bard fieldtype with a fixed toolbar _with focus_ */
+        &:has(.bard-fieldtype .bard-content:focus) {
+            /* release the sticky positioning so that it doesn't cover the focused Bard toolbar */
+            > .bard-fixed-toolbar {
+                position: unset;
+            }
+        }
+    }
+
     /* Bard > Grid > Bard */
     .bard-content .grid-fieldtype .bard-fixed-toolbar {
         @apply top-16;

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -164,10 +164,6 @@
         }
     }
 
-    /* Bard field with a fixed toolbar > then another fixed toolbar inside this */
-    .bard-fieldtype:has(> .bard-fixed-toolbar) .bard-content .bard-fixed-toolbar {
-        @apply top-8;
-    }
     /* Bard > Grid > Bard */
     .bard-content .grid-fieldtype .bard-fixed-toolbar {
         @apply top-16;


### PR DESCRIPTION
## Description of the Problem

This closes #13728.
When we have nested sticky toolbars in Bard, our existing approach is to cascade the sticky position.

For example:

- The first sticky toolbar effectively gets stuck to the top of the container  
- Nested fixed toolbars get stuck to the `top of the container + the assumed height of the first fixed toolbar`, like so:

https://github.com/user-attachments/assets/7e01fe27-a2b3-42c6-93b4-7399d6de2763

### The problem with this approach

The above works very well, however, it assumes there is a single row of Bard icons to offset the nested fixed toolbars, with `@apply top-8;`

As soon as the fixed toolbar has a second, or even(!) a third row, we can no longer rely on the assumed height of the toolbar.
The second or third rows of buttons can also appear when the viewport width is narrower. You can see the problem here:

https://github.com/user-attachments/assets/a787df3f-bd02-4480-be85-4b666f573c80

## What this PR Does

- I think the only way to reliably deal with this is to unstick inactive toolbars rather than stack them
  - This is also cleaner than seeing stacked toolbars
- Fixes the toolbar position for smaller viewports

Here is the video of the solution. Only the focused bard field has a stuck toolbar. You can see when we focus on an inner bard field around 0:05, all other toolbars get unstuck.

https://github.com/user-attachments/assets/8288cf63-9dd4-4ce2-84d9-2d5baea38286

## How to Reproduce

1. Nest a load of Bard fields