### PR TITLE
[6.x] Bard toolbar interactions

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -164,11 +164,11 @@
         }
     }
 
-    /* Where a Bard fieldtype with a fixed toolbar... */
+    /* [1] Where a Bard fieldtype with a fixed toolbar... */
     .bard-fieldtype:has(> .bard-fixed-toolbar) {
-        /* has a nested Bard fieldtype with focus */
-        &:has(.bard-fieldtype.form-group:focus-within) {
-            /* release the sticky positioning so that it doesn't cover the focused Bard toolbar */
+        /* [2] has a any nested fieldtype with focus, e.g. a Markdown toolbar or another Bard toolbar */
+        &:has(.publish-fields:focus-within) {
+            /* [/3] release the sticky positioning so that it doesn't cover other UI elements */
             > .bard-fixed-toolbar {
                 position: unset;
             }

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -166,8 +166,8 @@
 
     /* Where a Bard fieldtype with a fixed toolbar... */
     .bard-fieldtype:has(> .bard-fixed-toolbar) {
-        /* has a nested Bard fieldtype with a fixed toolbar _with focus_ */
-        &:has(.bard-fieldtype .bard-content:focus) {
+        /* has a nested Bard fieldtype with focus */
+        &:has(.bard-fieldtype.form-group:focus-within) {
             /* release the sticky positioning so that it doesn't cover the focused Bard toolbar */
             > .bard-fixed-toolbar {
                 position: unset;

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -269,14 +269,17 @@
         }
 
         .bard-fixed-toolbar {
-            padding: 7px 8px;
-            margin-block-end: 0;
-            top: 0;
-            background: unset;
-            border: unset;
+            /* Don't affect nested toolbars; only the one at the very top */
+            &:not(.bard-fieldtype.form-group .bard-fieldtype.form-group &) {
+                padding: 7px 8px;
+                margin-block-end: 0;
+                top: 0;
+                background: unset;
+                border: unset;
 
-            button {
-                @apply mx-1;
+                button {
+                    @apply mx-1;
+                }
             }
         }
 


### PR DESCRIPTION
## Description of the Problem

PR https://github.com/statamic/cms/pull/13750 introduced dynamic sticky toolbar behaviour for the active Bard editor, which resolved previous issues caused by stacking nested fixed Bard toolbars one on top of the other.

However, as per https://github.com/statamic/cms/issues/13854, this didn't go far enough — basically because the focus target (`.bard-content`) was too specific and didn't account for:

- Clicking a nested toolbar technically releases .bard-content focus
- We also want to release sticky positioning of parent Bard toolbars when we focus _any_ nested fieldtypes—not just nested Bard fieldtypes.

## What this PR Does

- Closes #13854
- Expands the focus rule, so fixed Bard toolbars that are parents are released when _any_ nested field has focus.
- Change specificity of full-screen Bard toolbar styling so we don't affect nested toolbars

## How to Reproduce

1. Add some nested Bard toolbars and follow the various issues listed in https://github.com/statamic/cms/issues/13854