### PR TITLE
[5.x] Avoid replacing nocache regions in initial full-measure response

### DIFF
--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -131,6 +131,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Replace Nocache Regions In Initial Response
+    |--------------------------------------------------------------------------
+    |
+    | Nocache regions are usually replaced server-side for the initial request,
+    | while the cached file stores placeholders with JS to fetch them via
+    | AJAX. You may wish to disable this behavior when using a CDN,
+    | so the initial response always includes the placeholders.
+    |
+    | Only applies to full-measure static caching.
+    |
+    */
+
+    'nocache_replace_in_initial_response' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Replacers
     |--------------------------------------------------------------------------
     |

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -131,20 +131,6 @@ return [
 
     /*
     |--------------------------------------------------------------------------
-    | Replace Nocache Regions In Initial Response
-    |--------------------------------------------------------------------------
-    |
-    | When using full-measure, nocache regions are replaced for the initial
-    | request to avoid needing to immediately re-request nocache regions
-    | via AJAX. You may wish to disable this behavior when using a CDN,
-    | so the initial response always includes the placeholders.
-    |
-    */
-
-    'nocache_replace_in_initial_response' => true,
-
-    /*
-    |--------------------------------------------------------------------------
     | Replacers
     |--------------------------------------------------------------------------
     |

--- a/config/static_caching.php
+++ b/config/static_caching.php
@@ -134,12 +134,10 @@ return [
     | Replace Nocache Regions In Initial Response
     |--------------------------------------------------------------------------
     |
-    | Nocache regions are usually replaced server-side for the initial request,
-    | while the cached file stores placeholders with JS to fetch them via
-    | AJAX. You may wish to disable this behavior when using a CDN,
+    | When using full-measure, nocache regions are replaced for the initial
+    | request to avoid needing to immediately re-request nocache regions
+    | via AJAX. You may wish to disable this behavior when using a CDN,
     | so the initial response always includes the placeholders.
-    |
-    | Only applies to full-measure static caching.
     |
     */
 

--- a/src/StaticCaching/Replacers/CsrfTokenReplacer.php
+++ b/src/StaticCaching/Replacers/CsrfTokenReplacer.php
@@ -4,6 +4,8 @@ namespace Statamic\StaticCaching\Replacers;
 
 use Illuminate\Http\Response;
 use Statamic\Facades\StaticCache;
+use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\Cachers\FileCacher;
 use Statamic\StaticCaching\Replacer;
 use Statamic\Support\Str;
 
@@ -32,6 +34,14 @@ class CsrfTokenReplacer implements Replacer
             self::REPLACEMENT,
             $content
         ));
