### PR TITLE
[6.x] Avoid animation when loading Bard field with `collapse: true`

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -391,10 +391,7 @@ export default {
         this.json = this.editor.getJSON().content;
         this.html = this.editor.getHTML();
 
-        this.$nextTick(() => {
-            this.mounted = true;
-            if (this.config.collapse) this.collapseAll();
-        });
+		this.$nextTick(() => this.mounted = true);
 
         this.pageHeader = document.querySelector('.global-header');
 

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -351,10 +351,6 @@ export default {
         },
     },
 
-    mounted() {
-        if (this.config.collapse) this.collapseAll();
-    },
-
     watch: {
         focused(focused, oldFocused) {
             if (focused === oldFocused) return;

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -637,7 +637,7 @@ class Bard extends Replicator
 
         $data = [
             'existing' => $existing,
-            'collapsed' => [],
+            'collapsed' => $this->config('collapse') ? array_keys($existing) : [],
             'previews' => $previews,
             '__collaboration' => ['existing'],
             'linkCollections' => $linkCollections,

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -230,7 +230,7 @@ class Replicator extends Fieldtype
 
         return [
             'existing' => $existing,
-            'collapsed' => [],
+            'collapsed' => $this->config('collapse') ? array_keys($existing) : [],
         ];
     }
 


### PR DESCRIPTION
This PR fixes an issue with Bard/Replicator fields and `collapse: true`. Sets would appear to be open by default, but close shortly after when the JS kicks in.

This pull request fixes it by sending the initial collapsed state down from the server rather than handling it in JS.[B

Fixes #13744
