### PR TITLE
[6.x] Cannot read properties of null (reading 'classList') & TypeErro…

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -20,7 +20,7 @@ import { Motion } from 'motion-v';
 
 const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField } = injectContainerContext();
 const tab = injectTabContext();
-const sections = tab.sections;
+const sections = Array.isArray(tab.sections) ? tab.sections : [];
 const visibleSections = computed(() => {
     return sections.filter((section) => {
         return section.fields.some((field) => {

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -22,7 +22,8 @@ const mainTabs = computed(() =>
 );
 const visibleMainTabs = computed(() => {
     return mainTabs.value.filter((tab) => {
-        return tab.sections.some((section) => {
+        const sections = Array.isArray(tab.sections) ? tab.sections : [];
+        return sections.some((section) => {
             return section.fields.some((field) => {
                 return new ShowField(
                     visibleValues.value,
@@ -39,7 +40,7 @@ const visibleMainTabs = computed(() => {
 });
 const hasMultipleVisibleMainTabs = computed(() => visibleMainTabs.value.length > 1);
 const shouldShowSidebar = computed(() => (slots.actions || sidebarTab.value) && width.value > 920);
-const activeTab = ref(visibleMainTabs.value[0].handle);
+const activeTab = ref(visibleMainTabs.value[0]?.handle);
 
 onMounted(() => setActiveTabFromHash());
 
@@ -47,7 +48,7 @@ function setActive(tab) {
     if (visibleMainTabs.value.some((t) => t.handle === tab)) {
         activeTab.value = tab;
     } else {
-        activeTab.value = visibleMainTabs.value[0].handle;
+        activeTab.value = visibleMainTabs.value[0]?.handle;
     }
 }
 
@@ -63,7 +64,7 @@ watch(
 	() => shouldShowSidebar.value,
 	() => {
 		if (shouldShowSidebar.value && activeTab.value === 'sidebar') {
-			setActive(visibleMainTabs.value[0].handle);
+			setActive(visibleMainTabs.value[0]?.handle);
 		}
 	}
 );
@@ -79,7 +80,8 @@ const fieldTabMap = computed(() => {
     let map = {};
 
     Object.values(tabs.value).forEach((tab) => {
-        tab.sections.forEach((section) => {
+        const sections = Array.isArray(tab.sections) ? tab.sections : [];
+        sections.forEach((section) => {
             section.fields.forEach((field) => {
                 map[field.handle] = tab.handle;
             });


### PR DESCRIPTION
Hello and thanks for making Statamic 6. I've got two errors after updating to 6.2.2 from 6.1.x.
On the `cp/collections/pages/entries/page-1094_en` site I got these two javascript errors
```javascript
index-Bwt0BGYS.js:132568 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'classList')
    at watch$1.immediate (index-Bwt0BGYS.js:132568:14)
    at callWithErrorHandling (index-Bwt0BGYS.js:2270:19)
    at callWithAsyncErrorHandling (index-Bwt0BGYS.js:2277:17)
    at baseWatchOptions.call (index-Bwt0BGYS.js:8303:48)
    at job (index-Bwt0BGYS.js:1998:18)
    at watch$2 (index-Bwt0BGYS.js:2033:7)
    at doWatch (index-Bwt0BGYS.js:8331:23)
    at watch$1 (index-Bwt0BGYS.js:8264:10)
    at index-Bwt0BGYS.js:132566:9
```

```javascript
index-Bwt0BGYS.js:110832 Uncaught (in promise) TypeError: tab.sections.some is not a function
    at index-Bwt0BGYS.js:110832:29
    at wrappedFn (index-Bwt0BGYS.js:1101:19)
    at Array.filter (<anonymous>)
    at apply$1 (index-Bwt0BGYS.js:1109:27)
    at Proxy.filter (index-Bwt0BGYS.js:1001:12)
    at ComputedRefImpl.fn (index-Bwt0BGYS.js:110831:29)
    at refreshComputed (index-Bwt0BGYS.js:648:29)
    at get value (index-Bwt0BGYS.js:1833:5)
    at setup (index-Bwt0BGYS.js:110849:45)
    at callWithErrorHandling (index-Bwt0BGYS.js:2270:19)
```

I tried it once with cp:dev as well as in production mode and the cp data from the vendor. I am currently using Statamic version 6.2.2 PRO. 

Before:
<img width="1047" height="420" alt="image" src="https://github.com/user-attachments/assets/50da304d-3559-4701-98de-bae59376931e" />

After:
<img width="911" height="422" alt="image" src="https://github.com/user-attachments/assets/8e9712a0-884a-42cb-a985-7376f69bf79b" />

Since this is my first PR in a large project, please let me know if there is anything else I need to provide. Thank you for reading.