### PR TITLE
[6.x] Only show site in search result badge when using multiple sites

### DIFF
--- a/src/Http/Controllers/CP/CommandPaletteController.php
+++ b/src/Http/Controllers/CP/CommandPaletteController.php
@@ -47,7 +47,11 @@ class CommandPaletteController extends CpController
     {
         $badge = $result->getCpBadge();
 
-        if (! Arr::has($index->config(), 'sites') && method_exists($result->getSearchable(), 'site')) {
+        if (
+            Site::hasMultiple()
+            && ! Arr::has($index->config(), 'sites')
+            && method_exists($result->getSearchable(), 'site')
+        ) {
             $badge = $result->getSearchable()->site()->name().' - '.$badge;
         }
 


### PR DESCRIPTION
In #13650 we added the site name to search result badges in the command palette to disambiguate results.
This isn't needed when you only have one site.
