### PR TITLE
[6.x] Add Statamic.configuring callback

### DIFF
--- a/resources/js/bootstrap/statamic.js
+++ b/resources/js/bootstrap/statamic.js
@@ -47,11 +47,16 @@ import {
 } from '@api';
 
 let bootingCallbacks = [];
+let configuringCallbacks = [];
 let bootedCallbacks = [];
 
 export default {
     booting(callback) {
         bootingCallbacks.push(callback);
+    },
+
+    configuring(callback) {
+        configuringCallbacks.push(callback);
     },
 
     booted(callback) {
@@ -313,6 +318,9 @@ export default {
 
         axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
         axios.defaults.headers.common['X-CSRF-TOKEN'] = Statamic.$config.get('csrfToken');
+
+        configuringCallbacks.forEach((callback) => callback(this));
+        configuringCallbacks = [];
 
         return this.$app;
     },


### PR DESCRIPTION
An additional callback is needed to configure the Vue app before it's mounted, adding globalProperties and plugins, since this cannot be done after the app is mounted.
