### PR TITLE
[6.x] Remove invisible "link" space that could be accidentally clicked

### DIFF
--- a/resources/css/components/index-fields.css
+++ b/resources/css/components/index-fields.css
@@ -9,9 +9,12 @@
 }
 
 .title-index-field {
-    @apply text-sm line-clamp-2 inline-flex items-center gap-2 hover:text-gray-925 dark:hover:text-white;
-    min-width: 15vw;
-    max-width: 30vw;
+    /* [1] This class is typically set on a link. We want it to be inline, otherwise it creates invisible clickable "link" space that could be accidentally clicked */
+    @apply text-sm inline line-clamp-2 hover:text-gray-925 dark:hover:text-white;
+    /* [/2] Where we have more than one child we need to use flexbox, e.g. /users. We want to avoid flexbox if it's not needed, else it creates invisible link space (explained above) */
+    &:has(> :nth-child(2)) {
+        @apply inline-flex items-center gap-2;
+    }
 }
 
 .date-index-field {


### PR DESCRIPTION
## Description of the Problem

While it's traditional to select entries using the left "checkbox" column, it's also possible—and convenient—to select entries using the white space available in the table rows.

**(Select any of these red areas, and you can also select/deselect entries).**
![2026-02-23 at 19 52 52@2x](https://github.com/user-attachments/assets/76554c1b-3766-4de1-9402-ac634cec4847) 

The problem is that parts of the title in the listings table contain "invisible" link space. For example, in this screenshot, if I click anywhere in the highlighted purple DOM, I will inadvertently be taken into the entry rather than selecting or deselecting the entry.
<img width="3886" height="1018" alt="image" src="https://github.com/user-attachments/assets/832f2d00-c258-4e4e-923f-d9929b08d061" />

This is unexpected behaviour and it's caught me out a few times, especially with shorter titles where the accidental click area is larger.

## What this PR Does

The behaviour above is caused by two things:

- Firstly the `min/max width` values.
  - While I would like to keep them, they require a block-like display value to work, which means we're stuck with the invisible click areas again.
  - I think in this instance, getting rid of the invisible click areas is more desirable for usability.
  - Besides this, `min/max` has limited utility within table elements, since they tend to naturally balance themselves out, layout-wise.
- Secondly a flexbox layout—which is a block-like display value (even inline-flex in this instance)—causes invisible click areas.
  - Flexbox is certainly desirable here sometimes, so to get around this I've conditionally applied flexbox when there is more than one child. This ensures layouts like _`/users`, where you have avatars and text, still work.

![2026-02-23 at 20 13 57@2x](https://github.com/user-attachments/assets/8eb5aade-ef06-4411-936c-ddc2189f03dc)

## How to Reproduce

1. Go to `cp/collections/something`
2. Make sure you have some long titles

- To test the clickable area you could pull the window in and click the "white space" in the tile areas
- You could also test a more complex listings layout like `cp/users` which contains avatars

### Before

This entire block contains a link to go to the entry

![2026-02-23 at 20 18 52@2x](https://github.com/user-attachments/assets/515401f6-073b-4b6e-ac55-effaa678fb61)

### After, with the fix

You can see here the entry link wraps nicely around the text
![2026-02-23 at 20 18 05@2x](https://github.com/user-attachments/assets/e24cd1cb-0059-4c50-ba6a-75cfdb7d6a22)
