### PR TITLE
[6.x] Fix StackFooter Dark Mode

### DIFF
--- a/resources/js/components/ui/Stack/Footer.vue
+++ b/resources/js/components/ui/Stack/Footer.vue
@@ -9,7 +9,7 @@ const slots = useSlots();
 <template>
     <div
         data-ui-stack-footer
-        class="bg-gray-50 p-4 border-t border-gray-200"
+        class="bg-gray-50 p-4 border-t border-gray-200 dark:bg-gray-800 dark:border-gray-700"
     >
         <template v-if="slots['start'] || slots['end']">
             <div class="flex justify-between items-center">


### PR DESCRIPTION
Closes #13911

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class change to a UI component; low chance of regressions outside footer styling.
> 
> **Overview**
> Fixes `StackFooter` dark mode appearance by adding Tailwind `dark:` classes to the footer container so its background and top border render correctly in dark theme.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b579d013da0d3b7348b08a318dc16a8edf6fa852. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->