### PR TITLE
[6.x] Fix horizontal content card overflow

### DIFF
--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -85,7 +85,7 @@ onUnmounted(() => {
             <div id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
                 <div id="content-card" tabindex="-1" class="focus:outline-none relative content-card grid min-h-full mx-auto">
                     <!-- Data attribute used by the CSS style tag below to override max-width when disabled.-->
-                    <div class="w-full mx-auto max-w-page" data-max-width-wrapper>
+                    <div class="w-full min-w-0 mx-auto max-w-page" data-max-width-wrapper>
                         <slot />
                     </div>
                 </div>


### PR DESCRIPTION
#13415 switched the main content card to `display: grid`. This fixes the vertical overflow, but causes horizontal overflow in some cases where its children are wider than itself. Looks like grid children by default cannot shrink past their inherent content width. Somewhat counterintuitively, setting `min-width: 0` seems to fix those cases.

### Before

Caused by overflowing filter badge component.

<img width="994" height="339" alt="Screenshot 2026-02-22 at 18 01 18" src="https://github.com/user-attachments/assets/7a434f5d-3800-4abf-ae86-894b1b1d65db" />

### After

<img width="994" height="339" alt="Screenshot 2026-02-22 at 18 02 42" src="https://github.com/user-attachments/assets/097e3869-f5c1-4210-a984-9ae6e106bcf9" />

