### PR TITLE
[6.x] Make `RunsUpdateScripts` trait usable in addon tests

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -115,4 +115,14 @@ abstract class AddonTestCase extends OrchestraTestCase
         $app['config']->set('statamic.stache.stores.form-submissions.directory', $directory.'/../tests/__fixtures__/content/submissions');
         $app['config']->set('statamic.stache.stores.users.directory', $directory.'/../tests/__fixtures__/users');
     }
+
+    protected function getPackage(): string
+    {
+        $reflector = new ReflectionClass($this->addonServiceProvider);
+        $directory = dirname($reflector->getFileName());
+
+        $json = json_decode($this->app['files']->get($directory.'/../composer.json'), true);
+
+        return $json['name'];
+    }
 }

--- a/src/Testing/Concerns/RunsUpdateScripts.php
+++ b/src/Testing/Concerns/RunsUpdateScripts.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Statamic\Testing\Concerns;
+
+trait RunsUpdateScripts
+{
+    /**
+     * Run update script in your tests without checking package version.
+     */
+    protected function runUpdateScript(string $fqcn, ?string $package = null)
+    {
+        $package = $package ?: $this->getPackage();
+
+        $script = new $fqcn($package);
+
+        $script->update();
+
+        return $script;
+    }
+
+    protected function assertUpdateScriptRegistered(string $class)
+    {
+        $this->assertTrue(
+            app('statamic.update-scripts')->map->class->contains($class),
+            "Update script $class is not registered."
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -142,6 +142,11 @@ en:
 YAML);
     }
 
+    protected function getPackage(): string
+    {
+        return 'statamic/cms';
+    }
+
     protected function setSites($sites)
     {
         Site::setSites($sites);

--- a/tests/UpdateScripts/Concerns/RunsUpdateScripts.php
+++ b/tests/UpdateScripts/Concerns/RunsUpdateScripts.php
@@ -2,28 +2,9 @@
 
 namespace Tests\UpdateScripts\Concerns;
 
+use Statamic\Testing\Concerns\RunsUpdateScripts as BaseRunsUpdateScripts;
+
 trait RunsUpdateScripts
 {
-    /**
-     * Run update script in your tests without checking package version.
-     *
-     * @param  string  $fqcn
-     * @param  string  $package
-     */
-    protected function runUpdateScript($fqcn, $package = 'statamic/cms')
-    {
-        $script = new $fqcn($package);
-
-        $script->update();
-
-        return $script;
-    }
-
-    protected function assertUpdateScriptRegistered($class)
-    {
-        $this->assertTrue(
-            app('statamic.update-scripts')->map->class->contains($class),
-            "Update script $class is not registered."
-        );
-    }
+    use BaseRunsUpdateScripts;
 }


### PR DESCRIPTION
This pull request makes the `RunsUpdateScripts` trait usable in addon tests. Previously, you'd have to copy it into your addon and change the `$package`.