### PR TITLE
[6.x] Increase inline padding of badges

### DIFF
--- a/resources/js/components/ui/Badge.vue
+++ b/resources/js/components/ui/Badge.vue
@@ -45,7 +45,7 @@ const badgeClasses = computed(() => {
         variants: {
             size: {
                 sm: 'text-2xs leading-normal px-1.25 rounded-[0.1875rem] [&_svg]:size-2.5',
-                default: 'text-xs leading-5.5 px-2 rounded-sm [&_svg]:size-3.5 gap-2',
+                default: 'text-xs leading-5.5 px-2.25 rounded-sm [&_svg]:size-3.5 gap-2',
                 lg: 'font-medium text-sm leading-7 px-2.5 rounded-lg [&_svg]:size-4 gap-2',
             },
             color: {


### PR DESCRIPTION
## Description of the Problem

- The space between the edges of the text and the radii of the badges is a little too tight, especially when caps are used e.g. `100 KB`
- Increasing the inline padding slightly makes it feel better to my eyes

## What this PR Does

- Increases the inline padding of the standard badge size so that text fits more comfortably

### Before

![2026-02-19 at 13 06 56@2x](https://github.com/user-attachments/assets/8ae9b31b-4056-44cb-adcd-57e33405d21c)

### After

![2026-02-19 at 13 07 54@2x](https://github.com/user-attachments/assets/5e37b82f-b068-493d-9529-817455245836)

## How to Reproduce

1. You can see this it the asset meta badges if you open up an asset in the cp