### PR TITLE
[6.x] Make red text values a consistent 600

### DIFF
--- a/resources/js/components/GitStatus.vue
+++ b/resources/js/components/GitStatus.vue
@@ -64,7 +64,7 @@ export default {
         'MM': { class: 'text-yellow-700 bg-yellow-50 border-yellow-200', text: __('Modified'), displayCode: 'M' },
         'A': { class: 'text-green-700 bg-green-50 border-green-200', text: __('Added'), displayCode: 'A' },
         '??': { class: 'text-green-700 bg-green-50 border-green-200', text: __('Added'), displayCode: 'A' },
-        'D': { class: 'text-red-700 bg-red-50 border-red-200', text: __('Deleted'), displayCode: 'D' },
+        'D': { class: 'text-red-600 bg-red-50 border-red-200', text: __('Deleted'), displayCode: 'D' },
         'R': { class: 'text-blue-700 bg-blue-50 border-blue-200', text: __('Renamed'), displayCode: 'R' },
         'C': { class: 'text-purple-700 bg-purple-50 border-purple-200', text: __('Copied'), displayCode: 'C' }
       }

--- a/resources/js/components/LicensingAlert.vue
+++ b/resources/js/components/LicensingAlert.vue
@@ -33,7 +33,7 @@ function manageLicenses() {
         blur
         @update:open="snooze"
         icon="alert-alarm-bell"
-        class="[&_[data-ui-heading]]:text-red-700! [&_svg]:text-red-700 dark:[&_[data-ui-heading]]:text-red-400! dark:[&_svg]:text-red-400!"
+        class="[&_[data-ui-heading]]:text-red-600! [&_svg]:text-red-600 dark:[&_[data-ui-heading]]:text-red-400! dark:[&_svg]:text-red-400!"
         :dismissible="false"
     >
         <div class="flex items-center justify-between">

--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -57,7 +57,7 @@ const buttonClasses = computed(() => {
                 primary: [
                     'bg-linear-to-b from-primary/90 to-primary hover:bg-primary-hover text-white disabled:opacity-60 disabled:text-white dark:disabled:text-white border border-primary-border shadow-ui-md inset-shadow-2xs inset-shadow-white/25 disabled:inset-shadow-none dark:disabled:inset-shadow-none [&_svg]:text-white [&_svg]:opacity-60',
                 ],
-                danger: 'bg-linear-to-b from-red-700/90 to-red-700 hover:bg-red-700/90 text-white border border-red-700 inset-shadow-xs inset-shadow-red-300 [&_svg]:text-red-200 disabled:text-white! disabled:opacity-60 disabled:inset-shadow-none',
+                danger: 'bg-linear-to-b from-red-600/90 to-red-600 hover:bg-red-600/90 text-white border border-red-600 inset-shadow-xs inset-shadow-red-300 [&_svg]:text-red-200 disabled:text-white! disabled:opacity-60 disabled:inset-shadow-none',
                 filled: 'bg-gray-950/5 hover:bg-gray-950/10 hover:text-gray-900 dark:hover:text-white dark:bg-white/15 dark:hover:bg-white/20 [&_svg]:opacity-70',
                 ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200',
                 'ghost-pressed': 'bg-transparent hover:bg-gray-400/10 text-gray-925 dark:text-white dark:hover:bg-white/7 dark:hover:text-white [&_svg]:opacity-100',
@@ -76,8 +76,8 @@ const buttonClasses = computed(() => {
             },
             groupBorder: {
                 danger: [
-                    'in-data-ui-button-group:text-red-500 in-data-ui-button-group:bg-linear-to-b in-data-ui-button-group:from-white in-data-ui-button-group:to-red-50 in-data-ui-button-group:hover:to-gray-100 in-data-ui-button-group:hover:bg-gray-50 in-data-ui-button-group:border in-data-ui-button-group:border-gray-300 in-data-ui-button-group:shadow-ui-sm in-data-ui-button-group:inset-shadow-none',
-                    'dark:in-data-ui-button-group:text-red-500 dark:in-data-ui-button-group:from-gray-850 dark:in-data-ui-button-group:to-red-900/10 dark:in-data-ui-button-group:hover:to-gray-850 dark:in-data-ui-button-group:hover:bg-gray-900 dark:in-data-ui-button-group:border-gray-700/80 dark:in-data-ui-button-group:shadow-ui-md',
+                    'in-data-ui-button-group:text-red-600 in-data-ui-button-group:bg-linear-to-b in-data-ui-button-group:from-white in-data-ui-button-group:to-red-50 in-data-ui-button-group:hover:to-gray-100 in-data-ui-button-group:hover:bg-gray-50 in-data-ui-button-group:border in-data-ui-button-group:border-gray-300 in-data-ui-button-group:shadow-ui-sm in-data-ui-button-group:inset-shadow-none',
+                    'dark:in-data-ui-button-group:text-red-600 dark:in-data-ui-button-group:from-gray-850 dark:in-data-ui-button-group:to-red-900/10 dark:in-data-ui-button-group:hover:to-gray-850 dark:in-data-ui-button-group:hover:bg-gray-900 dark:in-data-ui-button-group:border-gray-700/80 dark:in-data-ui-button-group:shadow-ui-md',
                 ],
                 ghost: '',
                 pressed: 'in-data-ui-button-group:border-s-0 [:is([data-ui-button-group]>&:first-child,_[data-ui-button-group]_:first-child>&)]:border-s-[1px]',

--- a/resources/js/pages/utilities/Email.vue
+++ b/resources/js/pages/utilities/Email.vue
@@ -35,7 +35,7 @@ function send() {
                         {{ __('Send') }}
                     </Button>
                 </div>
-                <p v-if="errors.email" class="mt-4 text-red-700 text-sm">{{ errors.email }}</p>
+                <p v-if="errors.email" class="mt-4 text-red-600 text-sm">{{ errors.email }}</p>
             </form>
         </CardPanel>
 

--- a/resources/js/pages/utilities/Licensing.vue
+++ b/resources/js/pages/utilities/Licensing.vue
@@ -122,7 +122,7 @@ const props = defineProps([
                                 </div>
                             </TableCell>
                             <TableCell>{{ addon.version }}</TableCell>
-                            <TableCell class="text-red-700 text-end">{{ addon.invalidReason }}</TableCell>
+                            <TableCell class="text-red-600 text-end">{{ addon.invalidReason }}</TableCell>
                         </TableRow>
                     </Table>
                 </Card>

--- a/resources/views/extend/forms/fields.antlers.html
+++ b/resources/views/extend/forms/fields.antlers.html
@@ -11,7 +11,7 @@
             <p class="text-gray-500" id="{{ id }}-instructions">{{ instructions }}</p>
         {{ /if }}
         {{ if error }}
-            <p class="text-red-700" id="{{ id }}-error">{{ error }}</p>
+            <p class="text-red-600" id="{{ id }}-error">{{ error }}</p>
         {{ /if }}
     </div>
 {{ /fields }}


### PR DESCRIPTION
## Description of the Problem

I noticed that we have most red text at value `700` and others, such as the floating toolbar "delete" text, at `500`.
I looked into the accessibility contrast of different values, and it seems like `600` is the minimum for us to hit AA.

If 600 is cool with AA, then I would favour that over `700`, which looks a bit dull to my eyes.

## What this PR Does

Adjusts danger text values to `red-600`

## How to Reproduce

1. Bring up various danger values, such as selecting a collection entry to see a delete action in the floating toolbar, or getting a licence warning modal by clearing cookies