### PR TITLE
[6.x] Fix uploading assets via Markdown fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -17,7 +17,7 @@
                 <uploader
                     ref="uploader"
                     :enabled="assetsEnabled"
-                    :container="container"
+                    :container="container.id"
                     :path="folder"
                     @updated="uploadsUpdated"
                     @upload-complete="uploadComplete"

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -13,6 +13,7 @@ use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Contracts\Assets\AssetFolder;
 use Statamic\Exceptions\AuthorizationException;
+use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\User;
@@ -84,6 +85,8 @@ class AssetsController extends CpController
         ]);
 
         $container = AssetContainer::find($request->container);
+
+        throw_unless($container, NotFoundHttpException::class);
 
         $this->authorize('store', [AssetContract::class, $container]);
 


### PR DESCRIPTION
This pull request fixes an issue where uploading assets via the Markdown Fieldtype would fail, due to the entire container object being passed to the `Uploader`, rather than just the ID.

This PR also ensures the `AssetsController::store()` method returns a 404 response when the asset container can't be found.

Fixes #13776
