### PR TITLE
[6.x] Fix the z-index of the sticky markdown toolbar, plus position on mobile

### DIFF
--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -53,7 +53,7 @@
                             :is-fullscreen="false"
                             @toggle-dark-mode="toggleDarkMode"
                             @button-click="handleButtonClick"
-                            class="sticky z-(--z-index-above) -top-2 mb-2 [&~*]:-mt-2"
+                            class="sticky z-(--z-index-portal) top-0 sm:-top-2 mb-2 [&~*]:-mt-2"
                         />
 
                         <div class="drag-notification" v-show="dragging">


### PR DESCRIPTION
## Description of the Problem

As per #13746, the sticky toolbar was broken on Markdown fields.

<img width="936" height="1366" alt="image" src="https://github.com/user-attachments/assets/a93f98e7-c2a3-4c60-aef1-16d0eae43917" />

## What this PR Does

- Closes #13746
- Pulls the sticky z-index toolbar up by 1
- Improves the position on smaller viewports

## How to Reproduce

1. Add some content to a Markdown field
2. Scroll to induce the sticky toolbar