### PR TITLE
[5.x] Fix `whereIn()`/`whereNotIn()` error for booleans

### DIFF
--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -157,20 +157,30 @@ abstract class Builder extends BaseBuilder
 
     protected function filterWhereIn($values, $where)
     {
-        $lookup = array_flip(array_map(fn ($v) => $v ?? '__NULL__', $where['values']));
+        $lookup = array_flip(array_map($this->normalizeLookupValue(...), $where['values']));
 
         return $values->filter(
-            fn ($value) => ! is_array($value) && isset($lookup[$value ?? '__NULL__'])
+            fn ($value) => ! is_array($value) && isset($lookup[$this->normalizeLookupValue($value)])
         );
     }
 
     protected function filterWhereNotIn($values, $where)
     {
-        $lookup = array_flip(array_map(fn ($v) => $v ?? '__NULL__', $where['values']));
+        $lookup = array_flip(array_map($this->normalizeLookupValue(...), $where['values']));
 
         return $values->filter(
-            fn ($value) => is_array($value) || ! isset($lookup[$value ?? '__NULL__'])
+            fn ($value) => is_array($value) || ! isset($lookup[$this->normalizeLookupValue($value)])
         );
+    }
+
+    private function normalizeLookupValue($value): string|int
+    {
+        return match (true) {
+            $value === null => '__NULL__',
+            $value === true => '__TRUE__',
+            $value === false => '__FALSE__',
+            default => $value,
+        };
     }
 
     protected function filterWhereNull($values, $where)

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -107,6 +107,21 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function entries_are_found_using_where_in_with_booleans()
+    {
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'featured' => true])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'featured' => false])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3'])->create(); // featured is null
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'featured' => true])->create();
+        EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5', 'featured' => false])->create();
+
+        $entries = Entry::query()->whereIn('featured', [false, null])->get();
+
+        $this->assertCount(3, $entries);
+        $this->assertEquals(['Post 2', 'Post 3', 'Post 5'], $entries->map->title->all());
+    }
+
+    #[Test]
     public function entries_are_found_using_where_not_in_with_null()
     {
         EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'category' => 'news'])->create();
@@ -119,6 +134,21 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->assertCount(1, $entries);
         $this->assertEquals(['Post 2'], $entries->map->title->all());
+    }
+
+    #[Test]
+    public function entries_are_found_using_where_not_in_with_booleans()
+    {
+        EntryFactory::id('1')->slug('post-1')->collection('posts')->data(['title' => 'Post 1', 'featured' => true])->create();
+        EntryFactory::id('2')->slug('post-2')->collection('posts')->data(['title' => 'Post 2', 'featured' => false])->create();
+        EntryFactory::id('3')->slug('post-3')->collection('posts')->data(['title' => 'Post 3'])->create(); // featured is null
+        EntryFactory::id('4')->slug('post-4')->collection('posts')->data(['title' => 'Post 4', 'featured' => true])->create();
+        EntryFactory::id('5')->slug('post-5')->collection('posts')->data(['title' => 'Post 5', 'featured' => false])->create();
+
+        $entries = Entry::query()->whereNotIn('featured', [false, null])->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 4'], $entries->map->title->all());
     }
 
     #[Test]


### PR DESCRIPTION
Similar to #13266, but for booleans.

Fixes #13924