### PR TITLE
[6.x] Dutch translations

### DIFF
--- a/lang/nl.json
+++ b/lang/nl.json
@@ -208,7 +208,7 @@
     "Close Markdown Cheatsheet": "Markdown-cheatsheet sluiten",
     "Close Modal": "Sluit modal",
     "Code Block": "Codeblok",
-    "Collapse": "Ineenstorting",
+    "Collapse": "Inklappen",
     "Collapse All": "Alles inklappen",
     "Collapse All Sets": "Alle sets inklappen",
     "Collapse Set": "Set inklappen",


### PR DESCRIPTION
Update for Dutch local key "Collapse" to "Inklappen" since this is the correct way in this context