### PR TITLE
[5.x] Handle `0` values in text fields and `null` string in slugs

### DIFF
--- a/resources/js/components/slugs/Slug.js
+++ b/resources/js/components/slugs/Slug.js
@@ -113,7 +113,7 @@ export default class Slug {
         this.#controller = new AbortController;
 
         let aborted = false;
-        return axios.post(cp_url('slug'), payload, { signal: this.#controller.signal })
+        return axios.post(cp_url('slug'), payload, { signal: this.#controller.signal, transformResponse: [(data) => data] })
             .then(response => response.data)
             .catch(e => {
                 if (axios.isCancel(e)) {

--- a/resources/js/components/slugs/Slugify.vue
+++ b/resources/js/components/slugs/Slugify.vue
@@ -42,7 +42,7 @@ export default {
             handler() {
                 if (!this.shouldSlugify) {
                     this.slug = this.to;
-                } else if (!this.from) {
+                } else if (this.from === null || this.from === undefined || this.from === '') {
                     this.slug = '';
                 } else {
                     this.slugify();

--- a/src/Fieldtypes/Text.php
+++ b/src/Fieldtypes/Text.php
@@ -154,8 +154,10 @@ class Text extends Fieldtype
 
     public function preProcessIndex($value)
     {
-        if ($value !== null && $value !== '') {
-            return $this->config('prepend').$value.$this->config('append');
+        if (is_null($value)) {
+            return null;
         }
+
+        return $this->config('prepend').$value.$this->config('append');
     }
 }

--- a/src/Fieldtypes/Text.php
+++ b/src/Fieldtypes/Text.php
@@ -154,7 +154,7 @@ class Text extends Fieldtype
 
     public function preProcessIndex($value)
     {
-        if ($value) {
+        if ($value !== null && $value !== '') {
             return $this->config('prepend').$value.$this->config('append');
         }
     }

--- a/src/Http/Controllers/CP/SlugController.php
+++ b/src/Http/Controllers/CP/SlugController.php
@@ -9,12 +9,10 @@ class SlugController extends CpController
 {
     public function __invoke(Request $request)
     {
-        $slug = Str::slug(...$request->validate([
+        return Str::slug(...$request->validate([
             'string' => ['required'],
             'separator' => ['required'],
             'language' => ['required'],
         ]));
-
-        return response()->json($slug);
     }
 }

--- a/src/Http/Controllers/CP/SlugController.php
+++ b/src/Http/Controllers/CP/SlugController.php
@@ -9,10 +9,12 @@ class SlugController extends CpController
 {
     public function __invoke(Request $request)
     {
-        return Str::slug(...$request->validate([
+        $slug = Str::slug(...$request->validate([
             'string' => ['required'],
             'separator' => ['required'],
             'language' => ['required'],
         ]));
+
+        return response()->json($slug);
     }
 }

--- a/tests/Feature/SlugTest.php
+++ b/tests/Feature/SlugTest.php
@@ -40,6 +40,9 @@ class SlugTest extends TestCase
             'german characters' => ['Björn Müller', '-', 'de', 'bjoern-mueller'],
             'arabic characters' => ['صباح الخير', '-', 'ar', 'sbah-alkhyr'],
             'alternate separator' => ['one two three', '_', 'en', 'one_two_three'],
+            'null string' => ['null', '-', 'en', 'null'],
+            'zero string' => ['0', '-', 'en', '0'],
+            'false string' => ['false', '-', 'en', 'false'],
         ];
     }
 }

--- a/tests/Feature/SlugTest.php
+++ b/tests/Feature/SlugTest.php
@@ -16,16 +16,15 @@ class SlugTest extends TestCase
     #[DataProvider('slugProvider')]
     public function it_generates_a_slug($string, $separator, $language, $expected)
     {
-        $response = $this
+        $this
             ->actingAs(tap(User::make()->makeSuper())->save())
             ->postJson('/cp/slug', [
                 'string' => $string,
                 'separator' => $separator,
                 'language' => $language,
             ])
-            ->assertOk();
-
-        $this->assertEquals($expected, $response->json());
+            ->assertOk()
+            ->assertContent($expected);
     }
 
     public static function slugProvider()

--- a/tests/Feature/SlugTest.php
+++ b/tests/Feature/SlugTest.php
@@ -16,15 +16,16 @@ class SlugTest extends TestCase
     #[DataProvider('slugProvider')]
     public function it_generates_a_slug($string, $separator, $language, $expected)
     {
-        $this
+        $response = $this
             ->actingAs(tap(User::make()->makeSuper())->save())
             ->postJson('/cp/slug', [
                 'string' => $string,
                 'separator' => $separator,
                 'language' => $language,
             ])
-            ->assertOk()
-            ->assertContent($expected);
+            ->assertOk();
+
+        $this->assertEquals($expected, $response->json());
     }
 
     public static function slugProvider()

--- a/tests/Fieldtypes/TextTest.php
+++ b/tests/Fieldtypes/TextTest.php
@@ -33,4 +33,29 @@ class TextTest extends TestCase
             'number' => ['number', [0, 3, 3, 3.14, null]],
         ];
     }
+
+    #[Test]
+    #[DataProvider('preProcessIndexProvider')]
+    public function it_pre_processes_index_values($config, $value, $expected)
+    {
+        $field = (new Text)->setField(new Field('test', array_merge([
+            'type' => 'text',
+        ], $config)));
+
+        $this->assertSame($expected, $field->preProcessIndex($value));
+    }
+
+    public static function preProcessIndexProvider()
+    {
+        return [
+            'string value' => [[], 'hello', 'hello'],
+            'null value' => [[], null, null],
+            'zero integer' => [[], 0, '0'],
+            'zero string' => [[], '0', '0'],
+            'zero with prepend' => [['prepend' => '$'], 0, '$0'],
+            'zero with append' => [['append' => '%'], 0, '0%'],
+            'zero with prepend and append' => [['prepend' => '$', 'append' => '%'], 0, '$0%'],
+            'string with prepend' => [['prepend' => '$'], 'hello', '$hello'],
+        ];
+    }
 }


### PR DESCRIPTION
This PR fixes two related bugs caused by improper falsy value handling.

1. Terms with `0` as title not displaying in listings.
2. Typing `null` clears slug field.

Having a taxonomy with terms like 0, 1, 2, 3,... is not uncommon though. But generally those fixes ensure proper handling of edge case string values that can be misinterpreted as falsy or null values.

Closes https://github.com/statamic/cms/issues/13785.