### PR TITLE
[5.x] Fix after_save preference not persisting when default preferences override 'listing'

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -622,8 +622,8 @@ export default {
                         window.location = this.createAnotherUrl;
                     }
 
-                    // If the user has opted to go to listing (default/null option), redirect them there.
-                    else if (!this.isInline && nextAction === null) {
+                    // If the user has opted to go to listing, redirect them there.
+                    else if (!this.isInline && (nextAction === null || nextAction === 'listing')) {
                         window.location = this.listingUrl;
                     }
 
@@ -794,8 +794,8 @@ export default {
                 window.location = this.createAnotherUrl;
             }
 
-            // If the user has opted to go to listing (default/null option), redirect them there.
-            else if (!this.isInline && nextAction === null) {
+            // If the user has opted to go to listing, redirect them there.
+            else if (!this.isInline && (nextAction === null || nextAction === 'listing')) {
                 window.location = this.listingUrl;
             }
 

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -504,7 +504,7 @@ export default {
         },
 
         afterSaveOption() {
-            return this.getPreference('after_save');
+            return this.getPreference('after_save') ?? 'listing';
         },
 
         originOptions() {
@@ -623,7 +623,7 @@ export default {
                     }
 
                     // If the user has opted to go to listing, redirect them there.
-                    else if (!this.isInline && (nextAction === null || nextAction === 'listing')) {
+                    else if (!this.isInline && nextAction === 'listing') {
                         window.location = this.listingUrl;
                     }
 
@@ -795,7 +795,7 @@ export default {
             }
 
             // If the user has opted to go to listing, redirect them there.
-            else if (!this.isInline && (nextAction === null || nextAction === 'listing')) {
+            else if (!this.isInline && nextAction === 'listing') {
                 window.location = this.listingUrl;
             }
 

--- a/resources/js/components/publish/SaveButtonOptions.vue
+++ b/resources/js/components/publish/SaveButtonOptions.vue
@@ -89,10 +89,14 @@ export default {
             this.currentOption = this.$preferences.get(this.preferencesKey) || 'listing';
         },
 
+        defaultValue() {
+            return this.$preferences.getDefault(this.preferencesKey) ?? 'listing';
+        },
+
         setPreference(value) {
             if (value === this.$preferences.get(this.preferencesKey)) return;
 
-            value === 'listing'
+            value === this.defaultValue()
                 ? this.$preferences.remove(this.preferencesKey)
                 : this.$preferences.set(this.preferencesKey, value);
         },

--- a/resources/js/components/publish/SaveButtonOptions.vue
+++ b/resources/js/components/publish/SaveButtonOptions.vue
@@ -89,16 +89,10 @@ export default {
             this.currentOption = this.$preferences.get(this.preferencesKey) || 'listing';
         },
 
-        defaultValue() {
-            return this.$preferences.getDefault(this.preferencesKey) ?? 'listing';
-        },
-
         setPreference(value) {
             if (value === this.$preferences.get(this.preferencesKey)) return;
 
-            value === this.defaultValue()
-                ? this.$preferences.remove(this.preferencesKey)
-                : this.$preferences.set(this.preferencesKey, value);
+            this.$preferences.set(this.preferencesKey, value);
         },
     },
 

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -399,7 +399,7 @@ export default {
         },
 
         afterSaveOption() {
-            return this.getPreference('after_save');
+            return this.getPreference('after_save') ?? 'listing';
         },
 
     },
@@ -499,7 +499,7 @@ export default {
                     }
 
                     // If the user has opted to go to listing, redirect them there.
-                    else if (!this.isInline && (nextAction === null || nextAction === 'listing')) {
+                    else if (!this.isInline && nextAction === 'listing') {
                         window.location = this.listingUrl;
                     }
 

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -498,8 +498,8 @@ export default {
                         window.location = this.createAnotherUrl;
                     }
 
-                    // If the user has opted to go to listing (default/null option), redirect them there.
-                    else if (!this.isInline && nextAction === null) {
+                    // If the user has opted to go to listing, redirect them there.
+                    else if (!this.isInline && (nextAction === null || nextAction === 'listing')) {
                         window.location = this.listingUrl;
                     }
 


### PR DESCRIPTION
When default preferences set after_save to a non-listing value (e.g. continue_editing via preferences.yaml), selecting 'Go To Listing' in the save button dropdown would not persist. 

The root cause was two-fold: 
1. SaveButtonOptions.vue hardcoded 'listing' as the assumed default. When the user selected listing, it removed the user preference instead of explicitly setting it. With a non-listing default configured, the removal caused the default to take over, reverting the selection on reload. It also caused the preference store and the radio UI to go out of sync within the same session.
2. The PublishForm components only checked for null (removed preference) when determining the listing redirect. If listing was explicitly stored as a string value, the redirect would never trigger. 

Fix: SaveButtonOptions now checks the actual configured default via getDefault() instead of assuming listing. The PublishForm components now also handle the explicit 'listing' string in addition to null.