### PR TITLE
[6.x] Adjust SVG dimensions

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -142,7 +142,7 @@
 
                 <div class="flex w-full items-center justify-end rounded-b border-t dark:border-gray-700 bg-gray-100 dark:bg-gray-900 px-4 py-3">
                     <div class="hidden h-full flex-1 gap-2 sm:gap-3 py-1 sm:flex">
-                        <ui-badge pill v-if="asset.width && asset.height" icon="assets" :text="__('messages.width_x_height', { width: Math.floor(asset.width), height: Math.floor(asset.height) })" />
+                        <ui-badge pill v-if="asset.width && asset.height" icon="assets" :text="__('messages.width_x_height', { width: Math.round(asset.width), height: Math.round(asset.height) })" />
                         <ui-badge pill icon="memory" :text="asset.size" />
                         <ui-badge pill icon="fingerprint">
                             <time

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -142,7 +142,7 @@
 
                 <div class="flex w-full items-center justify-end rounded-b border-t dark:border-gray-700 bg-gray-100 dark:bg-gray-900 px-4 py-3">
                     <div class="hidden h-full flex-1 gap-2 sm:gap-3 py-1 sm:flex">
-                        <ui-badge pill v-if="asset.width && asset.height" icon="assets" :text="__('messages.width_x_height', { width: asset.width, height: asset.height })" />
+                        <ui-badge pill v-if="asset.width && asset.height" icon="assets" :text="__('messages.width_x_height', { width: Math.floor(asset.width), height: Math.floor(asset.height) })" />
                         <ui-badge pill icon="memory" :text="asset.size" />
                         <ui-badge pill icon="fingerprint">
                             <time

--- a/src/Imaging/Attributes.php
+++ b/src/Imaging/Attributes.php
@@ -65,11 +65,11 @@ class Attributes
         if ($svg['width'] && $svg['height']
             && is_numeric((string) $svg['width'])
             && is_numeric((string) $svg['height'])) {
-            return ['width' => (float) $svg['width'], 'height' => (float) $svg['height']];
+            return ['width' => (int) $svg['width'], 'height' => (int) $svg['height']];
         } elseif ($svg['viewBox']) {
             [,,$width, $height] = preg_split('/[\s,]+/', $svg['viewBox'] ?: '');
 
-            return compact('width', 'height');
+            return ['width' => (int) $width, 'height' => (int) $height];
         }
 
         return $this->defaultSvgAttributes();

--- a/src/Imaging/Attributes.php
+++ b/src/Imaging/Attributes.php
@@ -65,11 +65,11 @@ class Attributes
         if ($svg['width'] && $svg['height']
             && is_numeric((string) $svg['width'])
             && is_numeric((string) $svg['height'])) {
-            return ['width' => (int) $svg['width'], 'height' => (int) $svg['height']];
+            return ['width' => (float) $svg['width'], 'height' => (float) $svg['height']];
         } elseif ($svg['viewBox']) {
             [,,$width, $height] = preg_split('/[\s,]+/', $svg['viewBox'] ?: '');
 
-            return ['width' => (int) $width, 'height' => (int) $height];
+            return ['width' => (float) $width, 'height' => (float) $height];
         }
 
         return $this->defaultSvgAttributes();


### PR DESCRIPTION
## Description of the Problem

SVGs can sometimes show as having floating decimals in the asset browser, like this:

![2026-02-19 at 16 40 02@2x](https://github.com/user-attachments/assets/e3cfda8f-c0ad-44eb-8868-2dd6de130443)

## What this PR Does

Forces an integer like this:

![2026-02-19 at 16 39 12@2x](https://github.com/user-attachments/assets/b0a73fc3-7381-44f1-8c06-540f23824fca)

## How to Reproduce

1. Upload a bunch of SVGs and check them out in the asset browser - one of them will probably have a floating number 