### PR TITLE
[6.x] Don't use `motion-vue` for bard/replicator set animations

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -75,14 +75,7 @@
                 </div>
             </header>
 
-            <Motion
-                layout
-                v-if="index !== undefined"
-                class="contain-paint"
-                :initial="{ height: collapsed ? '0px' : 'auto' }"
-                :animate="{ height: collapsed ? '0px' : 'auto' }"
-                :transition="{ duration: 0.25, type: 'tween' }"
-            >
+            <div v-if="index !== undefined" v-show="!collapsed" class="contain-paint">
                 <FieldsProvider
                     :fields="fields"
                     :as-config="false"
@@ -91,7 +84,7 @@
                 >
                     <Fields class="p-4" />
                 </FieldsProvider>
-            </Motion>
+            </div>
         </div>
     </node-view-wrapper>
 </template>

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -93,7 +93,6 @@
 import { NodeViewWrapper, nodeViewProps } from '@tiptap/vue-3';
 import ManagesPreviewText from '../replicator/ManagesPreviewText';
 import HasFieldActions from '../../field-actions/HasFieldActions.js';
-import { Motion } from 'motion-v';
 import {
     Badge,
     Button,
@@ -127,7 +126,6 @@ export default {
         Badge,
         Icon,
         NodeViewWrapper,
-        Motion,
     },
 
     mixins: [ManagesPreviewText, HasFieldActions],

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -211,13 +211,7 @@ function onAnimationComplete() {
                 </div>
             </header>
 
-            <Motion
-                :class="{ 'overflow-clip': shouldClipOverflow }"
-                :initial="{ height: collapsed ? '0px' : 'auto' }"
-                :animate="{ height: collapsed ? '0px' : 'auto' }"
-                :transition="{ duration: 0.25, type: 'tween' }"
-                @animation-complete="onAnimationComplete"
-            >
+            <div v-show="!collapsed" class="contain-paint">
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
                     <FieldsProvider
                         :fields="config.fields"
@@ -228,7 +222,7 @@ function onAnimationComplete() {
                         <Fields class="p-4" />
                     </FieldsProvider>
                 </div>
-            </Motion>
+            </div>
         </div>
 
         <confirmation-modal

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -14,7 +14,6 @@ import {
     PublishFieldsProvider as FieldsProvider,
     injectPublishContext as injectContainerContext,
 } from '@/components/ui';
-import { Motion } from 'motion-v';
 import PreviewHtml from '@/components/fieldtypes/replicator/PreviewHtml.js';
 import FieldAction from '@/components/field-actions/FieldAction.js';
 import toFieldActions from '@/components/field-actions/toFieldActions.js';

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, inject, ref, watch } from 'vue';
+import { computed, inject, ref } from 'vue';
 import {
     Icon,
     Switch,
@@ -120,16 +120,6 @@ function destroy() {
 
 const rootEl = ref();
 reveal.use(rootEl, () => emit('expanded'));
-
-const shouldClipOverflow = ref(props.collapsed);
-
-watch(() => props.collapsed, () => {
-    shouldClipOverflow.value = true;
-});
-
-function onAnimationComplete() {
-    shouldClipOverflow.value = props.collapsed;
-}
 </script>
 
 <template>
@@ -210,7 +200,7 @@ function onAnimationComplete() {
                 </div>
             </header>
 
-            <div v-show="!collapsed" class="contain-paint" :class="{ 'overflow-clip': shouldClipOverflow }">
+            <div v-show="!collapsed" class="contain-paint">
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
                     <FieldsProvider
                         :fields="config.fields"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -210,7 +210,7 @@ function onAnimationComplete() {
                 </div>
             </header>
 
-            <div v-show="!collapsed" class="contain-paint">
+            <div v-show="!collapsed" class="contain-paint" :class="{ 'overflow-clip': shouldClipOverflow }">
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
                     <FieldsProvider
                         :fields="config.fields"


### PR DESCRIPTION
This pull request removes the `Motion` component from Bard/Replicator sets to improve performance. Part of addressing #13385.

Fixes #13958

## Before


https://github.com/user-attachments/assets/c0e3855d-8c60-4933-b5ba-00f603ed91e0



## After

https://github.com/user-attachments/assets/5dfafe39-058c-4dcf-9e47-481ca2eb3dba

