### PR TITLE
[6.x] Avoid calling `->startOfDay()` on date range dates

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -302,8 +302,8 @@ class Date extends Fieldtype
 
         if ($this->config('mode') === 'range') {
             return [
-                'start' => $this->parseSaved($value['start'])->startOfDay(),
-                'end' => $this->parseSaved($value['end'])->startOfDay(),
+                'start' => $this->parseSaved($value['start']),
+                'end' => $this->parseSaved($value['end']),
             ];
         }
 

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -124,6 +124,23 @@ class DateTest extends TestCase
     }
 
     #[Test]
+    public function it_augments_a_range_in_a_positive_offset_timezone()
+    {
+        config()->set('app.timezone', 'Europe/Berlin');
+
+        $augmented = $this->fieldtype(['mode' => 'range'])->augment([
+            'start' => '2026-02-02',
+            'end' => '2026-02-05',
+        ]);
+
+        $this->assertIsArray($augmented);
+        $this->assertInstanceOf(Carbon::class, $augmented['start']);
+        $this->assertInstanceOf(Carbon::class, $augmented['end']);
+        $this->assertEquals('2026 Feb 02', $augmented['start']->setTimezone('Europe/Berlin')->format('Y M d'));
+        $this->assertEquals('2026 Feb 05', $augmented['end']->setTimezone('Europe/Berlin')->format('Y M d'));
+    }
+
+    #[Test]
     public function it_augments_a_null_range()
     {
         $augmented = $this->fieldtype(['mode' => 'range'])->augment(null);


### PR DESCRIPTION
This pull request avoids calling `->startOfDay()` when augmenting date ranges to avoid situations where the user selects one date but it saves another, which may cause the wrong date to be displayed on the frontend.

For example: if you're in Germany and select the 2nd February, it'll save as `2026-02-01 23:00`.

Related: https://github.com/statamic/cms/issues/13839#issuecomment-3871673956