### PR TITLE
[6.x] Fix debugbar helper binding

### DIFF
--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -389,7 +389,7 @@ class Tags extends BaseTags
      */
     protected function addToDebugBar($data, $formHandle)
     {
-        if (! config('debugbar.enabled') && ! function_exists('debugbar') || ! class_exists(ConfigCollector::class)) {
+        if (! function_exists('debugbar') || ! debugbar()->isEnabled() || ! class_exists(ConfigCollector::class)) {
             return;
         }
 

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -389,7 +389,7 @@ class Tags extends BaseTags
      */
     protected function addToDebugBar($data, $formHandle)
     {
-        if (! function_exists('debugbar') || ! class_exists(ConfigCollector::class)) {
+        if (! config('debugbar.enabled') && ! function_exists('debugbar') || ! class_exists(ConfigCollector::class)) {
             return;
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,6 @@
 <?php
 
-use Barryvdh\Debugbar\LaravelDebugbar;
+use Fruitcake\LaravelDebugbar\LaravelDebugbar;
 use Statamic\Facades\Path;
 use Statamic\Statamic;
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,5 @@
 <?php
 
-use Fruitcake\LaravelDebugbar\LaravelDebugbar;
 use Statamic\Facades\Path;
 use Statamic\Statamic;
 
@@ -17,6 +16,6 @@ function statamic_path($path = null)
 if (! function_exists('debugbar')) {
     function debugbar()
     {
-        return app()->bound(LaravelDebugbar::class) ? app(LaravelDebugbar::class) : optional();
+        return app()->bound('debugbar') ? app('debugbar') : optional();
     }
 }


### PR DESCRIPTION
This PR resolves #13872.

I'm not 100% sure of the implications for those who have v3 of the debugbar installed though.

The other change made is that if the debugbar is disabled, the `addToDebugBar` method will not attempt to load it too.