### PR TITLE
[6.x] Clearing a required date field should set the date/time to now

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -119,6 +119,11 @@ export default {
         },
 
         datePickerUpdated(value) {
+	        // Clearing the date on a required Date field should set the date/time to now.
+	        if (!value && !this.isRange && this.config.required) {
+				return this.addDate();
+	        }
+
             if (!value) {
                 return this.update(null);
             }


### PR DESCRIPTION
There's currently no way to reset a required Date field to the current date and time.

You can clear optional Date fields and click "Add Date" which will use the current date/time:

https://github.com/user-attachments/assets/f1190132-49b0-4b28-90c7-80952f41b2ae

However, you can't do the same for required Date fields. It nulls out the values and you have to select the current date manually:

https://github.com/user-attachments/assets/80949646-d1be-4292-9cda-7a873baf2c3c

This pull request makes it so clearing a required Date field sets the date and time to now.

Closes #13756
