### PR TITLE
[6.x] Only trap stack's focus when its the top portal

### DIFF
--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -81,6 +81,10 @@ function close() {
     wait(300).then(() => {
         mounted.value = false;
         updateOpen(false);
+
+        cleanup();
+        modal.value = null;
+        escBinding.value = null;
     });
 }
 
@@ -108,6 +112,11 @@ function runCloseCallback() {
 	return true;
 }
 
+function cleanup() {
+	modal.value?.destroy();
+	escBinding.value?.destroy();
+}
+
 watch(
     () => props.open,
     (value) => value ? open() : close(),
@@ -118,8 +127,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-    modal.value?.destroy();
-    escBinding.value?.destroy();
+    cleanup();
 });
 
 defineExpose({

--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -6,6 +6,8 @@ import Icon from '../Icon/Icon.vue';
 import Heading from '../Heading.vue';
 import { portals, keys } from '@api';
 import wait from '@/util/wait';
+import { FocusScope } from 'reka-ui';
+import stack from '@ui/Stack/Stack.vue';
 
 defineOptions({
     inheritAttrs: false,
@@ -58,6 +60,7 @@ const instance = getCurrentInstance();
 const hasModalTitleComponent = hasComponent('ModalTitle');
 const isUsingOpenProp = computed(() => instance?.vnode.props?.hasOwnProperty('open'));
 const portal = computed(() => modal.value ? `#portal-target-${modal.value.id}` : null);
+const isTopPortal = computed(() => portals.all()[portals.all().length - 1].id === modal.value.id);
 
 function open() {
     if (!modal.value) modal.value = portals.create('modal');
@@ -144,7 +147,7 @@ provide('closeModal', close);
         <slot name="trigger" />
     </div>
     <teleport :to="portal" v-if="mounted && portal">
-        <div class="vue-portal-target modal">
+        <FocusScope loop :trapped="isTopPortal" class="vue-portal-target modal">
             <transition
                 enter-active-class="duration-200"
                 enter-from-class="opacity-0"
@@ -174,6 +177,6 @@ provide('closeModal', close);
                     <slot name="footer" />
                 </div>
             </transition>
-        </div>
+        </FocusScope>
     </teleport>
 </template>

--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -59,6 +59,7 @@ const isUsingOpenProp = computed(() => instance?.vnode.props?.hasOwnProperty('op
 const portal = computed(() => stack.value ? `#portal-target-${stack.value.id}` : null);
 const depth = computed(() => stacks.stacks().findIndex(s => s.id === stack.value?.id) + 1);
 const isTopStack = computed(() => stacks.count() === depth.value);
+const isTopPortal = computed(() => portals.all()[portals.all().length - 1].id === stack.value.id);
 
 const shouldAddHeader = computed(() => !!(props.title || props.icon) && !hasStackHeaderComponent.value);
 const shouldWrapSlot = computed(() => props.wrapSlot && !hasStackContentComponent.value);
@@ -85,10 +86,6 @@ const leftOffset = computed(() => {
     }
 
     return offset.value * depth.value;
-});
-
-const isTopPortal = computed(() => {
-	return portals.all()[portals.all().length - 1].id === stack.value.id;
 });
 
 const hasChild = computed(() => stacks.count() > depth.value);

--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -10,7 +10,7 @@ import {
     provide,
     onMounted,
 } from 'vue';
-import { stacks, events, keys, config } from '@/api';
+import { stacks, events, keys, config, portals } from '@/api';
 import wait from '@/util/wait.js';
 import {hasComponent} from "@/composables/has-component.js";
 import { Button, Heading } from "@ui";
@@ -85,6 +85,10 @@ const leftOffset = computed(() => {
     }
 
     return offset.value * depth.value;
+});
+
+const isTopPortal = computed(() => {
+	return portals.all()[portals.all().length - 1].id === stack.value.id;
 });
 
 const hasChild = computed(() => stacks.count() > depth.value);
@@ -201,7 +205,9 @@ provide('closeStack', close);
     </Primitive>
     <teleport :to="portal" :order="depth" v-if="mounted">
         <div class="vue-portal-target stack">
-            <FocusScope trapped loop
+            <FocusScope
+	            :trapped="isTopPortal"
+	            loop
                 class="stack-container"
                 :class="{ 'stack-is-current': isTopStack }"
                 :style="direction === 'ltr' ? { left: `${leftOffset}px` } : { right: `${leftOffset}px` }"


### PR DESCRIPTION
This pull request ensures that the stack's focus is only trapped when its the top portal, allowing users to focus on modals on top of stacks.

This PR also fixes an issue where modals weren't being tidied up properly when closing. Mirroring what we do for stacks.

Fixes #13855
