### PR TITLE
[6.x] Fix entry date shifting on save

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -953,7 +953,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         ]);
 
         if ($this->hasDate()) {
-            $date = $this->date()->setTimezone(Statamic::displayTimezone());
+            $date = $this->date()->copy()->setTimezone(Statamic::displayTimezone());
 
             $data = $data->merge([
                 'date' => $date,


### PR DESCRIPTION
If you have `display_timezone` defined, whenever you saved a dated entry, the date would move through time.



![doc-brown-from-back-to-the-future-is-looking-up-at-the-sky](https://github.com/user-attachments/assets/b62f3dfc-e415-4ad0-9bfb-5dfcc3f74288)


This was due to a `->setTimezone(display timezone)` being called on the date instance, which would modify the original instance unintentionally. This PR makes sure to modify a copy of the date instead.

Fixes #13835