### PR TITLE
[5.x] Throw UnableToReadFile for invalid images in ImageGenerator

### DIFF
--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -306,7 +306,7 @@ class ImageGenerator
         }
 
         if (! ImageValidator::isValidImage($extension, $mime)) {
-            throw new \Exception("Image [{$path}] does not actually appear to be a valid image.");
+            throw UnableToReadFile::fromLocation($path, "Image [{$path}] does not actually appear to be a valid image.");
         }
     }
 

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -10,6 +10,7 @@ use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\UnableToReadFile;
 use League\Glide\Manipulators\Watermark;
 use League\Glide\Server;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -83,6 +84,22 @@ class ImageGeneratorTest extends TestCase
         $this->assertEquals($expectedCacheManifest, Glide::cacheStore()->get($manifestCacheKey));
         $this->assertEquals($expectedPath, Glide::cacheStore()->get($manipulationCacheKey));
         Event::assertDispatchedTimes(GlideImageGenerated::class, 1);
+    }
+
+    #[Test]
+    public function it_throws_unable_to_read_file_when_asset_is_not_a_valid_image()
+    {
+        Storage::fake('test');
+        $file = UploadedFile::fake()->create('foo/hoff.jpg', 100);
+        Storage::disk('test')->putFileAs('foo', $file, 'hoff.jpg');
+        $container = tap(AssetContainer::make('test_container')->disk('test'))->save();
+        $asset = tap($container->makeAsset('foo/hoff.jpg'))->save();
+
+        ImageValidator::shouldReceive('isValidImage')->andReturnFalse();
+
+        $this->expectException(UnableToReadFile::class);
+
+        $this->makeGenerator()->generateByAsset($asset, ['w' => 100]);
     }
 
     #[Test]


### PR DESCRIPTION
## Description

The `validateImage()` method in `ImageGenerator` throws a generic `\Exception` when an image fails validation (invalid extension or MIME type mismatch). This exception is not caught by `ThumbnailController::generate()`, which only catches `UnableToReadFile`, resulting in a **500 Internal Server Error** for what is essentially a "file not usable" scenario (e.g. corrupted uploads, non-image files with image extensions).

By throwing `UnableToReadFile` instead, the exception is now caught by the existing `catch` block in `ThumbnailController` and converted to a **404**, consistent with other file-not-found scenarios.

## Changes

- `ImageGenerator::validateImage()`: Throw `UnableToReadFile::fromLocation()` instead of generic `\Exception`
- Added test to verify `UnableToReadFile` is thrown when image validation fails

## Notes

The same gap exists in the `6.x` branch — happy to open a separate PR there if preferred.
