### PR TITLE
[6.x] Override `z-index` of DatePicker inside modals

### DIFF
--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -151,3 +151,16 @@ code:not(pre *) {
         background: hsl(from var(--theme-color-ui-accent-bg) h s 10 / 0.5);
     }
 }
+
+/**
+	Override the z-index of Reka's popper content wrapper under certain conditions.
+	We can't use a direct descendant selector because the DatePicker is inside a Portal.
+*/
+body:has(
+	[data-ui-modal-content],
+	.stack,
+	.live-preview,
+	.code-fullscreen
+) [data-reka-popper-content-wrapper] {
+    z-index: var(--z-index-portal)!important;
+}

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -555,18 +555,6 @@ defineExpose({
 </template>
 
 <style scoped>
-    /* Override the hardcoded z-index of Reka's popper content wrapper under certain conditions. We can't use a direct descendant selector because the combobox is inside a portal, so instead we'll check to see if certain conditions are present. */
-    body:has(
-        /* A modal is present */
-        [data-ui-modal-content],
-        /* Fullscreen Code Editor fieldtype */
-        .code-fullscreen,
-        .stack,
-        .live-preview
-    ) [data-reka-popper-content-wrapper] {
-        z-index: var(--z-index-portal)!important;
-    }
-
     @supports(text-box: ex alphabetic) {
         [data-ui-badge] {
             padding-block: 0.65rem;

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -218,3 +218,16 @@ const getInputLabel = (part) => {
         </DatePickerRoot>
     </div>
 </template>
+
+<style>
+/**
+	Override the z-index of Reka's popper content wrapper under certain conditions.
+	We can't use a direct descendant selector because the DatePicker is inside a Portal.
+*/
+body:has(
+	[data-ui-modal-content],
+	.stack
+) [data-reka-popper-content-wrapper] {
+	z-index: var(--z-index-portal)!important;
+}
+</style>

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -218,16 +218,3 @@ const getInputLabel = (part) => {
         </DatePickerRoot>
     </div>
 </template>
-
-<style>
-/**
-	Override the z-index of Reka's popper content wrapper under certain conditions.
-	We can't use a direct descendant selector because the DatePicker is inside a Portal.
-*/
-body:has(
-	[data-ui-modal-content],
-	.stack
-) [data-reka-popper-content-wrapper] {
-	z-index: var(--z-index-portal)!important;
-}
-</style>


### PR DESCRIPTION
This pull request aims to fix an issue where the `DatePicker` would be rendered underneath modals, instead of on top of them.

We already override the `z-index` of the popout in the `Combobox`, and there's no point in copying the same fix across multiple components so I've moved it into the `base.css` file (hopefully that's the right place).

Essentially, whenever a modal/stack/live preview/fullscreen code is open, we want to "up" the `z-index` of Reka's popper content wrapper.

Fixes #13773
