### PR TITLE
[6.x] Add support link to header

### DIFF
--- a/config/cp.php
+++ b/config/cp.php
@@ -86,8 +86,7 @@ return [
     | Support Link
     |--------------------------------------------------------------------------
     |
-    | Set the location of the support link in the "Useful Links" header
-    | dropdown. Use 'false' to remove it entirely.
+    | Set the location of the support link in the header.
     |
     */
 

--- a/resources/js/components/global-header/Header.vue
+++ b/resources/js/components/global-header/Header.vue
@@ -7,6 +7,7 @@ import SiteSelector from './SiteSelector.vue';
 import Search from './Search.vue';
 import ViewSiteButton from './ViewSiteButton.vue';
 import UserDropdown from './UserDropdown.vue';
+import SupportButton from "@/components/global-header/SupportButton.vue";
 
 const layout = inject('layout', {});
 const isMaxWidthEnabled = layout.isMaxWidthEnabled;
@@ -33,6 +34,7 @@ const toggleMaxWidth = layout.toggleMaxWidth;
             <div class="flex items-center">
                 <Search />
             </div>
+	        <SupportButton />
             <button
                 @click="toggleMaxWidth"
                 :aria-label="isMaxWidthEnabled ? __('Expand Layout') : __('Constrain Layout')"

--- a/resources/js/components/global-header/Header.vue
+++ b/resources/js/components/global-header/Header.vue
@@ -1,17 +1,12 @@
 <script setup>
-import { inject } from 'vue';
-import { Icon } from '@ui';
 import Logo from './Logo.vue';
 import Breadcrumbs from './Breadcrumbs.vue';
 import SiteSelector from './SiteSelector.vue';
 import Search from './Search.vue';
+import SupportButton from "@/components/global-header/SupportButton.vue";
+import MaxWidthButton from "@/components/global-header/MaxWidthButton.vue";
 import ViewSiteButton from './ViewSiteButton.vue';
 import UserDropdown from './UserDropdown.vue';
-import SupportButton from "@/components/global-header/SupportButton.vue";
-
-const layout = inject('layout', {});
-const isMaxWidthEnabled = layout.isMaxWidthEnabled;
-const toggleMaxWidth = layout.toggleMaxWidth;
 </script>
 
 <template>
@@ -35,15 +30,7 @@ const toggleMaxWidth = layout.toggleMaxWidth;
                 <Search />
             </div>
 	        <SupportButton />
-            <button
-                @click="toggleMaxWidth"
-                :aria-label="isMaxWidthEnabled ? __('Expand Layout') : __('Constrain Layout')"
-                v-tooltip="isMaxWidthEnabled ? __('Expand Layout') : __('Constrain Layout')"
-                class="hidden [@media(min-width:1800px)]:inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85! will-change-transform"
-                data-expand-layout-control
-            >
-                <Icon :name="isMaxWidthEnabled ? 'zoom-fit-screen' : 'fit-screen'" class="animate-pulse-on-appearance" />
-            </button>
+	        <MaxWidthButton />
             <ViewSiteButton />
             <UserDropdown />
         </div>

--- a/resources/js/components/global-header/MaxWidthButton.vue
+++ b/resources/js/components/global-header/MaxWidthButton.vue
@@ -1,0 +1,20 @@
+<script setup>
+import {Icon} from "@ui";
+import {inject} from "vue";
+
+const layout = inject('layout', {});
+const isMaxWidthEnabled = layout.isMaxWidthEnabled;
+const toggleMaxWidth = layout.toggleMaxWidth;
+</script>
+
+<template>
+	<button
+		@click="toggleMaxWidth"
+		:aria-label="isMaxWidthEnabled ? __('Expand Layout') : __('Constrain Layout')"
+		v-tooltip="isMaxWidthEnabled ? __('Expand Layout') : __('Constrain Layout')"
+		class="hidden [@media(min-width:1800px)]:inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85! will-change-transform"
+		data-expand-layout-control
+	>
+		<Icon :name="isMaxWidthEnabled ? 'zoom-fit-screen' : 'fit-screen'" class="animate-pulse-on-appearance" />
+	</button>
+</template>

--- a/resources/js/components/global-header/SupportButton.vue
+++ b/resources/js/components/global-header/SupportButton.vue
@@ -1,0 +1,17 @@
+<script setup>
+import { Icon } from '@ui';
+import useStatamicPageProps from '@/composables/page-props.js';
+
+const { supportUrl: url } = useStatamicPageProps();
+</script>
+
+<template>
+    <a
+        :href="url"
+        :aria-label="__('Support')"
+        class="inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85! v-popper--has-tooltip"
+        target="_blank"
+    >
+        <Icon name="support" />
+    </a>
+</template>

--- a/resources/js/components/global-header/SupportButton.vue
+++ b/resources/js/components/global-header/SupportButton.vue
@@ -7,6 +7,7 @@ const { supportUrl: url } = useStatamicPageProps();
 
 <template>
     <a
+        v-if="url"
         :href="url"
         :aria-label="__('Support')"
         class="inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85! v-popper--has-tooltip"

--- a/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
@@ -58,6 +58,7 @@ class HandleAuthenticatedInertiaRequests
         }
 
         return [
+            'supportUrl' => config('statamic.cp.support_url'),
             'selectedSiteUrl' => Site::selected()->url(),
             'licensing' => $this->licensing(),
             'sessionExpiry' => $this->sessionExpiry(),


### PR DESCRIPTION
This pull request adds a support link to the header, like we had in v5. This PR also moves the max width toggle into its own component (everything else in the header is split into their own components).

<img width="343" height="71" alt="CleanShot 2026-02-11 at 10 46 58" src="https://github.com/user-attachments/assets/5528df2c-8190-4298-a8b0-381e46a956ca" />

<p></p>

Closes #13888
