### PR TITLE
[6.x] Consistent Updates Widget Padding

### DIFF
--- a/resources/js/components/updater/UpdaterWidget.vue
+++ b/resources/js/components/updater/UpdaterWidget.vue
@@ -11,19 +11,21 @@ defineProps({
 <template>
     <Listing :items="items" v-slot="{ items }">
         <Widget :title="__('Updates')" icon="updates" :href="cp_url('updater')">
-            <table v-if="items.length" class="">
-                <tr v-for="update in items" class="text-sm">
-                    <td class="py-1 pr-4 leading-tight">
-                        <Link :href="update.url" class="flex items-center gap-2" v-text="update.name" />
-                    </td>
-                    <td>
-                        <Badge pill :color="update.critical ? 'red' : 'green'" :text="update.count" />
-                        <div class="inline-flex" v-tooltip="__('Critical')">
-                            <Icon v-if="update.critical" name="warning-diamond" color="red" />
-                        </div>
-                    </td>
-                </tr>
-            </table>
+            <div v-if="items.length" class="w-full px-4 py-3">
+                <table class="w-full">
+                    <tr v-for="update in items" class="text-sm">
+                        <td class="py-1 pr-4 leading-tight">
+                            <Link :href="update.url" class="flex items-center gap-2" v-text="update.name" />
+                        </td>
+                        <td>
+                            <Badge pill :color="update.critical ? 'red' : 'green'" :text="update.count" />
+                            <div class="inline-flex" v-tooltip="__('Critical')">
+                                <Icon v-if="update.critical" name="warning-diamond" color="red" />
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
             <ui-description v-else class="flex-1 flex items-center justify-center">
                 {{ __('Everything is up to date.') }}
             </ui-description>


### PR DESCRIPTION
This PR fixes #14028

## The Problem

Updater widget was missing padding and margin values, making it inconsistent with the other widgets.

## The Fix

Added the missing padding/margin values, which included adding a wrapper div to not fight table styling. Both were made `w-full`.

Before:

<img width="1070" height="230" alt="before" src="https://github.com/user-attachments/assets/629d8f09-a7ad-4ae0-af7d-c1821d8fb277" />

After:

<img width="1076" height="250" alt="after" src="https://github.com/user-attachments/assets/b6d9f733-a52e-4110-916e-abc1c80f686b" />
