### PR TITLE
[6.x] Preload replicator meta/defaults when blueprint doesn't have a FQH

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -527,6 +527,14 @@ export default {
                 const reference = this.publishContainer.reference;
                 const blueprint = this.publishContainer.blueprint.fqh;
 
+	            if (this.meta.new?.hasOwnProperty(set)) {
+		            let meta = this.meta.new[set];
+		            let defaults = this.meta.defaults[set];
+
+		            resolve({ new: meta, defaults });
+		            return;
+	            }
+
                 if (this.setsCache[setCacheKey]) {
                     resolve(this.setsCache[setCacheKey]);
                     return;

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -241,6 +241,14 @@ export default {
                 const reference = this.publishContainer.reference;
                 const blueprint = this.publishContainer.blueprint.fqh;
 
+				if (this.meta.new?.hasOwnProperty(set)) {
+					let meta = this.meta.new[set];
+					let defaults = this.meta.defaults[set];
+
+					resolve({ new: meta, defaults });
+					return;
+				}
+
                 if (this.setsCache[setCacheKey]) {
                     resolve(this.setsCache[setCacheKey]);
                     return;

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -617,6 +617,18 @@ class Bard extends Replicator
             return [$set['attrs']['id'] => $this->fields($values['type'], $index)->addValues($values)->meta()->put('_', '_')];
         })->toArray();
 
+        if ($this->shouldProcessNewValues()) {
+            $defaults = collect($this->flattenedSetsConfig())->map(function ($set, $handle) {
+                return $this->fields($handle)->all()->map(function ($field) {
+                    return $field->fieldtype()->preProcess($field->defaultValue());
+                })->all();
+            })->all();
+
+            $new = collect($this->flattenedSetsConfig())->map(function ($set, $handle) use ($defaults) {
+                return $this->fields($handle)->addValues($defaults[$handle])->meta()->put('_', '_');
+            })->toArray();
+        }
+
         $previews = collect($existing)->map(function ($fields) {
             return collect($fields)->map(function () {
                 return null;
@@ -637,6 +649,8 @@ class Bard extends Replicator
 
         $data = [
             'existing' => $existing,
+            'new' => $new ?? null,
+            'defaults' => $defaults ?? null,
             'collapsed' => $this->config('collapse') ? array_keys($existing) : [],
             'previews' => $previews,
             '__collaboration' => ['existing'],
@@ -661,6 +675,17 @@ class Bard extends Replicator
         }
 
         return $this->runHooks('preload', $data);
+    }
+
+    private function shouldProcessNewValues(): bool
+    {
+        $parent = $this->field()->parent();
+
+        if (! $parent || ! method_exists($parent, 'blueprint')) {
+            return true;
+        }
+
+        return is_null($parent->blueprint()->fullyQualifiedHandle());
     }
 
     public function preProcessValidatable($value)

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -228,10 +228,43 @@ class Replicator extends Fieldtype
             return [$set['_id'] => $this->fields($set['type'], $index)->addValues($set)->meta()->put('_', '_')];
         })->toArray();
 
+        // Most of the time, these values will be fetched over AJAX.
+        // However, if the blueprint doesn't have a FQH, we need to fallback here.
+        if ($this->shouldProcessNewValues()) {
+            $blink = md5(json_encode($this->flattenedSetsConfig()));
+
+            $defaults = Blink::once($blink.'-defaults', function () {
+                return collect($this->flattenedSetsConfig())->map(function ($set, $handle) {
+                    return $this->fields($handle)->all()->map(function ($field) {
+                        return $field->fieldtype()->preProcess($field->defaultValue());
+                    })->all();
+                })->all();
+            });
+
+            $new = Blink::once($blink.'-new', function () use ($defaults) {
+                return collect($this->flattenedSetsConfig())->map(function ($set, $handle) use ($defaults) {
+                    return $this->fields($handle)->addValues($defaults[$handle])->meta()->put('_', '_');
+                })->toArray();
+            });
+        }
+
         return [
             'existing' => $existing,
+            'new' => $new ?? null,
+            'defaults' => $defaults ?? null,
             'collapsed' => $this->config('collapse') ? array_keys($existing) : [],
         ];
+    }
+
+    private function shouldProcessNewValues(): bool
+    {
+        $parent = $this->field()->parent();
+
+        if (! $parent || ! method_exists($parent, 'blueprint')) {
+            return true;
+        }
+
+        return is_null($parent->blueprint()->fullyQualifiedHandle());
     }
 
     public function flattenedSetsConfig()


### PR DESCRIPTION
This pull request brings back preloading meta/defaults for Bard and Replicator fields, but only when the blueprint doesn't have a fully-qualified handle.

In #13427, we made it so set meta/defaults are only loaded when you add a new set, reducing the JSON payload sent down to clients. Adding a new set would trigger a network request to get the set and do the necessary processing.

However, the `ReplicatorSetController` requires a blueprint's fully-qualified handle, which on-the-fly blueprints (like addon settings ones) don't have. This PR ensures we fallback to the old and possibly slower behaviour in those cases.

Closes #13946