### PR TITLE
[6.x] Clear progress bar when unmounting listing

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -49,7 +49,10 @@ setup(async (app) => {
       $progress: {
           loading(name, loading) {
               //
-          }
+          },
+          complete(name) {
+              //
+          },
       }
   };
 

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -684,7 +684,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-    Statamic.$progress.remove(id);
+    Statamic.$progress.complete(id);
     if (props.pushQuery) window.removeEventListener('popstate', popState);
 });
 

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -684,7 +684,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-	Statamic.$progress.loading(id, false);
+    Statamic.$progress.loading(id, false);
     if (props.pushQuery) window.removeEventListener('popstate', popState);
 });
 

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -684,6 +684,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+	Statamic.$progress.loading(id, false);
     if (props.pushQuery) window.removeEventListener('popstate', popState);
 });
 

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -684,7 +684,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
-    Statamic.$progress.loading(id, false);
+    Statamic.$progress.remove(id);
     if (props.pushQuery) window.removeEventListener('popstate', popState);
 });
 


### PR DESCRIPTION
This pull request ensures that the progress state is cleared when the `Listing` component is unmounted.

This fixes an issue where closing a relationship selector while a request is happening would leave the progress bar showing, and prevent saving when revisions are enabled.

Fixes #14010
