### PR TITLE
[6.x] Add missing tooltips import

### DIFF
--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -5,6 +5,7 @@ import { ConfigProvider } from 'reka-ui';
 import SessionExpiry from '@/components/SessionExpiry.vue';
 import LicensingAlert from '@/components/LicensingAlert.vue';
 import PortalTargets from '@/components/portals/PortalTargets.vue';
+import Tooltips from '@/components/Tooltips.vue';
 import { provide, watch, ref, onMounted, onUnmounted, nextTick } from 'vue';
 import { router } from '@inertiajs/vue3';
 import useBodyClasses from './body-classes.js';


### PR DESCRIPTION
This pull request adds back the import for the `Tooltips` component which was accidentally removed in https://github.com/statamic/cms/pull/13357.