### PR TITLE
[6.x] Clean Asset Meta Command

### DIFF
--- a/src/Console/Commands/AssetsMetaClean.php
+++ b/src/Console/Commands/AssetsMetaClean.php
@@ -25,7 +25,7 @@ class AssetsMetaClean extends Command
     {
         $containers = $this->getContainers()->keyBy->handle();
 
-        $orphanedMetaFilesByContainer = $containers->map(fn ($container) => $this->orphanedMetaFiles($container));
+        $orphanedMetaFilesByContainer = $containers->map(fn ($container) => $this->getOrphanedMetaFiles($container));
         $orphanedMetaFilesCount = $orphanedMetaFilesByContainer->sum->count();
 
         if ($orphanedMetaFilesCount === 0) {
@@ -35,7 +35,7 @@ class AssetsMetaClean extends Command
         }
 
         $flatOrphanedMetaFiles = $orphanedMetaFilesByContainer
-            ->flatMap(fn ($paths, $container) => $paths->map(fn ($path) => [
+            ->flatMap(fn (Collection $paths, string $container) => $paths->map(fn ($path) => [
                 'container' => $container,
                 'path' => $path,
             ]))
@@ -47,7 +47,7 @@ class AssetsMetaClean extends Command
                 'files' => Str::plural('file', $orphanedMetaFilesCount),
             ]));
 
-            $flatOrphanedMetaFiles->each(function ($metaFile) {
+            $flatOrphanedMetaFiles->each(function (array $metaFile) {
                 $this->line("[{$metaFile['container']}] {$metaFile['path']}");
             });
 
@@ -57,14 +57,14 @@ class AssetsMetaClean extends Command
         progress(
             label: __('Deleting orphaned asset metadata...'),
             steps: $flatOrphanedMetaFiles,
-            callback: function ($metaFile, $progress) use ($containers) {
+            callback: function (array $metaFile, $progress) use ($containers) {
                 $containers->get($metaFile['container'])->disk()->delete($metaFile['path']);
                 $progress->advance();
             }
         );
 
-        $orphanedMetaFilesByContainer->each(function ($metaFiles, $containerHandle) use ($containers) {
-            $this->deleteEmptyMetaDirectories($containers->get($containerHandle), $metaFiles);
+        $orphanedMetaFilesByContainer->each(function (Collection $metaFiles, string $container) use ($containers) {
+            $this->deleteEmptyMetaDirectories($containers->get($container), $metaFiles);
         });
 
         $this->components->info(__('Deleted :count orphaned metadata :files.', [
@@ -84,13 +84,13 @@ class AssetsMetaClean extends Command
         return collect([AssetContainer::findOrFail($container)]);
     }
 
-    private function orphanedMetaFiles(AssetsContainer $container): Collection
+    private function getOrphanedMetaFiles(AssetsContainer $container): Collection
     {
         $assetPaths = $container->files()->flip();
 
         return $container->metaFiles()
-            ->filter(fn ($path) => Str::endsWith($path, '.yaml'))
-            ->filter(fn ($metaPath) => ! $assetPaths->has($this->metaPathToAssetPath($metaPath)))
+            ->filter(fn (string $path) => Str::endsWith($path, '.yaml'))
+            ->reject(fn (string $path) => $assetPaths->has($this->metaPathToAssetPath($path)))
             ->values();
     }
 
@@ -99,6 +99,7 @@ class AssetsMetaClean extends Command
         $pathWithoutYamlExtension = Str::endsWith($metaPath, '.yaml')
             ? substr($metaPath, 0, -5)
             : $metaPath;
+
         $pathWithoutMetaDirectory = str_replace('/.meta/', '/', $pathWithoutYamlExtension);
 
         if (Str::startsWith($pathWithoutMetaDirectory, '.meta/')) {
@@ -111,11 +112,11 @@ class AssetsMetaClean extends Command
     private function deleteEmptyMetaDirectories(AssetsContainer $container, Collection $metaFiles): void
     {
         $metaDirectories = $metaFiles
-            ->map(fn ($metaFile) => dirname($metaFile))
+            ->map(fn (string $metaFile) => dirname($metaFile))
             ->unique()
-            ->sortByDesc(fn ($dir) => substr_count($dir, '/'));
+            ->sortByDesc(fn (string $directory) => substr_count($directory, '/'));
 
-        $metaDirectories->each(function ($metaDirectory) use ($container) {
+        $metaDirectories->each(function (string $metaDirectory) use ($container) {
             $disk = $container->disk();
 
             if (! $disk->exists($metaDirectory)) {

--- a/src/Console/Commands/AssetsMetaClean.php
+++ b/src/Console/Commands/AssetsMetaClean.php
@@ -91,11 +91,7 @@ class AssetsMetaClean extends Command
             return AssetContainer::all();
         }
 
-        if (! $container = AssetContainer::find($container)) {
-            throw new \InvalidArgumentException('Invalid container');
-        }
-
-        return collect([$container]);
+        return collect([AssetContainer::findOrFail($container)]);
     }
 
     private function orphanedMetaFiles(AssetsContainer $container): Collection

--- a/src/Console/Commands/AssetsMetaClean.php
+++ b/src/Console/Commands/AssetsMetaClean.php
@@ -51,7 +51,7 @@ class AssetsMetaClean extends Command
                 $this->line("[{$metaFile['container']}] {$metaFile['path']}");
             });
 
-            return 0;
+            return self::SUCCESS;
         }
 
         progress(

--- a/src/Console/Commands/AssetsMetaClean.php
+++ b/src/Console/Commands/AssetsMetaClean.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Statamic\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Statamic\Assets\AssetContainer as AssetsContainer;
+use Statamic\Console\RunsInPlease;
+use Statamic\Facades\AssetContainer;
+
+use function Laravel\Prompts\progress;
+
+class AssetsMetaClean extends Command
+{
+    use RunsInPlease;
+
+    protected $signature = 'statamic:assets:meta-clean
+        { container? : Handle of a container }
+        {--dry-run : List orphaned files without deleting}';
+
+    protected $description = 'Clean orphaned asset metadata files';
+
+    public function handle(): int
+    {
+        $orphanedMetaFilesByContainer = $this->getContainers()
+            ->mapWithKeys(fn ($container) => [$container->handle() => $this->orphanedMetaFiles($container)]);
+
+        $totalOrphanedMetaFiles = $orphanedMetaFilesByContainer->sum->count();
+
+        if ($totalOrphanedMetaFiles === 0) {
+            $this->components->info(__('No orphaned metadata files were found.'));
+
+            return self::SUCCESS;
+        }
+
+        $flatOrphanedMetaFiles = $orphanedMetaFilesByContainer
+            ->flatMap(fn ($paths, $containerHandle) => $paths->map(fn ($path) => [
+                'container' => $containerHandle,
+                'path' => $path,
+            ]))
+            ->values();
+
+        if ($this->option('dry-run')) {
+            $this->components->warn(__('Found :count orphaned metadata :files.', [
+                'count' => $totalOrphanedMetaFiles,
+                'files' => Str::plural('file', $totalOrphanedMetaFiles),
+            ]));
+
+            $flatOrphanedMetaFiles->each(function ($metaFile) {
+                $this->line("[{$metaFile['container']}] {$metaFile['path']}");
+            });
+
+            return 0;
+        }
+
+        progress(
+            label: __('Deleting orphaned asset metadata...'),
+            steps: $flatOrphanedMetaFiles,
+            callback: function ($metaFile, $progress) {
+                /** @var AssetsContainer|null $container */
+                $container = AssetContainer::find($metaFile['container']);
+
+                if ($container) {
+                    $container->disk()->delete($metaFile['path']);
+                }
+
+                $progress->advance();
+            }
+        );
+
+        $orphanedMetaFilesByContainer->each(function ($metaFiles, $containerHandle) {
+            if (! $container = AssetContainer::find($containerHandle)) {
+                return;
+            }
+
+            $this->deleteEmptyMetaDirectories($container, $metaFiles);
+        });
+
+        $this->components->info(__('Deleted :count orphaned metadata :files.', [
+            'count' => $totalOrphanedMetaFiles,
+            'files' => Str::plural('file', $totalOrphanedMetaFiles),
+        ]));
+
+        return self::SUCCESS;
+    }
+
+    private function getContainers(): Collection
+    {
+        if (! $container = $this->argument('container')) {
+            return AssetContainer::all();
+        }
+
+        if (! $container = AssetContainer::find($container)) {
+            throw new \InvalidArgumentException('Invalid container');
+        }
+
+        return collect([$container]);
+    }
+
+    private function orphanedMetaFiles(AssetsContainer $container): Collection
+    {
+        $assetPaths = $container->files()->flip();
+
+        return $container->metaFiles()
+            ->filter(fn ($path) => Str::endsWith($path, '.yaml'))
+            ->filter(fn ($metaPath) => ! $assetPaths->has($this->metaPathToAssetPath($metaPath)))
+            ->values();
+    }
+
+    private function metaPathToAssetPath(string $metaPath): string
+    {
+        $pathWithoutYamlExtension = Str::endsWith($metaPath, '.yaml')
+            ? substr($metaPath, 0, -5)
+            : $metaPath;
+        $pathWithoutMetaDirectory = str_replace('/.meta/', '/', $pathWithoutYamlExtension);
+
+        if (Str::startsWith($pathWithoutMetaDirectory, '.meta/')) {
+            $pathWithoutMetaDirectory = Str::replaceFirst('.meta/', '', $pathWithoutMetaDirectory);
+        }
+
+        return ltrim($pathWithoutMetaDirectory, '/');
+    }
+
+    private function deleteEmptyMetaDirectories(AssetsContainer $container, Collection $metaFiles): void
+    {
+        $metaDirectories = $metaFiles
+            ->map(fn ($metaFile) => dirname($metaFile))
+            ->unique()
+            ->sortByDesc(fn ($dir) => substr_count($dir, '/'));
+
+        $metaDirectories->each(function ($metaDirectory) use ($container) {
+            $disk = $container->disk();
+
+            if (! $disk->exists($metaDirectory)) {
+                return;
+            }
+
+            if ($disk->isEmpty($metaDirectory)) {
+                $disk->filesystem()->deleteDirectory($metaDirectory);
+            }
+        });
+    }
+}

--- a/src/Console/Commands/AssetsMetaClean.php
+++ b/src/Console/Commands/AssetsMetaClean.php
@@ -17,34 +17,34 @@ class AssetsMetaClean extends Command
 
     protected $signature = 'statamic:assets:meta-clean
         { container? : Handle of a container }
-        {--dry-run : List orphaned files without deleting}';
+        { --dry-run : List orphaned files without deleting }';
 
     protected $description = 'Clean orphaned asset metadata files';
 
     public function handle(): int
     {
-        $orphanedMetaFilesByContainer = $this->getContainers()
-            ->mapWithKeys(fn ($container) => [$container->handle() => $this->orphanedMetaFiles($container)]);
+        $containers = $this->getContainers()->keyBy->handle();
 
-        $totalOrphanedMetaFiles = $orphanedMetaFilesByContainer->sum->count();
+        $orphanedMetaFilesByContainer = $containers->map(fn ($container) => $this->orphanedMetaFiles($container));
+        $orphanedMetaFilesCount = $orphanedMetaFilesByContainer->sum->count();
 
-        if ($totalOrphanedMetaFiles === 0) {
+        if ($orphanedMetaFilesCount === 0) {
             $this->components->info(__('No orphaned metadata files were found.'));
 
             return self::SUCCESS;
         }
 
         $flatOrphanedMetaFiles = $orphanedMetaFilesByContainer
-            ->flatMap(fn ($paths, $containerHandle) => $paths->map(fn ($path) => [
-                'container' => $containerHandle,
+            ->flatMap(fn ($paths, $container) => $paths->map(fn ($path) => [
+                'container' => $container,
                 'path' => $path,
             ]))
             ->values();
 
         if ($this->option('dry-run')) {
             $this->components->warn(__('Found :count orphaned metadata :files.', [
-                'count' => $totalOrphanedMetaFiles,
-                'files' => Str::plural('file', $totalOrphanedMetaFiles),
+                'count' => $orphanedMetaFilesCount,
+                'files' => Str::plural('file', $orphanedMetaFilesCount),
             ]));
 
             $flatOrphanedMetaFiles->each(function ($metaFile) {
@@ -57,29 +57,19 @@ class AssetsMetaClean extends Command
         progress(
             label: __('Deleting orphaned asset metadata...'),
             steps: $flatOrphanedMetaFiles,
-            callback: function ($metaFile, $progress) {
-                /** @var AssetsContainer|null $container */
-                $container = AssetContainer::find($metaFile['container']);
-
-                if ($container) {
-                    $container->disk()->delete($metaFile['path']);
-                }
-
+            callback: function ($metaFile, $progress) use ($containers) {
+                $containers->get($metaFile['container'])->disk()->delete($metaFile['path']);
                 $progress->advance();
             }
         );
 
-        $orphanedMetaFilesByContainer->each(function ($metaFiles, $containerHandle) {
-            if (! $container = AssetContainer::find($containerHandle)) {
-                return;
-            }
-
-            $this->deleteEmptyMetaDirectories($container, $metaFiles);
+        $orphanedMetaFilesByContainer->each(function ($metaFiles, $containerHandle) use ($containers) {
+            $this->deleteEmptyMetaDirectories($containers->get($containerHandle), $metaFiles);
         });
 
         $this->components->info(__('Deleted :count orphaned metadata :files.', [
-            'count' => $totalOrphanedMetaFiles,
-            'files' => Str::plural('file', $totalOrphanedMetaFiles),
+            'count' => $orphanedMetaFilesCount,
+            'files' => Str::plural('file', $orphanedMetaFilesCount),
         ]));
 
         return self::SUCCESS;

--- a/src/Console/Commands/AssetsMetaClean.php
+++ b/src/Console/Commands/AssetsMetaClean.php
@@ -29,7 +29,7 @@ class AssetsMetaClean extends Command
         $orphanedMetaFilesCount = $orphanedMetaFilesByContainer->sum->count();
 
         if ($orphanedMetaFilesCount === 0) {
-            $this->components->info(__('No orphaned metadata files were found.'));
+            $this->components->info('No orphaned metadata files were found.');
 
             return self::SUCCESS;
         }
@@ -42,10 +42,7 @@ class AssetsMetaClean extends Command
             ->values();
 
         if ($this->option('dry-run')) {
-            $this->components->warn(__('Found :count orphaned metadata :files.', [
-                'count' => $orphanedMetaFilesCount,
-                'files' => Str::plural('file', $orphanedMetaFilesCount),
-            ]));
+            $this->components->warn("Found {$orphanedMetaFilesCount} orphaned metadata ".Str::plural('file', $orphanedMetaFilesCount));
 
             $flatOrphanedMetaFiles->each(function (array $metaFile) {
                 $this->line("[{$metaFile['container']}] {$metaFile['path']}");
@@ -55,7 +52,7 @@ class AssetsMetaClean extends Command
         }
 
         progress(
-            label: __('Deleting orphaned asset metadata...'),
+            label: 'Deleting orphaned asset metadata...',
             steps: $flatOrphanedMetaFiles,
             callback: function (array $metaFile, $progress) use ($containers) {
                 $containers->get($metaFile['container'])->disk()->delete($metaFile['path']);
@@ -67,10 +64,7 @@ class AssetsMetaClean extends Command
             $this->deleteEmptyMetaDirectories($containers->get($container), $metaFiles);
         });
 
-        $this->components->info(__('Deleted :count orphaned metadata :files.', [
-            'count' => $orphanedMetaFilesCount,
-            'files' => Str::plural('file', $orphanedMetaFilesCount),
-        ]));
+        $this->components->warn("Deleted {$orphanedMetaFilesCount} orphaned metadata ".Str::plural('file', $orphanedMetaFilesCount));
 
         return self::SUCCESS;
     }

--- a/src/Providers/ConsoleServiceProvider.php
+++ b/src/Providers/ConsoleServiceProvider.php
@@ -14,6 +14,7 @@ class ConsoleServiceProvider extends ServiceProvider
         Commands\AssetsCacheClear::class,
         Commands\AssetsGeneratePresets::class,
         Commands\AssetsMeta::class,
+        Commands\AssetsMetaClean::class,
         Commands\GlideClear::class,
         Commands\Install::class,
         Commands\InstallCollaboration::class,

--- a/tests/Console/Commands/AssetsMetaCleanTest.php
+++ b/tests/Console/Commands/AssetsMetaCleanTest.php
@@ -4,8 +4,7 @@ namespace Tests\Console\Commands;
 
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\Test;
-use Statamic\Assets\AssetContainer;
-use Statamic\Facades\AssetContainer as AssetContainerFacade;
+use Statamic\Facades\AssetContainer;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -24,8 +23,7 @@ class AssetsMetaCleanTest extends TestCase
     #[Test]
     public function it_deletes_orphaned_meta_files_and_cleans_up_empty_meta_directories()
     {
-        $container = $this->containerWithDisk('test', 'test');
-        $this->mockContainers($container);
+        AssetContainer::make('test')->disk('test')->save();
 
         Storage::disk('test')->put('foo/.meta/bar.txt.yaml', 'size: 123');
 
@@ -42,8 +40,7 @@ class AssetsMetaCleanTest extends TestCase
     #[Test]
     public function it_preserves_meta_files_with_matching_assets()
     {
-        $container = $this->containerWithDisk('test', 'test');
-        $this->mockContainers($container);
+        AssetContainer::make('test')->disk('test')->save();
 
         Storage::disk('test')->put('foo/bar.txt', 'bar');
         Storage::disk('test')->put('foo/.meta/bar.txt.yaml', 'size: 123');
@@ -57,8 +54,7 @@ class AssetsMetaCleanTest extends TestCase
     #[Test]
     public function dry_run_lists_orphaned_files_without_deleting_them()
     {
-        $container = $this->containerWithDisk('test', 'test');
-        $this->mockContainers($container);
+        AssetContainer::make('test')->disk('test')->save();
 
         Storage::disk('test')->put('.meta/root.txt.yaml', 'size: 123');
 
@@ -72,9 +68,8 @@ class AssetsMetaCleanTest extends TestCase
     #[Test]
     public function it_only_cleans_the_requested_container()
     {
-        $one = $this->containerWithDisk('one', 'test');
-        $two = $this->containerWithDisk('two', 'test_two');
-        $this->mockContainers($one, $two);
+        AssetContainer::make('one')->disk('test')->save();
+        AssetContainer::make('two')->disk('test_two')->save();
 
         Storage::disk('test')->put('foo/.meta/one.jpg.yaml', 'size: 1');
         Storage::disk('test_two')->put('foo/.meta/two.jpg.yaml', 'size: 2');
@@ -89,9 +84,8 @@ class AssetsMetaCleanTest extends TestCase
     #[Test]
     public function it_cleans_all_containers_when_no_container_argument_is_provided()
     {
-        $one = $this->containerWithDisk('one', 'test');
-        $two = $this->containerWithDisk('two', 'test_two');
-        $this->mockContainers($one, $two);
+        AssetContainer::make('one')->disk('test')->save();
+        AssetContainer::make('two')->disk('test_two')->save();
 
         Storage::disk('test')->put('foo/.meta/one.jpg.yaml', 'size: 1');
         Storage::disk('test_two')->put('foo/.meta/two.jpg.yaml', 'size: 2');
@@ -106,8 +100,7 @@ class AssetsMetaCleanTest extends TestCase
     #[Test]
     public function it_detects_orphaned_meta_files_in_root_and_nested_meta_directories()
     {
-        $container = $this->containerWithDisk('test', 'test');
-        $this->mockContainers($container);
+        AssetContainer::make('test')->disk('test')->save();
 
         Storage::disk('test')->put('.meta/root.jpg.yaml', 'size: 1');
         Storage::disk('test')->put('foo/.meta/nested.jpg.yaml', 'size: 2');
@@ -117,25 +110,5 @@ class AssetsMetaCleanTest extends TestCase
 
         $this->assertFalse(Storage::disk('test')->exists('.meta/root.jpg.yaml'));
         $this->assertFalse(Storage::disk('test')->exists('foo/.meta/nested.jpg.yaml'));
-    }
-
-    private function containerWithDisk(string $handle, string $disk): AssetContainer
-    {
-        return (new AssetContainer)->handle($handle)->disk($disk);
-    }
-
-    private function mockContainers(AssetContainer ...$containers): void
-    {
-        $containersByHandle = collect($containers)->mapWithKeys(fn ($container) => [
-            $container->handle() => $container,
-        ]);
-
-        AssetContainerFacade::partialMock()
-            ->shouldReceive('all')
-            ->andReturn(collect($containers));
-
-        AssetContainerFacade::partialMock()
-            ->shouldReceive('findByHandle')
-            ->andReturnUsing(fn ($handle) => $containersByHandle->get($handle));
     }
 }

--- a/tests/Console/Commands/AssetsMetaCleanTest.php
+++ b/tests/Console/Commands/AssetsMetaCleanTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Assets\AssetContainer;
+use Statamic\Facades\AssetContainer as AssetContainerFacade;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class AssetsMetaCleanTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('test');
+        Storage::fake('test_two');
+    }
+
+    #[Test]
+    public function it_deletes_orphaned_meta_files_and_cleans_up_empty_meta_directories()
+    {
+        $container = $this->containerWithDisk('test', 'test');
+        $this->mockContainers($container);
+
+        Storage::disk('test')->put('foo/.meta/bar.txt.yaml', 'size: 123');
+
+        $this->assertTrue(Storage::disk('test')->exists('foo/.meta/bar.txt.yaml'));
+        $this->assertTrue(Storage::disk('test')->exists('foo/.meta'));
+
+        $this->artisan('statamic:assets:meta-clean test')
+            ->expectsOutputToContain('Deleted 1 orphaned metadata file.');
+
+        $this->assertFalse(Storage::disk('test')->exists('foo/.meta/bar.txt.yaml'));
+        $this->assertFalse(Storage::disk('test')->exists('foo/.meta'));
+    }
+
+    #[Test]
+    public function it_preserves_meta_files_with_matching_assets()
+    {
+        $container = $this->containerWithDisk('test', 'test');
+        $this->mockContainers($container);
+
+        Storage::disk('test')->put('foo/bar.txt', 'bar');
+        Storage::disk('test')->put('foo/.meta/bar.txt.yaml', 'size: 123');
+
+        $this->artisan('statamic:assets:meta-clean test')
+            ->expectsOutputToContain('No orphaned metadata files were found.');
+
+        $this->assertTrue(Storage::disk('test')->exists('foo/.meta/bar.txt.yaml'));
+    }
+
+    #[Test]
+    public function dry_run_lists_orphaned_files_without_deleting_them()
+    {
+        $container = $this->containerWithDisk('test', 'test');
+        $this->mockContainers($container);
+
+        Storage::disk('test')->put('.meta/root.txt.yaml', 'size: 123');
+
+        $this->artisan('statamic:assets:meta-clean test --dry-run')
+            ->expectsOutputToContain('Found 1 orphaned metadata file.')
+            ->expectsOutputToContain('[test] .meta/root.txt.yaml');
+
+        $this->assertTrue(Storage::disk('test')->exists('.meta/root.txt.yaml'));
+    }
+
+    #[Test]
+    public function it_only_cleans_the_requested_container()
+    {
+        $one = $this->containerWithDisk('one', 'test');
+        $two = $this->containerWithDisk('two', 'test_two');
+        $this->mockContainers($one, $two);
+
+        Storage::disk('test')->put('foo/.meta/one.jpg.yaml', 'size: 1');
+        Storage::disk('test_two')->put('foo/.meta/two.jpg.yaml', 'size: 2');
+
+        $this->artisan('statamic:assets:meta-clean one')
+            ->expectsOutputToContain('Deleted 1 orphaned metadata file.');
+
+        $this->assertFalse(Storage::disk('test')->exists('foo/.meta/one.jpg.yaml'));
+        $this->assertTrue(Storage::disk('test_two')->exists('foo/.meta/two.jpg.yaml'));
+    }
+
+    #[Test]
+    public function it_cleans_all_containers_when_no_container_argument_is_provided()
+    {
+        $one = $this->containerWithDisk('one', 'test');
+        $two = $this->containerWithDisk('two', 'test_two');
+        $this->mockContainers($one, $two);
+
+        Storage::disk('test')->put('foo/.meta/one.jpg.yaml', 'size: 1');
+        Storage::disk('test_two')->put('foo/.meta/two.jpg.yaml', 'size: 2');
+
+        $this->artisan('statamic:assets:meta-clean')
+            ->expectsOutputToContain('Deleted 2 orphaned metadata files.');
+
+        $this->assertFalse(Storage::disk('test')->exists('foo/.meta/one.jpg.yaml'));
+        $this->assertFalse(Storage::disk('test_two')->exists('foo/.meta/two.jpg.yaml'));
+    }
+
+    #[Test]
+    public function it_detects_orphaned_meta_files_in_root_and_nested_meta_directories()
+    {
+        $container = $this->containerWithDisk('test', 'test');
+        $this->mockContainers($container);
+
+        Storage::disk('test')->put('.meta/root.jpg.yaml', 'size: 1');
+        Storage::disk('test')->put('foo/.meta/nested.jpg.yaml', 'size: 2');
+
+        $this->artisan('statamic:assets:meta-clean test')
+            ->expectsOutputToContain('Deleted 2 orphaned metadata files.');
+
+        $this->assertFalse(Storage::disk('test')->exists('.meta/root.jpg.yaml'));
+        $this->assertFalse(Storage::disk('test')->exists('foo/.meta/nested.jpg.yaml'));
+    }
+
+    private function containerWithDisk(string $handle, string $disk): AssetContainer
+    {
+        return (new AssetContainer)->handle($handle)->disk($disk);
+    }
+
+    private function mockContainers(AssetContainer ...$containers): void
+    {
+        $containersByHandle = collect($containers)->mapWithKeys(fn ($container) => [
+            $container->handle() => $container,
+        ]);
+
+        AssetContainerFacade::partialMock()
+            ->shouldReceive('all')
+            ->andReturn(collect($containers));
+
+        AssetContainerFacade::partialMock()
+            ->shouldReceive('findByHandle')
+            ->andReturnUsing(fn ($handle) => $containersByHandle->get($handle));
+    }
+}

--- a/tests/Console/Commands/AssetsMetaCleanTest.php
+++ b/tests/Console/Commands/AssetsMetaCleanTest.php
@@ -21,6 +21,20 @@ class AssetsMetaCleanTest extends TestCase
     }
 
     #[Test]
+    public function dry_run_lists_orphaned_files_without_deleting_them()
+    {
+        AssetContainer::make('test')->disk('test')->save();
+
+        Storage::disk('test')->put('.meta/root.txt.yaml', 'size: 123');
+
+        $this->artisan('statamic:assets:meta-clean test --dry-run')
+            ->expectsOutputToContain('Found 1 orphaned metadata file.')
+            ->expectsOutputToContain('[test] .meta/root.txt.yaml');
+
+        $this->assertTrue(Storage::disk('test')->exists('.meta/root.txt.yaml'));
+    }
+
+    #[Test]
     public function it_deletes_orphaned_meta_files_and_cleans_up_empty_meta_directories()
     {
         AssetContainer::make('test')->disk('test')->save();
@@ -49,20 +63,6 @@ class AssetsMetaCleanTest extends TestCase
             ->expectsOutputToContain('No orphaned metadata files were found.');
 
         $this->assertTrue(Storage::disk('test')->exists('foo/.meta/bar.txt.yaml'));
-    }
-
-    #[Test]
-    public function dry_run_lists_orphaned_files_without_deleting_them()
-    {
-        AssetContainer::make('test')->disk('test')->save();
-
-        Storage::disk('test')->put('.meta/root.txt.yaml', 'size: 123');
-
-        $this->artisan('statamic:assets:meta-clean test --dry-run')
-            ->expectsOutputToContain('Found 1 orphaned metadata file.')
-            ->expectsOutputToContain('[test] .meta/root.txt.yaml');
-
-        $this->assertTrue(Storage::disk('test')->exists('.meta/root.txt.yaml'));
     }
 
     #[Test]


### PR DESCRIPTION
Closes https://github.com/statamic/ideas/issues/89

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes files from asset container disks, so incorrect orphan detection or path handling could remove valid metadata; tests reduce but don’t eliminate that risk.
> 
> **Overview**
> Adds a new `statamic:assets:meta-clean` console command to find and delete orphaned asset `.meta/*.yaml` files (optionally scoped to a single container) and to remove now-empty `.meta` directories afterward.
> 
> Includes a `--dry-run` mode to list what would be deleted without changing disks, registers the command in `ConsoleServiceProvider`, and adds coverage for deletion, preservation of valid metadata, container scoping, and root/nested `.meta` paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ed54f037c5e47d1e49d1b811f0c58a4a6f8ddf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->