### PR TITLE
[6.x] Select display input when adding tabs/sections to blueprint

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -39,7 +39,7 @@
             :open="editingSection !== false"
             :title="editText"
             @closed="editCancelled"
-            @opened="() => $nextTick(() => $refs.displayInput.focus())"
+            @opened="() => $nextTick(() => $refs.displayInput.select())"
         >
             <div class="">
                 <div class="space-y-6">

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -22,7 +22,7 @@
         <Stack
 	        size="narrow"
             :open="editing"
-            @opened="() => $nextTick(() => $refs.title.focus())"
+            @opened="() => $nextTick(() => $refs.title.select())"
             @update:open="editCancelled"
             :title="editText"
         >

--- a/resources/js/components/ui/Input/Input.vue
+++ b/resources/js/components/ui/Input/Input.vue
@@ -196,10 +196,7 @@ const clearable = computed(() => props.clearable && !props.readOnly && !props.di
 
 const input = useTemplateRef('input');
 const focus = () => input.value.focus();
-const select = () => {
-    input.value.focus();
-    input.value.select();
-};
+const select = () => input.value.select();
 
 onMounted(() => {
     if (props.focus) {

--- a/resources/js/components/ui/Input/Input.vue
+++ b/resources/js/components/ui/Input/Input.vue
@@ -196,6 +196,10 @@ const clearable = computed(() => props.clearable && !props.readOnly && !props.di
 
 const input = useTemplateRef('input');
 const focus = () => input.value.focus();
+const select = () => {
+    input.value.focus();
+    input.value.select();
+};
 
 onMounted(() => {
     if (props.focus) {
@@ -203,7 +207,7 @@ onMounted(() => {
     }
 })
 
-defineExpose({ focus });
+defineExpose({ focus, select });
 </script>
 
 <template>


### PR DESCRIPTION
Currently, when you add a tab/section to a blueprint, we focus the display input but you still need to "cmd + a" or click into the input to replace it.

This PR makes it so the input is focused and the text is selected, making it easier to rename the tab/section. Similar to what happens when you add a field.

## Before


https://github.com/user-attachments/assets/2fb35292-f1e2-4b87-a511-5b9efcb01d25




## After

https://github.com/user-attachments/assets/3d0357ac-474f-406d-a019-01a7c2efbdd7


