### PR TITLE
[6.x] Fix full width setting field widths

### DIFF
--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -54,7 +54,7 @@ const rootClasses = computed(() =>
                 true: 'grid md:grid-cols-2 items-start px-4.5 py-4 gap-y-3 md:gap-y-0 md:gap-x-5!',
             },
             fullWidthSetting: {
-                true: 'grid-cols-1',
+                true: 'md:grid-cols-1',
             },
         },
     })({


### PR DESCRIPTION
Fields marked with `full_width_setting` have ironically lost their full width, due to #13847.
