### PR TITLE
[6.x] fix bard grid set picker closing on reopen

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -838,7 +838,8 @@ export default {
                     setTimeout(() => {
                         const isInsideBard = this.$refs.container.contains(document.activeElement);
                         const isSetPickerSearch = document.activeElement.hasAttribute('data-set-picker-search-input');
-                        if (!isInsideBard && !isSetPickerSearch) {
+                        const isSetPickerOpen = !!this.$refs.setPicker?.isOpen;
+                        if (!isInsideBard && !isSetPickerSearch && !isSetPickerOpen) {
                             this.$emit('blur');
                             this.showAddSetButton = false;
                         }


### PR DESCRIPTION
Closes #13901

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-focus logic tweak confined to Bard’s blur handler; low risk but could affect focus/blur event timing in edge cases.
> 
> **Overview**
> Prevents the Bard field from emitting `blur` (and hiding the add-set UI) when focus leaves the editor due to the grid set picker being open. The `onBlur` handler now also checks `this.$refs.setPicker?.isOpen` before treating focus changes as leaving Bard, fixing the set picker closing unexpectedly on reopen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98ecf0d4d52e74fe5f0b1008d44300b1a5d70ed3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->