### PR TITLE
[6.x] Fix race condition in blueprint Apply & Save

### DIFF
--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -82,7 +82,9 @@ export default {
         // Listen for root-form-save events from child components
         // This also happens on the fieldset builder.
         this.$events.$on('root-form-save', () => {
-            this.save();
+            this.$nextTick(() => {
+                this.save();
+            });
         });
 
         if (this.isFormBlueprint) {
@@ -130,7 +132,7 @@ export default {
                 });
         },
 
-        saved(response) {
+        saved() {
             this.$toast.success(__('Saved'));
             this.errors = {};
             this.$dirty.remove('blueprints');

--- a/resources/js/components/blueprints/Builder.vue
+++ b/resources/js/components/blueprints/Builder.vue
@@ -82,9 +82,7 @@ export default {
         // Listen for root-form-save events from child components
         // This also happens on the fieldset builder.
         this.$events.$on('root-form-save', () => {
-            this.$nextTick(() => {
-                this.save();
-            });
+            this.$nextTick(() => this.save());
         });
 
         if (this.isFormBlueprint) {


### PR DESCRIPTION
Closes #13949.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to blueprint save timing and callback signature; primary risk is subtle regressions in save triggering/order.
> 
> **Overview**
> Fixes a race in blueprint “Apply & Save” by deferring `root-form-save` handling in `Builder.vue` to the next tick before calling `save()`, ensuring child edits are committed first.
> 
> Simplifies the save callback by making `saved()` ignore the Axios response payload and just perform post-save UI cleanup (toast, clear errors, clear dirty state).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d124fabf53a51d245c440e278c02c000b504afdf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->