### PR TITLE
[6.x] Starter kit install with dev stability

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -246,14 +246,21 @@ final class Installer
     {
         spin(
             function () {
-                $package = $this->branch
-                    ? "{$this->package}:{$this->branch}"
+                $version = $this->branch;
+
+                // Allow dev stability when installing from VCS repo without tagged releases
+                if (! $version && $this->url) {
+                    $version = '@dev';
+                }
+
+                $package = $version
+                    ? "{$this->package}:{$version}"
                     : $this->package;
 
                 try {
                     Composer::withoutQueue()->throwOnFailure()->require($package);
                 } catch (ProcessException $exception) {
-                    $this->rollbackWithError("Error installing starter kit [{$package}].", $exception->getMessage());
+                    $this->rollbackWithError("Error installing starter kit [{$this->package}].", $exception->getMessage());
                 }
             },
             "Preparing starter kit [{$this->package}]..."


### PR DESCRIPTION
`statamic/statamic` recently changed its `minimum-stability` from `dev` to `stable`. This is generally a good thing so you don't end up unintentionally installing dev/alpha/beta/etc versions.

However this pointed out that starter kits without any tags cannot be installed now as they don't meet the minimum stability.
We don't want to require that starter kits need to deal with tags.

This PR ensures that the starter kit is required with a `@dev` flag so it bypasses the minimum stability.