### PR TITLE
[5.x] Don't add published filter when in live preview

### DIFF
--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -165,7 +165,7 @@ class ApiController extends Controller
             ]);
         }
 
-        if ($this->filterPublished && $this->doesntHaveFilter('status') && $this->doesntHaveFilter('published') && !request()->isLivePreview()) {
+        if ($this->filterPublished && $this->doesntHaveFilter('status') && $this->doesntHaveFilter('published') && ! request()->isLivePreview()) {
             $filters->put('status:is', 'published');
         }
 

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -165,7 +165,7 @@ class ApiController extends Controller
             ]);
         }
 
-        if ($this->filterPublished && $this->doesntHaveFilter('status') && $this->doesntHaveFilter('published')) {
+        if ($this->filterPublished && $this->doesntHaveFilter('status') && $this->doesntHaveFilter('published') && !request()->isLivePreview()) {
             $filters->put('status:is', 'published');
         }
 


### PR DESCRIPTION
This PR adds to the check if the application is in live preview. we're using Statamic headless with nuxt and are using the `/entries` endpoint with slug filter, instead of the `/entries/{id}` endpoint to get our entries. To make the live preview work for draft entries we need this filter to not be on the query.