### PR TITLE
[6.x] Ensure sets in imported fields can be overridden

### DIFF
--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -142,10 +142,15 @@ export default {
     },
 
     watch: {
-        tabs(tabs) {
-            this.$emit('updated', tabs);
-            this.makeSortable();
-        },
+		tabs: {
+			deep: true,
+			handler(tabs) {
+				console.log('deep hello', tabs)
+
+				this.$emit('updated', tabs);
+				this.makeSortable();
+			},
+		},
     },
 
     mounted() {

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -128,7 +128,7 @@ export default {
 
     data() {
         return {
-            tabs: this.initialTabs,
+            tabs: clone(this.initialTabs),
             currentTab: this.initialTabs.length ? this.initialTabs[0]._id : null,
             lastInteractedTab: null,
             hiddenTabs: [],

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -145,8 +145,6 @@ export default {
 		tabs: {
 			deep: true,
 			handler(tabs) {
-				console.log('deep hello', tabs)
-
 				this.$emit('updated', tabs);
 				this.makeSortable();
 			},


### PR DESCRIPTION
This pull request fixes an issue where sets in imported Bard/Replicator fields couldn't be overridden due to the publish container's `localizedFields` state not being updated.

There was two things preventing the `localizedFields` state from updating correctly:
- The `tabs` watcher wasn't running when editing sets. It needed to be converted to a deep watcher.
- In `ui/Publish/Field.vue`, it [compares the container's existing value against the updated value](https://github.com/statamic/cms/blob/d1c09ee35a7d30a99d51f2b3581f88ec3c20f49e/resources/js/components/ui/Publish/Field.vue#L95). 
  - This condition was returning `true` because the `Tabs.vue` component was modifying the container value by reference. 
  - I've fixed it by cloning the initial tabs state, preventing the reference error.

Fixes #13770