### PR TITLE
[6.x] Ensure cache store is empty AFTER files have been removed

### DIFF
--- a/src/Console/Commands/GlideClear.php
+++ b/src/Console/Commands/GlideClear.php
@@ -47,6 +47,8 @@ class GlideClear extends Command
 
         $this->deleteEmptyDirectories($disk);
 
+        $this->clearCache();
+
         GlideCacheCleared::dispatch();
 
         $this->info('Your Glide image cache is now so very, very empty.');


### PR DESCRIPTION
Fixes: https://github.com/statamic/cms/issues/13906

This pr ensures all images will correctly get regenerated after they have been deleted by clearing the image cache after all files have been deleted.
Some images may have been generated in the meantime already, this is fine as the `makeImage` function in the Glide package already checks for the file's existence using file_exists.
