### PR TITLE
[6.x] Localize time picker

### DIFF
--- a/resources/js/components/ui/TimePicker/TimePicker.vue
+++ b/resources/js/components/ui/TimePicker/TimePicker.vue
@@ -33,6 +33,7 @@ const setToNow = () => {
         :model-value="modelValue"
         @update:model-value="emit('update:modelValue', $event)"
         v-slot="{ segments }"
+        :locale="$date.locale"
         :granularity="granularity"
         :class="[
             'flex items-center w-full bg-white dark:bg-gray-900',


### PR DESCRIPTION
The TimePicker component (which powers the time fieldtype) was missing the locale so it always showed using US formatting.

This PR passes the browser's locale the same way date fields do.

Fixes #13819
