### PR TITLE
[6.x] Disables PHP by default when calling Antlers::parse

### DIFF
--- a/src/Facades/Antlers.php
+++ b/src/Facades/Antlers.php
@@ -9,7 +9,7 @@ use Statamic\View\Antlers\AntlersString;
 /**
  * @method static Parser parser()
  * @method static mixed usingParser(Parser $parser, \Closure $callback)
- * @method static AntlersString parse(string $str, array $variables = [])
+ * @method static AntlersString parse(string $str, array $variables = [], bool $php = false)
  * @method static AntlersString parseUserContent(string $str, array $variables = [])
  * @method static string parseLoop(string $content, array $data, bool $supplement = true, array $context = [])
  * @method static array identifiers(string $content)

--- a/src/Facades/Endpoint/Parse.php
+++ b/src/Facades/Endpoint/Parse.php
@@ -22,7 +22,7 @@ class Parse
      */
     public function template($str, $variables = [], $context = [], $php = false)
     {
-        return Antlers::parse($str, $variables, $context, $php);
+        return Antlers::parse($str, array_merge($variables, $context), $php);
     }
 
     /**

--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -102,6 +102,7 @@ class ViewServiceProvider extends ServiceProvider
             $runtimeConfig->guardedContentVariablePatterns = config('statamic.antlers.guardedContentVariables', []);
             $runtimeConfig->guardedContentTagPatterns = config('statamic.antlers.guardedContentTags', []);
             $runtimeConfig->guardedContentModifiers = config('statamic.antlers.guardedContentModifiers', []);
+            $runtimeConfig->isPhpEnabled = config('statamic.antlers.allowPhp', true);
             $runtimeConfig->allowPhpInUserContent = config('statamic.antlers.allowPhpInContent', false);
             $runtimeConfig->allowMethodsInUserContent = config('statamic.antlers.allowMethodsInContent', false);
 

--- a/src/View/Antlers/Antlers.php
+++ b/src/View/Antlers/Antlers.php
@@ -27,9 +27,17 @@ class Antlers
         return $contents;
     }
 
-    public function parse($str, $variables = [])
+    public function parse($str, $variables = [], $php = false)
     {
-        return $this->parser()->parse($str, $variables);
+        $parser = $this->parser();
+        $previousState = GlobalRuntimeState::$isPhpEnabled;
+        GlobalRuntimeState::$isPhpEnabled = $php;
+
+        try {
+            return $parser->parse($str, $variables);
+        } finally {
+            GlobalRuntimeState::$isPhpEnabled = $previousState;
+        }
     }
 
     public function parseUserContent($str, $variables = [])

--- a/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
+++ b/src/View/Antlers/Language/Runtime/GlobalRuntimeState.php
@@ -185,6 +185,13 @@ class GlobalRuntimeState
     public static $allowPhpInContent = false;
 
     /**
+     * Controls whether PHP execution is globally enabled.
+     *
+     * @var bool
+     */
+    public static $isPhpEnabled = true;
+
+    /**
      * Controls if method invocations are evaluated in user content.
      *
      * @var bool
@@ -273,6 +280,7 @@ class GlobalRuntimeState
         self::$abandonedNodes = [];
         self::$isEvaluatingUserData = false;
         self::$isEvaluatingData = false;
+        self::$isPhpEnabled = true;
         self::$userContentEvalState = null;
 
         StackReplacementManager::clearStackState();

--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1213,6 +1213,10 @@ class NodeProcessor
                 }
 
                 if ($node instanceof PhpExecutionNode) {
+                    if (! GlobalRuntimeState::$isPhpEnabled) {
+                        continue;
+                    }
+
                     if (GlobalRuntimeState::$isEvaluatingUserData && ! GlobalRuntimeState::$allowPhpInContent) {
                         if (GlobalRuntimeState::$throwErrorOnAccessViolation) {
                             throw ErrorFactory::makeRuntimeError(
@@ -2453,7 +2457,7 @@ class NodeProcessor
         // one last time to make sure we didn't miss anything.
         $this->stopMeasuringTag();
 
-        if ($this->allowPhp) {
+        if ($this->allowPhp && GlobalRuntimeState::$isPhpEnabled) {
             $buffer = $this->evaluatePhp($buffer);
         }
 
@@ -2468,6 +2472,10 @@ class NodeProcessor
      */
     protected function evaluatePhp($buffer)
     {
+        if (! GlobalRuntimeState::$isPhpEnabled) {
+            return is_array($buffer) ? $buffer : StringUtilities::sanitizePhp($buffer);
+        }
+
         if (is_array($buffer) || $this->isLoopable($buffer)) {
             return $buffer;
         }
@@ -2527,6 +2535,10 @@ class NodeProcessor
 
     protected function evaluateAntlersPhpNode(PhpExecutionNode $node)
     {
+        if (! GlobalRuntimeState::$isPhpEnabled) {
+            return '';
+        }
+
         if (! GlobalRuntimeState::$allowPhpInContent && GlobalRuntimeState::$isEvaluatingUserData) {
             return StringUtilities::sanitizePhp($node->content);
         }

--- a/src/View/Antlers/Language/Runtime/RuntimeConfiguration.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeConfiguration.php
@@ -99,6 +99,13 @@ class RuntimeConfiguration
     public $guardedContentModifiers = [];
 
     /**
+     * Controls whether PHP execution is globally enabled.
+     *
+     * @var bool
+     */
+    public $isPhpEnabled = true;
+
+    /**
      * Indicates if PHP Code should be evaluated in user content.
      *
      * When disabled, *antlers.php templates will be allowed,

--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -138,6 +138,7 @@ class RuntimeParser implements Parser
      */
     public function setRuntimeConfiguration(RuntimeConfiguration $configuration)
     {
+        GlobalRuntimeState::$isPhpEnabled = $configuration->isPhpEnabled;
         GlobalRuntimeState::$allowPhpInContent = $configuration->allowPhpInUserContent;
         GlobalRuntimeState::$allowMethodsInContent = $configuration->allowMethodsInUserContent;
         GlobalRuntimeState::$throwErrorOnAccessViolation = $configuration->throwErrorOnAccessViolation;

--- a/tests/Antlers/Runtime/PhpDisabledTest.php
+++ b/tests/Antlers/Runtime/PhpDisabledTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Antlers\Runtime;
+
+use Statamic\Facades\Antlers;
+use Tests\TestCase;
+
+class PhpDisabledTest extends TestCase
+{
+    public function test_it_ignores_inline_php_blocks_when_disabled()
+    {
+        $result = (string) Antlers::parse('Before {{? echo "hello"; ?}} After', [], false);
+
+        $this->assertSame('Before  After', $result);
+    }
+
+    public function test_it_ignores_inline_echo_blocks_when_disabled()
+    {
+        $result = (string) Antlers::parse('Before {{$ "hello" $}} After', []);
+
+        $this->assertSame('Before  After', $result);
+    }
+
+    public function test_php_disabled_is_the_default()
+    {
+        $result = (string) Antlers::parse('Before {{? echo "hello"; ?}} After', []);
+
+        $this->assertSame('Before  After', $result);
+    }
+
+    public function test_inline_php_tags_disabled_is_the_default()
+    {
+        $result = (string) Antlers::parse('Before <?php echo "hello"; ?> After', []);
+
+        $this->assertSame('Before &lt;?php echo "hello"; ?> After', $result);
+    }
+
+    public function test_it_allows_inline_echo_blocks_when_enabled()
+    {
+        $result = (string) Antlers::parse('Before {{$ "hello" $}} After', [], true);
+
+        $this->assertSame('Before hello  After', $result);
+    }
+
+    public function test_it_allow_inline_php_blocks_when_enabled()
+    {
+        $result = (string) Antlers::parse('Before {{? echo "hello"; ?}} After', [], true);
+
+        $this->assertSame('Before hello After', $result);
+    }
+}

--- a/tests/Antlers/Runtime/PhpDisabledTest.php
+++ b/tests/Antlers/Runtime/PhpDisabledTest.php
@@ -39,7 +39,7 @@ class PhpDisabledTest extends TestCase
     {
         $result = (string) Antlers::parse('Before {{$ "hello" $}} After', [], true);
 
-        $this->assertSame('Before hello  After', $result);
+        $this->assertSame('Before hello After', $result);
     }
 
     public function test_it_allow_inline_php_blocks_when_enabled()


### PR DESCRIPTION
This PR disables PHP blocks/tags by default when calling `Antlers::parse(...)`