### PR TITLE
[6.x] Corrects Issues with Directive Node Parsing

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -353,7 +353,7 @@ class DocumentParser
             $lastOffset = $thisIndex;
         }
 
-        preg_match_all('/(@?{{|@?(props|aware|cascade))/u', $this->content, $antlersStartCandidates, PREG_OFFSET_CAPTURE);
+        preg_match_all('/(@?{{|@(props|aware|cascade))/u', $this->content, $antlersStartCandidates, PREG_OFFSET_CAPTURE);
 
         $lastAntlersOffset = 0;
         $lastWasEscaped = false;
@@ -368,6 +368,32 @@ class DocumentParser
                         if (mb_substr($this->content, $antlersMatch[1] - 1, 1) === '@') {
                             $lastAntlersOffset = mb_strpos($this->content, $antlersRegion, $lastAntlersOffset);
                             $lastWasEscaped = true;
+
+                            continue;
+                        }
+                    }
+
+
+                    if (in_array($antlersRegion, ['@props', '@aware'])) {
+                        $hasArgs = false;
+
+                        for ($k = $offset + mb_strlen($antlersRegion); $k < $this->inputLen; $k++) {
+                            $ch = mb_substr($this->content, $k, 1);
+
+                            if (ctype_space($ch)) {
+                                continue;
+                            }
+
+                            if ($ch === '(') {
+                                $hasArgs = true;
+                            }
+
+                            break;
+                        }
+
+                        if (! $hasArgs) {
+                            $lastAntlersOffset = $offset + mb_strlen($antlersRegion);
+                            $lastWasEscaped = false;
 
                             continue;
                         }
@@ -419,6 +445,7 @@ class DocumentParser
             '@{{' => '{{',
             '@@props' => '@props',
             '@@aware' => '@aware',
+            '@@cascade' => '@cascade',
         ]);
     }
 
@@ -1311,6 +1338,7 @@ class DocumentParser
     private function makeDirectiveNode($name, $args, $index)
     {
         $directive = new DirectiveNode();
+        $directive->withParser($this);
         $directive->directiveName = $name;
         $directive->args = $args;
 

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -373,7 +373,6 @@ class DocumentParser
                         }
                     }
 
-
                     if (in_array($antlersRegion, ['@props', '@aware'])) {
                         $hasArgs = false;
 

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -275,7 +275,7 @@ class RuntimeParser implements Parser
             return true;
         }
 
-        if (Str::contains($text, [DocumentParser::LeftBrace, '@props', '@aware'])) {
+        if (Str::contains($text, [DocumentParser::LeftBrace, '@props', '@aware', '@cascade'])) {
             return true;
         }
 

--- a/tests/Antlers/Parser/DirectivesTest.php
+++ b/tests/Antlers/Parser/DirectivesTest.php
@@ -2,6 +2,9 @@
 
 namespace Tests\Antlers\Parser;
 
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Text;
 use Tests\Antlers\ParserTestCase;
 
 class DirectivesTest extends ParserTestCase
@@ -52,5 +55,217 @@ Hellow
 EOT;
 
         $this->assertSame($expected, $this->renderString($template));
+    }
+
+    public function test_directive_word_collisions_dont_cause_errors()
+    {
+        $template = <<<'EOT'
+1aware2 @aware {{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+1aware2 @aware The Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_directive_keywords_without_args_are_literal()
+    {
+        $this->assertSame('@aware', $this->renderString('@aware'));
+        $this->assertSame('@props', $this->renderString('@props'));
+        $this->assertSame('@aware trailing', $this->renderString('@aware trailing'));
+        $this->assertSame('leading @props', $this->renderString('leading @props'));
+        $this->assertSame('leading @aware trailing', $this->renderString('leading @aware trailing'));
+        $this->assertSame('@aware     ', $this->renderString('@aware     '));
+    }
+
+    public function test_cascade_directive_can_be_escaped()
+    {
+        $template = <<<'EOT'
+@@cascade
+{{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+@cascade
+The Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_directive_substrings_in_words_dont_cause_errors()
+    {
+        $template = <<<'EOT'
+appropriate unaware cascading property {{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+appropriate unaware cascading property The Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_multiple_argless_directives()
+    {
+        $template = <<<'EOT'
+@aware @props {{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+@aware @props The Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_directive_adjacent_to_antlers()
+    {
+        $template = <<<'EOT'
+@aware{{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+@awareThe Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_whitespace_variations_before_args()
+    {
+        $template = "@props\t(['key' => 'value']){{ title }}";
+
+        $this->assertSame(
+            'The Title',
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+
+        $template = "@props\n(['key' => 'value']){{ title }}";
+
+        $this->assertSame(
+            'The Title',
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_mixed_valid_and_argless_directives()
+    {
+        $template = <<<'EOT'
+@props(['key' => 'value']) @aware {{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+ @aware The Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_directive_at_end_of_template()
+    {
+        $template = <<<'EOT'
+{{ title }} @aware
+EOT;
+
+        $expected = <<<'EOT'
+The Title @aware
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_antlers_rendered_field_with_directive_keywords()
+    {
+        $textFieldtype = new Text();
+        $field = new Field('text_field', [
+            'type' => 'text',
+            'antlers' => true,
+        ]);
+
+        $textFieldtype->setField($field);
+        $value = new Value('@aware some content @props here', 'text_field', $textFieldtype);
+
+        $template = <<<'EOT'
+{{ text_field }}
+EOT;
+
+        $this->assertSame(
+            '@aware some content @props here',
+            $this->renderString($template, ['text_field' => $value])
+        );
+    }
+
+    public function test_all_escaped_directives_together()
+    {
+        $template = <<<'EOT'
+@@props @@aware @@cascade
+{{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+@props @aware @cascade
+The Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_argless_directive_with_later_parens()
+    {
+        $template = <<<'EOT'
+@aware some text (parenthetical) {{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+@aware some text (parenthetical) The Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
+    }
+
+    public function test_directive_adjacent_no_space_before_antlers()
+    {
+        $template = <<<'EOT'
+@props{{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+@propsThe Title
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['title' => 'The Title'])
+        );
     }
 }

--- a/tests/Antlers/Parser/DirectivesTest.php
+++ b/tests/Antlers/Parser/DirectivesTest.php
@@ -268,4 +268,13 @@ EOT;
             $this->renderString($template, ['title' => 'The Title'])
         );
     }
+
+    public function test_directive_in_no_parse_is_correctly_escaped()
+    {
+        $template = <<<'EOT'
+{{ noparse }}@cascade{{ /noparse }}
+EOT;
+
+        $this->assertSame('@cascade', $this->renderString($template));
+    }
 }


### PR DESCRIPTION
This PR corrects an issue where the new directive parsing could cause issues with standalone words that match (aware, props, cascade).

## The Problem

There were three problematic scenarios discovered when investigating the issue:

1. Words that collided with directive names would get caught up in the directive parsing accidentally
2. Created directive nodes missing their `$parser` instances, resulting in `Call to a member function getText() on null` exceptions
3. Depending on _how_ you constructed your template, it was possible to get content before the directive to become duplicated when attempting to workaround the issue

## The Fixes

1. The directive regular expression was improved to help prevent standalone words from matching. Additionally, improved lookahead parsing was implemented to not capture `@props` or `@aware` without arguments.
2. All created directive nodes now correctly have their parser instances set
3. Proper escaped node handling for directives was implemented
