### PR TITLE
[6.x] Fix folders not displaying in Bard link stack selector

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -130,6 +130,7 @@
                 :restrict-folder-navigation="config.restrict_assets"
                 :selected="[]"
                 :max-files="1"
+                :columns="bard.meta.assets.columns"
                 @selected="assetSelected"
                 @closed="showAssetSelector = false"
             />


### PR DESCRIPTION
This pull request fixes an issue where folders weren't displaying properly in the asset selector when adding a link in Bard. 

This was happening because the `columns` prop was missing, which the `Table` component relies on to create "fake" cells in folder rows:

https://github.com/statamic/cms/blob/a397f896adb5f3eb54c630d2b9142c63d2fbb764/resources/js/components/assets/Browser/Table.vue#L25-L58

Fixes #13980.

## Before
<img width="1215" height="334" alt="CleanShot 2026-02-18 at 17 03 41" src="https://github.com/user-attachments/assets/b155476f-2661-4686-a886-89b66d4cf33a" />

## After

<img width="1215" height="334" alt="CleanShot 2026-02-18 at 17 03 15" src="https://github.com/user-attachments/assets/6367695d-7188-49c1-83eb-2cd6c621eb81" />
