### PR TITLE
[6.x] Fix replicator preview text merging during reorder

### DIFF
--- a/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
+++ b/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
@@ -7,7 +7,8 @@ export default {
                 .filter(([handle, value]) => {
                     if (!handle.endsWith('_')) return false;
                     handle = handle.substr(0, handle.length - 1); // Remove the trailing underscore.
-                    const config = this.config.fields.find((f) => f.handle === handle) || {};
+                    const config = this.config.fields.find((f) => f.handle === handle);
+                    if (!config) return false;
                     return config.replicator_preview === undefined ? this.showFieldPreviews : config.replicator_preview;
                 })
                 .map(([handle, value]) => value)

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -83,7 +83,8 @@ const previewText = computed(() => {
         .filter(([handle, value]) => {
             if (!handle.endsWith('_')) return false;
             handle = handle.substr(0, handle.length - 1); // Remove the trailing underscore.
-            const config = props.config.fields.find((f) => f.handle === handle) || {};
+            const config = props.config.fields.find((f) => f.handle === handle);
+            if (!config) return false;
             return config.replicator_preview === undefined ? props.showFieldPreviews : config.replicator_preview;
         })
         .map(([handle, value]) => value)


### PR DESCRIPTION
## Summary

- Fixes collapsed replicator preview text incorrectly merging fields from different set types after drag-and-drop reorder
- When a field handle from a stale preview entry doesn't exist in the current set's config, `previewText` now returns `false` (filters it out) instead of falling through to the default `showFieldPreviews` behavior
- Applied the same fix in both `Set.vue` (replicator) and `ManagesPreviewText.js` (shared by Bard sets & Group fieldtype)

Fixes #14071

## Test plan

- [x] Create a replicator field with 2+ set types having different fields
- [x] Add content to sets of different types
- [x] Collapse the sets to see preview text
- [x] Drag-and-drop to reorder sets of different types
- [x] Confirm preview text shows only the correct set's fields (no merging)
- [x] Refresh page and confirm previews still correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)