### PR TITLE
[6.x] Avoid overflowing hint in relationship selector

### DIFF
--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -17,11 +17,9 @@
             @search="search"
         >
             <template #option="{ title, hint, status }">
-                <div class="flex w-full items-center justify-between">
-                    <div class="flex items-center">
-                        <StatusIndicator v-if="status" class="me-2" :status="status" />
-                        <div v-text="title" class="truncate" />
-                    </div>
+                <div class="flex w-full text-left items-center gap-2">
+                    <StatusIndicator v-if="status" :status="status" />
+                    <div v-text="title" class="truncate grow" />
                     <ui-badge v-if="hint" size="sm" v-text="hint" />
                 </div>
             </template>


### PR DESCRIPTION
Make sure that overflowing text in a relationship select doesn't push the hint badge out of the item.

### Before

<img width="1421" height="288" alt="Screenshot 2026-02-22 at 19 39 10" src="https://github.com/user-attachments/assets/230b2772-36bd-4eb4-83d8-c46b2a09c35a" />

### After

<img width="1421" height="277" alt="Screenshot 2026-02-22 at 20 10 02" src="https://github.com/user-attachments/assets/2ca9b0c6-ad00-4b08-ae6c-7dfd3047697e" />