### PR TITLE
[6.x] Fix Command Palette recents not updating when navigating

### DIFF
--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -355,6 +355,7 @@ router.on('start', () => {
                                         :text-value="item.text"
                                         :as-child="true"
                                         :disabled="item.loading"
+                                        @select="item.trackRecent && addToRecentItems(item)"
                                     >
                                         <CommandPaletteLoadingItem class="rounded-lg px-2 py-1.5 w-full opacity-20" v-if="item.loading" />
                                         <CommandPaletteItem

--- a/resources/js/components/command-palette/CommandPalette.vue
+++ b/resources/js/components/command-palette/CommandPalette.vue
@@ -211,6 +211,7 @@ function searchContent() {
 
 function select(selected) {
     let item = findSelectedItem(selected);
+	if (!item) return;
 
     if (item.trackRecent) {
         addToRecentItems(item);
@@ -287,10 +288,7 @@ const modalClasses = cva({
     ],
 })({});
 
-router.on('start', () => {
-    Statamic.$commandPalette.clear();
-    open.value = false;
-});
+router.on('start', () => Statamic.$commandPalette.clear());
 </script>
 
 <template>
@@ -355,7 +353,6 @@ router.on('start', () => {
                                         :text-value="item.text"
                                         :as-child="true"
                                         :disabled="item.loading"
-                                        @select="item.trackRecent && addToRecentItems(item)"
                                     >
                                         <CommandPaletteLoadingItem class="rounded-lg px-2 py-1.5 w-full opacity-20" v-if="item.loading" />
                                         <CommandPaletteItem


### PR DESCRIPTION
This pull request fixes an issue where the recents state wasn't being updated when navigating in the Command Palette.

It looks like this was caused by a race condition introduced in #13569, where the Command Palette closed before it could call `addToRecentItems`. This PR effectively reverts that PR, and fixes the issue in a different way. 

The "Save", "Edit Blueprint" actions aren't returned by `findSelectedItem()` which causes an error in the `select()` function when it tries to add to recent, etc. 

The error means the `reset()` function isn't called, which is usually responsible for closing the Command Palette. This PR fixes it by adding a conditional in `select()` to avoid the error.

Fixes #13904
