### PR TITLE
[6.x] Fix `emojis: false` not persisting on countries dictionary field

### DIFF
--- a/src/Fieldtypes/DictionaryFields.php
+++ b/src/Fieldtypes/DictionaryFields.php
@@ -65,13 +65,13 @@ class DictionaryFields extends Fieldtype
     public function process($data): string|array
     {
         $dictionary = Dictionary::find($data['type']);
-        $values = $dictionary->fields()->addValues($data)->process()->values();
+        $values = $dictionary->fields()->addValues($data)->process()->values()->all();
 
-        if ($values->filter()->isEmpty()) {
+        if (count(Arr::removeNullValues($values)) === 0) {
             return $dictionary->handle();
         }
 
-        return array_merge(['type' => $dictionary->handle()], $values->filter()->all());
+        return array_merge(['type' => $dictionary->handle()], Arr::removeNullValues($values));
     }
 
     public function extraRules(): array


### PR DESCRIPTION
This pull request fixes an issue where `emojis: false` wasn't persisting when saving a Countries Dictionary field, due to it being filtered out for being `false`.

This PR replaces `->filter()` with the `Arr::removeNullValues()` method, which will only remove null values (which is what we want).

Fixes #13967
