### PR TITLE
[5.x] Correct test namespaces to avoid PSR-4 warnings

### DIFF
--- a/tests/Feature/Assets/DownloadAssetTest.php
+++ b/tests/Feature/Assets/DownloadAssetTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature\Assets;
+namespace Tests\Feature\Assets;
 
 use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Feature/Assets/ImageThumbnailTest.php
+++ b/tests/Feature/Assets/ImageThumbnailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature\Assets;
+namespace Tests\Feature\Assets;
 
 use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Feature/Assets/PdfThumbnailTest.php
+++ b/tests/Feature/Assets/PdfThumbnailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature\Assets;
+namespace Tests\Feature\Assets;
 
 use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\Attributes\Test;

--- a/tests/Feature/Assets/SvgThumbnailTest.php
+++ b/tests/Feature/Assets/SvgThumbnailTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Feature\Assets;
+namespace Tests\Feature\Assets;
 
 use Illuminate\Http\UploadedFile;
 use PHPUnit\Framework\Attributes\Test;


### PR DESCRIPTION
This pull request fixes incorrect namespaces to avoid PSR-4 warnings from Composer.

```
Class Feature\Assets\SvgThumbnailTest located in ./tests/Feature/Assets/SvgThumbnailTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.
Class Feature\Assets\ImageThumbnailTest located in ./tests/Feature/Assets/ImageThumbnailTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.
Class Feature\Assets\PdfThumbnailTest located in ./tests/Feature/Assets/PdfThumbnailTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.
Class Feature\Assets\DownloadAssetTest located in ./tests/Feature/Assets/DownloadAssetTest.php does not comply with psr-4 autoloading standard (rule: Tests\ => ./tests). Skipping.
```

Related:
* #13810
* #13883
