### PR TITLE
[6.x] Update docblock comment for `system.date_format` option

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -85,8 +85,8 @@ return [
     | Date Format
     |--------------------------------------------------------------------------
     |
-    | Whenever a Carbon date is cast to a string on front-end routes, it will
-    | use this format. On CP routes, the format defined in cp.php is used.
+    | This format will be used whenever a Carbon date is cast to a string on
+    | front-end routes. It doesn't affect how dates are formatted in the CP.
     | You can customize this format using PHP's date string constants.
     | Setting this value to null will use Carbon's default format.
     |


### PR DESCRIPTION
This pull request updates the docblock comment for the `system.date_format` config option, now that the `date_format` option in `cp.php` has been removed.

Closes #13836
