### PR TITLE
[6.x] Support Laravel Debugbar 4

### DIFF
--- a/src/View/Debugbar/AntlersProfiler/PerformanceCollector.php
+++ b/src/View/Debugbar/AntlersProfiler/PerformanceCollector.php
@@ -82,7 +82,7 @@ class PerformanceCollector extends DataCollector implements AssetProvider, Rende
         return str_replace(config('debugbar.remote_sites_path'), config('debugbar.local_sites_path'), $filePath);
     }
 
-    public function getWidgets()
+    public function getWidgets(): array
     {
         return [
             'custom_widget' => [
@@ -133,7 +133,7 @@ class PerformanceCollector extends DataCollector implements AssetProvider, Rende
         return array_values($newItems);
     }
 
-    public function collect()
+    public function collect(): array
     {
         /** @var PerformanceTracer $tracer */
         $tracer = app(PerformanceTracer::class);
@@ -180,12 +180,12 @@ class PerformanceCollector extends DataCollector implements AssetProvider, Rende
         return $this->filterSamples($result);
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'antlers';
     }
 
-    public function getAssets()
+    public function getAssets(): array
     {
         return [
             'js' => [

--- a/src/View/Debugbar/VariableCollector.php
+++ b/src/View/Debugbar/VariableCollector.php
@@ -6,7 +6,7 @@ use DebugBar\DataCollector\ConfigCollector;
 
 class VariableCollector extends ConfigCollector
 {
-    public function getWidgets()
+    public function getWidgets(): array
     {
         $widgets = parent::getWidgets();
 
@@ -21,6 +21,10 @@ class VariableCollector extends ConfigCollector
             $value = false;
         }
 
-        return parent::useHtmlVarDumper($value);
+        if (method_exists(parent::class, 'useHtmlVarDumper')) {
+            return parent::useHtmlVarDumper($value);
+        }
+
+        return $this;
     }
 }


### PR DESCRIPTION
This pull request adds return types and a `method_exists()` check necessary to support Laravel Debugbar 4.

Fixes #13780
