### PR TITLE
[6.x] Fix table height changes on grid line hover in Bard

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -328,7 +328,7 @@
         ul {
             margin-top: 0;
             margin-bottom: 0.85em;
-            table &:last-of-type {
+            table &:where(:last-child, :nth-last-child(2):has(+ .column-resize-handle)) {
                 /* If you type a single line of text in a table fieldtype cell you don't want it to have a bottom margin */
                 margin-block-end: 0;
             }

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -328,7 +328,7 @@
         ul {
             margin-top: 0;
             margin-bottom: 0.85em;
-            table &:last-child {
+            table &:last-of-type {
                 /* If you type a single line of text in a table fieldtype cell you don't want it to have a bottom margin */
                 margin-block-end: 0;
             }


### PR DESCRIPTION
Closes #13699

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, scoped CSS selector change limited to Bard table content; main risk is cross-browser support/regression around advanced selectors like `:has()`.
> 
> **Overview**
> Adjusts Bard typography CSS so the “remove bottom margin for last paragraph in a table cell” rule also applies when the last visible paragraph is immediately followed by the table’s `.column-resize-handle` element (using `:where(:last-child, :nth-last-child(2):has(+ .column-resize-handle))`). This prevents table row height/layout from changing when hovering grid lines/resize handles in Bard tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 730e77294412bbb86b482d46ec07ee782e14db0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->