### PR TITLE
[6.x] Fix svg test failure

### DIFF
--- a/tests/CP/Navigation/NavTest.php
+++ b/tests/CP/Navigation/NavTest.php
@@ -105,7 +105,10 @@ class NavTest extends TestCase
         $item = $this->build()->get('Utilities')->last();
 
         $this->assertNull($item->icon());
-        $this->assertEquals(\Statamic\Statamic::svg('icons/collections', 'size-4 shrink-0'), $item->svg());
+        $svg = $item->svg();
+        $this->assertStringContainsString('class="size-4 shrink-0"', $svg);
+        $this->assertStringContainsString('viewBox="0 0 17 14"', $svg);
+        $this->assertStringStartsWith('<svg ', $svg);
     }
 
     #[Test]


### PR DESCRIPTION
When merging #14077 into 6.x via 5.x 7e547cc7, it caused a test failure. Rather than asserting against the exact svg, this just checks some substrings are there. Things get a little moved around from the sanitization.