### PR TITLE
[6.x] Ctrl+k to open bard link stack

### DIFF
--- a/resources/js/components/fieldtypes/bard/Link.js
+++ b/resources/js/components/fieldtypes/bard/Link.js
@@ -61,6 +61,12 @@ export const Link = Mark.create({
         ];
     },
 
+    addKeyboardShortcuts() {
+        return {
+            'Ctrl-k': () => this.options.vm.events.emit('open-link-toolbar'),
+        };
+    },
+
     addProseMirrorPlugins() {
         const vm = this.options.vm;
         return [

--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -166,6 +166,8 @@ import AssetSelector from '../../assets/Selector.vue';
 import { Icon, Stack, StackContent, StackFooter } from '@/components/ui';
 
 export default {
+    emits: ['updated', 'canceled', 'deselected'],
+
     components: {
         AssetSelector,
         Icon,

--- a/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
@@ -74,5 +74,13 @@ export default {
         }
     },
 
+    created() {
+        this.bard.events.on('open-link-toolbar', () => this.showingToolbar = true);
+    },
+
+    beforeUnmount() {
+        this.bard.events.off('open-link-toolbar');
+    },
+
 };
 </script>


### PR DESCRIPTION
We removed the keyboard shortcut in https://github.com/statamic/cms/commit/ba6a4c72c06fd715c9ba3c6fe1d5c7139b7e103e because it conflicted with command palette.

That was cmd+k - but we can still use ctrl+k.

Closes #13755

While I was here I also added `emits` to prevent some warnings.
