### PR TITLE
[6.x] Fix asset index fieldtype slice length

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsIndexFieldtype.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="flex text-2xs gap-2">
-        <a v-for="asset in value.assets.splice(0, 5)" :key="asset.id" :href="asset.url" target="_blank">
+        <a v-for="asset in value.assets.slice(0, value.total > 6 ? 5 : 6)" :key="asset.id" :href="asset.url" target="_blank">
             <asset-thumbnail :asset="asset" class="-my-1 h-8 max-w-3xs" />
         </a>
         <span


### PR DESCRIPTION
While backporting #13708 to v5, I realized that the whole "show the 6th asset in place of the +1" logic wasn't even working as described. When you had 6 assets, you'd only get 5 and no +1.

The slice length is fixed now.

Also, it was using `splice`, which in Vue 2 was causing an infinite re-render. Changing `splice` to `slice` fixes that - `splice` modifies the original array and `slice` makes a new one. Doesn't have that problem in Vue 3 but doesn't hurt to fix it.
