### PR TITLE
[6.x] Fix external url logic

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -264,7 +264,7 @@ class URL
         }
 
         $isExternalToSites = self::getAbsoluteSiteUrls()
-            ->filter(fn ($siteUrl) => Str::startsWith($url, $siteUrl))
+            ->filter(fn ($siteUrl) => Str::startsWith($url.'/', $siteUrl.'/'))
             ->isEmpty();
 
         $isExternalToCurrentRequestDomain = ! Str::startsWith($url, self::getDomainFromAbsolute(url()->to('/')));

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -263,8 +263,11 @@ class URL
             return self::$externalAppUrlsCache[$url] = false;
         }
 
+        $urlWithoutQuery = Str::of($url)->before('?')->before('#');
+        $urlDomain = self::getDomainFromAbsolute($urlWithoutQuery);
+
         $isExternalToSites = self::getAbsoluteSiteUrls()
-            ->filter(fn ($siteUrl) => Str::startsWith($url.'/', $siteUrl.'/'))
+            ->filter(fn ($siteUrl) => $urlDomain === $siteUrl)
             ->isEmpty();
 
         $isExternalToCurrentRequestDomain = ! Str::startsWith($url, self::getDomainFromAbsolute(url()->to('/')));

--- a/tests/Auth/ForgotPasswordTest.php
+++ b/tests/Auth/ForgotPasswordTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Auth;
+
+use Illuminate\Support\Facades\Password;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ForgotPasswordTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']->set('app.url', 'http://absolute-url-resolved-from-request.com');
+    }
+
+    #[Test]
+    #[DataProvider('externalProvider')]
+    public function it_validates_reset_url_when_sending_reset_link_email($url, $isExternal)
+    {
+        $this->setSites([
+            'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
+            'b' => ['name' => 'B', 'locale' => 'en_US', 'url' => 'http://subdomain.this-site.com/'],
+            'c' => ['name' => 'C', 'locale' => 'fr_FR', 'url' => '/fr/'],
+        ]);
+
+        $this->simulateSuccessfulPasswordResetEmail();
+
+        User::make()
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $response = $this->post('/!/auth/password/email', [
+            'email' => 'san@holo.com',
+            '_reset_url' => $url,
+        ]);
+
+        if ($isExternal) {
+            $response->assertSessionHasErrors(['_reset_url']);
+
+            return;
+        }
+
+        $response->assertSessionHasNoErrors();
+    }
+
+    public static function externalProvider()
+    {
+        return [
+            ['http://this-site.com', false],
+            ['http://this-site.com?foo', false],
+            ['http://this-site.com#anchor', false],
+            ['http://this-site.com/', false],
+            ['http://this-site.com/?foo', false],
+            ['http://this-site.com/#anchor', false],
+
+            ['http://that-site.com', true],
+            ['http://that-site.com/', true],
+            ['http://that-site.com/?foo', true],
+            ['http://that-site.com/#anchor', true],
+            ['http://that-site.com/some-slug', true],
+            ['http://that-site.com/some-slug?foo', true],
+            ['http://that-site.com/some-slug#anchor', true],
+
+            ['http://subdomain.this-site.com', false],
+            ['http://subdomain.this-site.com/', false],
+            ['http://subdomain.this-site.com/?foo', false],
+            ['http://subdomain.this-site.com/#anchor', false],
+            ['http://subdomain.this-site.com/some-slug', false],
+            ['http://subdomain.this-site.com/some-slug?foo', false],
+            ['http://subdomain.this-site.com/some-slug#anchor', false],
+
+            ['http://absolute-url-resolved-from-request.com', false],
+            ['http://absolute-url-resolved-from-request.com/', false],
+            ['http://absolute-url-resolved-from-request.com/?foo', false],
+            ['http://absolute-url-resolved-from-request.com/?anchor', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug?foo', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug#anchor', false],
+            ['/', false],
+            ['/?foo', false],
+            ['/#anchor', false],
+            ['/some-slug', false],
+            ['?foo', false],
+            ['#anchor', false],
+            ['', false],
+            [null, false],
+
+            // External domain that starts with a valid domain.
+            ['http://this-site.com.au', true],
+            ['http://this-site.com.au/', true],
+            ['http://this-site.com.au/?foo', true],
+            ['http://this-site.com.au/#anchor', true],
+            ['http://this-site.com.au/some-slug', true],
+            ['http://this-site.com.au/some-slug?foo', true],
+            ['http://this-site.com.au/some-slug#anchor', true],
+            ['http://subdomain.this-site.com.au', true],
+            ['http://subdomain.this-site.com.au/', true],
+            ['http://subdomain.this-site.com.au/?foo', true],
+            ['http://subdomain.this-site.com.au/#anchor', true],
+            ['http://subdomain.this-site.com.au/some-slug', true],
+            ['http://subdomain.this-site.com.au/some-slug?foo', true],
+            ['http://subdomain.this-site.com.au/some-slug#anchor', true],
+        ];
+    }
+
+    #[Test]
+    public function it_allows_reset_url_for_current_request_domain_when_not_in_sites_config()
+    {
+        $this->setSites([
+            'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
+        ]);
+
+        $this->simulateSuccessfulPasswordResetEmail();
+
+        User::make()
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->post('/!/auth/password/email', [
+                'email' => 'san@holo.com',
+                '_reset_url' => 'http://absolute-url-resolved-from-request.com/some-slug',
+            ])
+            ->assertSessionHasNoErrors();
+    }
+
+    protected function simulateSuccessfulPasswordResetEmail()
+    {
+        $success = new class
+        {
+            public function sendResetLink()
+            {
+                return Password::RESET_LINK_SENT;
+            }
+        };
+
+        Password::shouldReceive('broker')->andReturn($success);
+    }
+}

