### PR TITLE
[6.x] Fix Textarea component story missing an end tag

### DIFF
--- a/resources/js/stories/Textarea.stories.ts
+++ b/resources/js/stories/Textarea.stories.ts
@@ -57,7 +57,7 @@ export const _Disabled: Story = {
 };
 
 const elasticCode = `
-<Textarea elastic rows="2" model-value="If you catch a chinchilla in Chile, and cut off its beard willy-nilly, you can honestly say, you made on that day, a Chilean chinchilla's chin chilly.">
+<Textarea elastic rows="2" model-value="If you catch a chinchilla in Chile, and cut off its beard willy-nilly, you can honestly say, you made on that day, a Chilean chinchilla's chin chilly." />
 `;
 
 export const _Elastic: Story = {


### PR DESCRIPTION
Currently doesn't render and gives an error.

<img width="1056" height="534" alt="image" src="https://github.com/user-attachments/assets/263fa201-cadb-464f-8160-cedb83797757" />
