### PR TITLE
[6.x] Use separate hot file for Control Panel Vite

### DIFF
--- a/src/Console/Commands/SetupCpVite.php
+++ b/src/Console/Commands/SetupCpVite.php
@@ -163,7 +163,7 @@ class SetupCpVite extends Command
                 'resources/js/cp.js',
                 'resources/css/cp.css',
             ],
-            'hotFile' => 'cp-hot',
+            'hotFile' => public_path('cp-hot'),
             'buildDirectory' => 'vendor/app',
         ]);
 PHP);

--- a/src/Console/Commands/SetupCpVite.php
+++ b/src/Console/Commands/SetupCpVite.php
@@ -163,6 +163,7 @@ class SetupCpVite extends Command
                 'resources/js/cp.js',
                 'resources/css/cp.css',
             ],
+            'hotFile' => 'cp-hot',
             'buildDirectory' => 'vendor/app',
         ]);
 PHP);

--- a/src/Console/Commands/SetupCpVite.php
+++ b/src/Console/Commands/SetupCpVite.php
@@ -87,7 +87,7 @@ class SetupCpVite extends Command
 
         $contents['scripts'] = [
             ...$contents['scripts'] ?? [],
-            'cp:dev' => 'vite build --config vite-cp.config.js --watch',
+            'cp:dev' => 'vite --config vite-cp.config.js',
             'cp:build' => 'vite build --config vite-cp.config.js',
         ];
 

--- a/src/Console/Commands/stubs/app/vite-cp.config.js.stub
+++ b/src/Console/Commands/stubs/app/vite-cp.config.js.stub
@@ -10,7 +10,7 @@ export default defineConfig({
                 'resources/css/cp.css',
                 'resources/js/cp.js',
             ],
-            hotFile: 'cp-hot',
+            hotFile: 'public/cp-hot',
             buildDirectory: 'vendor/app',
         }),
     ],

--- a/src/Console/Commands/stubs/app/vite-cp.config.js.stub
+++ b/src/Console/Commands/stubs/app/vite-cp.config.js.stub
@@ -10,6 +10,7 @@ export default defineConfig({
                 'resources/css/cp.css',
                 'resources/js/cp.js',
             ],
+            hotFile: 'cp-hot',
             buildDirectory: 'vendor/app',
         }),
     ],

--- a/tests/Console/Commands/SetupCpViteTest.php
+++ b/tests/Console/Commands/SetupCpViteTest.php
@@ -166,6 +166,7 @@ JSON, $this->files->get(base_path('package.json')));
                 'resources/js/cp.js',
                 'resources/css/cp.css',
             ],
+            'hotFile' => 'cp-hot',
             'buildDirectory' => 'vendor/app',
         ]);
 

--- a/tests/Console/Commands/SetupCpViteTest.php
+++ b/tests/Console/Commands/SetupCpViteTest.php
@@ -87,7 +87,7 @@ JSON);
         "build": "vite build",
         "dev": "vite",
         "watch": "vite",
-        "cp:dev": "vite build --config vite-cp.config.js --watch",
+        "cp:dev": "vite --config vite-cp.config.js",
         "cp:build": "vite build --config vite-cp.config.js"
     }
 JSON, $this->files->get(base_path('package.json')));

--- a/tests/Console/Commands/SetupCpViteTest.php
+++ b/tests/Console/Commands/SetupCpViteTest.php
@@ -166,7 +166,7 @@ JSON, $this->files->get(base_path('package.json')));
                 'resources/js/cp.js',
                 'resources/css/cp.css',
             ],
-            'hotFile' => 'cp-hot',
+            'hotFile' => public_path('cp-hot'),
             'buildDirectory' => 'vendor/app',
         ]);
 


### PR DESCRIPTION
This pull request ensures that the `vite-cp.config.js` stub as part of the `setup-cp-vite` command uses a separate hot file to the rest of the application.

Otherwise, running `npm run dev` for your site's assets may cause a conflict. When you quit the process, the hot file is deleted. Then even if your cp watcher is still running, the hot file would be gone, causing an exception.

This PR also updates the `cp:dev` command now that our Vite plugin supports hot module reloading (HMR).