### PR TITLE
[6.x] Handle many tabs for both the blueprint and entry view

### DIFF
--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -7,7 +7,7 @@
             class="h-4 w-4 me-1"
         />
 
-        {{ __(tab.display) }}
+        <span class="block max-w-48 overflow-hidden text-ellipsis whitespace-nowrap">{{ __(tab.display) }}</span>
 
         <Dropdown v-if="isActive" placement="left-start" class="me-3">
             <template #trigger>

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -7,7 +7,7 @@
             class="h-4 w-4 me-1"
         />
 
-        <span class="block max-w-48 overflow-clip text-ellipsis whitespace-nowrap">{{ __(tab.display) }}</span>
+        <span class="block max-w-48 overflow-clip text-ellipsis whitespace-nowrap" v-tooltip="__(tab.display).length > 24 ? __(tab.display) : null">{{ __(tab.display) }}</span>
 
         <Dropdown v-if="isActive" placement="left-start" class="me-3">
             <template #trigger>

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -7,7 +7,7 @@
             class="h-4 w-4 me-1"
         />
 
-        <span class="block max-w-48 overflow-hidden text-ellipsis whitespace-nowrap">{{ __(tab.display) }}</span>
+        <span class="block max-w-48 overflow-clip text-ellipsis whitespace-nowrap">{{ __(tab.display) }}</span>
 
         <Dropdown v-if="isActive" placement="left-start" class="me-3">
             <template #trigger>

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -29,10 +29,10 @@
                             >
                                 <template #trigger>
                                     <Button
-                                        icon="chevron-vertical"
+                                        icon="dots"
                                         variant="ghost"
                                         size="sm"
-                                        :aria-label="__('More tabs')"
+                                        :aria-label="__('Open dropdown menu')"
                                     />
                                 </template>
                                 <DropdownMenu>

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -5,7 +5,7 @@
                 <div v-if="!singleTab && tabs.length > 0" class="flex items-center justify-between gap-x-2 mb-6">
                     <TabList class="flex-1 min-w-0 overflow-x-clip overflow-y-visible pe-0.25">
                         <div ref="tabs" class="flex-1 flex items-center gap-x-2.5 min-w-0">
-                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-clip">
+                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-clip px-0.25">
                                 <div ref="tabInner" class="flex items-center gap-x-2.5 shrink-0">
                                     <BlueprintTab
                                         ref="tab"

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -95,7 +95,7 @@ import { createTabsOverflowTracker } from '@/util/tabs-overflow.js';
 import BlueprintTab from './Tab.vue';
 import BlueprintTabContent from './TabContent.vue';
 import CanDefineLocalizable from '../fields/CanDefineLocalizable';