--- a/tests/Auth/ForgotPasswordTest.php
+++ b/tests/Auth/ForgotPasswordTest.php
@@ -6,12 +6,14 @@ use Illuminate\Support\Facades\Password;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
+use Tests\Facades\Concerns\ProvidesExternalUrls;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class ForgotPasswordTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
+    use ProvidesExternalUrls;
 
     protected function resolveApplicationConfiguration($app)
     {
@@ -20,16 +22,21 @@ class ForgotPasswordTest extends TestCase
         $app['config']->set('app.url', 'http://absolute-url-resolved-from-request.com');
     }
 
-    #[Test]
-    #[DataProvider('externalProvider')]
-    public function it_validates_reset_url_when_sending_reset_link_email($url, $isExternal)
+    public function setUp(): void
     {
+        parent::setUp();
+
         $this->setSites([
             'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
             'b' => ['name' => 'B', 'locale' => 'en_US', 'url' => 'http://subdomain.this-site.com/'],
             'c' => ['name' => 'C', 'locale' => 'fr_FR', 'url' => '/fr/'],
         ]);
+    }
 
+    #[Test]
+    #[DataProvider('externalUrlProvider')]
+    public function it_validates_reset_url_when_sending_reset_link_email($url, $isExternal)
+    {
         $this->simulateSuccessfulPasswordResetEmail();
 
         User::make()
@@ -49,88 +56,6 @@ class ForgotPasswordTest extends TestCase
         }
 
         $response->assertSessionHasNoErrors();
