### PR TITLE
[6.x] Store passkey last login in metadata

### DIFF
--- a/src/Auth/File/Passkey.php
+++ b/src/Auth/File/Passkey.php
@@ -3,6 +3,7 @@
 namespace Statamic\Auth\File;
 
 use Carbon\Carbon;
+use Illuminate\Support\Collection;
 use Statamic\Auth\WebAuthn\Passkey as BasePasskey;
 use Statamic\Auth\WebAuthn\Serializer;
 
@@ -29,11 +30,7 @@ class Passkey extends BasePasskey
 
         $user->setPasskeys($passkeys);
 
-        $passkeys->each(function ($passkey) use ($user) {
-            if ($lastLogin = $passkey->lastLogin()) {
-                $user->setMeta('passkey_'.$passkey->id().'_last_login', $lastLogin);
-            }
-        });
+        $this->setLastLogins($user, $passkeys);
 
         $user->save();
 
@@ -51,9 +48,21 @@ class Passkey extends BasePasskey
     public function lastLogin(): ?Carbon
     {
         if (! parent::lastLogin()) {
-            $this->setLastLogin($this->user()->getMeta('passkey_'.$this->id().'_last_login'));
+            $this->setLastLogin(
+                $this->user()->getMeta('passkey_last_logins', [])[$this->id()] ?? null
+            );
         }
 
         return parent::lastLogin();
+    }
+
+    private function setLastLogins(User $user, Collection $passkeys): void
+    {
+        $timestamps = $passkeys
+            ->mapWithKeys(fn (Passkey $passkey) => [$passkey->id() => $passkey->lastLogin()?->timestamp])
+            ->filter()
+            ->all();
+
+        $user->setMeta('passkey_last_logins', $timestamps);
     }
 }

--- a/src/Auth/File/Passkey.php
+++ b/src/Auth/File/Passkey.php
@@ -14,7 +14,11 @@ class Passkey extends BasePasskey
         /** @var User $user */
         $user = $this->user();
 
-        $user->setPasskeys($user->passkeys()->except($this->id()));
+        $remaining = $user->passkeys()->except($this->id());
+
+        $user->setPasskeys($remaining);
+
+        $this->setLastLogins($user, $remaining);
 
         $user->save();
 

--- a/src/Auth/File/Passkey.php
+++ b/src/Auth/File/Passkey.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Auth\File;
 
+use Carbon\Carbon;
 use Statamic\Auth\WebAuthn\Passkey as BasePasskey;
 use Statamic\Auth\WebAuthn\Serializer;
 
@@ -28,6 +29,12 @@ class Passkey extends BasePasskey
 
         $user->setPasskeys($passkeys);
 
+        $passkeys->each(function ($passkey) use ($user) {
+            if ($lastLogin = $passkey->lastLogin()) {
+                $user->setMeta('passkey_'.$passkey->id().'_last_login', $lastLogin);
+            }
+        });
+
         $user->save();
 
         return true;
@@ -37,8 +44,16 @@ class Passkey extends BasePasskey
     {
         return [
             'name' => $this->name(),
-            'last_login' => $this->lastLogin()?->timestamp ?? null,
             'credential' => app(Serializer::class)->normalize($this->credential()),
         ];
+    }
+
+    public function lastLogin(): ?Carbon
+    {
+        if (! parent::lastLogin()) {
+            $this->setLastLogin($this->user()->getMeta('passkey_'.$this->id().'_last_login'));
+        }
+
+        return parent::lastLogin();
     }
 }

--- a/src/Stache/Stores/UsersStore.php
+++ b/src/Stache/Stores/UsersStore.php
@@ -59,7 +59,6 @@ class UsersStore extends BasicStore
                 return app(Passkey::class)
                     ->setUser($user)
                     ->setName($keydata['name'])
-                    ->setLastLogin($keydata['last_login'])
                     ->setCredential($keydata['credential']);
             }));
 

