### PR TITLE
[5.x] Fix user name and email logic

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -51,7 +51,7 @@ class Impersonate extends Action
 
             $guard->login($users->first());
             session()->put('statamic_impersonated_by', $impersonator->getKey());
-            Toast::success(__('You are now impersonating').' '.$impersonated->name());
+            Toast::success(__('You are now impersonating').' '.($impersonated->name() ?? $impersonated->email()));
 
             ImpersonationStarted::dispatch($impersonator, $impersonated);
         } finally {

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -77,13 +77,13 @@ abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticata
 
     public function initials()
     {
+        if (! $name = $this->name()) {
+            return '?';
+        }
+
         $surname = '';
-        if ($name = $this->get('name')) {
-            if (Str::contains($name, ' ')) {
-                [$name, $surname] = explode(' ', $name);
-            }
-        } else {
-            $name = (string) $this->email();
+        if (Str::contains($name, ' ')) {
+            [$name, $surname] = explode(' ', $name, 2);
         }
 
         return strtoupper(mb_substr($name, 0, 1).mb_substr($surname, 0, 1));
@@ -320,7 +320,7 @@ abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticata
             return $name;
         }
 
-        return $this->email();
+        return null;
     }
 
     public function defaultAugmentedArrayKeys()

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -3,8 +3,8 @@
 namespace Statamic\Fieldtypes;
 
 use Illuminate\Support\Collection;
-use Statamic\CP\Column;
 use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\CP\Column;
 use Statamic\Facades\GraphQL;
 use Statamic\Facades\Scope;
 use Statamic\Facades\Search;

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -4,6 +4,7 @@ namespace Statamic\Fieldtypes;
 
 use Illuminate\Support\Collection;
 use Statamic\CP\Column;
+use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\GraphQL;
 use Statamic\Facades\Scope;
 use Statamic\Facades\Search;
@@ -86,8 +87,10 @@ class Users extends Relationship
     protected function toItemArray($id, $site = null)
     {
         if ($user = User::find($id)) {
+            $canViewUsers = $this->canViewUser($user);
+
             return [
-                'title' => $user->name(),
+                'title' => $this->userTitle($user, $canViewUsers),
                 'id' => $id,
                 'edit_url' => $user->editUrl(),
                 'editable' => User::current()->can('edit', $user),
@@ -132,11 +135,18 @@ class Users extends Relationship
                 $user = $user->getSearchable();
             }
 
-            return [
+            $canViewUsers = $this->canViewUser($user);
+
+            $fields = [
                 'id' => $user->id(),
-                'title' => $user->name(),
-                'email' => $user->email(),
+                'title' => $this->userTitle($user, $canViewUsers),
             ];
+
+            if ($canViewUsers) {
+                $fields['email'] = $user->email();
+            }
+
+            return $fields;
         };
 
         if ($request->boolean('paginate', true)) {
@@ -152,22 +162,52 @@ class Users extends Relationship
 
     protected function getColumns()
     {
-        return [
+        $columns = [
             Column::make('title')->label('Name'),
-            Column::make('email'),
         ];
+
+        if ($this->canViewUsers()) {
+            $columns[] = Column::make('email');
+        }
+
+        return $columns;
     }
 
     public function preProcessIndex($data)
     {
-        return $this->getItemsForPreProcessIndex($data)->map(function ($user) {
+        $canViewUsers = $this->canViewUsers();
+
+        return $this->getItemsForPreProcessIndex($data)->map(function ($user) use ($canViewUsers) {
             return [
                 'id' => $user->id(),
-                'title' => $user->name(),
+                'title' => $this->userTitle($user, $canViewUsers),
                 'edit_url' => $user->editUrl(),
                 'published' => null,
             ];
         })->filter()->values();
+    }
+
+    private function userTitle($user, bool $canViewUsers): ?string
+    {
+        return $user->name() ?? ($canViewUsers ? $user->email() : $user->id());
+    }
+
+    private function canViewUsers(): bool
+    {
+        if (! $current = User::current()) {
+            return false;
+        }
+
+        return $current->can('index', UserContract::class);
+    }
+
+    private function canViewUser($user): bool
+    {
+        if (! $current = User::current()) {
+            return false;
+        }
+
+        return $current->can('view', $user);
     }
 
     protected function getItemsForPreProcessIndex($values): Collection

--- a/src/Query/Scopes/Filters/Fields/User.php
+++ b/src/Query/Scopes/Filters/Fields/User.php
@@ -69,7 +69,8 @@ class User extends FieldtypeFilter
             return null;
         }
 
-        $user = Users::find($user)->name();
+        $user = Users::find($user);
+        $user = $user->name() ?? $user->email();
 
         return $field.' '.strtolower($operator).' '.$user;
     }

--- a/src/Revisions/Revision.php
+++ b/src/Revisions/Revision.php
@@ -113,7 +113,7 @@ class Revision implements Arrayable, Contract
             $user = [
                 'id' => $user->id(),
                 'email' => $user->email(),
-                'name' => $user->name(),
+                'name' => $user->name() ?? $user->email(),
                 'avatar' => $user->avatar(),
                 'initials' => $user->initials(),
             ];

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -66,7 +66,7 @@ trait UserContractTests
         $this->assertEquals('John Smith', $this->makeUser()->set('name', 'John Smith')->name());
         $this->assertEquals('John', $this->makeUser()->data(['name' => null, 'first_name' => 'John'])->name());
         $this->assertEquals('John Smith', $this->makeUser()->data(['name' => null, 'first_name' => 'John', 'last_name' => 'Smith'])->name());
-        $this->assertEquals('john@example.com', $this->makeUser()->remove('name')->email('john@example.com')->name());
+        $this->assertNull($this->makeUser()->remove('name')->email('john@example.com')->name());
     }
 
     #[Test]
@@ -324,11 +324,11 @@ trait UserContractTests
     }
 
     #[Test]
-    public function it_gets_initials_from_email_if_name_doesnt_exist()
+    public function it_gets_question_mark_initials_if_name_doesnt_exist()
     {
         $user = $this->user()->remove('name');
 
-        $this->assertEquals('J', $user->initials());
+        $this->assertEquals('?', $user->initials());
     }
 
     #[Test]

--- a/tests/Fieldtypes/UsersTest.php
+++ b/tests/Fieldtypes/UsersTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fieldtypes;
 
+use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Auth\UserCollection;
@@ -11,12 +12,14 @@ use Statamic\Data\AugmentedCollection;
 use Statamic\Facades;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Users;
+use Tests\FakesRoles;
 use Tests\Fieldtypes\Concerns\TestsQueryableValueWithMaxItems;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class UsersTest extends TestCase
 {
+    use FakesRoles;
     use PreventSavingStacheItemsToDisk;
     use TestsQueryableValueWithMaxItems;
 
@@ -26,6 +29,7 @@ class UsersTest extends TestCase
 
         Facades\User::make()->id('123')->set('name', 'One')->email('one@domain.com')->save();
         Facades\User::make()->id('456')->set('name', 'Two')->email('two@domain.com')->save();
+        Facades\User::make()->id('789')->email('nameless@domain.com')->save();
     }
 
     #[Test]
@@ -94,6 +98,53 @@ class UsersTest extends TestCase
         ], $augmented->toArray());
     }
 