-    }
-
-    public static function externalProvider()
-    {
-        return [
-            ['http://this-site.com', false],
-            ['http://this-site.com?foo', false],
-            ['http://this-site.com#anchor', false],
-            ['http://this-site.com/', false],
-            ['http://this-site.com/?foo', false],
-            ['http://this-site.com/#anchor', false],
-
-            ['http://that-site.com', true],
-            ['http://that-site.com/', true],
-            ['http://that-site.com/?foo', true],
-            ['http://that-site.com/#anchor', true],
-            ['http://that-site.com/some-slug', true],
-            ['http://that-site.com/some-slug?foo', true],
-            ['http://that-site.com/some-slug#anchor', true],
-
-            ['http://subdomain.this-site.com', false],
-            ['http://subdomain.this-site.com/', false],
-            ['http://subdomain.this-site.com/?foo', false],
-            ['http://subdomain.this-site.com/#anchor', false],
-            ['http://subdomain.this-site.com/some-slug', false],
-            ['http://subdomain.this-site.com/some-slug?foo', false],
-            ['http://subdomain.this-site.com/some-slug#anchor', false],
-
-            ['http://absolute-url-resolved-from-request.com', false],
-            ['http://absolute-url-resolved-from-request.com/', false],
-            ['http://absolute-url-resolved-from-request.com/?foo', false],
-            ['http://absolute-url-resolved-from-request.com/?anchor', false],
-            ['http://absolute-url-resolved-from-request.com/some-slug', false],
-            ['http://absolute-url-resolved-from-request.com/some-slug?foo', false],
-            ['http://absolute-url-resolved-from-request.com/some-slug#anchor', false],
-            ['/', false],
-            ['/?foo', false],
-            ['/#anchor', false],
-            ['/some-slug', false],
-            ['?foo', false],
-            ['#anchor', false],
-            ['', false],
-            [null, false],
-
-            // External domain that starts with a valid domain.
-            ['http://this-site.com.au', true],
-            ['http://this-site.com.au/', true],
-            ['http://this-site.com.au/?foo', true],
-            ['http://this-site.com.au/#anchor', true],
-            ['http://this-site.com.au/some-slug', true],
-            ['http://this-site.com.au/some-slug?foo', true],
-            ['http://this-site.com.au/some-slug#anchor', true],
-            ['http://subdomain.this-site.com.au', true],
-            ['http://subdomain.this-site.com.au/', true],
-            ['http://subdomain.this-site.com.au/?foo', true],
-            ['http://subdomain.this-site.com.au/#anchor', true],
-            ['http://subdomain.this-site.com.au/some-slug', true],
-            ['http://subdomain.this-site.com.au/some-slug?foo', true],
-            ['http://subdomain.this-site.com.au/some-slug#anchor', true],
-        ];
-    }
-
-    #[Test]
-    public function it_allows_reset_url_for_current_request_domain_when_not_in_sites_config()
-    {
-        $this->setSites([
-            'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
-        ]);
-
-        $this->simulateSuccessfulPasswordResetEmail();
-
-        User::make()
-            ->email('san@holo.com')
-            ->password('chewy')
-            ->save();
-
-        $this
-            ->post('/!/auth/password/email', [
-                'email' => 'san@holo.com',
-                '_reset_url' => 'http://absolute-url-resolved-from-request.com/some-slug',
-            ])
-            ->assertSessionHasNoErrors();
     }
 
     protected function simulateSuccessfulPasswordResetEmail()

