### PR TITLE
[6.x] Fix missing site name on Statamic Solo sites

### DIFF
--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -37,7 +37,12 @@ class HandleInertiaRequests extends Middleware
     private function logos()
     {
         if (! Statamic::pro()) {
-            return false;
+            return [
+                'text' => null,
+                'siteName' => config('app.name'),
+                'light' => ['nav' => null, 'outside' => null],
+                'dark' => ['nav' => null, 'outside' => null],
+            ];
         }
 
         if (is_string($light = config('statamic.cp.custom_logo_url'))) {


### PR DESCRIPTION
This pull request fixes an issue where the site name was missing from the header on Statamic Solo/Core sites.

## Before

<img width="482" height="115" alt="CleanShot 2026-02-23 at 15 38 58" src="https://github.com/user-attachments/assets/5d309f40-2902-4ff5-8513-39fb1cda7265" />


## After

<img width="520" height="114" alt="CleanShot 2026-02-23 at 15 38 41" src="https://github.com/user-attachments/assets/0057782c-8b0b-40e9-bcde-f67f177b864a" />
