### PR TITLE
[6.x] Fix asset windows path issue

### DIFF
--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -93,6 +93,7 @@ class AssetRepository implements Contract
     public function findById(string $id)
     {
         [$container_id, $path] = explode('::', $id);
+        $path = str_replace('\\', '/', $path);
 
         // If a container can't be found, we'll assume there's no asset.
         if (! $container = AssetContainer::find($container_id)) {

--- a/tests/Assets/AssetRepositoryTest.php
+++ b/tests/Assets/AssetRepositoryTest.php
@@ -107,6 +107,21 @@ EOT;
     }
 
     #[Test]
+    public function it_finds_assets_by_id_when_the_path_contains_windows_separators()
+    {
+        Storage::fake('test');
+        Storage::disk('test')->put('foo/bar.jpg', UploadedFile::fake()->image('bar.jpg')->getContent());
+
+        $container = tap(AssetContainer::make('test_container')->disk('test'))->save();
+        $asset = tap($container->makeAsset('foo/bar.jpg'))->save();
+
+        $found = (new AssetRepository)->find('test_container::foo\\bar.jpg');
+
+        $this->assertInstanceOf(AssetContract::class, $found);
+        $this->assertEquals($asset->id(), $found->id());
+    }
+
+    #[Test]
     public function test_find_or_fail_throws_exception_when_asset_does_not_exist()
     {
         $assetRepository = new AssetRepository;


### PR DESCRIPTION
Closes #6064

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to path normalization plus a regression test; minimal behavioral impact outside Windows-style ID inputs.
> 
> **Overview**
> Fixes asset lookup by ID when the asset path contains Windows-style `\\` separators.
> 
> `AssetRepository::findById` now normalizes the extracted path by converting backslashes to `/` before resolving the asset, and a new test asserts `find('container::foo\\bar.jpg')` correctly returns the saved asset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbc5da128d3ed2df206af813ce550e716d0db560. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->