### PR TITLE
[6.x] Fix asset browser sorting

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -20,6 +20,8 @@
                     ref="listing"
                     :url="requestUrl"
                     :columns="columns"
+                    :sort-column="sortColumn"
+                    :sort-direction="sortDirection"
                     :action-url="actionUrl"
                     :action-context="actionContext"
                     :allow-bulk-actions="allowBulkActions"


### PR DESCRIPTION
This pull request fixes an issue where the `sort_by` and `sort_dir` options on the asset container weren't affecting the asset browser listing.

Fixes #14085