### PR TITLE
[6.x] Fix Bard debounce race condition, Set move error, and Firefox scroll jumps

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -154,6 +154,8 @@
     .bard-fixed-toolbar {
         z-index: var(--z-index-portal);
         position: sticky;
+        /* Opt out the toolbar of scroll anchoring. Firefox's scroll anchoring adjusts the scroll position to compensate for the perceived layout change, scrolling up to the parent Bard's top. */
+        overflow-anchor: none;
         @apply sm:-top-2;
         /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
         margin-block-end: 8px;

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -4,7 +4,7 @@ import debounce from '@/util/debounce.js';
 import props from './props.js';
 import emits from './emits.js';
 import { publishContextKey } from '@/components/ui';
-import { isRef } from 'vue';
+import { isRef, markRaw } from 'vue';
 
 export default {
     emits,
@@ -24,13 +24,15 @@ export default {
             this.$emit('update:value', value);
         },
 
-        updateDebounced: debounce(function (value) {
-            this.update(value);
-        }, 150),
-
         updateMeta(value) {
             this.$emit('update:meta', value);
         },
+    },
+
+    created() {
+        this.updateDebounced = markRaw(debounce((value) => {
+            this.update(value);
+        }, 150));
     },
 
     computed: {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -428,6 +428,8 @@ export default {
         },
 
         value(value, oldValue) {
+            if (!this.editor) return;
+
             const oldContent = this.editor.getJSON();
             const content = this.valueToContent(value);
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -416,14 +416,15 @@ export default {
 
             if (JSON.stringify(json) === JSON.stringify(oldJson)) return;
 
-            // Temporarily disable debouncing.
-            this.debounceNextUpdate = false;
-
-            this.debounceNextUpdate
-                ? this.updateDebounced(json)
-                : this.update(json);
-
+            const shouldDebounce = this.debounceNextUpdate;
             this.debounceNextUpdate = true;
+
+            if (shouldDebounce) {
+                this.updateDebounced(json);
+            } else {
+                this.updateDebounced.cancel();
+                this.update(json);
+            }
         },
 
         value(value, oldValue) {

--- a/resources/js/util/debounce.js
+++ b/resources/js/util/debounce.js
@@ -1,7 +1,7 @@
 export default function (func, wait, immediate) {
     let timeout;
 
-    return function () {
+    const debounced = function () {
         const context = this,
             args = arguments;
 
@@ -14,4 +14,11 @@ export default function (func, wait, immediate) {
             if (!immediate) func.apply(context, args);
         }, wait);
     };
+
+    debounced.cancel = function () {
+        clearTimeout(timeout);
+        timeout = null;
+    };
+
+    return debounced;
 }


### PR DESCRIPTION
Fixes #13698
Fixes #13772

This addresses a few Bard issues:

1) Re-enable debouncing and fix race condition
As a workaround PR #13797 previously disabled debouncing. The debouncing issues were caused by the user editing content faster than the 150ms debounce delay (e.g. when deleting content and pasting new content). This adds a `cancel()` method to the debounce utility to cancel pending debounced updates before immediate updates, preventing stale content from overwriting fresh changes.

2) Fix type error when moving Sets
Moving Sets caused the error: `Uncaught (in promise) TypeError: can't access property "getJSON", this.editor is null`.

3) Fix scroll jumps in Firefox Browsers
The stylesheet changes introduced in #13750 caused Firefox to scroll to the top of the parent Bard field when clicking into nested Bard fields.