--- a/tests/Auth/WebAuthn/EloquentPasskeyTest.php
+++ b/tests/Auth/WebAuthn/EloquentPasskeyTest.php
@@ -19,7 +19,7 @@ use Webauthn\TrustPath\EmptyTrustPath;
 #[Group('passkeys')]
 class EloquentPasskeyTest extends TestCase
 {
-    use RefreshDatabase;
+    use PasskeyTests, RefreshDatabase;
 
     public static $migrationsGenerated = false;
 
@@ -66,7 +66,12 @@ class EloquentPasskeyTest extends TestCase
         parent::tearDownAfterClass();
     }
 
-    private function createTestCredential(string $id = 'test-credential-id-123'): PublicKeyCredentialSource
+    protected function newPasskey(): \Statamic\Contracts\Auth\Passkey
+    {
+        return new Passkey;
+    }
+
+    protected function createTestCredential(string $id = 'test-credential-id-123'): PublicKeyCredentialSource
     {
         return PublicKeyCredentialSource::create(
             publicKeyCredentialId: $id,

--- a/tests/Auth/WebAuthn/FilePasskeyTest.php
+++ b/tests/Auth/WebAuthn/FilePasskeyTest.php
@@ -16,9 +16,14 @@ use Webauthn\TrustPath\EmptyTrustPath;
 #[Group('passkeys')]
 class FilePasskeyTest extends TestCase
 {
-    use PreventSavingStacheItemsToDisk;
+    use PasskeyTests, PreventSavingStacheItemsToDisk;
 
-    private function createTestCredential(string $id = 'test-credential-id-123'): PublicKeyCredentialSource
+    protected function newPasskey(): \Statamic\Contracts\Auth\Passkey
+    {
+        return new Passkey;
+    }
+
+    protected function createTestCredential(string $id = 'test-credential-id-123'): PublicKeyCredentialSource
     {
         return PublicKeyCredentialSource::create(
             publicKeyCredentialId: $id,

--- a/tests/Auth/WebAuthn/FilePasskeyTest.php
+++ b/tests/Auth/WebAuthn/FilePasskeyTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Auth\File\Passkey;
+use Statamic\Facades\File;
 use Statamic\Facades\User;
 use Symfony\Component\Uid\Uuid;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -17,6 +18,13 @@ use Webauthn\TrustPath\EmptyTrustPath;
 class FilePasskeyTest extends TestCase
 {
     use PasskeyTests, PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        File::delete(storage_path('statamic/users'));
+    }
 
     protected function newPasskey(): \Statamic\Contracts\Auth\Passkey
     {
@@ -59,6 +67,25 @@ class FilePasskeyTest extends TestCase
         $freshUser = User::find('test-user');
         $this->assertCount(1, $freshUser->passkeys());
         $this->assertEquals('My Passkey', $freshUser->passkeys()->first()->name());
+        $this->assertEquals([], $user->getMeta('passkey_last_logins'));
+    }
+
+    #[Test]
+    public function it_reads_last_login_from_meta()
+    {
+        $user = User::make()->id('test-user')->email('test@example.com');
+        $user->save();
+
+        $passkey = (new Passkey)
+            ->setName('My Passkey')
+            ->setUser($user)
+            ->setCredential($this->createTestCredential());
+        $passkey->save();
+
+        $lastLogin = Carbon::create(2024, 1, 15, 10, 30, 0);
+        $user->setMeta('passkey_last_logins', [$passkey->id() => $lastLogin->timestamp]);
+
+        $this->assertTrue($passkey->lastLogin()->eq($lastLogin));
     }
 
     #[Test]
@@ -78,7 +105,7 @@ class FilePasskeyTest extends TestCase
 
         // Update the passkey
         $passkey->setName('Updated Passkey Name');
-        $passkey->setLastLogin(Carbon::create(2024, 1, 15, 10, 30, 0));
+        $passkey->setLastLogin($lastLogin = Carbon::create(2024, 1, 15, 10, 30, 0));
         $result = $passkey->save();
 
         $this->assertTrue($result);
@@ -88,6 +115,7 @@ class FilePasskeyTest extends TestCase
         $this->assertCount(1, $freshUser->passkeys());
         $this->assertEquals('Updated Passkey Name', $freshUser->passkeys()->first()->name());
         $this->assertNotNull($freshUser->passkeys()->first()->lastLogin());
+        $this->assertEquals([$passkey->id() => $lastLogin->timestamp], $user->getMeta('passkey_last_logins'));
     }
 
     #[Test]
@@ -117,6 +145,7 @@ class FilePasskeyTest extends TestCase
         $names = $freshUser->passkeys()->map->name()->values();
         $this->assertTrue($names->contains('Passkey 1'));
         $this->assertTrue($names->contains('Passkey 2'));
+        $this->assertEquals([], $user->getMeta('passkey_last_logins'));
     }
 
     #[Test]
@@ -144,6 +173,7 @@ class FilePasskeyTest extends TestCase
         // Verify passkey was removed
         $freshUser = User::find('test-user');
         $this->assertCount(0, $freshUser->passkeys());
+        $this->assertEquals([], $user->getMeta('passkey_last_logins'));
     }
 
     #[Test]
@@ -154,17 +184,20 @@ class FilePasskeyTest extends TestCase
 
         $credential1 = $this->createTestCredential('credential-1');
         $credential2 = $this->createTestCredential('credential-2');
+        $lastLogin = Carbon::create(2024, 1, 15, 10, 30, 0);
 
         $passkey1 = (new Passkey)
             ->setName('Passkey 1')
             ->setUser($user)
-            ->setCredential($credential1);
+            ->setCredential($credential1)
+            ->setLastLogin($lastLogin->timestamp);
         $passkey1->save();
 
         $passkey2 = (new Passkey)
             ->setName('Passkey 2')
             ->setUser($user)
-            ->setCredential($credential2);
+            ->setCredential($credential2)
+            ->setLastLogin($lastLogin->timestamp);
         $passkey2->save();
 
         // Delete only the first passkey
@@ -173,6 +206,7 @@ class FilePasskeyTest extends TestCase
         $freshUser = User::find('test-user');
         $this->assertCount(1, $freshUser->passkeys());
         $this->assertEquals('Passkey 2', $freshUser->passkeys()->first()->name());
+        $this->assertEquals([$passkey2->id() => $lastLogin->timestamp], $user->getMeta('passkey_last_logins'));
     }
 
     #[Test]
@@ -180,6 +214,7 @@ class FilePasskeyTest extends TestCase
     {
         $user = User::make()->id('test-user')->email('test@example.com');
         $user->save();
+        $this->assertNull($user->getMeta('passkey_last_logins'));
 
         $credential = $this->createTestCredential();
         $lastLogin = Carbon::create(2024, 1, 15, 10, 30, 0);
@@ -198,5 +233,6 @@ class FilePasskeyTest extends TestCase
         $this->assertEquals('test-credential-id-123', $savedPasskey->credential()->publicKeyCredentialId);
         $this->assertEquals('2024-01-15 10:30:00', $savedPasskey->lastLogin()->format('Y-m-d H:i:s'));
         $this->assertEquals('test-user', $savedPasskey->user()->id());
+        $this->assertEquals([$savedPasskey->id() => $lastLogin->timestamp], $user->getMeta('passkey_last_logins'));
     }
 }

