### PR TITLE
[6.x] Hide "Collapsible" option for bard/replicator sets

### DIFF
--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -33,6 +33,7 @@
             :initial-tabs="tabs"
             :errors="errors?.tabs"
             :can-define-localizable="canDefineLocalizable"
+            show-section-collapsible-field
             @updated="tabsUpdated"
         />
     </div>

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -57,10 +57,10 @@
                     <ui-field :label="__('Instructions')">
                         <ui-input type="text" v-model="editingSection.instructions" />
                     </ui-field>
-                    <ui-field :label="__('Collapsible')">
+                    <ui-field :label="__('Collapsible')" v-if="showCollapsibleField">
                         <ui-switch v-model="editingSection.collapsible" />
                     </ui-field>
-                    <ui-field :label="__('Collapsed by default')" v-if="editingSection.collapsible">
+                    <ui-field :label="__('Collapsed by default')" v-if="showCollapsibleField && editingSection.collapsible">
                         <ui-switch v-model="editingSection.collapsed" />
                     </ui-field>
                     <ui-field :label="__('Icon')" v-if="showHandleField">
@@ -143,6 +143,7 @@ export default {
         tabId: { type: String },
         section: { type: Object, required: true },
         showHandleField: { type: Boolean, default: false },
+	    showCollapsibleField: { type: Boolean, default: false },
         showHideField: { type: Boolean, default: false },
         editText: { type: String },
     },

--- a/resources/js/components/blueprints/Sections.vue
+++ b/resources/js/components/blueprints/Sections.vue
@@ -9,6 +9,7 @@
                 :can-define-localizable="canDefineLocalizable"
                 :tab-id="tabId"
                 :show-handle-field="showSectionHandleField"
+                :show-collapsible-field="showSectionCollapsibleField"
                 :show-hide-field="showSectionHideField"
                 :edit-text="editSectionText"
                 @updated="updateSection(i, $event)"
@@ -67,6 +68,10 @@ export default {
             type: Boolean,
             default: false,
         },
+	    showSectionCollapsibleField: {
+			type: Boolean,
+		    default: false,
+	    },
         showSectionHideField: {
             type: Boolean,
             default: false,

--- a/resources/js/components/blueprints/TabContent.vue
+++ b/resources/js/components/blueprints/TabContent.vue
@@ -8,6 +8,7 @@
             :add-section-text="addSectionText"
             :edit-section-text="editSectionText"
             :show-section-handle-field="showSectionHandleField"
+            :show-section-collapsible-field="showSectionCollapsibleField"
             :show-section-hide-field="showSectionHideField"
             :can-define-localizable="canDefineLocalizable"
             @updated="sectionsUpdated($event)"
@@ -36,6 +37,10 @@ export default {
             type: Boolean,
             default: false,
         },
+	    showSectionCollapsibleField: {
+			type: Boolean,
+		    default: false,
+	    },
         showSectionHideField: {
             type: Boolean,
             default: false,

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -38,6 +38,7 @@
                     :tab="tab"
                     v-show="currentTab === tab._id"
                     :show-section-handle-field="showSectionHandleField"
+                    :show-section-collapsible-field="showSectionCollapsibleField"
                     :show-section-hide-field="showSectionHideField"
                     :new-section-text="newSectionText"
                     :edit-section-text="editSectionText"
@@ -112,6 +113,10 @@ export default {
             type: Boolean,
             default: false,
         },
+	    showSectionCollapsibleField: {
+			type: Boolean,
+		    default: false,
+	    },
         showSectionHideField: {
             type: Boolean,
             default: false,


### PR DESCRIPTION
This pull request hides the "Collapsible" toggle when configuring Bard/Replicator sets.

Related: #13745