### PR TITLE
[6.x] Handle trailing slashes in CP Nav

### DIFF
--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -409,7 +409,7 @@ class NavItem
             }
         }
 
-        return request()->url() === URL::removeQueryAndFragment($this->url);
+        return URL::tidy(request()->url()) === URL::removeQueryAndFragment($this->url);
     }
 
     /**
@@ -438,7 +438,7 @@ class NavItem
         if ($childrenUrls = NavBuilder::getUnresolvedChildrenUrlsForItem($this)) {
             return collect($childrenUrls)
                 ->map(fn ($url) => URL::removeQueryAndFragment($url))
-                ->contains(request()->url());
+                ->contains(URL::tidy(request()->url()));
         }
 
         return false;
@@ -451,7 +451,7 @@ class NavItem
      */
     protected function currentUrlIsNotExplicitlyReferencedInNav()
     {
-        return ! NavBuilder::getAllUrls()->contains(request()->url());
+        return ! NavBuilder::getAllUrls()->contains(URL::tidy(request()->url()));
     }
 
     /**


### PR DESCRIPTION
This pull request fixes an issue where breadcrumbs and the active nav item was missing in the CP when trailing slashes are being enforced.

This was happening because `request()->url()` strips off the trailing slash, but the value we're comparing it against includes the trailing slash.

I had to spin up a site on Laravel Forge to reproduce the issue.

Fixes #13842