### PR TITLE
[6.x] Avoid searching server results with fuzzysort

### DIFF
--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -77,6 +77,7 @@ const aggregatedItems = computed(() => [
 const results = computed(() => {
     let items = aggregatedItems.value.map(item => normalizeItem(item));
     let filterableItems = items.filter(item => item.category !== 'Content Search');
+    const highlightClasses = 'text-blue-600 dark:text-blue-400 underline underline-offset-4 decoration-blue-200 dark:decoration-blue-600/45';
 
     let filtered = fuzzysort
         .go(query.value, filterableItems, {
@@ -87,7 +88,7 @@ const results = computed(() => {
         .map(result => {
             return {
                 score: result._score,
-                html: result[0].highlight('<span class="text-blue-600 dark:text-blue-400 underline underline-offset-4 decoration-blue-200 dark:decoration-blue-600/45">', '</span>'),
+                html: result[0].highlight(`<span class="${highlightClasses}">`, '</span>'),
                 ...result.obj,
             };
         });
@@ -99,7 +100,7 @@ const results = computed(() => {
 
 			return {
 				...item,
-				html: result?.highlight('<span class="text-blue-600 dark:text-blue-400 underline underline-offset-4 decoration-blue-200 dark:decoration-blue-600/45">', '</span>') || item.text,
+				html: result?.highlight(`<span class="${highlightClasses}">`, '</span>') || item.text,
 			};
 		});
 

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -76,9 +76,10 @@ const aggregatedItems = computed(() => [
 
 const results = computed(() => {
     let items = aggregatedItems.value.map(item => normalizeItem(item));
+    let filterableItems = items.filter(item => item.category !== 'Content Search');
 
     let filtered = fuzzysort
-        .go(query.value, items, {
+        .go(query.value, filterableItems, {
             all: true,
             keys: ['text'],
             scoreFn: fuzzysortScoringAlgorithm,
@@ -90,6 +91,19 @@ const results = computed(() => {
                 ...result.obj,
             };
         });
+
+	let contentSearchResults = items
+		.filter(item => item.category === 'Content Search')
+		.map(item => {
+			let result = fuzzysort.single(query.value, item.text);
+
+			return {
+				...item,
+				html: result?.highlight('<span class="text-blue-600 dark:text-blue-400 underline underline-offset-4 decoration-blue-200 dark:decoration-blue-600/45">', '</span>') || item.text,
+			};
+		});
+
+    filtered = [...contentSearchResults, ...filtered];
 
     let categoryOrder = query.value
         ? uniq(filtered.map(item => item.category))


### PR DESCRIPTION
This PR aims to fix the issue mentioned in #13768, where content results would only be returned if the query matched the title, and not any of the other "indexed fields".

**Example:** An entry with the title "Kaboom", and an additional indexed field containing "Loud explosion". Searching for "Kaboom" would return the result (as expected), but searching "Loud" wouldn't return the result even though it's part of the server's results.

This pull request attempts to fix it by _not_ passing server results to fuzzysort and prepending them to the results array. We _do_ still pass them through fuzzysort, but only for highlighting purposes.

Another approach would be to include a `keywords` string in the result object, and use that in addition to the item text when searching with fuzzysort.

Fixes #13768