### PR TITLE
[6.x] Fix TypeError with CarbonImmutable in Timezone Support

### DIFF
--- a/src/Http/Middleware/CP/Localize.php
+++ b/src/Http/Middleware/CP/Localize.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Http\Middleware\CP;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Closure;
 use DateTime;
 use Illuminate\Support\Facades\Date;
@@ -24,7 +24,7 @@ class Localize
 
         // Get original Carbon format so it can be restored later.
         $originalToStringFormat = $this->getToStringFormat();
-        Date::setToStringFormat(function (Carbon $date) {
+        Date::setToStringFormat(function (CarbonInterface $date) {
             return $date->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
         });
 

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Http\Middleware;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Closure;
 use Illuminate\Support\Facades\Date;
 use ReflectionClass;
@@ -32,7 +32,7 @@ class Localize
 
         // Get original Carbon format so it can be restored later.
         $originalToStringFormat = $this->getToStringFormat();
-        Date::setToStringFormat(function (Carbon $date) {
+        Date::setToStringFormat(function (CarbonInterface $date) {
             return $date->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
         });
 


### PR DESCRIPTION
The improved timezone handling introduced in PR #11409 causes a `TypeError` when `CarbonImmutable` instances are used:

> Statamic\Http\Middleware\Localize::Statamic\Http\Middleware{closure}(): Argument #1 ($date) must be of type Carbon\Carbon, Carbon\CarbonImmutable given


The callback in the `Localize` middleware type-hints the parameter as `Carbon\Carbon`, but Laravel's `Date` facade can return both `Carbon` and `CarbonImmutable` instances depending on the application configuration. This also affects applications using custom DTOs that utilize `CarbonInterface`.

This PR replaces the Carbon\Carbon type hint with Carbon\CarbonInterface in both affected middleware classes. Since both Carbon and CarbonImmutable implement CarbonInterface.

####  Example

In our application, we have a custom `EventData` DTO that uses `CarbonImmutable` for all date properties:

```php
    readonly class EventData
    {
        public function __construct(
            public CarbonImmutable $starts_at,
            public CarbonImmutable $ends_at,
            // ...
        ) {}
    }
```

We combine these external event DTOs with Statamic entries in our Events component, merging them into a unified collection.