### PR TITLE
[6.x] Remove deprecated errors

### DIFF
--- a/src/Http/Middleware/CP/Localize.php
+++ b/src/Http/Middleware/CP/Localize.php
@@ -50,7 +50,6 @@ class Localize
         $reflection = new ReflectionClass($date = Date::now());
 
         $factory = $reflection->getMethod('getFactory');
-        $factory->setAccessible(true);
 
         return Arr::get($factory->invoke($date)->getSettings(), 'toStringFormat');
     }

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -58,7 +58,6 @@ class Localize
         $reflection = new ReflectionClass($date = Date::now());
 
         $factory = $reflection->getMethod('getFactory');
-        $factory->setAccessible(true);
 
         return Arr::get($factory->invoke($date)->getSettings(), 'toStringFormat');
     }


### PR DESCRIPTION
After upgrading to Statamic 6 and logging in to CP, this is the only error I get with E_DEPRECATED errors turned on. I think it should be deleted since it has no effect since PHP 8.1:

Method ReflectionMethod::setAccessible() is deprecated since 8.5, as it has no effect since PHP 8.1
<img width="834" height="522" alt="image" src="https://github.com/user-attachments/assets/2fd6eefd-9ebb-45e9-9247-9767e782016e" />
