### PR TITLE
[6.x] Fix sidebar not showing after quick resize

### DIFF
--- a/resources/js/components/ElementContainer.vue
+++ b/resources/js/components/ElementContainer.vue
@@ -16,13 +16,17 @@ export default {
     },
 
     mounted() {
-        const observer = new ResizeObserver(
-            throttle((entries) => {
-                this.width = entries[0].contentRect.width;
-            }, 200),
-        );
+        this.throttledCallback = throttle((entries) => {
+            this.width = entries[0].contentRect.width;
+        }, 200);
 
-        observer.observe(this.$el);
+        this.observer = new ResizeObserver(this.throttledCallback);
+        this.observer.observe(this.$el);
+    },
+
+    beforeUnmount() {
+        this.observer.disconnect();
+        this.throttledCallback.cancel();
     },
 
     watch: {

--- a/resources/js/tests/throttle.test.js
+++ b/resources/js/tests/throttle.test.js
@@ -1,0 +1,124 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import throttle from '../util/throttle';
+
+beforeEach(() => {
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+test('it calls the function immediately on first call', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled('a');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('a');
+});
+
+test('it suppresses calls within the time frame', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled();
+    throttled();
+    throttled();
+
+    expect(fn).toHaveBeenCalledTimes(1);
+});
+
+test('it fires a trailing call after the time frame', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled('first');
+    throttled('second');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith('first');
+
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('second');
+});
+
+test('the trailing call uses the most recent arguments', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled('first');
+    throttled('second');
+    throttled('third');
+
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('third');
+});
+
+test('it allows another immediate call after the time frame elapses', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(200);
+
+    throttled();
+    expect(fn).toHaveBeenCalledTimes(2);
+});
+
+test('cancel prevents the trailing call from firing', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled('first');
+    throttled('second');
+
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    throttled.cancel();
+    vi.advanceTimersByTime(200);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+});
+
+test('it works normally after cancel is called', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled('first');
+    throttled('second');
+    throttled.cancel();
+
+    vi.advanceTimersByTime(200);
+
+    throttled('third');
+
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('third');
+});
+
+test('the trailing call fires after the remaining time in the window', () => {
+    const fn = vi.fn();
+    const throttled = throttle(fn, 200);
+
+    throttled();
+
+    vi.advanceTimersByTime(100);
+    throttled('trailing');
+
+    // Should not have fired yet — only 100ms remaining
+    vi.advanceTimersByTime(99);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    // Now it should fire
+    vi.advanceTimersByTime(1);
+    expect(fn).toHaveBeenCalledTimes(2);
+    expect(fn).toHaveBeenLastCalledWith('trailing');
+});

--- a/resources/js/util/throttle.js
+++ b/resources/js/util/throttle.js
@@ -2,7 +2,7 @@ export default function (func, timeFrame) {
     let lastTime = 0;
     let timeoutId = null;
 
-    return function (...args) {
+    const throttled = function (...args) {
         const now = Date.now();
 
         clearTimeout(timeoutId);
@@ -18,4 +18,11 @@ export default function (func, timeFrame) {
             }, timeFrame - (now - lastTime));
         }
     };
+
+    throttled.cancel = function () {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+    };
+
+    return throttled;
 }

--- a/resources/js/util/throttle.js
+++ b/resources/js/util/throttle.js
@@ -1,12 +1,21 @@
 export default function (func, timeFrame) {
     let lastTime = 0;
+    let timeoutId = null;
 
     return function (...args) {
-        const now = new Date();
+        const now = Date.now();
+
+        clearTimeout(timeoutId);
 
         if (now - lastTime >= timeFrame) {
             func(...args);
             lastTime = now;
+        } else {
+            timeoutId = setTimeout(() => {
+                func(...args);
+                lastTime = Date.now();
+                timeoutId = null;
+            }, timeFrame - (now - lastTime));
         }
     };
 }


### PR DESCRIPTION
This pull request fixes an issue where resizing a publish form quickly could lead to the sidebar not being "expanded" correctly.

The `ElementContainer.vue` used in `Publish/Tabs.vue` uses a throttled `ResizeObserver`, but the throttle would only fire once immediately, then ignore all calls for 200ms. If resizing finished within that window, the final width was never reported.

Fixes #13915
