### PR TITLE
[6.x] Fix error when publishing webauthn migration

### DIFF
--- a/src/UpdateScripts/PublishMigrationForWebauthnTable.php
+++ b/src/UpdateScripts/PublishMigrationForWebauthnTable.php
@@ -23,7 +23,7 @@ class PublishMigrationForWebauthnTable extends UpdateScript
 
             $contents = str_replace('WEBAUTHN_TABLE', config('statamic.users.tables.webauthn', 'webauthn'), $contents);
 
-            File::put(database_path("migrations/$filename"), File::get($contents));
+            File::put(database_path("migrations/$filename"), $contents);
 
             $this->console->line(sprintf(
                 'Migration <info>database/migrations/%s</info> created successfully.',


### PR DESCRIPTION
This pull request fixes an error when the update script attempts to publish the `webauthn` migration:

```
Running update script [Statamic\UpdateScripts\PublishMigrationForWebauthnTable]

   Illuminate\Contracts\Filesystem\FileNotFoundException

  File does not exist at path <?php

use Illuminate\Support\Facades\Schema;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Database\Migrations\Migration;

class StatamicWebauthnTable extends Migration
{
```

Caused by #13769 (sorry! 😬)