### PR TITLE
[6.x] Update instructions for `Heading` component's `level` prop

### DIFF
--- a/resources/js/components/ui/Heading.vue
+++ b/resources/js/components/ui/Heading.vue
@@ -11,7 +11,7 @@ const props = defineProps({
     target: { type: String, default: null },
     /** Icon name. [Browse available icons](/?path=/story/components-icon--all-icons) */
     icon: { type: [String, null], default: null },
-    /** Controls the heading level, `h1`, `h2`, etc */
+    /** Controls the heading level */
     level: { type: [Number, null], default: null },
     /** Controls the size of the heading. Options: `base`, `lg`, `xl`, `2xl` */
     size: { type: String, default: 'base' },


### PR DESCRIPTION
This pull request updates instructions for the `Heading` component's `level` prop. You should pass numbers to it (like the example in the story), not strings like `h1`, `h2`, etc.