### PR TITLE
[6.x] Focus input when creating/renaming filter views

### DIFF
--- a/resources/js/components/ui/Listing/Presets.vue
+++ b/resources/js/components/ui/Listing/Presets.vue
@@ -228,7 +228,7 @@ function deletePreset() {
         @cancel="isCreating = false"
         @confirm="saveNew"
     >
-        <Input v-model="savingPresetName" @keydown.enter="saveNew" />
+        <Input focus v-model="savingPresetName" @keydown.enter="saveNew" />
 
         <ui-error-message
             v-if="presets && Object.keys(presets).includes(savingPresetHandle)"
@@ -243,7 +243,7 @@ function deletePreset() {
         @cancel="isRenaming = false"
         @confirm="saveExisting"
     >
-        <Input v-model="savingPresetName" @keydown.enter="saveExisting" />
+        <Input focus v-model="savingPresetName" @keydown.enter="saveExisting" />
 
         <div
             v-if="


### PR DESCRIPTION
This pull request ensures the name input is focused when creating or renaming filter views.

## Before

https://github.com/user-attachments/assets/7b712be3-e29d-4376-a31e-1f1f9a839006



## After


https://github.com/user-attachments/assets/94cf9853-7fed-472a-90af-66760ac2cf89

