### PR TITLE
[6.x] Improve file upload handling when `max_files: 1`

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -665,7 +665,11 @@ export default {
                 this.sortColumn = 'last_modified';
                 this.sortDirection = 'desc';
 
-                this.selectedAssets.push(asset.id);
+                if (this.maxFiles === 1) {
+                    this.selectedAssets.splice(0, this.selectedAssets.length, asset.id);
+                } else if (!this.reachedSelectionLimit) {
+                    this.selectedAssets.push(asset.id);
+                }
                 this.$emit('selections-updated', this.selectedAssets);
             }
 


### PR DESCRIPTION
When `max_files: 1` and an asset is already selected, uploading a new asset (either via the "upload" button or drag & drop) now replaces the existing selection rather than adding to it.

This fixes an issue where replacing an inline image in Bard would result in both the old & new assets being selected, with only the old one actually visible in the Bard contents.

This fix also applies to the Assets fieldtype.

Fixes #13684