--- a/tests/Auth/WebAuthn/PasskeyTest.php
+++ b/tests/Auth/WebAuthn/PasskeyTest.php
@@ -97,54 +97,6 @@ class PasskeyTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_last_login()
-    {
-        $user = User::make()->id('test-user')->email('test@example.com');
-        $credential = $this->createTestCredential();
-        $lastLogin = Carbon::create(2024, 1, 15, 10, 30, 0);
-
-        $passkey = (new Passkey)
-            ->setName('My Passkey')
-            ->setUser($user)
-            ->setCredential($credential)
-            ->setLastLogin($lastLogin);
-
-        $this->assertInstanceOf(Carbon::class, $passkey->lastLogin());
-        $this->assertEquals('2024-01-15 10:30:00', $passkey->lastLogin()->format('Y-m-d H:i:s'));
-    }
-
-    #[Test]
-    public function it_handles_null_last_login()
-    {
-        $user = User::make()->id('test-user')->email('test@example.com');
-        $credential = $this->createTestCredential();
-
-        $passkey = (new Passkey)
-            ->setName('My Passkey')
-            ->setUser($user)
-            ->setCredential($credential);
-
-        $this->assertNull($passkey->lastLogin());
-    }
-
-    #[Test]
-    public function it_sets_last_login_from_timestamp()
-    {
-        $user = User::make()->id('test-user')->email('test@example.com');
-        $credential = $this->createTestCredential();
-        $timestamp = 1705315800; // 2024-01-15 10:30:00 UTC
-
-        $passkey = (new Passkey)
-            ->setName('My Passkey')
-            ->setUser($user)
-            ->setCredential($credential)
-            ->setLastLogin($timestamp);
-
-        $this->assertInstanceOf(Carbon::class, $passkey->lastLogin());
-        $this->assertEquals($timestamp, $passkey->lastLogin()->timestamp);
-    }
-
-    #[Test]
     public function it_serializes()
     {
         $user = User::make()->id('test-user')->email('test@example.com');

--- a/tests/Auth/WebAuthn/PasskeyTests.php
+++ b/tests/Auth/WebAuthn/PasskeyTests.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Auth\WebAuthn;
+
+use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Auth\Passkey;
+use Statamic\Facades\User;
+use Webauthn\PublicKeyCredentialSource;
+
+trait PasskeyTests
+{
+    abstract protected function newPasskey(): Passkey;
+
+    abstract protected function createTestCredential(string $id = 'test-credential-id-123'): PublicKeyCredentialSource;
+
+    #[Test]
+    public function it_gets_last_login()
+    {
+        $user = tap(User::make()->email('test@example.com')->data(['name' => 'John Smith']))->save();
+        $credential = $this->createTestCredential();
+        $lastLogin = Carbon::create(2024, 1, 15, 10, 30, 0);
+
+        $passkey = $this->newPasskey()
+            ->setName('My Passkey')
+            ->setUser($user)
+            ->setCredential($credential)
+            ->setLastLogin($lastLogin);
+
+        $this->assertInstanceOf(Carbon::class, $passkey->lastLogin());
+        $this->assertEquals('2024-01-15 10:30:00', $passkey->lastLogin()->format('Y-m-d H:i:s'));
+    }
+
+    #[Test]
+    public function it_handles_null_last_login()
+    {
+        $user = tap(User::make()->email('test@example.com')->data(['name' => 'John Smith']))->save();
+        $credential = $this->createTestCredential();
+
+        $passkey = $this->newPasskey()
+            ->setName('My Passkey')
+            ->setUser($user)
+            ->setCredential($credential);
+
+        $this->assertNull($passkey->lastLogin());
+    }
+
+    #[Test]
+    public function it_sets_last_login_from_timestamp()
+    {
+        $user = tap(User::make()->email('test@example.com')->data(['name' => 'John Smith']))->save();
+        $credential = $this->createTestCredential();
+        $timestamp = 1705315800; // 2024-01-15 10:30:00 UTC
+
+        $passkey = $this->newPasskey()
+            ->setName('My Passkey')
+            ->setUser($user)
+            ->setCredential($credential)
+            ->setLastLogin($timestamp);
+
+        $this->assertInstanceOf(Carbon::class, $passkey->lastLogin());
+        $this->assertEquals($timestamp, $passkey->lastLogin()->timestamp);
+    }
+}


### PR DESCRIPTION
This PR moves the passkeys' last login timestamps into the meta file, rather than in the user file itself. This will prevent every login from updating the user causing git changes. This is the same place we store the last login timestamp for the users in general already.

This doesn't affect db users.

Fixes statamic/ideas#1403
