### PR TITLE
[6.x] Apply existing container width breakpoints

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -20,9 +20,9 @@ function classes(widget) {
 
 function tailwindWidthClass(width) {
     const sizes = {
-        sm: 'w-full @2xl:w-1/2 @4xl:w-1/3 @8xl:w-1/4',
-        md: 'w-full @2xl:w-1/2 @4xl:w-1/2 @8xl:w-1/3',
-        lg: 'w-full @2xl:w-full @4xl:w-2/3 @8xl:w-3/4',
+        sm: 'w-full @2xl:w-1/2 @4xl:w-1/3 @7xl:w-1/4',
+        md: 'w-full @2xl:w-1/2 @4xl:w-1/2 @7xl:w-1/3',
+        lg: 'w-full @2xl:w-full @4xl:w-2/3 @7xl:w-3/4',
         full: 'w-full',
     };
 

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -258,9 +258,9 @@ class Str
     public static function tailwindWidthClass($width)
     {
         $sizes = [
-            'sm' => 'w-full @lg:w-1/2 @4xl:w-1/3 @8xl:w-1/4',
-            'md' => 'w-full @lg:w-1/2 @4xl:w-1/2 @8xl:w-1/3',
-            'lg' => 'w-full @lg:w-full @4xl:w-2/3 @8xl:w-3/4',
+            'sm' => 'w-full @lg:w-1/2 @4xl:w-1/3 @7xl:w-1/4',
+            'md' => 'w-full @lg:w-1/2 @4xl:w-1/2 @7xl:w-1/3',
+            'lg' => 'w-full @lg:w-full @4xl:w-2/3 @7xl:w-3/4',
             'full' => 'w-full',
         ];
 

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -190,13 +190,13 @@ class StrTest extends TestCase
     #[Test]
     public function it_makes_tailwind_width_classes()
     {
-        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/3 @8xl:w-1/4', Str::tailwindWidthClass(25));
-        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/3 @8xl:w-1/4', Str::tailwindWidthClass(33));
-        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/2 @8xl:w-1/3', Str::tailwindWidthClass(50));
-        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/2 @8xl:w-1/3', Str::tailwindWidthClass(66));
-        $this->assertEquals('w-full @lg:w-full @4xl:w-2/3 @8xl:w-3/4', Str::tailwindWidthClass(75));
+        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/3 @7xl:w-1/4', Str::tailwindWidthClass(25));
+        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/3 @7xl:w-1/4', Str::tailwindWidthClass(33));
+        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/2 @7xl:w-1/3', Str::tailwindWidthClass(50));
+        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/2 @7xl:w-1/3', Str::tailwindWidthClass(66));
+        $this->assertEquals('w-full @lg:w-full @4xl:w-2/3 @7xl:w-3/4', Str::tailwindWidthClass(75));
         $this->assertEquals('w-full', Str::tailwindWidthClass(100));
-        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/2 @8xl:w-1/3', Str::tailwindWidthClass('foo'));
+        $this->assertEquals('w-full @lg:w-1/2 @4xl:w-1/2 @7xl:w-1/3', Str::tailwindWidthClass('foo'));
     }
 
     #[Test]


### PR DESCRIPTION
I was wondering why widgets no longer resize to `1/4` width when setting the `width` config to `25`. Turns out the tailwind width classes use a container width value of `8xl`, which doesn't seem to exist, so the breakpoint is never triggered.

Current classes for `sm`: `w-full @2xl:w-1/2 @4xl:w-1/3 @8xl:w-1/4`. Note that `8xl` doesn't exist.

### Before

Widgets using `25` (or now `sm`) never shrink to `1/4`. The smallest they go is `1/3`. Hard to see, sorry.

<img width="2238" height="632" alt="Screenshot 2026-02-12 at 15 12 35" src="https://github.com/user-attachments/assets/3e21ba74-7f4f-4d00-b072-ee7458777ee0" />

### After

Widgets using `25` (or now `sm`) shrink to `1/4`.

<img width="2238" height="518" alt="Screenshot 2026-02-12 at 15 13 04" src="https://github.com/user-attachments/assets/c89e46b5-e980-4301-b512-30db5b6926f1" />

### Considerations

It's rather unfortunate that this solution would no longer reliably allow widgets to be exactly `1/2` on all sizes. The new `md` will become `1/3` at some point, leading to awkward layouts on large screens.

**→ Could this whole scenario better be solved by a new `xs` class that is `1/4` at `4xl` already?**
