### PR TITLE
[6.x] Fix Starter Kit make:user command

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -460,7 +460,7 @@ final class Installer
         }
 
         if (confirm('Create a super user?', false)) {
-            $this->console->call('make:user', ['--super' => true]);
+            $this->console->call('statamic:make:user', ['--super' => true]);
         }
 
         return $this;


### PR DESCRIPTION
When running `php artisan statamic:starter-kit:install` and creating a user via the CLI prompt it throws an error (`Command make:user is not defined`). Running `php please starter-kit:install` works fine. This fixes the issue so both commands run fine.

Closes https://github.com/statamic/cms/issues/13998.