### PR TITLE
[6.x] Cache parsed items during Stache warming

### DIFF
--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -328,6 +328,8 @@ abstract class Store
             return $isDuplicate ?? false;
         });
 
+        $items->each(fn ($item) => $this->cacheItem($item['item']));
+
         $paths = $items->pluck('path', 'key');
 
         $this->cachePaths($paths);


### PR DESCRIPTION
This PR optimizes the Stache warming process. 

### The issue
When warming an empty Stache, every YAML file is currently parsed _twice_. This happens in 

1) `Store::paths()` where you store the parsed `item`, but the parsed result is immediately discarded:
https://github.com/statamic/cms/blob/8881a3e73b7867eaf211d36f7c6323928db286de/src/Stache/Stores/Store.php#L312-L318

2) Then again in `BasicStore::getItem()`:
https://github.com/statamic/cms/blob/8881a3e73b7867eaf211d36f7c6323928db286de/src/Stache/Stores/BasicStore.php#L34

### Solution

We can solve this double parsing issue by caching the parsed items inside `paths()` so when `getItem()` is subsequently called, it finds the item in cache ✨

With this optimization I could reduce my Stache warming time from 56.8s to 36.24s 🚀