### PR TITLE
[6.x] Fix markdown fieldtype error when theres no container

### DIFF
--- a/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
+++ b/resources/js/components/fieldtypes/markdown/MarkdownFieldtype.vue
@@ -17,7 +17,7 @@
                 <uploader
                     ref="uploader"
                     :enabled="assetsEnabled"
-                    :container="container.id"
+                    :container="container?.id"
                     :path="folder"
                     @updated="uploadsUpdated"
                     @upload-complete="uploadComplete"


### PR DESCRIPTION
This prevents an error when the markdown field doesn't have a `container` defined. From #13782