+
+        if (app(Cacher::class) instanceof FileCacher) {
+            $initial->setContent(str_replace(
+                $token,
+                self::REPLACEMENT,
+                $initial->getContent()
+            ));
+        }
     }
 
     public function replaceInCachedResponse(Response $response)

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -23,11 +23,11 @@ class NoCacheReplacer implements Replacer
 
     public function prepareResponseToCache(Response $responseToBeCached, Response $initialResponse)
     {
-        if (config('statamic.static_caching.nocache_replace_in_initial_response', true)) {
-            $this->replaceInResponse($initialResponse);
-        } else {
+        if (app(Cacher::class) instanceof FileCacher) {
             $this->includeJsIfNeeded($initialResponse);
             $this->modifyFullMeasureResponse($initialResponse);
+        } else {
+            $this->replaceInResponse($initialResponse);
         }
 
         $this->modifyFullMeasureResponse($responseToBeCached);

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -23,7 +23,12 @@ class NoCacheReplacer implements Replacer
 
     public function prepareResponseToCache(Response $responseToBeCached, Response $initialResponse)
     {
-        $this->replaceInResponse($initialResponse);
+        if (config('statamic.static_caching.nocache_replace_in_initial_response', true)) {
+            $this->replaceInResponse($initialResponse);
+        } else {
+            $this->includeJsIfNeeded($initialResponse);
+            $this->modifyFullMeasureResponse($initialResponse);
+        }
 
         $this->modifyFullMeasureResponse($responseToBeCached);
     }
@@ -39,13 +44,22 @@ class NoCacheReplacer implements Replacer
             return;
         }
 
+        $this->includeJsIfNeeded($response);
+
+        $response->setContent($this->replace($content));
+    }
+
+    private function includeJsIfNeeded(Response $response)
+    {
+        if (! $content = $response->getContent()) {
+            return;
+        }
+
         if (preg_match(self::PATTERN, $content)) {
             $this->session->restore();
 
             StaticCache::includeJs();
         }
-
-        $response->setContent($this->replace($content));
     }
 
     public function replace(string $content)

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -56,14 +56,16 @@ class NoCacheReplacer implements Replacer
         }
 
         if (preg_match(self::PATTERN, $content)) {
-            $this->session->restore();
-
             StaticCache::includeJs();
         }
     }
 
     public function replace(string $content)
     {
+        if (preg_match(self::PATTERN, $content)) {
+            $this->session->restore();
+        }
+
         while (preg_match(self::PATTERN, $content)) {
             $content = $this->performReplacement($content);
         }

--- a/src/StaticCaching/Replacers/NoCacheReplacer.php
+++ b/src/StaticCaching/Replacers/NoCacheReplacer.php
@@ -24,7 +24,7 @@ class NoCacheReplacer implements Replacer
     public function prepareResponseToCache(Response $responseToBeCached, Response $initialResponse)
     {
         if (app(Cacher::class) instanceof FileCacher) {
-            $this->includeJsIfNeeded($initialResponse);
+            $this->includeJs($initialResponse);
             $this->modifyFullMeasureResponse($initialResponse);
         } else {
             $this->replaceInResponse($initialResponse);
@@ -44,12 +44,12 @@ class NoCacheReplacer implements Replacer
             return;
         }
 
-        $this->includeJsIfNeeded($response);
+        $this->includeJs($response);
 
         $response->setContent($this->replace($content));
     }
 
-    private function includeJsIfNeeded(Response $response)
+    private function includeJs(Response $response)
     {
         if (! $content = $response->getContent()) {
             return;

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -74,10 +74,14 @@ class FullMeasureStaticCachingTest extends TestCase
 
         $region = app(Session::class)->regions()->first();
 
-        // Initial response should be dynamic and not contain javascript.
-        $this->assertEquals('<html><body>1 2</body></html>', $response->getContent());
+        // Initial response should have the placeholder and javascript, NOT the rendered content.
+        $this->assertEquals(vsprintf('<html><body>1 <span class="nocache" data-nocache="%s">%s</span>%s</body></html>', [
+            $region->key(),
+            '<svg>Loading...</svg>',
+            '<script>js here</script>',
+        ]), $response->getContent());
 
-        // The cached response should have the nocache placeholder, and the javascript.
+        // The cached response should be the same as the initial response.
         $this->assertTrue(file_exists($this->dir.'/about_.html'));
         $this->assertEquals(vsprintf('<html><body>1 <span class="nocache" data-nocache="%s">%s</span>%s</body></html>', [
             $region->key(),
@@ -148,69 +152,12 @@ class FullMeasureStaticCachingTest extends TestCase
             ->get('/about')
             ->assertOk();
 
-        // Initial response should be dynamic and not contain javascript.
-        $this->assertEquals('<html><body>'.csrf_token().'</body></html>', $response->getContent());
+        // Initial response should have the CSRF token and the javascript.
+        $this->assertEquals('<html><body>'.csrf_token().'<script>js here</script></body></html>', $response->getContent());
 
         // The cached response should have the token placeholder, and the javascript.
         $this->assertTrue(file_exists($this->dir.'/about_.html'));
         $this->assertEquals(vsprintf('<html><body>STATAMIC_CSRF_TOKEN%s</body></html>', [
-            '<script>js here</script>',
-        ]), file_get_contents($this->dir.'/about_.html'));
-    }
-
-    #[Test]
-    public function it_can_disable_nocache_replacement_on_initial_response()
-    {
-        config(['statamic.static_caching.nocache_replace_in_initial_response' => false]);
-
-        // Use a tag that outputs something dynamic.
-        // It will just increment by one every time it's used.
-
-        app()->instance('example_count', 0);
-
-        (new class extends \Statamic\Tags\Tags
-        {
-            public static $handle = 'example_count';
-
-            public function index()
-            {
-                $count = app('example_count');
-                $count++;
-                app()->instance('example_count', $count);
-
-                return $count;
-            }
-        })::register();
-
-        $this->withFakeViews();
-        $this->viewShouldReturnRaw('layout', '<html><body>{{ template_content }}</body></html>');
-        $this->viewShouldReturnRaw('default', '{{ example_count }} {{ nocache }}{{ example_count }}{{ /nocache }}');
-
-        $this->createPage('about');
-
-        StaticCache::nocacheJs('js here');
-        StaticCache::nocachePlaceholder('<svg>Loading...</svg>');
-
-        $this->assertFalse(file_exists($this->dir.'/about_.html'));
-
-        $response = $this
-            ->get('/about')
-            ->assertOk();
-
-        $region = app(Session::class)->regions()->first();
-
-        // Initial response should have the placeholder and javascript, NOT the rendered content.
-        $this->assertEquals(vsprintf('<html><body>1 <span class="nocache" data-nocache="%s">%s</span>%s</body></html>', [
-            $region->key(),
-            '<svg>Loading...</svg>',
-            '<script>js here</script>',
-        ]), $response->getContent());
-
-        // The cached response should be the same as the initial response.
-        $this->assertTrue(file_exists($this->dir.'/about_.html'));
-        $this->assertEquals(vsprintf('<html><body>1 <span class="nocache" data-nocache="%s">%s</span>%s</body></html>', [
-            $region->key(),
-            '<svg>Loading...</svg>',
             '<script>js here</script>',
         ]), file_get_contents($this->dir.'/about_.html'));
     }

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -157,4 +157,61 @@ class FullMeasureStaticCachingTest extends TestCase
             '<script>js here</script>',
         ]), file_get_contents($this->dir.'/about_.html'));
     }
+
+    #[Test]
+    public function it_can_disable_nocache_replacement_on_initial_response()
+    {
+        config(['statamic.static_caching.nocache_replace_in_initial_response' => false]);
+
+        // Use a tag that outputs something dynamic.
+        // It will just increment by one every time it's used.
+
+        app()->instance('example_count', 0);
+
+        (new class extends \Statamic\Tags\Tags
+        {
+            public static $handle = 'example_count';
+
+            public function index()
+            {
+                $count = app('example_count');
+                $count++;
+                app()->instance('example_count', $count);
+
+                return $count;
+            }
+        })::register();
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '<html><body>{{ template_content }}</body></html>');
+        $this->viewShouldReturnRaw('default', '{{ example_count }} {{ nocache }}{{ example_count }}{{ /nocache }}');
+
+        $this->createPage('about');
+
+        StaticCache::nocacheJs('js here');
+        StaticCache::nocachePlaceholder('<svg>Loading...</svg>');
+
+        $this->assertFalse(file_exists($this->dir.'/about_.html'));
+
+        $response = $this
+            ->get('/about')
+            ->assertOk();
+
+        $region = app(Session::class)->regions()->first();
+
+        // Initial response should have the placeholder and javascript, NOT the rendered content.
+        $this->assertEquals(vsprintf('<html><body>1 <span class="nocache" data-nocache="%s">%s</span>%s</body></html>', [
+            $region->key(),
+            '<svg>Loading...</svg>',
+            '<script>js here</script>',
+        ]), $response->getContent());
+
+        // The cached response should be the same as the initial response.
+        $this->assertTrue(file_exists($this->dir.'/about_.html'));
+        $this->assertEquals(vsprintf('<html><body>1 <span class="nocache" data-nocache="%s">%s</span>%s</body></html>', [
+            $region->key(),
+            '<svg>Loading...</svg>',
+            '<script>js here</script>',
+        ]), file_get_contents($this->dir.'/about_.html'));
+    }
 }

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -152,13 +152,11 @@ class FullMeasureStaticCachingTest extends TestCase
             ->get('/about')
             ->assertOk();
 
-        // Initial response should have the CSRF token and the javascript.
-        $this->assertEquals('<html><body>'.csrf_token().'<script>js here</script></body></html>', $response->getContent());
+        // Initial response should have the placeholder and the javascript, NOT the real token.
+        $this->assertEquals('<html><body>STATAMIC_CSRF_TOKEN<script>js here</script></body></html>', $response->getContent());
 
-        // The cached response should have the token placeholder, and the javascript.
+        // The cached response should be the same as the initial response.
         $this->assertTrue(file_exists($this->dir.'/about_.html'));
-        $this->assertEquals(vsprintf('<html><body>STATAMIC_CSRF_TOKEN%s</body></html>', [
-            '<script>js here</script>',
-        ]), file_get_contents($this->dir.'/about_.html'));
+        $this->assertEquals('<html><body>STATAMIC_CSRF_TOKEN<script>js here</script></body></html>', file_get_contents($this->dir.'/about_.html'));
     }
 }


### PR DESCRIPTION
This pull request adjusts full-measure to avoid nocache regions and csrf tokens being replaced in the initial response, allowing CDNs (like Cloudflare) to cache the placeholders and JS code.

Closes #13800
