### PR TITLE
[6.x] Fix calculation of current state

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -791,11 +791,11 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             return 'published';
         }
 
-        if ($collection->futureDateBehavior() === 'private' && $this->date()->isFuture()) {
+        if (($collection->futureDateBehavior() === 'private' || $collection->futureDateBehavior() === 'unlisted') && $this->date()->isFuture()) {
             return 'scheduled';
         }
 
-        if ($collection->pastDateBehavior() === 'private' && $this->date()->isPast()) {
+        if (($collection->pastDateBehavior() === 'private' || $collection->pastDateBehavior() === 'unlisted') && $this->date()->isPast()) {
             return 'expired';
         }
 

--- a/src/Stache/Query/QueriesEntryStatus.php
+++ b/src/Stache/Query/QueriesEntryStatus.php
@@ -45,7 +45,7 @@ trait QueriesEntryStatus
             return;
         }
 
-        if ($collection->futureDateBehavior() === 'private') {
+        if ($collection->futureDateBehavior() === 'private' || $collection->futureDateBehavior() === 'unlisted') {
             $status === 'scheduled'
                 ? $query->where('date', '>', now())
                 : $query->where('date', '<', now());
@@ -55,7 +55,7 @@ trait QueriesEntryStatus
             }
         }
 
-        if ($collection->pastDateBehavior() === 'private') {
+        if ($collection->pastDateBehavior() === 'private' || $collection->pastDateBehavior() === 'unlisted') {
             $status === 'expired'
                 ? $query->where('date', '<', now())
                 : $query->where('date', '>', now());

--- a/tests/Tags/Collection/EntriesTest.php
+++ b/tests/Tags/Collection/EntriesTest.php
@@ -281,10 +281,10 @@ class EntriesTest extends TestCase
 
         // Only future
         $this->collection->dated(true)->futureDateBehavior('public')->pastDateBehavior('unlisted')->save();
-        $this->assertCount(3, $this->getEntries());
+
         $this->assertCount(0, $this->getEntries(['show_future' => false]));
         $this->assertCount(3, $this->getEntries(['show_future' => true]));
-        $this->assertCount(8, $this->getEntries(['show_past' => true]));
+        $this->assertCount(3, $this->getEntries(['show_past' => true]));
         $this->assertCount(3, $this->getEntries(['show_past' => false]));
         $this->assertCount(3, $this->getEntries(['show_past' => false, 'show_future' => true]));
 
@@ -300,10 +300,10 @@ class EntriesTest extends TestCase
         $this->collection->dated(true)->futureDateBehavior('unlisted')->pastDateBehavior('public')->save();
         $this->assertCount(4, $this->getEntries());
         $this->assertCount(4, $this->getEntries(['show_future' => false]));
-        $this->assertCount(8, $this->getEntries(['show_future' => true]));
+        $this->assertCount(4, $this->getEntries(['show_future' => true]));
         $this->assertCount(4, $this->getEntries(['show_past' => true]));
         $this->assertCount(0, $this->getEntries(['show_past' => false]));
-        $this->assertCount(3, $this->getEntries(['show_past' => false, 'show_future' => true]));
+        $this->assertCount(0, $this->getEntries(['show_past' => false, 'show_future' => true]));
 
         $this->collection->dated(true)->futureDateBehavior('private')->pastDateBehavior('public')->save();
         $this->assertCount(4, $this->getEntries());


### PR DESCRIPTION
I looked into the issue #13341  of incorrect status calculations and found that unlisted entries were not being checked, which led to this incorrect calculation.

To fix this problem, I have now added the implementation for unlisted entries. In principle, the calculation here is the same as for privately listed entries.