### PR TITLE
[5.x] Fixes `shouldUpdateUris` regex adding additional brackets to Antlers

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -454,7 +454,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             return false;
         }
 
-        $antlersRoute = preg_replace_callback('/{\s*([a-zA-Z0-9_\-]+)\s*}/', function ($match) {
+        $antlersRoute = preg_replace_callback('/(?<!{){\s*([a-zA-Z0-9_\-]+)\s*}(?!})/', function ($match) {
             return "{{ {$match[1]} }}";
         }, $this->route());
 


### PR DESCRIPTION
This PR revises the regex to improve Antlers support in the route configuration for a Collection.

My Collection has a `route` of:
```antlers
{{ if depth > 1 }}{{ parent_uri }}/{{ slug }}{{ else }}portal/brands/{{ slug }}{{ /if }}
```

The `$antlersRoute` with the original regex becomes:
```antlers
{{ if depth > 1 }}{{{ parent_uri }}}/{{{ slug }}}{{{ else }}}portal/brands/{{{ slug }}}{{ /if }}
```
Notice the triple { and }?

This causes an error when saving:
```
Unpaired "else" control structure
```

This update revises the regex to allow Antlers without adding additional brackets, so the `$antlersRoute` correctly returns
```antlers
{{ if depth > 1 }}{{ parent_uri }}/{{ slug }}{{ else }}portal/brands/{{ slug }}{{ /if }}
```
again.

This would also need to be rolled up to Statamic 6 too.