### PR TITLE
[6.x] Update `itemActions` state when switching localization

### DIFF
--- a/resources/js/components/actions/ItemActions.vue
+++ b/resources/js/components/actions/ItemActions.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, useTemplateRef } from 'vue';
+import { ref, computed, useTemplateRef, watch } from 'vue';
 import useActions from './Actions.js';
 import ConfirmableAction from './ConfirmableAction.vue';
 import axios from 'axios';
@@ -19,6 +19,12 @@ const { prepareActions, runServerAction } = useActions();
 const confirmableActions = useTemplateRef('confirmableActions');
 const actions = ref(props.actions);
 const actionsLoaded = ref(props.actions !== undefined);
+
+watch(
+	() => props.actions,
+	() => actions.value = props.actions,
+	{ deep: true }
+);
 
 let preparedActions = computed(() => {
     return prepareActions(actions.value, confirmableActions.value);

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -682,6 +682,7 @@ export default {
                 this.collection = data.collection;
                 this.title = data.editing ? data.values.title : this.title;
                 this.actions = data.actions;
+				this.itemActions = data.itemActions;
                 this.fieldset = data.blueprint;
                 this.permalink = data.permalink;
                 this.site = localization.handle;


### PR DESCRIPTION
This pull request ensures that the `itemActions` state on the entry publish form is updated when switching localizations, fixing an issue where the deletion behaviour field was missing when switching from a localization to the origin.

This PR also adds a watcher to the `ItemActions` component, ensuring its internal `actions` state is updated when the prop changes.

Fixes #13778
