### PR TITLE
[6.x] Fix some field filters not being applied

### DIFF
--- a/src/Query/Scopes/Filters/Fields/Date.php
+++ b/src/Query/Scopes/Filters/Fields/Date.php
@@ -85,6 +85,10 @@ class Date extends FieldtypeFilter
             return false;
         }
 
+        if (in_array($operator, ['null', 'not-null'])) {
+            return true;
+        }
+
         if ($operator === 'between') {
             return Arr::has($values, 'range_value.start') && Arr::has($values, 'range_value.end');
         }

--- a/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
@@ -74,6 +74,14 @@ class FieldtypeFilter
     {
         $values = array_filter($values);
 
-        return Arr::has($values, 'operator') && Arr::has($values, 'value');
+        if (! $operator = Arr::get($values, 'operator')) {
+            return false;
+        }
+
+        if (in_array($operator, ['null', 'not-null'])) {
+            return true;
+        }
+
+        return Arr::has($values, 'value');
     }
 }

--- a/src/Query/Scopes/Filters/Fields/Terms.php
+++ b/src/Query/Scopes/Filters/Fields/Terms.php
@@ -70,6 +70,14 @@ class Terms extends FieldtypeFilter
     {
         $values = array_filter($values);
 
-        return Arr::has($values, 'operator') && Arr::has($values, 'term');
+        if (! $operator = Arr::get($values, 'operator')) {
+            return false;
+        }
+
+        if (in_array($operator, ['null', 'not-null'])) {
+            return true;
+        }
+
+        return Arr::has($values, 'term');
     }
 }

--- a/src/Query/Scopes/Filters/Fields/Toggle.php
+++ b/src/Query/Scopes/Filters/Fields/Toggle.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
+use Illuminate\Support\Arr;
+
 class Toggle extends FieldtypeFilter
 {
     public function fieldItems()
@@ -32,5 +34,12 @@ class Toggle extends FieldtypeFilter
         $value = $values['value'];
 
         return $field.' '.strtolower($operator).' '.$value;
+    }
+
+    public function isComplete($values): bool
+    {
+        $values = array_filter($values);
+
+        return Arr::has($values, 'value');
     }
 }


### PR DESCRIPTION
Fix #14014 by whitelisting `null` and `not-null` as filter operators that don't require a value to be considered complete.

Should also fix #13987 by defining toggle filters with any value as complete.