### PR TITLE
[6.x] Remove the inset style for relationship fields to make dark mode more consistent

### DIFF
--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -3,7 +3,7 @@
         class="shadow-ui-sm relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-gray-700 dark:with-contrast:border-gray-500 dark:bg-gray-900"
         :class="{ invalid: item.invalid }"
     >
-        <ui-icon name="handles" class="item-move sortable-handle size-4 cursor-grab text-gray-300 dark:text-gray-600" v-if="sortable" />
+        <ui-icon name="handles" class="item-move sortable-handle size-4 cursor-grab text-gray-300 dark:text-gray-700" v-if="sortable" />
         <div class="flex flex-1 items-center line-clamp-1 text-sm text-gray-600 dark:text-gray-300">
             <ui-status-indicator v-if="item.status" :status="item.status" class="me-2" />
 

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="shadow-ui-sm relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-x-0 dark:border-t-0 dark:border-white/10 dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black"
+        class="shadow-ui-sm relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-gray-700 dark:with-contrast:border-gray-500 dark:bg-gray-900"
         :class="{ invalid: item.invalid }"
     >
         <ui-icon name="handles" class="item-move sortable-handle size-4 cursor-grab text-gray-300 dark:text-gray-600" v-if="sortable" />

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="shadow-ui-sm relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-gray-700 dark:with-contrast:border-gray-500 dark:bg-gray-900"
+        class="relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-x-0 border-t-0 dark:border-white/10 dark:bg-gray-900 inset-shadow-2xs inset-shadow-gray-300 dark:inset-shadow-black"
         :class="{ invalid: item.invalid }"
     >
         <ui-icon name="handles" class="item-move sortable-handle size-4 cursor-grab text-gray-300 dark:text-gray-700" v-if="sortable" />

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-x-0 border-t-0 dark:border-white/10 dark:bg-gray-900 inset-shadow-2xs inset-shadow-gray-300 dark:inset-shadow-black"
+        class="shadow-ui-sm relative z-(--z-index-above) flex w-full h-full items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 [&:has(.cursor-grab)]:px-1.5 py-1.5 mb-1.5 last:mb-0 text-base dark:border-gray-700 dark:with-contrast:border-gray-500 dark:bg-gray-900"
         :class="{ invalid: item.invalid }"
     >
         <ui-icon name="handles" class="item-move sortable-handle size-4 cursor-grab text-gray-300 dark:text-gray-700" v-if="sortable" />


### PR DESCRIPTION
## Description of the Problem

In dark mode, relationship entry bars have a sunken aesthetic, like this:

(Before)

![2026-02-02 at 12 15 27@2x](https://github.com/user-attachments/assets/95451c28-580d-468d-a38e-d9088f014c2f)

It's been commented that this feels inconsistent/off as per #13619.

The sunken bars were part of our design exploration for dark mode. Since they're rarely used, I think it's fine just to make them the same aesthetic as light mode until we touch the relationship field again.

We had an internal discussion in our design channel about this and agreed this way forward.

(After)

![2026-02-02 at 12 18 27@2x](https://github.com/user-attachments/assets/7c4d2bd0-1008-4a2a-9040-e2de862056bd)

## What this PR Does

- Closes #13619
- Removes the inset aesthetic from any relationship field

## How to Reproduce

1. Add a relationship fieldtype such as Entries.