### PR TITLE
[6.x] Fixes an issue with PHP tag and assignments

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2559,7 +2559,7 @@ class NodeProcessor
                 foreach ($___antlersVarAfter as $___varKey => $___varValue) {
                     if (
                         str_starts_with($___varKey, '___') ||
-                        isset($___antlersVarBefore[$___varKey]) && $___antlersVarBefore[$___varKey] == $___varValue
+                        (isset($___antlersVarBefore[$___varKey]) && $___antlersVarBefore[$___varKey] === $___varValue)
                     ) {
                         continue;
                     }

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2557,7 +2557,10 @@ class NodeProcessor
                 $___antlersVarAfter = get_defined_vars();
 
                 foreach ($___antlersVarAfter as $___varKey => $___varValue) {
-                    if (str_starts_with($___varKey, '___')) {
+                    if (
+                        str_starts_with($___varKey, '___') ||
+                        isset($___antlersVarBefore[$___varKey]) && $___antlersVarBefore[$___varKey] == $___varValue
+                    ) {
                         continue;
                     }
 

--- a/tests/Antlers/Runtime/ParserIsolationTest.php
+++ b/tests/Antlers/Runtime/ParserIsolationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Antlers\Runtime;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Str;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Nav;
 use Statamic\Facades\Taxonomy;
@@ -273,5 +274,48 @@ EXPECTED;
 
         $this->assertSame($expectedOne, $contentOne);
         $this->assertSame($expectedTwo, $contentTwo);
+    }
+
+    public function test_php_nodes_do_overwrite_parent_scope_needlessly()
+    {
+        $this->createBlueprintsAndData();
+        $this->withFakeViews();
+
+        $layout = <<<'EOT'
+{{ template_content }}
+Layout: {{ title }}
+EOT;
+
+        $template = <<<'EOT'
+{{?
+    $loop_data = [
+        [
+            'title' => 'A different title',
+        ],
+    ];
+?}}
+
+Before: {{ title }}
+{{ collection:news }}
+    {{ collection:news }}
+        {{ loop_data }}
+            {{? /* */ ?}}
+        {{ /loop_data }}
+    {{ /collection:news }}
+{{ /collection:news }}
+After: {{ title }}
+EOT;
+
+        $this->viewShouldReturnRaw('layout', $layout);
+        $this->viewShouldReturnRaw('default', $template);
+
+        $result = $this->get('bravo/news-2')
+            ->assertOk()
+            ->content();
+
+        $this->assertSame(
+            'Before: News 2 After: News 2 Layout: News 2',
+            Str::squish($result)
+        );
     }
 }

--- a/tests/Antlers/Runtime/ParserIsolationTest.php
+++ b/tests/Antlers/Runtime/ParserIsolationTest.php
@@ -276,7 +276,7 @@ EXPECTED;
         $this->assertSame($expectedTwo, $contentTwo);
     }
 
-    public function test_php_nodes_do_overwrite_parent_scope_needlessly()
+    public function test_php_nodes_dont_overwrite_parent_scope_needlessly()
     {
         $this->createBlueprintsAndData();
         $this->withFakeViews();


### PR DESCRIPTION
This PR fixes an issue caused by an interaction with `{{? ?}}` tags and runtime assignments.

## The Problem

Depending on the current setup and stack, when you use `{{? /* .... */ ?}}`, the runtime would attempt to propagate changes to variable assignments from the inner scope. The runtime was missing a guard preventing assignments from being updated when they shouldn't.

When assignments are updated incorrectly, you can get into a situation where outer scope variables are overwritten.

## The Solution

The fix was to add an extra guard preventing the reassignment of unchanged variables, which could change their internal references as scope frames are popped.