--- a/tests/Facades/Concerns/ProvidesExternalUrls.php
+++ b/tests/Facades/Concerns/ProvidesExternalUrls.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Facades\Concerns;
+
+trait ProvidesExternalUrls
+{
+    public static function externalUrlProvider()
+    {
+        return [
+            ['http://this-site.com', false],
+            ['http://this-site.com?foo', false],
+            ['http://this-site.com#anchor', false],
+            ['http://this-site.com/', false],
+            ['http://this-site.com/?foo', false],
+            ['http://this-site.com/#anchor', false],
+
+            ['http://that-site.com', true],
+            ['http://that-site.com/', true],
+            ['http://that-site.com/?foo', true],
+            ['http://that-site.com/#anchor', true],
+            ['http://that-site.com/some-slug', true],
+            ['http://that-site.com/some-slug?foo', true],
+            ['http://that-site.com/some-slug#anchor', true],
+
+            ['http://subdomain.this-site.com', false],
+            ['http://subdomain.this-site.com/', false],
+            ['http://subdomain.this-site.com/?foo', false],
+            ['http://subdomain.this-site.com/#anchor', false],
+            ['http://subdomain.this-site.com/some-slug', false],
+            ['http://subdomain.this-site.com/some-slug?foo', false],
+            ['http://subdomain.this-site.com/some-slug#anchor', false],
+
+            ['http://absolute-url-resolved-from-request.com', false],
+            ['http://absolute-url-resolved-from-request.com/', false],
+            ['http://absolute-url-resolved-from-request.com/?foo', false],
+            ['http://absolute-url-resolved-from-request.com/?anchor', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug?foo', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug#anchor', false],
+            ['/', false],
+            ['/?foo', false],
+            ['/#anchor', false],
+            ['/some-slug', false],
+            ['?foo', false],
+            ['#anchor', false],
+            ['', false],
+            [null, false],
+
+            // External domain that starts with a valid domain.
+            ['http://this-site.com.au', true],
+            ['http://this-site.com.au/', true],
+            ['http://this-site.com.au/?foo', true],
+            ['http://this-site.com.au/#anchor', true],
+            ['http://this-site.com.au/some-slug', true],
+            ['http://this-site.com.au/some-slug?foo', true],
+            ['http://this-site.com.au/some-slug#anchor', true],
+            ['http://subdomain.this-site.com.au', true],
+            ['http://subdomain.this-site.com.au/', true],
+            ['http://subdomain.this-site.com.au/?foo', true],
+            ['http://subdomain.this-site.com.au/#anchor', true],
+            ['http://subdomain.this-site.com.au/some-slug', true],
+            ['http://subdomain.this-site.com.au/some-slug?foo', true],
+            ['http://subdomain.this-site.com.au/some-slug#anchor', true],
+        ];
+    }
+}

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -237,9 +237,9 @@ class UrlTest extends TestCase
     public function it_determines_if_external_url_to_application($url, $expected)
     {
         $this->setSites([
-            'first' => ['name' => 'First', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
-            'third' => ['name' => 'Third', 'locale' => 'en_US', 'url' => 'http://subdomain.this-site.com/'],
-            'second' => ['name' => 'Second', 'locale' => 'fr_FR', 'url' => '/fr/'],
+            'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
+            'b' => ['name' => 'B', 'locale' => 'en_US', 'url' => 'http://subdomain.this-site.com/'],
+            'c' => ['name' => 'C', 'locale' => 'fr_FR', 'url' => '/fr/'],
         ]);
 
         $this->assertEquals($expected, URL::isExternalToApplication($url));

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -10,6 +10,8 @@ use Tests\TestCase;
 
 class UrlTest extends TestCase
 {
+    use Concerns\ProvidesExternalUrls;
+
     public function tearDown(): void
     {
         URL::enforceTrailingSlashes(false);
@@ -233,7 +235,7 @@ class UrlTest extends TestCase
     }
 
     #[Test]
-    #[DataProvider('externalProvider')]
+    #[DataProvider('externalUrlProvider')]
     public function it_determines_if_external_url_to_application($url, $expected)
     {
         $this->setSites([
@@ -245,64 +247,14 @@ class UrlTest extends TestCase
         $this->assertEquals($expected, URL::isExternalToApplication($url));
     }
 
-    public static function externalProvider()
+    #[Test]
+    public function it_determines_if_external_url_to_application_when_only_current_request_domain_matches()
     {
-        return [
-            ['http://this-site.com', false],
-            ['http://this-site.com?foo', false],
-            ['http://this-site.com#anchor', false],
-            ['http://this-site.com/', false],
-            ['http://this-site.com/?foo', false],
-            ['http://this-site.com/#anchor', false],
+        $this->setSites([
+            'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
+        ]);
 
-            ['http://that-site.com', true],
-            ['http://that-site.com/', true],
-            ['http://that-site.com/?foo', true],
-            ['http://that-site.com/#anchor', true],
-            ['http://that-site.com/some-slug', true],
-            ['http://that-site.com/some-slug?foo', true],
-            ['http://that-site.com/some-slug#anchor', true],
-
-            ['http://subdomain.this-site.com', false],
-            ['http://subdomain.this-site.com/', false],
-            ['http://subdomain.this-site.com/?foo', false],
-            ['http://subdomain.this-site.com/#anchor', false],
-            ['http://subdomain.this-site.com/some-slug', false],
-            ['http://subdomain.this-site.com/some-slug?foo', false],
-            ['http://subdomain.this-site.com/some-slug#anchor', false],
-
-            ['http://absolute-url-resolved-from-request.com', false],
-            ['http://absolute-url-resolved-from-request.com/', false],
-            ['http://absolute-url-resolved-from-request.com/?foo', false],
-            ['http://absolute-url-resolved-from-request.com/?anchor', false],
-            ['http://absolute-url-resolved-from-request.com/some-slug', false],
-            ['http://absolute-url-resolved-from-request.com/some-slug?foo', false],
-            ['http://absolute-url-resolved-from-request.com/some-slug#anchor', false],
-            ['/', false],
-            ['/?foo', false],
-            ['/#anchor', false],
-            ['/some-slug', false],
-            ['?foo', false],
-            ['#anchor', false],
-            ['', false],
-            [null, false],
-
-            // External domain that starts with a valid domain
-            ['http://this-site.com.au', true],
-            ['http://this-site.com.au/', true],
-            ['http://this-site.com.au/?foo', true],
-            ['http://this-site.com.au/#anchor', true],
-            ['http://this-site.com.au/some-slug', true],
-            ['http://this-site.com.au/some-slug?foo', true],
-            ['http://this-site.com.au/some-slug#anchor', true],
-            ['http://subdomain.this-site.com.au', true],
-            ['http://subdomain.this-site.com.au/', true],
-            ['http://subdomain.this-site.com.au/?foo', true],
-            ['http://subdomain.this-site.com.au/#anchor', true],
-            ['http://subdomain.this-site.com.au/some-slug', true],
-            ['http://subdomain.this-site.com.au/some-slug?foo', true],
-            ['http://subdomain.this-site.com.au/some-slug#anchor', true],
-        ];
+        $this->assertFalse(URL::isExternalToApplication('http://absolute-url-resolved-from-request.com/some-slug'));
     }
 
     #[Test]

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -233,7 +233,8 @@ class UrlTest extends TestCase
     }
 
     #[Test]
-    public function it_determines_if_external_url_to_application()
+    #[DataProvider('externalProvider')]
+    public function it_determines_if_external_url_to_application($url, $expected)
     {
         $this->setSites([
             'first' => ['name' => 'First', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
@@ -241,25 +242,38 @@ class UrlTest extends TestCase
             'second' => ['name' => 'Second', 'locale' => 'fr_FR', 'url' => '/fr/'],
         ]);
 
-        $this->assertTrue(URL::isExternalToApplication('http://that-site.com'));
-        $this->assertTrue(URL::isExternalToApplication('http://that-site.com/'));
-        $this->assertTrue(URL::isExternalToApplication('http://that-site.com/some-slug'));
-        $this->assertTrue(URL::isExternalToApplication('http://that-site.com/some-slug?foo'));
-        $this->assertTrue(URL::isExternalToApplication('http://that-site.com/some-slug#anchor'));
+        $this->assertEquals($expected, URL::isExternalToApplication($url));
+    }
 
-        $this->assertFalse(URL::isExternalToApplication('http://subdomain.this-site.com'));
-        $this->assertFalse(URL::isExternalToApplication('http://subdomain.this-site.com/'));
-        $this->assertFalse(URL::isExternalToApplication('http://subdomain.this-site.com/some-slug'));
-        $this->assertFalse(URL::isExternalToApplication('http://subdomain.this-site.com/some-slug?foo'));
-        $this->assertFalse(URL::isExternalToApplication('http://subdomain.this-site.com/some-slug#anchor'));
+    public static function externalProvider()
+    {
+        return [
+            ['http://that-site.com', true],
+            ['http://that-site.com/', true],
+            ['http://that-site.com/some-slug', true],
+            ['http://that-site.com/some-slug?foo', true],
+            ['http://that-site.com/some-slug#anchor', true],
 
-        $this->assertFalse(URL::isExternalToApplication('http://absolute-url-resolved-from-request.com'));
-        $this->assertFalse(URL::isExternalToApplication('http://absolute-url-resolved-from-request.com/'));
-        $this->assertFalse(URL::isExternalToApplication('http://absolute-url-resolved-from-request.com/some-slug'));
-        $this->assertFalse(URL::isExternalToApplication('/foo'));
-        $this->assertFalse(URL::isExternalToApplication('#anchor'));
-        $this->assertFalse(URL::isExternalToApplication(''));
-        $this->assertFalse(URL::isExternalToApplication(null));
+            ['http://subdomain.this-site.com', false],
+            ['http://subdomain.this-site.com/', false],
+            ['http://subdomain.this-site.com/some-slug', false],
+            ['http://subdomain.this-site.com/some-slug?foo', false],
+            ['http://subdomain.this-site.com/some-slug#anchor', false],
+
+            ['http://absolute-url-resolved-from-request.com', false],
+            ['http://absolute-url-resolved-from-request.com/', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug', false],
+            ['/foo', false],
+            ['#anchor', false],
+            ['', false],
+            [null, false],
+
+            // External domain that starts with a valid domain
+            ['http://this-site.com.au', true],
+            ['http://this-site.com.au/', true],
+            ['http://subdomain.this-site.com.au', true],
+            ['http://subdomain.this-site.com.au/', true],
+        ];
     }
 
     #[Test]

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -248,22 +248,41 @@ class UrlTest extends TestCase
     public static function externalProvider()
     {
         return [
+            ['http://this-site.com', false],
+            ['http://this-site.com?foo', false],
+            ['http://this-site.com#anchor', false],
+            ['http://this-site.com/', false],
+            ['http://this-site.com/?foo', false],
+            ['http://this-site.com/#anchor', false],
+
             ['http://that-site.com', true],
             ['http://that-site.com/', true],
+            ['http://that-site.com/?foo', true],
+            ['http://that-site.com/#anchor', true],
             ['http://that-site.com/some-slug', true],
             ['http://that-site.com/some-slug?foo', true],
             ['http://that-site.com/some-slug#anchor', true],
 
             ['http://subdomain.this-site.com', false],
             ['http://subdomain.this-site.com/', false],
+            ['http://subdomain.this-site.com/?foo', false],
+            ['http://subdomain.this-site.com/#anchor', false],
             ['http://subdomain.this-site.com/some-slug', false],
             ['http://subdomain.this-site.com/some-slug?foo', false],
             ['http://subdomain.this-site.com/some-slug#anchor', false],
 
             ['http://absolute-url-resolved-from-request.com', false],
             ['http://absolute-url-resolved-from-request.com/', false],
+            ['http://absolute-url-resolved-from-request.com/?foo', false],
+            ['http://absolute-url-resolved-from-request.com/?anchor', false],
             ['http://absolute-url-resolved-from-request.com/some-slug', false],
-            ['/foo', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug?foo', false],
+            ['http://absolute-url-resolved-from-request.com/some-slug#anchor', false],
+            ['/', false],
+            ['/?foo', false],
+            ['/#anchor', false],
+            ['/some-slug', false],
+            ['?foo', false],
             ['#anchor', false],
             ['', false],
             [null, false],
@@ -271,8 +290,18 @@ class UrlTest extends TestCase
             // External domain that starts with a valid domain
             ['http://this-site.com.au', true],
             ['http://this-site.com.au/', true],
+            ['http://this-site.com.au/?foo', true],
+            ['http://this-site.com.au/#anchor', true],
+            ['http://this-site.com.au/some-slug', true],
+            ['http://this-site.com.au/some-slug?foo', true],
+            ['http://this-site.com.au/some-slug#anchor', true],
             ['http://subdomain.this-site.com.au', true],
             ['http://subdomain.this-site.com.au/', true],
+            ['http://subdomain.this-site.com.au/?foo', true],
+            ['http://subdomain.this-site.com.au/#anchor', true],
+            ['http://subdomain.this-site.com.au/some-slug', true],
+            ['http://subdomain.this-site.com.au/some-slug?foo', true],
+            ['http://subdomain.this-site.com.au/some-slug#anchor', true],
         ];
     }
 


### PR DESCRIPTION
Fixes `URL::isExternalToValidation` not detecting external domains where the starting substring is the same. e.g. yoursite.com.au should not be considered the same as yoursite.com

In addition:
- Tests are improved.
- Data provider is shared between the `URL::isExternalToValidation` tests and the password reset test added in #14023
- Fixes test failure from the merge commit https://github.com/statamic/cms/commit/efb0c22a6be8221f883c63668914412e2b58093d. I intentionally merged only what came from 5.x and didn't update the implementation, since that's what this PR is doing.