### PR TITLE
[6.x] Provide extra values through container and publish form

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -86,7 +86,7 @@
             :track-dirty-state="trackDirtyState"
             :sync-field-confirmation-text="syncFieldConfirmationText"
             :remember-tab="!isInline"
-            :provide="{ isWorkingCopy }"
+            :provide="{ isWorkingCopy, revisionsEnabled }"
         >
             <LivePreview
                 :enabled="isPreviewing"

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -86,6 +86,7 @@
             :track-dirty-state="trackDirtyState"
             :sync-field-confirmation-text="syncFieldConfirmationText"
             :remember-tab="!isInline"
+            :provide="{ isWorkingCopy }"
         >
             <LivePreview
                 :enabled="isPreviewing"

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -181,6 +181,7 @@ watch(
 
 const avoidTrackingDirtyState = ref(false);
 const trackingDirtyState = computed(() => props.trackDirtyState && !avoidTrackingDirtyState.value)
+const isDirty = computed(() => Statamic.$dirty.has(props.name));
 
 function dirty() {
     if (trackingDirtyState.value) Statamic.$dirty.add(props.name);
@@ -277,6 +278,7 @@ const provided = {
     setRevealerField,
     unsetRevealerField,
     setHiddenField,
+    isDirty,
     withoutDirtying,
     ...additionalProvides,
 };

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -92,7 +92,7 @@ const props = defineProps({
     provide: {
         type: Object,
         default: () => ({})
-    }
+    },
 });
 
 const parentContainer = injectContainerContext(containerContextKey);
@@ -285,7 +285,7 @@ const builtInProvides = {
 if (import.meta.env.DEV) {
     for (const key of Object.keys(additionalProvides)) {
         if (key in builtInProvides) {
-            console.warn(`PublishContainer: provide key "${key}" collides with a built-in context key and will be ignored.`);
+            console.warn(`PublishContainer: provide key "${key}" collides with a built-in context key, which takes precedence.`);
         }
     }
 }

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -246,7 +246,7 @@ const additionalProvides = Object.fromEntries(
     Object.entries(props.provide).map(([key]) => [key, toRef(() => props.provide[key])])
 );
 
-const provided = {
+const builtInProvides = {
     name: toRef(() => props.name),
     parentContainer,
     blueprint: toRef(() => props.blueprint),
@@ -280,8 +280,17 @@ const provided = {
     setHiddenField,
     isDirty,
     withoutDirtying,
-    ...additionalProvides,
 };
+
+if (import.meta.env.DEV) {
+    for (const key of Object.keys(additionalProvides)) {
+        if (key in builtInProvides) {
+            console.warn(`PublishContainer: provide key "${key}" collides with a built-in context key and will be ignored.`);
+        }
+    }
+}
+
+const provided = { ...additionalProvides, ...builtInProvides };
 
 provideContainerContext({ ...provided, container: provided });
 

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -88,6 +88,11 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
+    /** Extra values to be provided through the context. */
+    provide: {
+        type: Object,
+        default: () => ({})
+    }
 });
 
 const parentContainer = injectContainerContext(containerContextKey);
@@ -236,6 +241,10 @@ function pushComponent(name, { props }) {
     return component;
 }
 
+const additionalProvides = Object.fromEntries(
+    Object.entries(props.provide).map(([key]) => [key, toRef(() => props.provide[key])])
+);
+
 const provided = {
     name: toRef(() => props.name),
     parentContainer,
@@ -269,6 +278,7 @@ const provided = {
     unsetRevealerField,
     setHiddenField,
     withoutDirtying,
+    ...additionalProvides,
 };
 
 provideContainerContext({ ...provided, container: provided });


### PR DESCRIPTION
This adds a `provide` prop to `PublishContainer` that'll allow extra values to be injected into a child component.

```html
<Container
   :provide="{ foo: 'bar' }"
/>
```
```js
import { injectPublishContext } from '@statamic/cms/ui';
const { foo } = injectPublishContext();
console.log(foo); // 'bar'
```

Also:
- Adds an `isDirty` computed to container, and provides it.
- Entry publish form provides `isWorkingCopy` and `revisionsEnabled`

Closes #13914