### PR TITLE
[6.x] Fix hidden field filters when applying to all fields

### DIFF
--- a/resources/js/components/ui/Listing/FieldFilter.vue
+++ b/resources/js/components/ui/Listing/FieldFilter.vue
@@ -162,5 +162,5 @@ defineExpose({
         />
     </div>
 
-    <div v-else v-text="__('No available filters')"></div>
+    <div v-else-if="!rows.length" v-text="__('No available filters')" class="text-gray-500 dark:text-gray-400"></div>
 </template>

--- a/resources/js/components/ui/Listing/FieldFilter.vue
+++ b/resources/js/components/ui/Listing/FieldFilter.vue
@@ -140,7 +140,6 @@ defineExpose({
 </script>
 
 <template>
-    <div v-if="hasAvailableFieldFilters">
         <FieldFilterRow
             v-for="filter in rows"
             :key="filter.handle"
@@ -154,6 +153,7 @@ defineExpose({
             @enter-pressed="handleEnterPressed"
         />
 
+    <div v-if="hasAvailableFieldFilters">
         <Combobox
             ref="fieldSelect"
             :placeholder="__('Add Field')"

--- a/resources/js/components/ui/Listing/FieldFilter.vue
+++ b/resources/js/components/ui/Listing/FieldFilter.vue
@@ -140,18 +140,18 @@ defineExpose({
 </script>
 
 <template>
-        <FieldFilterRow
-            v-for="filter in rows"
-            :key="filter.handle"
-            :ref="(el) => { if (el) rowRefs[filter.handle] = el }"
-            :display="filter.display"
-            :fields="filter.fields"
-            :meta="filter.meta"
-            :values="filter.values"
-            @update:values="rowUpdated(filter.handle, $event)"
-            @removed="removeRow(filter.handle)"
-            @enter-pressed="handleEnterPressed"
-        />
+    <FieldFilterRow
+        v-for="filter in rows"
+        :key="filter.handle"
+        :ref="(el) => { if (el) rowRefs[filter.handle] = el }"
+        :display="filter.display"
+        :fields="filter.fields"
+        :meta="filter.meta"
+        :values="filter.values"
+        @update:values="rowUpdated(filter.handle, $event)"
+        @removed="removeRow(filter.handle)"
+        @enter-pressed="handleEnterPressed"
+    />
 
     <div v-if="hasAvailableFieldFilters">
         <Combobox


### PR DESCRIPTION
Fix #14018 by

- Never hiding the currently applied filters
- Only hiding the input for adding new filters if all fields are already in use for filtering
- Only showing the "no filters" warning if no filters were ever available

### Before

All filters are hidden once all fields are selected for filtering.

![Screen Recording 2026-02-20 at 15 22 09](https://github.com/user-attachments/assets/87f67cfd-7541-4d44-8c9b-97607532c1f7)

### After: Scenario A: all fields already selected

If all fields of a blueprint are already selected for filtering, show no message at all.

<img width="1234" height="468" alt="Screenshot 2026-02-20 at 15 25 54" src="https://github.com/user-attachments/assets/3f0962b5-72fc-41ab-8a6d-617be28c012b" />

### After: Scenario B: no fields available

If no fields are available for filtering at all, show the message, but subdued.

<img width="1234" height="312" alt="Screenshot 2026-02-20 at 15 26 14" src="https://github.com/user-attachments/assets/69881230-85db-4410-a417-fecee3e1678f" />
