### PR TITLE
[6.x] Add docblocks for some store, stache and permission methods

### DIFF
--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -20,6 +20,9 @@ class Permission
     protected $description;
     protected $group;
 
+    /**
+     * @return ($value is null ? string|string[] : static)
+     */
     public function value(?string $value = null)
     {
         if (func_num_args() > 0) {
@@ -41,6 +44,9 @@ class Permission
         return $this->label;
     }
 
+    /**
+     * @return ($value is null ? string|null : static)
+     */
     public function label(?string $label = null)
     {
         if (func_num_args() > 0) {

--- a/src/Facades/Stache.php
+++ b/src/Facades/Stache.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static mixed defaultSite()
  * @method static self registerStore(\Statamic\Stache\Stores\Store $store)
  * @method static self registerStores(array $stores)
- * @method static mixed stores()
+ * @method static \Illuminate\Support\Collection<string, \Statamic\Stache\Stores\Store> stores()
  * @method static mixed store($key)
  * @method static \Illuminate\Contracts\Cache\Store cacheStore()
  * @method static string generateId()

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -5,6 +5,7 @@ namespace Statamic\Stache;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Collection;
 use Statamic\Events\StacheCleared;
 use Statamic\Events\StacheWarmed;
 use Statamic\Extensions\FileStore;
@@ -17,6 +18,10 @@ use Symfony\Component\Lock\LockInterface;
 class Stache
 {
     protected $sites;
+
+    /**
+     * @var Collection<string,Store>
+     */
     protected $stores;
     protected $startTime;
     protected $updateIndexes = true;
@@ -69,6 +74,9 @@ class Stache
         return $this;
     }
 
+    /**
+     * @return Collection<string,Store>
+     */
     public function stores()
     {
         return $this->stores;

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -28,6 +28,15 @@ abstract class Store
     protected $modified;
     protected $keys;
 
+    /**
+     * @return string
+     */
+    abstract public function key();
+
+    /**
+     * @param string|null $directory
+     * @return ($directory is null ? string : static)
+     */
     public function directory($directory = null)
     {
         if (func_num_args() === 0) {


### PR DESCRIPTION
The reason for this PR is that doing static analysis on addons is pretty hard due to a lot of missing types in statamic.

I opted for only doing "docblocks" so it wont be breaking, but preferably native types would be used.