### PR TITLE
[6.x] Fix error in relationship select field

### DIFF
--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -117,7 +117,7 @@ export default {
 
     methods: {
         request(params = {}) {
-			if (!params.length && loaders.value[this.cacheKey]) return;
+			if (!Object.keys(params).length && loaders.value[this.cacheKey]) return Promise.resolve();
 
             params = { ...this.parameters, ...params };
 


### PR DESCRIPTION
This pull request fixes an error coming from the `SelectField` component. The `request` method normally returns a promise, but we weren't returning anything when bailing out early.

It was also checking the `length` of the `params` object, but that doesn't work for objects, so I've wrapped it in `Object.keys()`.

Fixes #13913