### PR TITLE
[6.x] Disable Bard debouncing

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -419,6 +419,9 @@ export default {
 
             if (JSON.stringify(json) === JSON.stringify(oldJson)) return;
 
+            // Temporarily disable debouncing.
+            this.debounceNextUpdate = false;
+
             this.debounceNextUpdate
                 ? this.updateDebounced(json)
                 : this.update(json);


### PR DESCRIPTION
This PR disables Bard debouncing. It seems that debouncing is the cause of a number of issues.

The performance problems that debouncing was initially added to resolve may not be as problematic now that we're on TipTap 3, Vue 3, and have reworked publish forms.

This is temporary - at least in the sense that it doesn't remove all the added debounce code. It just bypasses it.
