### PR TITLE
[6.x] Antlers Blade Components: Correct extra parenthesis in output

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -944,6 +944,7 @@ class DocumentParser
         $this->nodes[] = $node;
         $this->lastAntlersNode = $node;
         $this->startIndex = $this->currentIndex;
+        $this->currentIndex += 1;
     }
 
     private function advanceWhitespace()

--- a/tests/Antlers/Parser/DirectivesTest.php
+++ b/tests/Antlers/Parser/DirectivesTest.php
@@ -34,4 +34,23 @@ EXECTED;
 
         $this->renderString('@props ("this isnt()", "done!"');
     }
+
+    public function test_directives_dont_leave_extra_parenthesis()
+    {
+        $template = <<<'EOT'
+@props([
+
+])a
+
+Hellow
+EOT;
+
+        $expected = <<<'EOT'
+a
+
+Hellow
+EOT;
+
+        $this->assertSame($expected, $this->renderString($template));
+    }
 }


### PR DESCRIPTION
This PR corrects an issue where directives will add an extra parenthesis to the output when it's not followed by another Antlers construct:

```antlers
@props([

])

Hello
```

In that scenario, the final `)` would currently be incorrectly added to the output buffer.