### PR TITLE
[6.x] Apply default pagination size in control panel listings

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -143,7 +143,7 @@ const props = defineProps({
     /** Number of items to display per page. */
     perPage: {
         type: Number,
-        default: 15,
+        default: null,
     },
     /** When `true`, shows the totals in the paginator. e.g. "1-5 of 10" */
     showPaginationTotals: {
@@ -487,7 +487,7 @@ function setPerPage(value) {
 }
 
 function initializePerPage() {
-    let perPage = props.perPage;
+    let perPage = props.perPage ?? Statamic.$config.get('paginationSize') ?? 15;
 
     if (props.preferencesPrefix) {
         perPage = Statamic.$preferences.get(props.preferencesPrefix + '.per_page', perPage);

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -143,7 +143,7 @@ const props = defineProps({
     /** Number of items to display per page. */
     perPage: {
         type: Number,
-        default: null,
+        default: () => Statamic.$config.get('paginationSize', 15),
     },
     /** When `true`, shows the totals in the paginator. e.g. "1-5 of 10" */
     showPaginationTotals: {
@@ -487,7 +487,7 @@ function setPerPage(value) {
 }
 
 function initializePerPage() {
-    let perPage = props.perPage ?? Statamic.$config.get('paginationSize') ?? 15;
+    let perPage = props.perPage;
 
     if (props.preferencesPrefix) {
         perPage = Statamic.$preferences.get(props.preferencesPrefix + '.per_page', perPage);


### PR DESCRIPTION
Try to fix #13892 by preferring the config value from `cp.php` over the hardcoded default value 15.