### PR TITLE
[5.x] Asset auth fix

### DIFF
--- a/routes/cp.php
+++ b/routes/cp.php
@@ -229,7 +229,6 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
 
     Route::resource('asset-containers', AssetContainersController::class);
     Route::post('asset-containers/{asset_container}/folders', [FoldersController::class, 'store']);
-    Route::patch('asset-containers/{asset_container}/folders/{path}', [FoldersController::class, 'update'])->where('path', '.*');
     Route::get('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'edit'])->name('asset-containers.blueprint.edit');
     Route::patch('asset-containers/{asset_container}/blueprint', [AssetContainerBlueprintController::class, 'update'])->name('asset-containers.blueprint.update');
     Route::post('assets/actions', [AssetActionController::class, 'run'])->name('assets.actions.run');

--- a/src/Http/Controllers/CP/Assets/FoldersController.php
+++ b/src/Http/Controllers/CP/Assets/FoldersController.php
@@ -37,9 +37,4 @@ class FoldersController extends CpController
 
         return $container->assetFolder($path)->save();
     }
-
-    public function update(Request $request, $container, $folder)
-    {
-        return $container->assetFolder($folder)->save();
-    }
 }

--- a/src/Http/Controllers/CP/Assets/PdfController.php
+++ b/src/Http/Controllers/CP/Assets/PdfController.php
@@ -15,9 +15,11 @@ class PdfController extends Controller
      */
     public function show($encodedAssetId)
     {
-        if (! $contents = $this->asset($encodedAssetId)->contents()) {
-            abort(500);
-        }
+        $asset = $this->asset($encodedAssetId);
+
+        abort_if(! $contents = $asset->contents(), 500);
+
+        $this->authorize('view', $asset);
 
         return response($contents)->header('Content-Type', 'application/pdf');
     }

--- a/src/Http/Controllers/CP/Assets/SvgController.php
+++ b/src/Http/Controllers/CP/Assets/SvgController.php
@@ -17,9 +17,9 @@ class SvgController extends Controller
     {
         $asset = $this->asset($asset);
 
-        if (! $contents = $asset->disk()->get($asset->path())) {
-            abort(500);
-        }
+        abort_if(! $contents = $asset->disk()->get($asset->path()), 500);
+
+        $this->authorize('view', $asset);
 
         return response($contents)->header('Content-Type', 'image/svg+xml');
     }

--- a/src/Http/Controllers/CP/Assets/ThumbnailController.php
+++ b/src/Http/Controllers/CP/Assets/ThumbnailController.php
@@ -65,6 +65,8 @@ class ThumbnailController extends Controller
         $this->orientation = $orientation;
         $this->asset = $this->asset($asset);
 
+        $this->authorize('view', $this->asset);
+
         if ($placeholder = $this->getPlaceholderResponse()) {
             return $placeholder;
         }

--- a/tests/Feature/Assets/ImageThumbnailTest.php
+++ b/tests/Feature/Assets/ImageThumbnailTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Feature\Assets;
+
+use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\AssetContainer;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ImageThumbnailTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    private $tempDir;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => $this->tempDir = __DIR__.'/tmp',
+        ]]);
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory($this->tempDir);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_returns_thumbnail()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.png')
+            ->upload(UploadedFile::fake()->image('one.png'));
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/thumbnails/'.base64_encode('test::one.png'))
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_404s_when_the_asset_doesnt_exist()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/thumbnails/'.base64_encode('test::unknown.png'))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function it_denies_access_without_permission_to_view_asset()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.png')
+            ->upload(UploadedFile::fake()->image('one.png'));
+
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/thumbnails/'.base64_encode('test::one.png'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Assets/PdfThumbnailTest.php
+++ b/tests/Feature/Assets/PdfThumbnailTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Feature\Assets;
+
+use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\AssetContainer;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class PdfThumbnailTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    private $tempDir;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => $this->tempDir = __DIR__.'/tmp',
+        ]]);
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory($this->tempDir);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_returns_thumbnail()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.pdf')
+            ->upload(UploadedFile::fake()->createWithContent('one.pdf', ' '));
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/pdfs/'.base64_encode('test::one.pdf'))
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_404s_when_the_asset_doesnt_exist()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/pdfs/'.base64_encode('test::unknown.pdf'))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function it_denies_access_without_permission_to_view_asset()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.pdf')
+            ->upload(UploadedFile::fake()->createWithContent('one.pdf', ' '));
+
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/pdfs/'.base64_encode('test::one.pdf'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Assets/SvgThumbnailTest.php
+++ b/tests/Feature/Assets/SvgThumbnailTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Feature\Assets;
+
+use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\AssetContainer;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class SvgThumbnailTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    private $tempDir;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => $this->tempDir = __DIR__.'/tmp',
+        ]]);
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory($this->tempDir);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_returns_thumbnail()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.png')
+            ->upload(UploadedFile::fake()->createWithContent('one.svg', '<svg></svg>'));
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/svgs/'.base64_encode('test::one.svg'))
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_404s_when_the_asset_doesnt_exist()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/svgs/'.base64_encode('test::unknown.svg'))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function it_denies_access_without_permission_to_view_asset()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.svg')
+            ->upload(UploadedFile::fake()->createWithContent('one.svg', '<svg></svg>'));
+
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/svgs/'.base64_encode('test::one.svg'))
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
The asset thumbnail routes didn't have auth on them. Control Panel access was required though.