### PR TITLE
[6.x] Fix clipped floating bard toolbar in replicators

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -75,7 +75,7 @@
                 </div>
             </header>
 
-            <div v-if="index !== undefined" v-show="!collapsed" class="contain-paint">
+            <div v-if="index !== undefined" v-show="!collapsed" :class="{ 'contain-paint': collapsed }">
                 <FieldsProvider
                     :fields="fields"
                     :as-config="false"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -200,7 +200,7 @@ reveal.use(rootEl, () => emit('expanded'));
                 </div>
             </header>
 
-            <div v-show="!collapsed" class="overflow-clip">
+            <div v-show="!collapsed" :class="{ 'overflow-clip': collapsed }">
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
                     <FieldsProvider
                         :fields="config.fields"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -200,7 +200,7 @@ reveal.use(rootEl, () => emit('expanded'));
                 </div>
             </header>
 
-            <div v-show="!collapsed" class="contain-paint">
+            <div v-show="!collapsed" class="overflow-clip">
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
                     <FieldsProvider
                         :fields="config.fields"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -200,7 +200,7 @@ reveal.use(rootEl, () => emit('expanded'));
                 </div>
             </header>
 
-            <div v-show="!collapsed" :class="{ 'overflow-clip': collapsed }">
+            <div v-show="!collapsed" :class="{ 'contain-paint': collapsed }">
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
                     <FieldsProvider
                         :fields="config.fields"


### PR DESCRIPTION
## Description of the Problem

We recently removed motion. This PR should fix the replaced overflow clipping logic reported in https://github.com/statamic/cms/issues/13997, which was slightly different to the working motion version.

## What this PR Does

- `contain-paint` should only be used on the outer set _when it's collapsed_
- For replicators I've:
  - Replaced `contain-paint` with `overflow-clip` for replicator sets, restoring a change made previously (4be1d9d26c777b9571b87bff5c87ce6075c1807c)
  - `overflow-clip` should only be added once the set is _collapsed_ 
- Fixes https://github.com/statamic/cms/issues/13997

### Before

![2026-02-19 at 18 04 44@2x](https://github.com/user-attachments/assets/a8fceced-e60b-4171-b929-583b50d9c794)

### After

![2026-02-19 at 18 04 31@2x](https://github.com/user-attachments/assets/a25fa36f-c113-4ab0-8083-1f73c8723462)

## How to Reproduce

1. Add replicator field to your pages blueprint
2. Add a bard field to that replicator - set Toolbar Mode to Floating
3. Create entry, add replicator, enter content in bard, select text to make toolbar appear.