### PR TITLE
[6.x] Fix login and passkeys

### DIFF
--- a/resources/js/composables/passkey.js
+++ b/resources/js/composables/passkey.js
@@ -1,5 +1,5 @@
 import { ref } from 'vue';
-import { startAuthentication, browserSupportsWebAuthn } from '@simplewebauthn/browser';
+import { startAuthentication, browserSupportsWebAuthn, WebAuthnAbortService } from '@simplewebauthn/browser';
 import axios from 'axios';
 
 export function usePasskey() {
@@ -19,6 +19,7 @@ export function usePasskey() {
             try {
                 startAuthResponse = await startAuthentication({ optionsJSON, useBrowserAutofill });
             } catch (e) {
+                if (e.name === 'AbortError') return;
                 console.error(e);
                 error.value = __('Authentication failed.');
                 if (!useBrowserAutofill) waiting.value = false;
@@ -37,6 +38,10 @@ export function usePasskey() {
         }
     }
 
+    function cancel() {
+        WebAuthnAbortService.cancelCeremony();
+    }
+
     function handleError(e) {
         if (e.response) {
             const { message } = e.response.data;
@@ -52,5 +57,6 @@ export function usePasskey() {
         waiting,
         supported,
         authenticate,
+        cancel,
     };
 }

--- a/resources/js/composables/passkey.js
+++ b/resources/js/composables/passkey.js
@@ -19,7 +19,7 @@ export function usePasskey() {
             try {
                 startAuthResponse = await startAuthentication({ optionsJSON, useBrowserAutofill });
             } catch (e) {
-                if (e.name === 'AbortError') return;
+                if (e.name === 'AbortError' || e.name === 'NotAllowedError') return;
                 console.error(e);
                 error.value = __('Authentication failed.');
                 if (!useBrowserAutofill) waiting.value = false;

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -3,7 +3,7 @@ import Head from '@/pages/layout/Head.vue';
 import Outside from '@/pages/layout/Outside.vue';
 import { AuthCard, Input, Field, Button, Separator, Checkbox, ErrorMessage } from '@ui';
 import { Link, router } from '@inertiajs/vue3';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
 import { usePasskey } from '@/composables/passkey';
 
 defineOptions({ layout: Outside });
@@ -86,6 +86,8 @@ async function loginWithPasskey(useBrowserAutofill = false) {
 onMounted(() => {
     if (showPasskeyLogin.value) loginWithPasskey(true);
 });
+
+onUnmounted(() => passkey.cancel());
 </script>
 
 <template>
@@ -133,7 +135,7 @@ onMounted(() => {
                             :icon="passkey.waiting.value ? null : 'key'"
                             :disabled="passkey.waiting.value"
                             :loading="passkey.waiting.value"
-                            @click="loginWithPasskey"
+                            @click="loginWithPasskey()"
                         />
                         <ErrorMessage v-if="passkey.error.value" :text="passkey.error.value" />
                     </template>


### PR DESCRIPTION
- Both AbortError and NotAllowedError are expected states and should not result in "Authentication failed" being shown.
	- AbortError happens when the ceremony is cancelled (e.g. navigating away or starting a new authentication)       
	- NotAllowedError is when the user dismisses the popup
- Fixed the Passkey button click handler passing a MouseEvent as the useBrowserAutofill parameter, which caused it 
to use the wrong authentication mode
- Cancel any pending WebAuthn ceremony when the login page unmounts (e.g. you navigate away)
	- This was not strictly necessary as it would get aborted on return, which we now silently ignore, but its better to cancel when it's supposed to.

Fixes #13753
