### PR TITLE
[6.x] Fix asset pagination when first page only contains folders

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -300,7 +300,7 @@ const parameters = computed(() => {
 });
 
 const shouldRequestFirstPage = computed(() => {
-    if (currentPage.value > 1 && currentPage.value > (meta.value?.last_page ?? 1)) {
+    if (currentPage.value > 1 && meta.value?.last_page && currentPage.value > meta.value.last_page) {
         currentPage.value = 1;
         return true;
     }

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -300,7 +300,7 @@ const parameters = computed(() => {
 });
 
 const shouldRequestFirstPage = computed(() => {
-    if (currentPage.value > 1 && items.value.length === 0 && !meta.value?.total) {
+    if (currentPage.value > 1 && currentPage.value > (meta.value?.last_page ?? 1)) {
         currentPage.value = 1;
         return true;
     }

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -300,7 +300,7 @@ const parameters = computed(() => {
 });
 
 const shouldRequestFirstPage = computed(() => {
-    if (currentPage.value > 1 && items.value.length === 0) {
+    if (currentPage.value > 1 && items.value.length === 0 && !meta.value?.total) {
         currentPage.value = 1;
         return true;
     }


### PR DESCRIPTION
This pull request fixes an issue when browsing a folder with more folders than the page size (eg. 30 folders, with a page size of 25) where navigating to page 2 would snap back to page 1.

This was happening because the `Listing` component was resetting to page 1 when `items` was empty, but in the asset browser, `items` only contains files - folders are returned separately. 

The `Listing` component now checks `meta.total` before resetting, which includes both files and folders.

Fixes #13960