### PR TITLE
[6.x] Fix Textarea component resize

### DIFF
--- a/resources/js/components/ui/Textarea.vue
+++ b/resources/js/components/ui/Textarea.vue
@@ -47,11 +47,17 @@ const classes = cva({
 const textarea = useTemplateRef('textarea');
 
 onMounted(() => {
-    autosize(textarea.value);
-    setTimeout(() => nextTick(() => autosize.update(textarea.value)), 1);
+    if (props.elastic) {
+        autosize(textarea.value);
+        setTimeout(() => nextTick(() => autosize.update(textarea.value)), 1);
+    }
 });
 
-onBeforeUnmount(() => autosize.destroy(textarea.value));
+onBeforeUnmount(() => {
+    if (props.elastic) {
+        autosize.destroy(textarea.value);
+    }
+});
 </script>
 
 <template>

--- a/resources/js/stories/Textarea.stories.ts
+++ b/resources/js/stories/Textarea.stories.ts
@@ -108,9 +108,9 @@ export const _Placeholder: Story = {
 };
 
 const resizeCode = `
+<Textarea resize="horizontal" rows="1" placeholder="Resize horizontal"/>
 <Textarea resize="vertical" rows="1" placeholder="Resize vertical"/>
 <Textarea resize="both" rows="1" placeholder="Resize both"/>
-<Textarea resize="horizontal" rows="1" placeholder="Resize horizontal"/>
 <Textarea resize="none" rows="1" placeholder="Resize none"/>
 `;
 


### PR DESCRIPTION
Currently, `autosize` is being applied to all Textarea components unconditionally preventing actual resize functionality when passed as a prop to the component.

<img width="1002" height="582" alt="Screenshot 2026-02-02 at 15 03 36" src="https://github.com/user-attachments/assets/9ea7a0fb-fc7c-465d-b038-2d7f23ec3de1" />

This adds a conditional check around `autosize` initialization and cleanup to only run when the `elastic` prop is `true`.
