### PR TITLE
[5.x] Account for custom fields when checking if entry URIs should be updated

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -450,6 +450,10 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
 
     private function shouldUpdateUris(): bool
     {
+        if (! $this->route()) {
+            return false;
+        }
+
         $antlersRoute = preg_replace_callback('/{\s*([a-zA-Z0-9_\-]+)\s*}/', function ($match) {
             return "{{ {$match[1]} }}";
         }, $this->route());

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -416,7 +416,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
 
         $this->taxonomize();
 
-        if ($this->isDirty('slug')) {
+        if ($this->shouldUpdateUris()) {
             optional(Collection::findByMount($this))->updateEntryUris();
             $this->updateChildPageUris();
         }
@@ -446,6 +446,17 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         $this->syncOriginal();
 
         return true;
+    }
+
+    private function shouldUpdateUris(): bool
+    {
+        $antlersRoute = preg_replace_callback('/{\s*([a-zA-Z0-9_\-]+)\s*}/', function ($match) {
+            return "{{ {$match[1]} }}";
+        }, $this->route());
+
+        return collect(Antlers::identifiers($antlersRoute))
+            ->filter(fn (string $identifier) => $this->isDirty($identifier))
+            ->isNotEmpty();
     }
 
     private function updateChildPageUris()


### PR DESCRIPTION
Currently, we only update child & mounted entry URIs when the `slug` field changes. 

However, this means that updating a custom field used in the collection's route will leave child/mounted entries with the "old" URI until either the Stache is cleared or the slug is updated.

This PR ensures that we check the dirty state of fields used in the collection route by taking advantage of the `Antlers::identifiers()` method.

Closes #13828