### PR TITLE
[6.x] Remove some unneeded z-indexes from the CodeMirror gutter. This fixes the CodeMirror gutter overlapping encompassing Bard toolbars

### DIFF
--- a/resources/css/vendors/codemirror.css
+++ b/resources/css/vendors/codemirror.css
@@ -318,7 +318,6 @@ div.CodeMirror span {
     left: 0;
     top: 0;
     min-height: 100%;
-    z-index: 3;
 }
 
 .CodeMirror-gutter {
@@ -331,7 +330,7 @@ div.CodeMirror span {
 
 .CodeMirror-gutter-wrapper {
     position: absolute;
-    z-index: 4;
+    z-index: var(--z-index-above);
     background: none !important;
     border: none !important;
 }
@@ -346,7 +345,6 @@ div.CodeMirror span {
 .CodeMirror-gutter-elt {
     position: absolute;
     cursor: default;
-    z-index: 4;
 }
 
 .CodeMirror-gutter-wrapper ::selection {
@@ -377,7 +375,6 @@ div.CodeMirror span {
     word-wrap: normal;
     line-height: inherit;
     color: inherit;
-    z-index: 2;
     position: relative;
     overflow: visible;
     -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## Description of the Problem

As reported in issue #14060 there is an issue when a fixed Bard toolbar scrolls over a Code field, as you can see below.

<img width="1051" height="566" alt="image" src="https://github.com/user-attachments/assets/1298114d-e44c-4f65-82bf-3fbf8e21d2d7" />

This actually happens in both Firefox _and_ Safari. Chrome is OK because it supports `container-type: scroll-state`, which is being applied to the Bard toolbar, rendering a new stacking context.

While it might be tempting to slap a higher `z-index` on the Bard toolbar, the issue is more with our CodeMirror CSS applying unnecessarily high z-indexes to the gutter and field contents.

## What this PR Does

- Removes some z-index values (mostly gutter values)
- Applies a z-index variable only where it's needed
- Closes #14060

Here is the fix in place:

<img width="1045" height="558" alt="image" src="https://github.com/user-attachments/assets/3b348fe0-0944-41d0-ab0e-971685789a46" />

I checked the code field with a lot of content, including in dark mode, and I can't see any issues with removing these z-indexes.
There are a few more z-index values in CodeMirror's CSS, but I let sleeping dogs lie there. Once the code field is focused the z-index values don't matter as much since the fixed Bard toolbar is released from its stick position then.

## How to Reproduce

1. Add a Bard field with a fixed toolbar (default)
2. Add a Code fieldtype inside that
3. Click inside the Bard fieldtype so the toolbar is sticky, then scroll down to the code fieldtype. Without the fix the code gutter and contents will overlap the Bard toolbar