### PR TITLE
[6.x] Stack config publish fields on mobile

### DIFF
--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -51,7 +51,7 @@ const rootClasses = computed(() =>
                 true: 'opacity-50',
             },
             inline: {
-                true: 'grid grid-cols-2 items-start px-4.5 py-4 gap-x-5!',
+                true: 'grid md:grid-cols-2 items-start px-4.5 py-4 gap-y-3 md:gap-y-0 md:gap-x-5!',
             },
             fullWidthSetting: {
                 true: 'grid-cols-1',


### PR DESCRIPTION
While working on #13843, I noticed that config publish fields are split 50/50 like they are on desktop. It doesn't give you much room for typing, or selecting so I thought it might be better if they were stacked (like they were in v5).

## Before

<img width="418" height="634" alt="CleanShot 2026-02-06 at 17 56 59" src="https://github.com/user-attachments/assets/af962fa4-79c3-4002-98fd-30a333304c12" />


## After

<img width="414" height="765" alt="CleanShot 2026-02-06 at 17 56 41" src="https://github.com/user-attachments/assets/6f113e9e-229a-4ca9-9250-f3a873076a9a" />