+    #[Test]
+    public function it_hides_email_from_index_items_without_view_users_permission()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp']));
+
+        $items = $this->fieldtype()->getIndexItems(new Request(['paginate' => false]));
+        $namelessUser = $items->firstWhere('id', '789');
+
+        $this->assertArrayNotHasKey('email', $namelessUser);
+        $this->assertEquals('789', $namelessUser['title']);
+    }
+
+    #[Test]
+    public function it_includes_email_in_index_items_with_view_users_permission()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp', 'view users']));
+
+        $items = $this->fieldtype()->getIndexItems(new Request(['paginate' => false]));
+        $namelessUser = $items->firstWhere('id', '789');
+
+        $this->assertEquals('nameless@domain.com', $namelessUser['title']);
+        $this->assertEquals('nameless@domain.com', $namelessUser['email']);
+    }
+
+    #[Test]
+    public function it_hides_the_email_column_without_view_users_permission()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp']));
+
+        $columns = $this->getColumns($this->fieldtype());
+
+        $this->assertCount(1, $columns);
+        $this->assertEquals('title', $columns[0]->field);
+    }
+
+    #[Test]
+    public function it_includes_the_email_column_with_view_users_permission()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp', 'view users']));
+
+        $columns = $this->getColumns($this->fieldtype());
+
+        $this->assertCount(2, $columns);
+        $this->assertEquals('title', $columns[0]->field);
+        $this->assertEquals('email', $columns[1]->field);
+    }
+
     public function fieldtype($config = [])
     {
         $field = new Field('test', array_merge([
@@ -101,5 +152,20 @@ class UsersTest extends TestCase
         ], $config));
 
         return (new Users)->setField($field);
+    }
+
+    private function cpUserWithPermissions(array $permissions)
+    {
+        $this->setTestRoles(['test' => $permissions]);
+
+        return tap(Facades\User::make()->id(uniqid())->assignRole('test'))->save();
+    }
+
+    private function getColumns(Users $fieldtype): array
+    {
+        $method = new \ReflectionMethod($fieldtype, 'getColumns');
+        $method->setAccessible(true);
+
+        return $method->invoke($fieldtype);
     }
 }


### PR DESCRIPTION
`$user->name()`, as the method name suggests, should return the user's name. Previously it would fall back to the email. Now it falls back to `null` as expected.

The users fieldtype now only displays emails if you have permission to view users.