### PR TITLE
[6.x] Prevent layout change when reordering grid rows

### DIFF
--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -1,6 +1,6 @@
 <template>
     <div
-        class="bg-white dark:bg-gray-850 rounded-xl ring ring-gray-300 dark:ring-x-0 dark:ring-b-0 dark:ring-gray-700 shadow-ui-md"
+        class="@container/panel bg-white dark:bg-gray-850 rounded-xl ring ring-gray-300 dark:ring-x-0 dark:ring-b-0 dark:ring-gray-700 shadow-ui-md"
         :class="[sortableItemClass, { 'opacity-50': isExcessive, 'ring-red-500': hasError }]"
         :data-error="hasError ?? undefined"
     >


### PR DESCRIPTION
This PR fixes an issue when reordering stacked Grid rows, where fields with percentage widths would temporarily expand to full width while dragging.

This was happening because the drag mirror is appended to the `body`, losing the `@container/panel` ancestor which provides the container query context for field widths. Without it, the @lg/panel` variant doesn't apply and fields default to full-width.

This PR fixes it by adding the `@container/panel` class directly to the stacked row, so the container context is included when the element is cloned from the drag mirror.

Fixes #13817

## Before

https://github.com/user-attachments/assets/87aeaf8e-1573-4f9b-b7c8-27bb4602abe9


## After

https://github.com/user-attachments/assets/6994a121-e540-4944-a9ea-0daeb34ce2f4

