### PR TITLE
[6.x] Removes trailing slash when building relative Site URLs

### DIFF
--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -79,7 +79,9 @@ class Site implements Augmentable
 
     public function relativePath($url)
     {
-        return URL::makeRelative(Str::removeLeft($url, $this->absoluteUrl()));
+        $absoluteUrl = Str::removeRight($this->absoluteUrl(), '/');
+
+        return URL::makeRelative(Str::removeLeft($url, $absoluteUrl));
     }
 
     public function isDefault()

--- a/tests/Data/DataRepositoryTest.php
+++ b/tests/Data/DataRepositoryTest.php
@@ -9,6 +9,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Entries\EntryRepository;
 use Statamic\Data\DataRepository;
 use Statamic\Facades\Collection;
+use Statamic\Facades\URL;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -30,6 +31,8 @@ class DataRepositoryTest extends TestCase
 
     public function tearDown(): void
     {
+        URL::enforceTrailingSlashes(false);
+
         parent::tearDown();
         static::$functions = null;
     }
@@ -189,6 +192,34 @@ class DataRepositoryTest extends TestCase
             'fr dir with query' => ['http://localhost/fr/le-foo?a=b', 'le-foo'],
             'fr dir with query and slash' => ['http://localhost/fr/le-foo/?a=b', 'le-foo'],
         ];
+    }
+
+    #[Test]
+    #[DataProvider('findByRequestUrlProvider')]
+    public function it_finds_by_request_url_with_trailing_slash_enforcement($requestUrl, $entryId)
+    {
+        URL::enforceTrailingSlashes();
+
+        $this->setSites([
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+
+        $this->findByRequestUrlTest($requestUrl, $entryId);
+    }
+
+    #[Test]
+    #[DataProvider('findByRequestUrlNoRootSiteProvider')]
+    public function it_finds_by_request_url_with_no_root_site_and_trailing_slash_enforcement($requestUrl, $entryId)
+    {
+        URL::enforceTrailingSlashes();
+
+        $this->setSites([
+            'english' => ['url' => 'http://localhost/en/', 'locale' => 'en'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+
+        $this->findByRequestUrlTest($requestUrl, $entryId);
     }
 
     private function findByRequestUrlTest($requestUrl, $entryId)


### PR DESCRIPTION
This PR fixes #14024 

## The Problem

The incoming URL we ultimately compare against already has its trailing slash removed (https://github.com/laravel/framework/blob/12.x/src/Illuminate/Http/Request.php#L132).

The Site's `relativePath` method was leaving trailing slashes in-tact, which would make it so we never found the right thing.

## The Fix

Remove the trailing slashes so comparisons are nice and happy.