-import { Tabs, TabList, Button, Description, Dropdown, DropdownMenu, DropdownItem, DropdownSeparator, Icon } from '@/components/ui';
+import { Tabs, TabList, Button, Description, Dropdown, DropdownMenu, DropdownItem, DropdownSeparator } from '@/components/ui';
 
 export default {
     mixins: [CanDefineLocalizable],
@@ -111,7 +111,6 @@ export default {
         DropdownMenu,
         DropdownItem,
         DropdownSeparator,
-        Icon,
     },
 
     props: {
@@ -181,7 +180,6 @@ export default {
             sortableTabs: null,
             sortableSections: null,
             sortableFields: null,
-            hasOverflow: false,
             overflowedTabs: [],
         };
     },
@@ -193,6 +191,9 @@ export default {
     },
 
     watch: {
+        currentTab() {
+            this.$nextTick(this.checkOverflow);
+        },
 		tabs: {
 			deep: true,
 			handler(tabs) {
@@ -210,8 +211,7 @@ export default {
             getWrapper: () => this.$refs.tabWrapper,
             getInner: () => this.$refs.tabInner,
             getItems: () => this.tabs,
-            onUpdate: ({ hasOverflow, overflowedItems }) => {
-                this.hasOverflow = hasOverflow;
+            onUpdate: ({ overflowedItems }) => {
                 this.overflowedTabs = overflowedItems;
             },
         });

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -39,11 +39,14 @@
                                     <DropdownItem
                                         v-for="tab in tabs"
                                         :key="tab._id"
-                                        :text="__(tab.display)"
                                         :icon="tab.icon"
                                         :class="{ 'bg-gray-100 dark:bg-gray-800': currentTab === tab._id }"
                                         @click="selectTab(tab._id)"
-                                    />
+                                    >
+                                        <span class="block max-w-48 overflow-hidden text-ellipsis whitespace-nowrap">
+                                            {{ __(tab.display) }}
+                                        </span>
+                                    </DropdownItem>
                                 </DropdownMenu>
                             </Dropdown>
                         </div>

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -3,7 +3,7 @@
         <div>
             <Tabs v-model="currentTab" :unmount-on-hide="false">
                 <div v-if="!singleTab && tabs.length > 0" class="flex items-center justify-between gap-x-2 mb-6">
-                    <TabList class="flex-1 min-w-0 overflow-x-clip overflow-y-visible">
+                    <TabList class="flex-1 min-w-0 overflow-x-clip overflow-y-visible pe-0.25">
                         <div ref="tabs" class="flex-1 flex items-center gap-x-2.5 min-w-0">
                             <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-clip">
                                 <div ref="tabInner" class="flex items-center gap-x-2.5 shrink-0">

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -3,9 +3,9 @@
         <div>
             <Tabs v-model="currentTab" :unmount-on-hide="false">
                 <div v-if="!singleTab && tabs.length > 0" class="flex items-center justify-between gap-x-2 mb-6">
-                    <TabList class="flex-1 min-w-0">
+                    <TabList class="flex-1 min-w-0 overflow-x-clip overflow-y-visible">
                         <div ref="tabs" class="flex-1 flex items-center gap-x-2.5 min-w-0">
-                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-hidden">
+                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-clip">
                                 <div ref="tabInner" class="flex items-center gap-x-2.5 shrink-0">
                                     <BlueprintTab
                                         ref="tab"

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -91,7 +91,7 @@
 <script>
 import { Sortable, Plugins } from '@shopify/draggable';
 import { nanoid as uniqid } from 'nanoid';
-import throttle from '@/util/throttle.js';
+import { createTabsOverflowTracker } from '@/util/tabs-overflow.js';
 import BlueprintTab from './Tab.vue';
 import BlueprintTabContent from './TabContent.vue';
 import CanDefineLocalizable from '../fields/CanDefineLocalizable';
@@ -206,43 +206,31 @@ export default {
     mounted() {
         this.ensureTab();
         this.makeSortable();
-        this.throttledCheckOverflow = throttle(() => this.$nextTick(this.checkOverflow), 100);
-        this.resizeObserver = new ResizeObserver(this.throttledCheckOverflow);
-        const wrapper = this.$refs.tabWrapper;
-        if (wrapper) this.resizeObserver.observe(wrapper);
-        this.$nextTick(this.checkOverflow);
+        this.overflowTracker = createTabsOverflowTracker({
+            getWrapper: () => this.$refs.tabWrapper,
+            getInner: () => this.$refs.tabInner,
+            getItems: () => this.tabs,
+            onUpdate: ({ hasOverflow, overflowedItems }) => {
+                this.hasOverflow = hasOverflow;
+                this.overflowedTabs = overflowedItems;
+            },
+        });
+        this.$nextTick(() => {
+            this.overflowTracker.observe();
+            this.overflowTracker.checkOverflow();
+        });
     },
 
     unmounted() {
         if (this.sortableTabs) this.sortableTabs.destroy();
         if (this.sortableSections) this.sortableSections.destroy();
         if (this.sortableFields) this.sortableFields.destroy();
-        if (this.resizeObserver) this.resizeObserver.disconnect();
-        if (this.throttledCheckOverflow?.cancel) this.throttledCheckOverflow.cancel();
+        this.overflowTracker?.disconnect();
     },
 
     methods: {
         checkOverflow() {
-            const wrapper = this.$refs.tabWrapper;
-            const inner = this.$refs.tabInner;
-            if (!wrapper || !inner || !this.tabs.length) {
-                this.hasOverflow = false;
-                this.overflowedTabs = [];
-                return;
-            }
-            this.hasOverflow = inner.scrollWidth > wrapper.clientWidth;
-            if (!this.hasOverflow) {
-                this.overflowedTabs = [];
-                return;
-            }
-            const wrapperRect = wrapper.getBoundingClientRect();
-            const buttons = inner.querySelectorAll('[role="tab"]');
-            this.overflowedTabs = this.tabs.filter((tab, i) => {
-                const el = buttons[i];
-                if (!el) return false;
-                const rect = el.getBoundingClientRect();
-                return rect.right > wrapperRect.right || rect.left < wrapperRect.left;
-            });
+            this.overflowTracker?.checkOverflow();
         },
 
         ensureTab() {

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -3,20 +3,49 @@
         <div>
             <Tabs v-model="currentTab" :unmount-on-hide="false">
                 <div v-if="!singleTab && tabs.length > 0" class="flex items-center justify-between gap-x-2 mb-6">
-                    <TabList class="flex-1">
-                        <div ref="tabs" class="flex-1 flex items-center gap-x-2.5">
-                            <BlueprintTab
-                                ref="tab"
-                                v-for="tab in tabs"
-                                :key="tab._id"
-                                :tab="tab"
-                                :current-tab="currentTab"
-                                :show-instructions="showTabInstructionsField"
-                                :edit-text="editTabText"
-                                @removed="removeTab(tab._id)"
-                                @updated="updateTab(tab._id, $event)"
-                                @mouseenter="mouseEnteredTab(tab._id)"
-                            />
+                    <TabList class="flex-1 min-w-0">
+                        <div ref="tabs" class="flex-1 flex items-center gap-x-2.5 min-w-0">
+                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-hidden">
+                                <div ref="tabInner" class="flex items-center gap-x-2.5 shrink-0">
+                                    <BlueprintTab
+                                        ref="tab"
+                                        v-for="tab in tabs"
+                                        :key="tab._id"
+                                        :tab="tab"
+                                        :current-tab="currentTab"
+                                        :show-instructions="showTabInstructionsField"
+                                        :edit-text="editTabText"
+                                        @removed="removeTab(tab._id)"
+                                        @updated="updateTab(tab._id, $event)"
+                                        @mouseenter="mouseEnteredTab(tab._id)"
+                                    />
+                                </div>
+                            </div>
+                            <Dropdown
+                                v-if="hasOverflow"
+                                align="end"
+                                side="bottom"
+                                class="shrink-0"
+                            >
+                                <template #trigger>
+                                    <Button
+                                        icon="chevron-vertical"
+                                        variant="ghost"
+                                        size="sm"
+                                        :aria-label="__('More tabs')"
+                                    />
+                                </template>
+                                <DropdownMenu>
+                                    <DropdownItem
+                                        v-for="tab in tabs"
+                                        :key="tab._id"
+                                        :text="__(tab.display)"
+                                        :icon="tab.icon"
+                                        :class="{ 'bg-gray-100 dark:bg-gray-800': currentTab === tab._id }"
+                                        @click="selectTab(tab._id)"
+                                    />
+                                </DropdownMenu>
+                            </Dropdown>
                         </div>
                     </TabList>
 
@@ -54,10 +83,11 @@
 <script>
 import { Sortable, Plugins } from '@shopify/draggable';
 import { nanoid as uniqid } from 'nanoid';
+import throttle from '@/util/throttle.js';
 import BlueprintTab from './Tab.vue';
 import BlueprintTabContent from './TabContent.vue';
 import CanDefineLocalizable from '../fields/CanDefineLocalizable';
-import { Tabs, TabList, Button, Description } from '@/components/ui';
+import { Tabs, TabList, Button, Description, Dropdown, DropdownMenu, DropdownItem } from '@/components/ui';
 
 export default {
     mixins: [CanDefineLocalizable],
@@ -69,6 +99,9 @@ export default {
         TabList,
         Button,
         Description,
+        Dropdown,
+        DropdownMenu,
+        DropdownItem,
     },
 
     props: {
@@ -138,6 +171,7 @@ export default {
             sortableTabs: null,
             sortableSections: null,
             sortableFields: null,
+            hasOverflow: false,
         };
     },
 
@@ -147,6 +181,7 @@ export default {
 			handler(tabs) {
 				this.$emit('updated', tabs);
 				this.makeSortable();
+				this.$nextTick(this.checkOverflow);
 			},
 		},
     },
@@ -154,15 +189,32 @@ export default {
     mounted() {
         this.ensureTab();
         this.makeSortable();
+        this.throttledCheckOverflow = throttle(() => this.$nextTick(this.checkOverflow), 100);
+        this.resizeObserver = new ResizeObserver(this.throttledCheckOverflow);
+        const wrapper = this.$refs.tabWrapper;
+        if (wrapper) this.resizeObserver.observe(wrapper);
+        this.$nextTick(this.checkOverflow);
     },
 
     unmounted() {
         if (this.sortableTabs) this.sortableTabs.destroy();
         if (this.sortableSections) this.sortableSections.destroy();
         if (this.sortableFields) this.sortableFields.destroy();
+        if (this.resizeObserver) this.resizeObserver.disconnect();
+        if (this.throttledCheckOverflow?.cancel) this.throttledCheckOverflow.cancel();
     },
 
     methods: {
+        checkOverflow() {
+            const wrapper = this.$refs.tabWrapper;
+            const inner = this.$refs.tabInner;
+            if (!wrapper || !inner || !this.tabs.length) {
+                this.hasOverflow = false;
+                return;
+            }
+            this.hasOverflow = inner.scrollWidth > wrapper.clientWidth;
+        },
+
         ensureTab() {
             if (this.requireSection && this.tabs.length === 0) {
                 this.addTab();
@@ -180,7 +232,10 @@ export default {
         makeTabsSortable() {
             if (this.sortableTabs) this.sortableTabs.destroy();
 
-            this.sortableTabs = new Sortable(this.$refs.tabs, {
+            const container = this.$refs.tabInner || this.$refs.tabs;
+            if (!container) return;
+
+            this.sortableTabs = new Sortable(container, {
                 draggable: '.blueprint-tab',
                 mirror: { constrainDimensions: true },
                 swapAnimation: { horizontal: true },

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -22,7 +22,7 @@
                                 </div>
                             </div>
                             <Dropdown
-                                v-if="hasOverflow"
+                                v-if="overflowedTabs.length"
                                 align="end"
                                 side="bottom"
                                 class="shrink-0"
@@ -37,7 +37,7 @@
                                 </template>
                                 <DropdownMenu>
                                     <DropdownItem
-                                        v-for="tab in tabs"
+                                        v-for="tab in overflowedTabs"
                                         :key="tab._id"
                                         :icon="tab.icon"
                                         :class="{ 'bg-gray-100 dark:bg-gray-800': currentTab === tab._id }"
@@ -175,6 +175,7 @@ export default {
             sortableSections: null,
             sortableFields: null,
             hasOverflow: false,
+            overflowedTabs: [],
         };
     },
 
@@ -213,9 +214,22 @@ export default {
             const inner = this.$refs.tabInner;
             if (!wrapper || !inner || !this.tabs.length) {
                 this.hasOverflow = false;
+                this.overflowedTabs = [];
                 return;
             }
             this.hasOverflow = inner.scrollWidth > wrapper.clientWidth;
+            if (!this.hasOverflow) {
+                this.overflowedTabs = [];
+                return;
+            }
+            const wrapperRect = wrapper.getBoundingClientRect();
+            const buttons = inner.querySelectorAll('[role="tab"]');
+            this.overflowedTabs = this.tabs.filter((tab, i) => {
+                const el = buttons[i];
+                if (!el) return false;
+                const rect = el.getBoundingClientRect();
+                return rect.right > wrapperRect.right || rect.left < wrapperRect.left;
+            });
         },
 
         ensureTab() {

--- a/resources/js/components/blueprints/Tabs.vue
+++ b/resources/js/components/blueprints/Tabs.vue
@@ -47,6 +47,11 @@
                                             {{ __(tab.display) }}
                                         </span>
                                     </DropdownItem>
+                                    <template v-if="activeTabIsOverflowed">
+                                        <DropdownSeparator />
+                                        <DropdownItem :text="__('Edit')" icon="edit" @click="editActiveOverflowedTab" />
+                                        <DropdownItem :text="__('Delete')" icon="trash" variant="destructive" @click="removeActiveOverflowedTab" />
+                                    </template>
                                 </DropdownMenu>
                             </Dropdown>
                         </div>
@@ -90,7 +95,7 @@ import throttle from '@/util/throttle.js';
 import BlueprintTab from './Tab.vue';
 import BlueprintTabContent from './TabContent.vue';
 import CanDefineLocalizable from '../fields/CanDefineLocalizable';
-import { Tabs, TabList, Button, Description, Dropdown, DropdownMenu, DropdownItem } from '@/components/ui';
+import { Tabs, TabList, Button, Description, Dropdown, DropdownMenu, DropdownItem, DropdownSeparator, Icon } from '@/components/ui';
 
 export default {
     mixins: [CanDefineLocalizable],
@@ -105,6 +110,8 @@ export default {
         Dropdown,
         DropdownMenu,
         DropdownItem,
+        DropdownSeparator,
+        Icon,
     },
 
     props: {
@@ -177,6 +184,12 @@ export default {
             hasOverflow: false,
             overflowedTabs: [],
         };
+    },
+
+    computed: {
+        activeTabIsOverflowed() {
+            return this.overflowedTabs.some((t) => t._id === this.currentTab);
+        },
     },
 
     watch: {
@@ -364,6 +377,22 @@ export default {
 
         selectTab(tabId) {
             this.currentTab = tabId;
+        },
+
+        editOverflowedTab(tab) {
+            if (!tab) return;
+            const refs = this.$refs.tab;
+            const tabRef = Array.isArray(refs) ? refs.find((c) => c.tab?._id === tab._id) : refs;
+            tabRef?.edit();
+        },
+
+        editActiveOverflowedTab() {
+            const tab = this.overflowedTabs.find((t) => t._id === this.currentTab);
+            if (tab) this.editOverflowedTab(tab);
+        },
+
+        removeActiveOverflowedTab() {
+            this.removeTab(this.currentTab);
         },
 
         mouseEnteredTab(tabId) {

--- a/resources/js/components/ui/Dropdown/Item.vue
+++ b/resources/js/components/ui/Dropdown/Item.vue
@@ -61,7 +61,7 @@ const iconClasses = cva({
         <div v-if="icon" class="flex size-5 items-center justify-center p-1">
             <Icon :name="icon" :class="iconClasses" />
         </div>
-        <div class="col-start-2 px-2">
+        <div class="px-2" :class="icon ? 'col-start-2' : 'col-span-full'">
             <slot v-if="hasDefaultSlot" />
             <template v-else>{{ text }}</template>
         </div>

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -15,7 +15,7 @@ import Sections from './Sections.vue';
 import { ref, computed, useSlots, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import ElementContainer from '@/components/ElementContainer.vue';
 import ShowField from '@/components/field-conditions/ShowField.js';
-import throttle from '@/util/throttle.js';
+import { createTabsOverflowTracker } from '@/util/tabs-overflow.js';
 
 const slots = useSlots();
 const { blueprint, visibleValues, extraValues, revealerValues, errors, hiddenFields, setHiddenField, container, rememberTab } = injectContainerContext();
@@ -113,48 +113,33 @@ const tabWrapper = ref(null);
 const tabInner = ref(null);
 const hasOverflow = ref(false);
 const overflowedTabs = ref([]);
+const overflowTracker = createTabsOverflowTracker({
+    getWrapper: () => tabWrapper.value,
+    getInner: () => tabInner.value,
+    getItems: () => visibleMainTabs.value,
+    onUpdate: ({ hasOverflow: nextHasOverflow, overflowedItems }) => {
+        hasOverflow.value = nextHasOverflow;
+        overflowedTabs.value = overflowedItems;
+    },
+});
 
 function checkOverflow() {
-    if (!tabWrapper.value || !tabInner.value) {
-        hasOverflow.value = false;
-        overflowedTabs.value = [];
-        return;
-    }
-    const wrapper = tabWrapper.value;
-    const inner = tabInner.value;
-    hasOverflow.value = inner.scrollWidth > wrapper.clientWidth;
-    if (!hasOverflow.value) {
-        overflowedTabs.value = [];
-        return;
-    }
-    const wrapperRect = wrapper.getBoundingClientRect();
-    const buttons = inner.querySelectorAll('[role="tab"]');
-    overflowedTabs.value = visibleMainTabs.value.filter((tab, i) => {
-        const el = buttons[i];
-        if (!el) return false;
-        const rect = el.getBoundingClientRect();
-        return rect.right > wrapperRect.right || rect.left < wrapperRect.left;
-    });
+    overflowTracker.checkOverflow();
 }
 
-const throttledCheckOverflow = throttle(() => nextTick(checkOverflow), 100);
-let resizeObserver = null;
-
 watch(tabWrapper, (el) => {
-    if (resizeObserver) {
-        resizeObserver.disconnect();
-        resizeObserver = null;
-    }
     if (el) {
-        resizeObserver = new ResizeObserver(throttledCheckOverflow);
-        resizeObserver.observe(el);
+        overflowTracker.observe();
         nextTick(checkOverflow);
     }
 });
 
+watch(visibleMainTabs, () => {
+    nextTick(checkOverflow);
+}, { deep: true });
+
 onUnmounted(() => {
-    if (resizeObserver) resizeObserver.disconnect();
-    if (throttledCheckOverflow?.cancel) throttledCheckOverflow.cancel();
+    overflowTracker.disconnect();
 });
 </script>
 

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -112,13 +112,29 @@ function tabHasError(tab) {
 const tabWrapper = ref(null);
 const tabInner = ref(null);
 const hasOverflow = ref(false);
+const overflowedTabs = ref([]);
 
 function checkOverflow() {
     if (!tabWrapper.value || !tabInner.value) {
         hasOverflow.value = false;
+        overflowedTabs.value = [];
         return;
     }
-    hasOverflow.value = tabInner.value.scrollWidth > tabWrapper.value.clientWidth;
+    const wrapper = tabWrapper.value;
+    const inner = tabInner.value;
+    hasOverflow.value = inner.scrollWidth > wrapper.clientWidth;
+    if (!hasOverflow.value) {
+        overflowedTabs.value = [];
+        return;
+    }
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const buttons = inner.querySelectorAll('[role="tab"]');
+    overflowedTabs.value = visibleMainTabs.value.filter((tab, i) => {
+        const el = buttons[i];
+        if (!el) return false;
+        const rect = el.getBoundingClientRect();
+        return rect.right > wrapperRect.right || rect.left < wrapperRect.left;
+    });
 }
 
 const throttledCheckOverflow = throttle(() => nextTick(checkOverflow), 100);
@@ -162,7 +178,7 @@ onUnmounted(() => {
                                 </div>
                             </div>
                             <Dropdown
-                                v-if="hasOverflow"
+                                v-if="overflowedTabs.length"
                                 align="end"
                                 side="bottom"
                                 class="shrink-0"
@@ -177,7 +193,7 @@ onUnmounted(() => {
                                 </template>
                                 <DropdownMenu>
                                     <DropdownItem
-                                        v-for="tab in visibleMainTabs"
+                                        v-for="tab in overflowedTabs"
                                         :key="tab.handle"
                                         :icon="tab.icon"
                                         :class="{ 'bg-gray-100 dark:bg-gray-800': activeTab === tab.handle }"

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -149,7 +149,7 @@ onUnmounted(() => {
                 <div v-if="hasMultipleVisibleMainTabs" class="flex items-center gap-x-2 -mt-2 mb-6">
                     <TabList class="flex-1 min-w-0 overflow-x-clip overflow-y-visible pe-0.25">
                         <div class="flex-1 flex items-center gap-x-2.5 min-w-0">
-                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-clip">
+                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-clip px-0.25">
                                 <div ref="tabInner" class="flex items-center gap-x-2.5 shrink-0">
                                     <TabTrigger
                                         v-for="tab in visibleMainTabs"

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -4,13 +4,18 @@ import {
     TabList,
     TabTrigger,
     TabProvider,
+    Button,
+    Dropdown,
+    DropdownMenu,
+    DropdownItem,
 } from '@ui';
 import TabContent from './TabContent.vue';
 import { injectContainerContext } from './Container.vue';
 import Sections from './Sections.vue';
-import { ref, computed, useSlots, onMounted, watch } from 'vue';
+import { ref, computed, useSlots, onMounted, onUnmounted, nextTick, watch } from 'vue';
 import ElementContainer from '@/components/ElementContainer.vue';
 import ShowField from '@/components/field-conditions/ShowField.js';
+import throttle from '@/util/throttle.js';
 
 const slots = useSlots();
 const { blueprint, visibleValues, extraValues, revealerValues, errors, hiddenFields, setHiddenField, container, rememberTab } = injectContainerContext();
@@ -103,21 +108,89 @@ const tabsWithErrors = computed(() => {
 function tabHasError(tab) {
     return tabsWithErrors.value.includes(tab.handle);
 }
+
+const tabWrapper = ref(null);
+const tabInner = ref(null);
+const hasOverflow = ref(false);
+
+function checkOverflow() {
+    if (!tabWrapper.value || !tabInner.value) {
+        hasOverflow.value = false;
+        return;
+    }
+    hasOverflow.value = tabInner.value.scrollWidth > tabWrapper.value.clientWidth;
+}
+
+const throttledCheckOverflow = throttle(() => nextTick(checkOverflow), 100);
+let resizeObserver = null;
+
+watch(tabWrapper, (el, oldEl) => {
+    if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+    }
+    if (el) {
+        resizeObserver = new ResizeObserver(throttledCheckOverflow);
+        resizeObserver.observe(el);
+        nextTick(checkOverflow);
+    }
+});
+
+onUnmounted(() => {
+    if (resizeObserver) resizeObserver.disconnect();
+    if (throttledCheckOverflow?.cancel) throttledCheckOverflow.cancel();
+});
 </script>
 
 <template>
     <ElementContainer @resized="width = $event.width">
         <div>
             <Tabs v-if="width" v-model:modelValue="activeTab">
-                <TabList v-if="hasMultipleVisibleMainTabs" class="-mt-2 mb-6">
-                    <TabTrigger
-                        v-for="tab in visibleMainTabs"
-                        :key="tab.handle"
-                        :name="tab.handle"
-                        :text="__(tab.display)"
-                        :class="{ '!text-red-600': tabHasError(tab) }"
-                    />
-                </TabList>
+                <div v-if="hasMultipleVisibleMainTabs" class="flex items-center gap-x-2 -mt-2 mb-6">
+                    <TabList class="flex-1 min-w-0 overflow-x-clip overflow-y-visible pe-0.25">
+                        <div class="flex-1 flex items-center gap-x-2.5 min-w-0">
+                            <div ref="tabWrapper" class="min-w-0 flex-1 flex overflow-clip">
+                                <div ref="tabInner" class="flex items-center gap-x-2.5 shrink-0">
+                                    <TabTrigger
+                                        v-for="tab in visibleMainTabs"
+                                        :key="tab.handle"
+                                        :name="tab.handle"
+                                        :class="{ '!text-red-600': tabHasError(tab) }"
+                                    >
+                                        <span class="block max-w-48 overflow-clip text-ellipsis whitespace-nowrap">{{ __(tab.display) }}</span>
+                                    </TabTrigger>
+                                </div>
+                            </div>
+                            <Dropdown
+                                v-if="hasOverflow"
+                                align="end"
+                                side="bottom"
+                                class="shrink-0"
+                            >
+                                <template #trigger>
+                                    <Button
+                                        icon="dots"
+                                        variant="ghost"
+                                        size="sm"
+                                        :aria-label="__('Open dropdown menu')"
+                                    />
+                                </template>
+                                <DropdownMenu>
+                                    <DropdownItem
+                                        v-for="tab in visibleMainTabs"
+                                        :key="tab.handle"
+                                        :class="{ 'bg-gray-100 dark:bg-gray-800': activeTab === tab.handle }"
+                                        @click="setActive(tab.handle)"
+                                    >
+                                        <span class="block max-w-48 overflow-hidden text-ellipsis whitespace-nowrap">
+                                            {{ __(tab.display) }}
+                                        </span>
+                                    </DropdownItem>
+                                </DropdownMenu>
+                            </Dropdown>
+                        </div>
+                    </TabList>
+                </div>
 
                 <div :class="{ 'grid grid-cols-[1fr_320px] gap-8': shouldShowSidebar }">
                     <component

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -124,7 +124,7 @@ function checkOverflow() {
 const throttledCheckOverflow = throttle(() => nextTick(checkOverflow), 100);
 let resizeObserver = null;
 
-watch(tabWrapper, (el, oldEl) => {
+watch(tabWrapper, (el) => {
     if (resizeObserver) {
         resizeObserver.disconnect();
         resizeObserver = null;
@@ -179,6 +179,7 @@ onUnmounted(() => {
                                     <DropdownItem
                                         v-for="tab in visibleMainTabs"
                                         :key="tab.handle"
+                                        :icon="tab.icon"
                                         :class="{ 'bg-gray-100 dark:bg-gray-800': activeTab === tab.handle }"
                                         @click="setActive(tab.handle)"
                                     >

--- a/resources/js/components/ui/Publish/Tabs.vue
+++ b/resources/js/components/ui/Publish/Tabs.vue
@@ -157,7 +157,7 @@ onUnmounted(() => {
                                         :name="tab.handle"
                                         :class="{ '!text-red-600': tabHasError(tab) }"
                                     >
-                                        <span class="block max-w-48 overflow-clip text-ellipsis whitespace-nowrap">{{ __(tab.display) }}</span>
+                                        <span class="block max-w-48 overflow-clip text-ellipsis whitespace-nowrap" v-tooltip="__(tab.display).length > 24 ? __(tab.display) : null">{{ __(tab.display) }}</span>
                                     </TabTrigger>
                                 </div>
                             </div>

--- a/resources/js/util/tabs-overflow.js
+++ b/resources/js/util/tabs-overflow.js
@@ -1,0 +1,72 @@
+import throttle from '@/util/throttle.js';
+
+export function createTabsOverflowTracker({
+    getWrapper,
+    getInner,
+    getItems,
+    onUpdate,
+    wait = 100,
+}) {
+    let observer = null;
+    const throttledCheck = throttle(() => checkOverflow(), wait);
+
+    function checkOverflow() {
+        const wrapper = getWrapper();
+        const inner = getInner();
+        const items = getItems();
+
+        if (!wrapper || !inner || !items.length) {
+            onUpdate({ hasOverflow: false, overflowedItems: [] });
+            return;
+        }
+
+        const hasOverflow = inner.scrollWidth > wrapper.clientWidth;
+
+        if (!hasOverflow) {
+            onUpdate({ hasOverflow: false, overflowedItems: [] });
+            return;
+        }
+
+        const wrapperRect = wrapper.getBoundingClientRect();
+        const tabNodes = inner.querySelectorAll('[role="tab"]');
+        const overflowedItems = items.filter((item, index) => {
+            const node = tabNodes[index];
+
+            if (!node) {
+                return false;
+            }
+
+            const rect = node.getBoundingClientRect();
+
+            return rect.right > wrapperRect.right || rect.left < wrapperRect.left;
+        });
+
+        onUpdate({ hasOverflow: true, overflowedItems });
+    }
+
+    function observe() {
+        observer?.disconnect();
+        observer = null;
+
+        const wrapper = getWrapper();
+
+        if (!wrapper) {
+            return;
+        }
+
+        observer = new ResizeObserver(throttledCheck);
+        observer.observe(wrapper);
+    }
+
+    function disconnect() {
+        observer?.disconnect();
+        observer = null;
+        throttledCheck.cancel();
+    }
+
+    return {
+        checkOverflow,
+        observe,
+        disconnect,
+    };
+}


### PR DESCRIPTION
## Description of the Problem

This issue is also detailed in https://github.com/statamic/cms/issues/14062
For both the blueprint and publish views, if you add either many tabs, or tabs with long names, it can cause issues, like this:

Text stacks up vertically

![2026-02-25 at 14 22 09@2x](https://github.com/user-attachments/assets/990bded9-1483-4a63-90f7-8bbcc067f215)

You get horizontal overflow on mobile

<img src="https://github.com/user-attachments/assets/c43e3ab8-f05c-40e7-afc5-421719c21de8" width="400"/>

## What this PR Does

- **Constrained width** — Tab rows no longer grow past the viewport; it clips with a max width.
- **Overflow dropdown** — When tabs don’t fit, a button appears and lists overflowed tabs so you can switch from the dropdown.
  - `ResizeObserver` is used for overflow detection
  - Our existing dropdown component is used
  - If you have overflowed tabs, and you select the menu, we expose edit/delete controls so you can still access the usual dropdown (this is not a perfect solution but at least there's still a way to access controls here)
![2026-02-25 at 15 38 18@2x](https://github.com/user-attachments/assets/3abeef1b-84d5-4468-aa53-79747ddd9bdc)
- Adds a bit of logic to extend the text to span the dropdown grid column row if there's no icon, as we have with these overflow menus—otherwise, there is a blank space where the icon usually sits.

- **Truncated labels** — Tab and dropdown labels are truncated so long names don’t break the layout.
  - Truncated labels get a tooltip so they're still accessible to users
- Closes #14062

### Here are some examples of an egregious amount of tabs  / long tab names with the new PR

Long tab name truncated, and many tabs trigger an overflow menu
![2026-02-25 at 14 41 26@2x](https://github.com/user-attachments/assets/47df9331-e999-4e08-a38f-e4a1fb58c1c3)

Here is the overflow menu
![2026-02-25 at 15 30 56@2x](https://github.com/user-attachments/assets/ce40ef9b-096e-4cff-aa77-9d67ba32a3c4)

and here it is at a narrow viewport
<img src="https://github.com/user-attachments/assets/2dd20e02-ad33-4651-af5e-b91c1b08069d" width="400"/>

## How to Reproduce

1. Add long tab names in a blueprint
2. Also add _many_ tab names
3. Check out the behaviour for both the blueprints _and_ the publish form