### PR TITLE
[6.x] Tweak `modelValue` descriptions for DatePicker components

### DIFF
--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -31,11 +31,11 @@ const props = defineProps({
     /** Badge text to display. */
     badge: { type: String, default: null },
     required: { type: Boolean, default: false },
-    /** The controlled date value. <br><br> Should be an ISO 8601 date and time string with a UTC offset (eg. `2021-11-07T07:45:00Z` or `2021-11-07T07:45:00-07:00`) */
+    /** The controlled date value. <br><br> Should be a [`DateValue` object](https://reka-ui.com/docs/guides/dates) or an ISO 8601 datetime string with a UTC offset. */
     modelValue: { type: [Object, String], default: null },
-    /** The minimum selectable date. <br><br> Should be an ISO 8601 date and time string with a UTC offset (eg. `2021-11-07T07:45:00Z` or `2021-11-07T07:45:00-07:00`) */
+    /** The minimum selectable date. <br><br> Should be a [`DateValue` object](https://reka-ui.com/docs/guides/dates) or an ISO 8601 datetime string with a UTC offset. */
     min: { type: [String, Object], default: null },
-    /** The maximum selectable date. <br><br> Should be an ISO 8601 date and time string with a UTC offset (eg. `2021-11-07T07:45:00Z` or `2021-11-07T07:45:00-07:00`) */
+    /** The maximum selectable date. <br><br> Should be a [`DateValue` object](https://reka-ui.com/docs/guides/dates) or an ISO 8601 datetime string with a UTC offset. */
     max: { type: [String, Object], default: null },
     /** The granularity of the date picker. <br><br> Options: `day`, `hour`, `minute`, `second` */
     granularity: { type: String, default: null },

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -31,11 +31,11 @@ const props = defineProps({
     /** Badge text to display. */
     badge: { type: String, default: null },
     required: { type: Boolean, default: false },
-    /** The controlled date range value with `start` and `end` properties. <br><br> Each should be an ISO 8601 date and time string with a UTC offset (eg. `2021-11-07T07:45:00Z` or `2021-11-07T07:45:00-07:00`) */
+    /** The controlled date range value. <br><br> Should be a [`DateRange` object](https://reka-ui.com/docs/guides/dates) or an object with `start` and `end` keys, where each value is an ISO 8601 datetime string with a UTC offset. */
     modelValue: { type: [Object, String], default: null },
-    /** The minimum selectable date. <br><br> Should be an ISO 8601 date and time string with a UTC offset (eg. `2021-11-07T07:45:00Z` or `2021-11-07T07:45:00-07:00`) */
+    /** The minimum selectable date. <br><br> Should be a [`DateValue` object](https://reka-ui.com/docs/guides/dates) or an ISO 8601 datetime string with a UTC offset. */
     min: { type: [String, Object], default: null },
-    /** The maximum selectable date. <br><br> Should be an ISO 8601 date and time string with a UTC offset (eg. `2021-11-07T07:45:00Z` or `2021-11-07T07:45:00-07:00`) */
+    /** The maximum selectable date. <br><br> Should be a [`DateValue` object](https://reka-ui.com/docs/guides/dates) or an ISO 8601 datetime string with a UTC offset. */
     max: { type: [String, Object], default: null },
     /** The granularity of the date range picker. <br><br> Options: `day`, `hour`, `minute`, `second` */
     granularity: { type: String, default: null },

--- a/resources/js/stories/DatePicker.stories.ts
+++ b/resources/js/stories/DatePicker.stories.ts
@@ -12,10 +12,10 @@ const meta = {
             options: ['day', 'hour', 'minute', 'second'],
         },
         'update:modelValue': {
-            description: 'Event handler called when the date value changes. Returns the date as an ISO 8601 date and time string.',
+            description: 'Event handler called when the date value changes. <br><br> Returns a [`DateValue` object](https://reka-ui.com/docs/guides/dates).',
             table: {
                 category: 'events',
-                type: { summary: '(value: string) => void' }
+                type: { summary: '(value: DateValue) => void' }
             }
         }
     },

--- a/resources/js/stories/DateRangePicker.stories.ts
+++ b/resources/js/stories/DateRangePicker.stories.ts
@@ -12,10 +12,10 @@ const meta = {
             options: ['day', 'hour', 'minute', 'second'],
         },
         'update:modelValue': {
-            description: 'Event handler called when the date range value changes. <br><br> Returns an object with `start` and `end` properties, each as an ISO 8601 date and time string.',
+            description: 'Event handler called when the date range value changes. <br><br> Returns a [`DateRange` object](https://reka-ui.com/docs/guides/dates).',
             table: {
                 category: 'events',
-                type: { summary: '(value: { start: string, end: string }) => void' }
+                type: { summary: '(value: DateRange) => void' }
             }
         }
     },


### PR DESCRIPTION
#13512 (currently unmerged) updates the description of the `update:modelValue` event in the `DateRangePicker` story. 

However, it doesn't update the prop description or update descriptions for the `DatePicker` component. This PR does that and links out to Reka's date guide (which I think is _slightly_ more helpful than Adobe's docs).