### PR TITLE
[6.x] Adding wildcard permission support

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -232,7 +232,15 @@ class User extends BaseUser
 
     public function hasPermission($permission)
     {
-        return $this->permissions()->contains($permission);
+        $permissions = $this->permissions();
+
+        if ($permissions->contains($permission)) {
+            return true;
+        }
+
+        return $permissions->contains(function ($userPermission) use ($permission) {
+            return $this->matchesWildcard($userPermission, $permission);
+        });
     }
 
     public function makeSuper()
@@ -410,5 +418,18 @@ class User extends BaseUser
             ->get()
             ->map(fn ($model) => app(Passkey::class)->setModel($model))
             ->keyBy(fn ($passkey) => $passkey->id());
+    }
+
+    protected function matchesWildcard(string $wildcardPermission, string $requestedPermission): bool
+    {
+        if (! str_contains($wildcardPermission, '*')) {
+            return false;
+        }
+
+        $pattern = preg_quote($wildcardPermission, '/');
+        $pattern = str_replace('\*', '.*', $pattern);
+        $pattern = '/^'.$pattern.'$/';
+
+        return (bool) preg_match($pattern, $requestedPermission);
     }
 }

--- a/src/Auth/File/Role.php
+++ b/src/Auth/File/Role.php
@@ -98,12 +98,31 @@ class Role extends BaseRole
 
     public function hasPermission(string $permission): bool
     {
-        return $this->permissions->contains($permission);
+        if ($this->permissions->contains($permission)) {
+            return true;
+        }
+
+        return $this->permissions->contains(function ($rolePermission) use ($permission) {
+            return $this->matchesWildcard($rolePermission, $permission);
+        });
     }
 
     public function isSuper(): bool
     {
         return $this->hasPermission('super');
+    }
+
+    protected function matchesWildcard(string $wildcardPermission, string $requestedPermission): bool
+    {
+        if (! str_contains($wildcardPermission, '*')) {
+            return false;
+        }
+
+        $pattern = preg_quote($wildcardPermission, '/');
+        $pattern = str_replace('\*', '.*', $pattern);
+        $pattern = '/^'.$pattern.'$/';
+
+        return (bool) preg_match($pattern, $requestedPermission);
     }
 
     public function save()

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -292,7 +292,15 @@ class User extends BaseUser
 
     public function hasPermission($permission)
     {
-        return $this->permissions()->contains($permission);
+        $permissions = $this->permissions();
+
+        if ($permissions->contains($permission)) {
+            return true;
+        }
+
+        return $permissions->contains(function ($userPermission) use ($permission) {
+            return $this->matchesWildcard($userPermission, $permission);
+        });
     }
 
     public function makeSuper()
@@ -379,6 +387,19 @@ class User extends BaseUser
             'roles' => $this->get('roles', []),
             'super' => $this->get('super', false),
         ], $this->data()->toArray());
+    }
+
+    protected function matchesWildcard(string $wildcardPermission, string $requestedPermission): bool
+    {
+        if (! str_contains($wildcardPermission, '*')) {
+            return false;
+        }
+
+        $pattern = preg_quote($wildcardPermission, '/');
+        $pattern = str_replace('\*', '.*', $pattern);
+        $pattern = '/^'.$pattern.'$/';
+
+        return (bool) preg_match($pattern, $requestedPermission);
     }
 
     public function passkeys(): Collection

--- a/src/Auth/UserGroup.php
+++ b/src/Auth/UserGroup.php
@@ -133,9 +133,17 @@ abstract class UserGroup implements Arrayable, ArrayAccess, Augmentable, UserGro
 
     public function hasPermission($permission)
     {
-        return $this->roles->reduce(function ($carry, $role) {
+        $permissions = $this->roles->reduce(function ($carry, $role) {
             return $carry->merge($role->permissions());
-        }, collect())->contains($permission);
+        }, collect());
+
+        if ($permissions->contains($permission)) {
+            return true;
+        }
+
+        return $permissions->contains(function ($groupPermission) use ($permission) {
+            return $this->matchesWildcard($groupPermission, $permission);
+        });
     }
 
     public function isSuper(): bool
@@ -200,5 +208,18 @@ abstract class UserGroup implements Arrayable, ArrayAccess, Augmentable, UserGro
     public function blueprint()
     {
         return Facades\UserGroup::blueprint();
+    }
+
+    protected function matchesWildcard(string $wildcardPermission, string $requestedPermission): bool
+    {
+        if (! str_contains($wildcardPermission, '*')) {
+            return false;
+        }
+
+        $pattern = preg_quote($wildcardPermission, '/');
+        $pattern = str_replace('\*', '.*', $pattern);
+        $pattern = '/^'.$pattern.'$/';
+
+        return (bool) preg_match($pattern, $requestedPermission);
     }
 }

--- a/tests/Auth/RoleTest.php
+++ b/tests/Auth/RoleTest.php
@@ -138,4 +138,43 @@ class RoleTest extends TestCase
             ->each(fn ($value, $key) => $this->assertEquals($value, $role->{$key}))
             ->each(fn ($value, $key) => $this->assertEquals($value, $role[$key]));
     }
