### PR TITLE
[6.x] Fix saving nested Bard fields

### DIFF
--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -275,8 +275,10 @@ export default {
                     this.$emit('committed', response.data, this.editedFields);
 
                     if (shouldCommitParent && this.commitParentField) {
-                        this.commitParentField(params);
-                        this.close();
+						this.$nextTick(() => {
+							this.commitParentField(params);
+							this.close();
+						});
 
                         return;
                     }


### PR DESCRIPTION
When editing a field inside a Bard set (eg. a nested Bard field), click "Apply" or "Save & Close All" would fail to save the field's settings.

This was because `commitParentField()` was called immediately after emitting the committed event, before Vue's reactivity system had propagated the child's changes up to the parent.

Wrapping the `commitParentField()` and `close()` calls in `$nextTick()` ensures the parent's values are updated before committing.

Fixes #14012