### PR TITLE
[6.x] Fix base css overriding addons

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,5 +1,5 @@
 /* =Jay. Tailwind already uses "Cascade Layers" internally. Here we are just adding an extra layer (to their internal layers) to manage states--particulary with complex fields like Bard--where specificity is much easier to handle with layers. */
-@layer addon-theme, addon-utilities, base, components, utilities, ui, ui-states;
+@layer base, addon-theme, addon-utilities, components, utilities, ui, ui-states;
 
 /* =Jay. Map layers to Tailwind's internal layers so that we can inject custom layers as needed */
 @layer base {


### PR DESCRIPTION
This moves the `base` css layer to the start, before addons.
Addon layers were added in #12329 but they should have been placed after `base`.

Related #13884