### PR TITLE
[6.x] Fix Firefox not receiving text selection in nested Bards

### DIFF
--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -213,11 +213,5 @@ export default {
             this.closeEditor();
         },
     },
-
-    updated() {
-        // This is a workaround to avoid Firefox's inability to select inputs/textareas when the
-        // parent element is set to draggable: https://bugzilla.mozilla.org/show_bug.cgi?id=739071
-        this.$el.setAttribute('draggable', false);
-    },
 };
 </script>

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -330,12 +330,25 @@ export default {
         );
 
         reveal.mount(this.$refs.container, this.expand);
+
+        // Firefox bug 739071: text selection doesn't work inside elements with a
+        // draggable ancestor. ProseMirror sets draggable=true on the node-view-wrapper
+        // because the Set node spec has draggable:true. We must keep it false.
+        this.$el.setAttribute('draggable', false);
+        this._draggableObserver = new MutationObserver(() => {
+            if (this.$el.getAttribute('draggable') !== 'false') {
+                this.$el.setAttribute('draggable', false);
+            }
+        });
+        this._draggableObserver.observe(this.$el, { attributes: true, attributeFilter: ['draggable'] });
     },
 
     updated() {
-        // This is a workaround to avoid Firefox's inability to select inputs/textareas when the
-        // parent element is set to draggable: https://bugzilla.mozilla.org/show_bug.cgi?id=739071
         this.$el.setAttribute('draggable', false);
+    },
+
+    beforeUnmount() {
+        this._draggableObserver?.disconnect();
     },
 };
 </script>


### PR DESCRIPTION
## Description of the Problem

As per #13852, In Firefox, clicking inside a Bard field that is nested within another Bard field (e.g. Bard > Replicator > Bard) doesn't work properly. You cannot single-click to place the cursor or double-click to select a word. Triple-clicking to select a paragraph does work.

This is caused by [Firefox bug 739071](https://bugzilla.mozilla.org/show_bug.cgi?id=739071) (opened 13 years ago, WOW) — text selection doesn't work inside elements that have an ancestor with `draggable=true`. ProseMirror sets `draggable=true` on the Bard Set's node-view-wrapper element during initialization because the Set node spec has `draggable: true`. The existing workaround in the `updated()` hook resets this to `false`, but only on Vue re-renders — ProseMirror can set it back at any time in between.

## What this PR Does

- Fixes #13852
- Adds a `MutationObserver` in the Bard Set component's `mounted()` hook that watches the `draggable` attribute on the node-view-wrapper and immediately resets it to `false` whenever ProseMirror changes it. This ensures `draggable` never stays `true` long enough for Firefox's bug to prevent text selection in nested editors.

## How to Reproduce

1. Add text in a nested Bard field and try to highlight something in Firefox