### PR TITLE
[6.x] Convert PHPUnit metadata to attributes

### DIFF
--- a/tests/Data/Users/UserQueryBuilderTest.php
+++ b/tests/Data/Users/UserQueryBuilderTest.php
@@ -483,7 +483,7 @@ class UserQueryBuilderTest extends TestCase
         ], User::query()->where('type', 'b')->pluck('name')->all());
     }
 
-    /** @test **/
+    #[Test]
     public function users_are_found_using_scopes()
     {
         CustomScope::register();

--- a/tests/Fields/BlueprintRepositoryTest.php
+++ b/tests/Fields/BlueprintRepositoryTest.php
@@ -440,7 +440,7 @@ EOT;
         $this->repo->findOrFail('does-not-exist');
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_a_blueprint_from_split_repository()
     {
         $repo = (new BlueprintRepository())

--- a/tests/Modifiers/DoesntOverlapTest.php
+++ b/tests/Modifiers/DoesntOverlapTest.php
@@ -2,15 +2,15 @@
 
 namespace Tests\Modifiers;
 
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
-/**
- * @group array
- */
+#[Group('array')]
 class DoesntOverlapTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_returns_false_if_needle_found_in_array(): void
     {
         $haystack = ['a', 'b', 'c'];
@@ -19,7 +19,7 @@ class DoesntOverlapTest extends TestCase
         $this->assertFalse($modified);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_true_if_needle_is_not_found_in_array(): void
     {
         $haystack = ['a', 'b', 'c'];
@@ -28,7 +28,7 @@ class DoesntOverlapTest extends TestCase
         $this->assertTrue($modified);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_true_if_haystack_is_not_an_array(): void
     {
         $haystack = 'this is a string';
@@ -37,7 +37,7 @@ class DoesntOverlapTest extends TestCase
         $this->assertTrue($modified);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_false_if_needle_is_an_array_and_is_found_in_array(): void
     {
         $haystack = ['a', 'b', 'c'];
@@ -46,7 +46,7 @@ class DoesntOverlapTest extends TestCase
         $this->assertFalse($modified);
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_false_if_needle_is_an_array_and_some_are_not_found_in_array(): void
     {
         $haystack = ['a', 'b', 'c'];


### PR DESCRIPTION
While working on another PR, I came across a few tests using the deprecated PHPUnit metadata syntax. This PR converts them to attributes.