### PR TITLE
[6.x] Avoid stretching images to 100% height

### DIFF
--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -124,7 +124,7 @@
                                                 loading="lazy"
                                                 :draggable="false"
                                                 :class="{
-                                                    'size-full p-4': asset.extension === 'svg',
+                                                    'w-full p-4': asset.extension === 'svg',
                                                     'rounded-lg p-1': asset.orientation === 'square',
                                                 }"
                                             />

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -26,7 +26,7 @@
                 </template>
 
                 <template v-else>
-                    <img v-if="canShowSvg" :src="asset.url" :title="label" class="p-4 size-full relative" />
+                    <img v-if="canShowSvg" :src="asset.url" :title="label" class="p-4 w-full relative" />
 
                     <template v-else>
                         <img :src="thumbnail" v-if="thumbnail" :title="label" class="rounded-md relative"  />


### PR DESCRIPTION
## Description of the Problem

- Currently `size-full` is applied to thumbnail sizes in the asset editor.
- This can cause some issues when there are taller SVGs that have a different aspect ratio to other SVGs on the asset row. The shorter SVGs get stretched to fill the height of the row.

You can see this here, where the second image from the left (BBC) is stretched because the third image from the left, which is square, changes the aspect ratio of the the row:

<img width="1134" height="283" alt="image" src="https://github.com/user-attachments/assets/02877bdb-4d2f-43e4-989a-73549d03a6b8" />

## What this PR Does

- Switches `size-full` for `w-full`

### Before Examples

<img width="1134" height="283" alt="image" src="https://github.com/user-attachments/assets/7014ec2a-1446-47a6-b636-8fbce3dae7d8" />
<img width="2262" height="836" alt="image" src="https://github.com/user-attachments/assets/edffe1f5-7e7f-490a-b052-3cb093b50679" />

### After Examples

<img width="1171" height="281" alt="image" src="https://github.com/user-attachments/assets/eb51f175-941b-497f-8c2b-423838fffb00" />
<img width="2254" height="842" alt="image" src="https://github.com/user-attachments/assets/bdd00d28-a606-4d4a-a145-addb39be9326" />


## How to Reproduce

1. Upload some SVGs with different aspect ratios to an asset field