### PR TITLE
[6.x] Fix dotted lines on Prefs screen

### DIFF
--- a/resources/js/pages/preferences/Index.vue
+++ b/resources/js/pages/preferences/Index.vue
@@ -18,8 +18,7 @@ defineProps([
 
         <Header :title="__('Preferences')" icon="preferences" />
 
-        <section class="relative flex flex-col gap-8">
-            <div class="absolute top-0 start-8 border-s w-px border-gray-300 dark:border-gray-700 h-[calc(100%-1.25rem)] border-dashed"></div>
+        <section class="flex flex-col">
             <CardPanel class="mb-0!" :heading="__('Global Preferences')" :subheading="__('Applied to all users by default.')">
                 <div class="flex items-center justify-between">
                     <div class="flex items-center gap-2 sm:gap-3">
@@ -31,6 +30,10 @@ defineProps([
                 </div>
             </CardPanel>
 
+            <div class="h-8 ps-8">
+                <div data-pref-connector class="h-full border-s border-dashed border-gray-300 dark:border-gray-700"></div>
+            </div>
+
             <CardPanel class="mb-0!" v-if="roles.length" :heading="__('Role Preferences')" :subheading="__('Applied to users in specific roles.')">
                 <div v-for="role in roles" :key="role.handle" class="flex items-center justify-between">
                     <div class="flex items-center gap-2 sm:gap-3">
@@ -40,6 +43,10 @@ defineProps([
                     <Badge v-if="Object.keys(role.preferences).length" color="green">{{ __('Modified') }}</Badge>
                 </div>
             </CardPanel>
+
+            <div v-if="roles.length" class="h-8 ps-8">
+                <div data-pref-connector class="h-full border-s border-dashed border-gray-300 dark:border-gray-700"></div>
+            </div>
 
             <CardPanel class="mb-0!" :heading="__('User Preferences')" :subheading="__('Applied to your account.')">
                 <div class="flex items-center justify-between">


### PR DESCRIPTION
Closes #13863

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Purely presentational Vue template/CSS class changes to the Preferences page layout/connector lines, with no data or logic changes.
> 
> **Overview**
> Fixes the Preferences page’s vertical dotted connector styling by replacing the single absolutely-positioned border line with **explicit connector segments** between cards.
> 
> The `Index.vue` layout is adjusted (`section` spacing/positioning removed) and new `data-pref-connector` divider blocks are inserted (including a role-conditional connector) to ensure the dashed line renders correctly across sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d794ad9af822d3909a77f49fe4b6d324188c3deb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->