+
+    #[Test]
+    public function it_checks_wildcard_permission_with_asterisk_at_beginning()
+    {
+        $role = (new Role)->addPermission('* blog entries');
+
+        $this->assertTrue($role->hasPermission('view blog entries'));
+        $this->assertTrue($role->hasPermission('edit blog entries'));
+        $this->assertTrue($role->hasPermission('delete blog entries'));
+        $this->assertFalse($role->hasPermission('view news entries'));
+        $this->assertFalse($role->hasPermission('view blog posts'));
+    }
+
+    #[Test]
+    public function it_checks_wildcard_permission_with_asterisk_in_middle()
+    {
+        $role = (new Role)->addPermission('view * entries');
+
+        $this->assertTrue($role->hasPermission('view blog entries'));
+        $this->assertTrue($role->hasPermission('view news entries'));
+        $this->assertTrue($role->hasPermission('view products entries'));
+        $this->assertFalse($role->hasPermission('edit blog entries'));
+        $this->assertFalse($role->hasPermission('view blog posts'));
+    }
+
+    #[Test]
+    public function it_checks_multiple_wildcard_permissions()
+    {
+        $role = (new Role)
+            ->addPermission('view * entries')
+            ->addPermission('* blog entries');
+
+        $this->assertTrue($role->hasPermission('view blog entries'));
+        $this->assertTrue($role->hasPermission('view news entries'));
+        $this->assertTrue($role->hasPermission('edit blog entries'));
+        $this->assertTrue($role->hasPermission('delete blog entries'));
+        $this->assertFalse($role->hasPermission('delete news entries'));
+        $this->assertFalse($role->hasPermission('view blog posts'));
+    }
 }

--- a/tests/Auth/UserGroupTest.php
+++ b/tests/Auth/UserGroupTest.php
@@ -392,4 +392,85 @@ class UserGroupTest extends TestCase
         $this->assertEquals('A', $group->getSupplement('bar'));
         $this->assertEquals('B', $clone->getSupplement('bar'));
     }
+
+    #[Test]
+    public function it_checks_wildcard_permission_with_asterisk_at_beginning()
+    {
+        $role = new class extends Role
+        {
+            public function permissions($permissions = null)
+            {
+                return collect(['* blog entries']);
+            }
+        };
+
+        $group = UserGroup::make()->assignRole($role);
+
+        $this->assertTrue($group->hasPermission('view blog entries'));
+        $this->assertTrue($group->hasPermission('edit blog entries'));
+        $this->assertTrue($group->hasPermission('delete blog entries'));
+        $this->assertFalse($group->hasPermission('view news entries'));
+        $this->assertFalse($group->hasPermission('view blog posts'));
+    }
+
+    #[Test]
+    public function it_checks_wildcard_permission_with_asterisk_in_middle()
+    {
+        $role = new class extends Role
+        {
+            public function permissions($permissions = null)
+            {
+                return collect(['view * entries']);
+            }
+        };
+
+        $group = UserGroup::make()->assignRole($role);
+
+        $this->assertTrue($group->hasPermission('view blog entries'));
+        $this->assertTrue($group->hasPermission('view news entries'));
+        $this->assertTrue($group->hasPermission('view products entries'));
+        $this->assertFalse($group->hasPermission('edit blog entries'));
+        $this->assertFalse($group->hasPermission('view blog posts'));
+    }
+
+    #[Test]
+    public function it_checks_multiple_roles_with_wildcard_permissions()
+    {
+        $roleOne = new class extends Role
+        {
+            public function handle(?string $handle = null)
+            {
+                return 'role_one';
+            }
+
+            public function permissions($permissions = null)
+            {
+                return collect(['view * entries']);
+            }
+        };
+
+        $roleTwo = new class extends Role
+        {
+            public function handle(?string $handle = null)
+            {
+                return 'role_two';
+            }
+
+            public function permissions($permissions = null)
+            {
+                return collect(['* blog entries']);
+            }
+        };
+
+        $group = UserGroup::make()
+            ->assignRole($roleOne)
+            ->assignRole($roleTwo);
+
+        $this->assertTrue($group->hasPermission('view blog entries'));
+        $this->assertTrue($group->hasPermission('view news entries'));
+        $this->assertTrue($group->hasPermission('edit blog entries'));
+        $this->assertTrue($group->hasPermission('delete blog entries'));
+        $this->assertFalse($group->hasPermission('delete news entries'));
+        $this->assertFalse($group->hasPermission('view blog posts'));
+    }
 }


### PR DESCRIPTION
_Reopening https://github.com/statamic/cms/pull/12791_

Implement wildcard permission support to allow using * as a placeholder in permission strings, enabling simplified role configuration.

In nutshell, I have extended `hasPermission()` function and created a new `matchesWildcard()` function to use a regex and parse the wildcard entries in `roles.yaml` file.

What is allowed now:
`roles.yaml`:
```yaml
- view * entries #instead of 'view pages entries', 'view news entries', 'view team entries' etc.
- view * terms #instead of 'view tags terms'
- view * assets #instead of 'view pictures assets'
```

**What led me to this change:**
The current `roles.yaml` file can contain 11 times the same, repetitive setup. For example, the "editor" role lists the same permissions for 11 different collections, resulting in 99 nearly identical permission entries.

**Example Transformations**

| Wildcard Pattern | Regex Pattern | Matches | Doesn't Match |
|-----------------|---------------|---------|---------------|
| `view * entries` | `/^view .* entries$/` | `view courses entries`<br>`view news entries` | `edit courses entries`<br>`view courses terms` |
| `* * terms` | `/^.* .* terms$/` | `view machines terms`<br>`edit regions terms` | `view machines entries` |
| `edit other authors * entries` | `/^edit other authors .* entries$/` | `edit other authors courses entries` | `delete other authors courses entries` |

**Testing**
I tried to write some tests for that, but I'm not sure, if its OK, havent practiced much in writing tests.
