### PR TITLE
[6.x] Grid child fields should never use inline config style

### DIFF
--- a/resources/js/components/fieldtypes/grid/Cell.vue
+++ b/resources/js/components/fieldtypes/grid/Cell.vue
@@ -1,6 +1,6 @@
 <template>
     <td class="grid-cell" :class="classes" :width="width">
-        <Field :config="field" />
+        <Field :config="field" :inline="false" />
     </td>
 </template>
 


### PR DESCRIPTION
Closes #13707

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change forcing grid cell fields to render non-inline; low risk aside from potential minor layout/styling regressions in grid publishing.
> 
> **Overview**
> Grid cell rendering now explicitly passes `:inline="false"` to the `PublishField` component in `Cell.vue`, ensuring grid child fields never use the inline config style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 729c48f4068e53c32a0846e7ba11cc948cc6057b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->