### PR TITLE
[6.x] Widen google2fa constraint to support ^9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "michelf/php-smartypants": "^1.8.1",
         "nesbot/carbon": "^3.0",
         "pixelfear/composer-dist-plugin": "^0.1.4",
-        "pragmarx/google2fa": "^8.0",
+        "pragmarx/google2fa": "^8.0|^9.0",
         "rebing/graphql-laravel": "^9.8",
         "rhukster/dom-sanitizer": "^1.0.7",
         "spatie/blink": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "michelf/php-smartypants": "^1.8.1",
         "nesbot/carbon": "^3.0",
         "pixelfear/composer-dist-plugin": "^0.1.4",
-        "pragmarx/google2fa": "^8.0|^9.0",
+        "pragmarx/google2fa": "^8.0 || ^9.0",
         "rebing/graphql-laravel": "^9.8",
         "rhukster/dom-sanitizer": "^1.0.7",
         "spatie/blink": "^1.3",


### PR DESCRIPTION
## Summary

Widens the `pragmarx/google2fa` version constraint from `^8.0` to `^8.0|^9.0`.

## Problem

Projects using `laravel/fortify` [v1.32.0+](https://github.com/laravel/fortify/releases/tag/v1.32.0) require `pragmarx/google2fa ^9.0`, which conflicts with Statamic v6's `^8.0` constraint. This makes it impossible to install Statamic v6 alongside Laravel Fortify.


The google2fa v9.0 API is fully backward-compatible with v8.0 — the public API (`generateSecretKey()`, `verifyKey()`, `verify()`, etc.) is identical between versions.

## Solution

Change the constraint to `^8.0|^9.0` to allow either major version, maintaining backward compatibility while enabling installation alongside packages that require v9.0.