### PR TITLE
[6.x] Sanitize html in html fieldtype

### DIFF
--- a/lang/en/fieldtypes.php
+++ b/lang/en/fieldtypes.php
@@ -110,6 +110,7 @@ return [
     'group.title' => 'Group',
     'hidden.title' => 'Hidden',
     'html.config.html_instruct' => 'Manage the HTML to be displayed in the publish form. This is for display purposes only, the HTML will not be saved.',
+    'html.config.sanitize_instruct' => 'Whether the HTML should be sanitized before being displayed. Only disable this if you have a good reason.',
     'html.title' => 'HTML',
     'icon.config.set' => 'The name of a custom icon set.',
     'icon.title' => 'Icon',

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "codemirror": "5.65.12",
         "cookies-js": "^1.2.2",
         "cva": "^1.0.0-beta.3",
+        "dompurify": "^3.3.1",
         "floating-vue": "^5.2.2",
         "fuzzysort": "^3.1.0",
         "highlight.js": "^11.7.0",
@@ -2882,6 +2883,13 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/unist": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
@@ -4412,6 +4420,15 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
+      "integrity": "sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "codemirror": "5.65.12",
     "cookies-js": "^1.2.2",
     "cva": "^1.0.0-beta.3",
+    "dompurify": "^3.3.1",
     "floating-vue": "^5.2.2",
     "fuzzysort": "^3.1.0",
     "highlight.js": "^11.7.0",

--- a/resources/js/components/fieldtypes/HtmlFieldtype.vue
+++ b/resources/js/components/fieldtypes/HtmlFieldtype.vue
@@ -1,18 +1,13 @@
+<script setup>
+import Fieldtype from '@/components/fieldtypes/fieldtype';
+import { computed } from 'vue';
+import DOMPurify from 'dompurify';
+
+const props = defineProps(Fieldtype.props);
+
+const html = computed(() => DOMPurify.sanitize(props.config.html));
+</script>
+
 <template>
     <div v-html="html" />
 </template>
-
-<script>
-import Fieldtype from './Fieldtype.vue';
-import DOMPurify from 'dompurify';
-
-export default {
-    mixins: [Fieldtype],
-
-    computed: {
-        html() {
-            return DOMPurify.sanitize(this.config.html);
-        },
-    },
-};
-</script>

--- a/resources/js/components/fieldtypes/HtmlFieldtype.vue
+++ b/resources/js/components/fieldtypes/HtmlFieldtype.vue
@@ -1,11 +1,18 @@
 <template>
-    <div v-html="config.html" />
+    <div v-html="html" />
 </template>
 
 <script>
 import Fieldtype from './Fieldtype.vue';
+import DOMPurify from 'dompurify';
 
 export default {
     mixins: [Fieldtype],
+
+    computed: {
+        html() {
+            return DOMPurify.sanitize(this.config.html);
+        },
+    },
 };
 </script>

--- a/resources/js/components/fieldtypes/HtmlFieldtype.vue
+++ b/resources/js/components/fieldtypes/HtmlFieldtype.vue
@@ -5,7 +5,7 @@ import DOMPurify from 'dompurify';
 
 const props = defineProps(Fieldtype.props);
 
-const html = computed(() => DOMPurify.sanitize(props.config.html));
+const html = computed(() => props.config.sanitize ? DOMPurify.sanitize(props.config.html) : props.config.html);
 </script>
 
 <template>

--- a/src/Fieldtypes/Html.php
+++ b/src/Fieldtypes/Html.php
@@ -21,6 +21,12 @@ class Html extends Fieldtype
                         'mode' => 'htmlmixed',
                         'mode_selectable' => false,
                     ],
+                    'sanitize' => [
+                        'display' => __('Sanitize'),
+                        'instructions' => __('statamic::fieldtypes.html.config.sanitize_instruct'),
+                        'type' => 'toggle',
+                        'default' => true,
+                    ],
                 ],
             ],
         ];


### PR DESCRIPTION
This PR adds sanitization to the `html` fieldtype using the `dompurify` package.
Technically, by its nature, it would render what you'd tell it. But its a gray area for whether JS should be executable on it.
For safety, it's now sanitized (onerror, onload, etc get stripped out) but I have added an option to opt out, if you actually need them there. At your own risk.

I also made this fieldtype use the composition API since I was in here.
