### PR TITLE
[6.x] Fix auth redirects

### DIFF
--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password as PasswordRules;
 use Illuminate\Validation\ValidationException;
+use Statamic\Facades\URL;
 
 /**
  * A copy of Illuminate\Auth\ResetsPasswords.
@@ -49,8 +50,10 @@ trait ResetsPasswords
         $validator = Validator::make($request->all(), $this->rules(), $this->validationErrorMessages());
 
         if (! $validator->passes()) {
-            $redirect = $request->has('_error_redirect')
-                ? redirect($request->input('_error_redirect'))
+            $errorRedirect = $request->input('_error_redirect');
+
+            $redirect = $errorRedirect && ! URL::isExternalToApplication($errorRedirect)
+                ? redirect($errorRedirect)
                 : back();
 
             return $redirect
@@ -173,8 +176,10 @@ trait ResetsPasswords
             ]);
         }
 
-        $redirect = $request->has('_error_redirect')
-            ? redirect($request->input('_error_redirect'))
+        $errorRedirect = $request->input('_error_redirect');
+
+        $redirect = $errorRedirect && ! URL::isExternalToApplication($errorRedirect)
+            ? redirect($errorRedirect)
             : back();
 
         return $redirect

--- a/src/Auth/SendsPasswordResetEmails.php
+++ b/src/Auth/SendsPasswordResetEmails.php
@@ -6,6 +6,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
+use Statamic\Facades\URL;
 
 /**
  * A copy of Illuminate\Auth\SendsPasswordResetEmails.
@@ -85,8 +86,10 @@ trait SendsPasswordResetEmails
     {
         session()->flash('user.forgot_password.success', __(Password::RESET_LINK_SENT));
 
-        $redirect = $request->has('_redirect')
-            ? redirect($request->input('_redirect'))
+        $successRedirect = $request->input('_redirect');
+
+        $redirect = $successRedirect && ! URL::isExternalToApplication($successRedirect)
+            ? redirect($successRedirect)
             : back();
 
         return $request->wantsJson()
@@ -102,8 +105,10 @@ trait SendsPasswordResetEmails
      */
     protected function sendResetLinkFailedResponse(Request $request, $response)
     {
-        $redirect = $request->has('_error_redirect')
-            ? redirect($request->input('_error_redirect'))
+        $errorRedirect = $request->input('_error_redirect');
+
+        $redirect = $errorRedirect && ! URL::isExternalToApplication($errorRedirect)
+            ? redirect($errorRedirect)
             : back();
 
         if ($request->wantsJson()) {

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -259,6 +259,10 @@ class URL
 
         $url = Str::ensureRight($url, '/');
 
+        if (Str::startsWith($url, '//')) {
+            return self::$externalAppUrlsCache[$url] = true;
+        }
+
         if (Str::startsWith($url, ['/', '?', '#'])) {
             return self::$externalAppUrlsCache[$url] = false;
         }

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -13,6 +13,7 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 use Statamic\OAuth\Provider;
 use Statamic\Statamic;
+use Statamic\Facades\URL;
 use Statamic\Support\Str;
 
 use function Statamic\trans as __;
@@ -137,7 +138,9 @@ class LoginController extends CpController
 
         $request->session()->regenerateToken();
 
-        return redirect($request->redirect ?? '/');
+        $redirect = $request->redirect ?? '/';
+
+        return redirect(URL::isExternalToApplication($redirect) ? '/' : $redirect);
     }
 
     protected function getReferrer()

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -7,13 +7,13 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Statamic\Facades\OAuth;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\Concerns\HandlesLogins;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 use Statamic\OAuth\Provider;
 use Statamic\Statamic;
-use Statamic\Facades\URL;
 use Statamic\Support\Str;
 
 use function Statamic\trans as __;

--- a/src/Http/Controllers/CP/Auth/PasskeyLoginController.php
+++ b/src/Http/Controllers/CP/Auth/PasskeyLoginController.php
@@ -6,6 +6,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Statamic\Auth\WebAuthn\Serializer;
 use Statamic\Contracts\Auth\User as UserContract;
+use Statamic\Facades\URL;
 use Statamic\Facades\WebAuthn;
 use Statamic\Support\Str;
 
@@ -41,8 +42,9 @@ class PasskeyLoginController
 
     private function successRedirectUrl()
     {
-        $referer = request('referer');
+        $referer = request('referer') ?? cp_route('index');
+        $shouldUseReferer = ! URL::isExternalToApplication($referer) && Str::contains($referer, '/'.config('statamic.cp.route'));
 
-        return Str::contains($referer, '/'.config('statamic.cp.route')) ? $referer : cp_route('index');
+        return $shouldUseReferer ? $referer : cp_route('index');
     }
 }

--- a/src/Http/Controllers/ForgotPasswordController.php
+++ b/src/Http/Controllers/ForgotPasswordController.php
@@ -33,13 +33,11 @@ class ForgotPasswordController extends Controller
     public function sendResetLinkEmail(Request $request)
     {
         if ($url = $request->_reset_url) {
-            $url = URL::makeAbsolute($url);
-
             throw_if(URL::isExternalToApplication($url), ValidationException::withMessages([
                 '_reset_url' => trans('validation.url', ['attribute' => '_reset_url']),
             ]));
 
-            PasswordReset::resetFormUrl($url);
+            PasswordReset::resetFormUrl(URL::makeAbsolute($url));
         }
 
         return $this->traitSendResetLinkEmail($request);

--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -8,6 +8,7 @@ use Laravel\Socialite\Facades\Socialite;
 use Laravel\Socialite\Two\InvalidStateException;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\OAuth;
+use Statamic\Facades\URL;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -79,7 +80,9 @@ class OAuthController
 
         parse_str($query, $query);
 
-        return Arr::get($query, 'redirect', $default);
+        $redirect = Arr::get($query, 'redirect', $default);
+
+        return URL::isExternalToApplication($redirect) ? $default : $redirect;
     }
 
     protected function unauthorizedRedirectUrl()

--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -9,6 +9,7 @@ use Inertia\Inertia;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Auth\ResetsPasswords;
 use Statamic\Contracts\Auth\User;
+use Statamic\Facades\URL;
 use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 
@@ -46,7 +47,11 @@ class ResetPasswordController extends Controller
 
     public function redirectPath()
     {
-        return request('redirect') ?? route('statamic.site');
+        $redirect = request('redirect');
+
+        return $redirect && ! URL::isExternalToApplication($redirect)
+            ? $redirect
+            : route('statamic.site');
     }
 
     protected function setUserPassword($user, $password)

--- a/src/Http/Controllers/User/LoginController.php
+++ b/src/Http/Controllers/User/LoginController.php
@@ -6,10 +6,10 @@ use Illuminate\Auth\Events\Failed;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\Concerns\HandlesLogins;
 use Statamic\Http\Controllers\Controller;
-use Statamic\Facades\URL;
 use Statamic\Http\Requests\UserLoginRequest;
 
 class LoginController extends Controller

--- a/src/Http/Controllers/User/LoginController.php
+++ b/src/Http/Controllers/User/LoginController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\Concerns\HandlesLogins;
 use Statamic\Http\Controllers\Controller;
+use Statamic\Facades\URL;
 use Statamic\Http\Requests\UserLoginRequest;
 
 class LoginController extends Controller
@@ -27,7 +28,9 @@ class LoginController extends Controller
 
         $this->authenticate($request, $user);
 
-        return redirect($request->input('_redirect', '/'))->withSuccess(__('Login successful.'));
+        $redirect = $request->input('_redirect', '/');
+
+        return redirect(URL::isExternalToApplication($redirect) ? '/' : $redirect)->withSuccess(__('Login successful.'));
     }
 
     protected function twoFactorChallengeRedirect(): string
@@ -44,7 +47,10 @@ class LoginController extends Controller
      */
     protected function throwFailedAuthenticationException(Request $request)
     {
-        $errorResponse = $request->has('_error_redirect') ? redirect($request->input('_error_redirect')) : back();
+        $errorRedirect = $request->input('_error_redirect');
+        $errorResponse = $errorRedirect && ! URL::isExternalToApplication($errorRedirect)
+            ? redirect($errorRedirect)
+            : back();
 
         throw new HttpResponseException($errorResponse->withInput()->withErrors(__('Invalid credentials.')));
     }
@@ -68,7 +74,9 @@ class LoginController extends Controller
     {
         Auth::logout();
 
-        return redirect(request()->get('redirect', '/'));
+        $redirect = request()->get('redirect', '/');
+
+        return redirect(URL::isExternalToApplication($redirect) ? '/' : $redirect);
     }
 
     protected function username()

--- a/src/Http/Controllers/User/PasswordController.php
+++ b/src/Http/Controllers/User/PasswordController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\User;
 
 use Illuminate\Support\Facades\Password;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Requests\UserPasswordRequest;
 
@@ -21,7 +22,8 @@ class PasswordController
 
     private function successfulResponse()
     {
-        $response = request()->has('_redirect') ? redirect(request()->get('_redirect')) : back();
+        $redirect = request()->get('_redirect');
+        $response = ! URL::isExternalToApplication($redirect) ? redirect($redirect) : back();
 
         if (request()->ajax() || request()->wantsJson()) {
             return response([

--- a/src/Http/Controllers/User/ProfileController.php
+++ b/src/Http/Controllers/User/ProfileController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Controllers\User;
 
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Requests\UserProfileRequest;
 
@@ -26,7 +27,8 @@ class ProfileController
 
     private function successfulResponse()
     {
-        $response = request()->has('_redirect') ? redirect(request()->get('_redirect')) : back();
+        $redirect = request()->get('_redirect');
+        $response = ! URL::isExternalToApplication($redirect) ? redirect($redirect) : back();
 
         if (request()->ajax() || request()->wantsJson()) {
             return response([

--- a/src/Http/Controllers/User/RegisterController.php
+++ b/src/Http/Controllers/User/RegisterController.php
@@ -8,6 +8,7 @@ use Illuminate\Validation\ValidationException;
 use Statamic\Events\UserRegistered;
 use Statamic\Events\UserRegistering;
 use Statamic\Exceptions\SilentFormFailureException;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Requests\UserRegisterRequest;
 use Statamic\Support\Arr;
@@ -52,7 +53,8 @@ class RegisterController
 
     private function successfulResponse(bool $silentFailure = false)
     {
-        $response = request()->has('_redirect') ? redirect(request()->get('_redirect')) : back();
+        $redirect = request()->get('_redirect');
+        $response = $redirect && ! URL::isExternalToApplication($redirect) ? redirect($redirect) : back();
 
         if (request()->ajax() || request()->wantsJson()) {
             return response([
@@ -85,7 +87,8 @@ class RegisterController
             return (new ValidationException($validator))->errorBag(new MessageBag($errors));
         }
 
-        $errorResponse = request()->has('_error_redirect') ? redirect(request()->input('_error_redirect')) : back();
+        $errorRedirect = request()->input('_error_redirect');
+        $errorResponse = $errorRedirect && ! URL::isExternalToApplication($errorRedirect) ? redirect($errorRedirect) : back();
 
         return $errorResponse->withInput()->withErrors($errors, 'user.register');
     }

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -4,7 +4,7 @@ namespace Statamic\Http\Requests;
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\URL;
+use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
@@ -42,7 +42,7 @@ class FrontendFormRequest extends FormRequest
         $url = $this->redirector->getUrlGenerator();
 
         if ($redirect = $this->input('_error_redirect')) {
-            return $url->to($redirect);
+            return URL::isExternalToApplication($redirect) ? $url->previous() : $url->to($redirect);
         }
 
         return $url->previous();

--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -4,10 +4,10 @@ namespace Statamic\Http\Requests;
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Statamic\Rules\AllowedFile;
 use Statamic\Support\Arr;
 

--- a/src/Http/Requests/UserLoginRequest.php
+++ b/src/Http/Requests/UserLoginRequest.php
@@ -4,7 +4,8 @@ namespace Statamic\Http\Requests;
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\URL as LaravelURL;
+use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
@@ -45,14 +46,15 @@ class UserLoginRequest extends FormRequest
             throw (new ValidationException($validator, $response));
         }
 
-        $errorResponse = $this->has('_error_redirect') ? redirect($this->input('_error_redirect')) : back();
+        $errorRedirect = $this->input('_error_redirect');
+        $errorResponse = $errorRedirect && ! URL::isExternalToApplication($errorRedirect) ? redirect($errorRedirect) : back();
 
         throw (new ValidationException($validator, $errorResponse->withInput()->withErrors(__('Invalid credentials.'))));
     }
 
     public function validateResolved()
     {
-        $site = Site::findByUrl(URL::previous()) ?? Site::default();
+        $site = Site::findByUrl(LaravelURL::previous()) ?? Site::default();
 
         return $this->withLocale($site->lang(), fn () => parent::validateResolved());
     }

--- a/src/Http/Requests/UserLoginRequest.php
+++ b/src/Http/Requests/UserLoginRequest.php
@@ -5,10 +5,10 @@ namespace Statamic\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\URL as LaravelURL;
-use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 
 class UserLoginRequest extends FormRequest
 {

--- a/src/Http/Requests/UserPasswordRequest.php
+++ b/src/Http/Requests/UserPasswordRequest.php
@@ -5,11 +5,11 @@ namespace Statamic\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\URL as LaravelURL;
-use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 
 class UserPasswordRequest extends FormRequest

--- a/src/Http/Requests/UserPasswordRequest.php
+++ b/src/Http/Requests/UserPasswordRequest.php
@@ -4,7 +4,8 @@ namespace Statamic\Http\Requests;
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\URL as LaravelURL;
+use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
@@ -47,14 +48,15 @@ class UserPasswordRequest extends FormRequest
             throw (new ValidationException($validator, $response));
         }
 
-        $errorResponse = $this->has('_error_redirect') ? redirect($this->input('_error_redirect')) : back();
+        $errorRedirect = $this->input('_error_redirect');
+        $errorResponse = $errorRedirect && ! URL::isExternalToApplication($errorRedirect) ? redirect($errorRedirect) : back();
 
         throw (new ValidationException($validator, $errorResponse->withInput()->withErrors($validator->errors(), 'user.password')));
     }
 
     public function validateResolved()
     {
-        $site = Site::findByUrl(URL::previous()) ?? Site::default();
+        $site = Site::findByUrl(LaravelURL::previous()) ?? Site::default();
 
         return $this->withLocale($site->lang(), fn () => parent::validateResolved());
     }

--- a/src/Http/Requests/UserProfileRequest.php
+++ b/src/Http/Requests/UserProfileRequest.php
@@ -4,7 +4,8 @@ namespace Statamic\Http\Requests;
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\URL as LaravelURL;
+use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
@@ -42,7 +43,8 @@ class UserProfileRequest extends FormRequest
             throw (new ValidationException($validator, $response));
         }
 
-        $errorResponse = $this->has('_error_redirect') ? redirect($this->input('_error_redirect')) : back();
+        $errorRedirect = $this->input('_error_redirect');
+        $errorResponse = $errorRedirect && ! URL::isExternalToApplication($errorRedirect) ? redirect($errorRedirect) : back();
 
         throw (new ValidationException($validator, $errorResponse->withInput()->withErrors($validator->errors(), 'user.profile')));
     }
@@ -73,7 +75,7 @@ class UserProfileRequest extends FormRequest
 
     public function validateResolved()
     {
-        $site = Site::findByUrl(URL::previous()) ?? Site::default();
+        $site = Site::findByUrl(LaravelURL::previous()) ?? Site::default();
 
         return $this->withLocale($site->lang(), fn () => parent::validateResolved());
     }

--- a/src/Http/Requests/UserProfileRequest.php
+++ b/src/Http/Requests/UserProfileRequest.php
@@ -5,10 +5,10 @@ namespace Statamic\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\URL as LaravelURL;
-use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Rules\UniqueUserValue;
 

--- a/src/Http/Requests/UserRegisterRequest.php
+++ b/src/Http/Requests/UserRegisterRequest.php
@@ -4,7 +4,8 @@ namespace Statamic\Http\Requests;
 
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\URL;
+use Illuminate\Support\Facades\URL as LaravelURL;
+use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
@@ -43,7 +44,8 @@ class UserRegisterRequest extends FormRequest
             throw (new ValidationException($validator, $response));
         }
 
-        $errorResponse = $this->has('_error_redirect') ? redirect($this->input('_error_redirect')) : back();
+        $errorRedirect = $this->input('_error_redirect');
+        $errorResponse = $errorRedirect && ! URL::isExternalToApplication($errorRedirect) ? redirect($errorRedirect) : back();
 
         throw (new ValidationException($validator, $errorResponse->withInput()->withErrors($validator->errors(), 'user.register')));
     }
@@ -76,7 +78,7 @@ class UserRegisterRequest extends FormRequest
 
     public function validateResolved()
     {
-        $site = Site::findByUrl(URL::previous()) ?? Site::default();
+        $site = Site::findByUrl(LaravelURL::previous()) ?? Site::default();
 
         return $this->withLocale($site->lang(), fn () => parent::validateResolved());
     }

--- a/src/Http/Requests/UserRegisterRequest.php
+++ b/src/Http/Requests/UserRegisterRequest.php
@@ -5,11 +5,11 @@ namespace Statamic\Http\Requests;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\URL as LaravelURL;
-use Statamic\Facades\URL;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\Rules\Password;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Rules\UniqueUserValue;
 

--- a/tests/Auth/LoginTest.php
+++ b/tests/Auth/LoginTest.php
@@ -133,7 +133,29 @@ class LoginTest extends TestCase
         $this
             ->actingAs($this->user())
             ->get(cp_route('logout'))
-            ->assertRedirect();
+            ->assertRedirect('/');
+
+        $this->assertGuest();
+    }
+
+    #[Test]
+    public function it_can_logout_with_redirect()
+    {
+        $this
+            ->actingAs($this->user())
+            ->get(cp_route('logout').'?redirect=/cp')
+            ->assertRedirect('/cp');
+
+        $this->assertGuest();
+    }
+
+    #[Test]
+    public function it_does_not_redirect_to_external_url_on_logout()
+    {
+        $this
+            ->actingAs($this->user())
+            ->get(cp_route('logout').'?redirect=https://evil.com')
+            ->assertRedirect('/');
 
         $this->assertGuest();
     }

--- a/tests/Facades/Concerns/ProvidesExternalUrls.php
+++ b/tests/Facades/Concerns/ProvidesExternalUrls.php
@@ -50,7 +50,7 @@ trait ProvidesExternalUrls
             ['//evil.com', true],
             ['//evil.com/', true],
             ['//evil.com/path', true],
-            ['//this-site.com', true], // Even matching domain with // prefix is treated as external
+            ['//this-site.com', true],
 
             // External domain that starts with a valid domain.
             ['http://this-site.com.au', true],

--- a/tests/Facades/Concerns/ProvidesExternalUrls.php
+++ b/tests/Facades/Concerns/ProvidesExternalUrls.php
@@ -46,6 +46,12 @@ trait ProvidesExternalUrls
             ['', false],
             [null, false],
 
+            // Protocol-relative URLs are external
+            ['//evil.com', true],
+            ['//evil.com/', true],
+            ['//evil.com/path', true],
+            ['//this-site.com', true], // Even matching domain with // prefix is treated as external
+
             // External domain that starts with a valid domain.
             ['http://this-site.com.au', true],
             ['http://this-site.com.au/', true],

--- a/tests/Feature/Auth/PasskeyLoginTest.php
+++ b/tests/Feature/Auth/PasskeyLoginTest.php
@@ -123,6 +123,21 @@ class PasskeyLoginTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_redirect_to_external_referer()
+    {
+        $user = $this->createUser();
+        WebAuthn::shouldReceive('getUserFromCredentials')->once()->andReturn($user);
+        WebAuthn::shouldReceive('validateAssertion')->once()->andReturnTrue();
+
+        $this
+            ->loginRequest(['referer' => 'http://evil.com'])
+            ->assertOk()
+            ->assertJson(['redirect' => cp_route('index')]);
+
+        $this->assertAuthenticatedAs($user);
+    }
+
+    #[Test]
     public function it_fails_when_validation_throws_exception()
     {
         $user = $this->createUser();

--- a/tests/OAuth/OAuthRedirectTest.php
+++ b/tests/OAuth/OAuthRedirectTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\OAuth;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Http\Controllers\OAuthController;
+use Tests\TestCase;
+
+class OAuthRedirectTest extends TestCase
+{
+    #[Test]
+    public function it_redirects_to_local_url()
+    {
+        session(['_previous.url' => 'http://localhost/oauth/test?redirect=/dashboard']);
+
+        $this->assertEquals('/dashboard', $this->getSuccessRedirectUrl());
+    }
+
+    #[Test]
+    public function it_does_not_redirect_to_external_url()
+    {
+        session(['_previous.url' => 'http://localhost/oauth/test?redirect=https://evil.com']);
+
+        $this->assertEquals('/', $this->getSuccessRedirectUrl());
+    }
+
+    /**
+     * The successRedirectUrl() method is protected, so we need to new up a fake class to call it.
+     */
+    private function getSuccessRedirectUrl(): string
+    {
+        $controller = new class extends OAuthController
+        {
+            public function getSuccessRedirectUrl()
+            {
+                return $this->successRedirectUrl();
+            }
+        };
+
+        return $controller->getSuccessRedirectUrl();
+    }
+}

--- a/tests/Tags/User/ForgotPasswordFormTest.php
+++ b/tests/Tags/User/ForgotPasswordFormTest.php
@@ -213,6 +213,37 @@ EOT
     }
 
     #[Test]
+    public function it_wont_follow_redirect_to_external_url()
+    {
+        $this->simulateSuccessfulPasswordResetEmail();
+
+        User::make()
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->from('/forgot-password')
+            ->post('/!/auth/password/email', [
+                'email' => 'san@holo.com',
+                '_redirect' => 'https://external-site.com/phishing',
+            ])
+            ->assertLocation('/forgot-password');
+    }
+
+    #[Test]
+    public function it_wont_follow_redirect_to_external_url_on_error()
+    {
+        $this
+            ->from('/forgot-password')
+            ->post('/!/auth/password/email', [
+                'email' => 'nonexistent@test.com',
+                '_error_redirect' => 'https://external-site.com/phishing',
+            ])
+            ->assertLocation('/forgot-password');
+    }
+
+    #[Test]
     public function it_will_use_redirect_query_param_off_url()
     {
         $this->get('/?redirect=password-reset-successful&error_redirect=password-reset-failure');

--- a/tests/Tags/User/LoginFormTest.php
+++ b/tests/Tags/User/LoginFormTest.php
@@ -236,7 +236,7 @@ EOT
                 'password' => 'wrong',
                 '_error_redirect' => 'https://evil.com',
             ])
-            ->assertLocation('/'); // Falls back to back() which is /
+            ->assertLocation('/');
     }
 
     #[Test]

--- a/tests/Tags/User/LoginFormTest.php
+++ b/tests/Tags/User/LoginFormTest.php
@@ -223,6 +223,42 @@ EOT
     }
 
     #[Test]
+    public function it_does_not_redirect_to_external_url()
+    {
+        User::make()
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->post('/!/auth/login', [
+                'token' => 'test-token',
+                'email' => 'san@holo.com',
+                'password' => 'chewy',
+                '_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
+    public function it_does_not_redirect_to_external_url_on_error()
+    {
+        User::make()
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->post('/!/auth/login', [
+                'token' => 'test-token',
+                'email' => 'san@holo.com',
+                'password' => 'wrong',
+                '_error_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/'); // Falls back to back() which is /
+    }
+
+    #[Test]
     public function it_fetches_form_data()
     {
         $form = Statamic::tag('user:login_form')->fetch();

--- a/tests/Tags/User/LoginFormTest.php
+++ b/tests/Tags/User/LoginFormTest.php
@@ -204,26 +204,7 @@ EOT
     }
 
     #[Test]
-    public function it_will_use_redirect_query_param_off_url()
-    {
-        $this->get('/?redirect=login-successful&error_redirect=login-failure');
-
-        $expectedRedirect = '<input type="hidden" name="_redirect" value="login-successful" />';
-        $expectedErrorRedirect = '<input type="hidden" name="_error_redirect" value="login-failure" />';
-
-        $output = $this->tag('{{ user:login_form }}{{ /user:login_form }}');
-
-        $this->assertStringNotContainsString($expectedRedirect, $output);
-        $this->assertStringNotContainsString($expectedErrorRedirect, $output);
-
-        $output = $this->tag('{{ user:login_form allow_request_redirect="true" }}{{ /user:login_form }}');
-
-        $this->assertStringContainsString($expectedRedirect, $output);
-        $this->assertStringContainsString($expectedErrorRedirect, $output);
-    }
-
-    #[Test]
-    public function it_does_not_redirect_to_external_url()
+    public function it_wont_follow_redirect_to_external_url()
     {
         User::make()
             ->email('san@holo.com')
@@ -241,7 +222,7 @@ EOT
     }
 
     #[Test]
-    public function it_does_not_redirect_to_external_url_on_error()
+    public function it_wont_follow_redirect_to_external_url_on_error()
     {
         User::make()
             ->email('san@holo.com')
@@ -256,6 +237,25 @@ EOT
                 '_error_redirect' => 'https://evil.com',
             ])
             ->assertLocation('/'); // Falls back to back() which is /
+    }
+
+    #[Test]
+    public function it_will_use_redirect_query_param_off_url()
+    {
+        $this->get('/?redirect=login-successful&error_redirect=login-failure');
+
+        $expectedRedirect = '<input type="hidden" name="_redirect" value="login-successful" />';
+        $expectedErrorRedirect = '<input type="hidden" name="_error_redirect" value="login-failure" />';
+
+        $output = $this->tag('{{ user:login_form }}{{ /user:login_form }}');
+
+        $this->assertStringNotContainsString($expectedRedirect, $output);
+        $this->assertStringNotContainsString($expectedErrorRedirect, $output);
+
+        $output = $this->tag('{{ user:login_form allow_request_redirect="true" }}{{ /user:login_form }}');
+
+        $this->assertStringContainsString($expectedRedirect, $output);
+        $this->assertStringContainsString($expectedErrorRedirect, $output);
     }
 
     #[Test]

--- a/tests/Tags/User/LogoutTest.php
+++ b/tests/Tags/User/LogoutTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Tags\User;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class LogoutTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_can_logout()
+    {
+        $this
+            ->actingAs($this->createUser())
+            ->get(route('statamic.logout'))
+            ->assertRedirect('/');
+
+        $this->assertGuest();
+    }
+
+    #[Test]
+    public function it_redirects_to_local_url()
+    {
+        $this
+            ->actingAs($this->createUser())
+            ->get(route('statamic.logout').'?redirect=/home')
+            ->assertRedirect('/home');
+
+        $this->assertGuest();
+    }
+
+    #[Test]
+    public function it_does_not_redirect_to_external_url()
+    {
+        $this
+            ->actingAs($this->createUser())
+            ->get(route('statamic.logout').'?redirect=https://evil.com')
+            ->assertRedirect('/');
+
+        $this->assertGuest();
+    }
+
+    private function createUser()
+    {
+        return tap(User::make()->id('test-user')->email('test@example.com')->password('secret'))->save();
+    }
+}

--- a/tests/Tags/User/PasswordFormTest.php
+++ b/tests/Tags/User/PasswordFormTest.php
@@ -276,6 +276,21 @@ EOT
     }
 
     #[Test]
+    public function it_wont_follow_redirect_to_external_url()
+    {
+        $this->actingAs(User::make()->password('mypassword')->save());
+
+        $this
+            ->post('/!/auth/password', [
+                'current_password' => 'mypassword',
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+                '_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
     public function it_will_use_redirect_query_param_off_url()
     {
         $this->get('/?redirect=password-successful&error_redirect=registration-failure');
@@ -292,21 +307,6 @@ EOT
 
         $this->assertStringContainsString($expectedRedirect, $output);
         $this->assertStringContainsString($expectedErrorRedirect, $output);
-    }
-
-    #[Test]
-    public function it_does_not_redirect_to_external_url()
-    {
-        $this->actingAs(User::make()->password('mypassword')->save());
-
-        $this
-            ->post('/!/auth/password', [
-                'current_password' => 'mypassword',
-                'password' => 'newpassword',
-                'password_confirmation' => 'newpassword',
-                '_redirect' => 'https://evil.com',
-            ])
-            ->assertLocation('/');
     }
 
     #[Test]

--- a/tests/Tags/User/PasswordFormTest.php
+++ b/tests/Tags/User/PasswordFormTest.php
@@ -295,6 +295,21 @@ EOT
     }
 
     #[Test]
+    public function it_does_not_redirect_to_external_url()
+    {
+        $this->actingAs(User::make()->password('mypassword')->save());
+
+        $this
+            ->post('/!/auth/password', [
+                'current_password' => 'mypassword',
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+                '_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
     public function it_handles_precognitive_requests()
     {
         if (! method_exists($this, 'withPrecognition')) {

--- a/tests/Tags/User/ProfileFormTest.php
+++ b/tests/Tags/User/ProfileFormTest.php
@@ -331,6 +331,19 @@ EOT
     }
 
     #[Test]
+    public function it_wont_follow_redirect_to_external_url()
+    {
+        $this->actingAs(User::make()->id('1')->email('san@holo.com')->save());
+
+        $this
+            ->post('/!/auth/profile', [
+                'email' => 'san@holo.com',
+                '_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
     public function it_will_use_redirect_query_param_off_url()
     {
         $this->get('/?redirect=profile-successful&error_redirect=registration-failure');
@@ -347,19 +360,6 @@ EOT
 
         $this->assertStringContainsString($expectedRedirect, $output);
         $this->assertStringContainsString($expectedErrorRedirect, $output);
-    }
-
-    #[Test]
-    public function it_does_not_redirect_to_external_url()
-    {
-        $this->actingAs(User::make()->id('1')->email('san@holo.com')->save());
-
-        $this
-            ->post('/!/auth/profile', [
-                'email' => 'san@holo.com',
-                '_redirect' => 'https://evil.com',
-            ])
-            ->assertLocation('/');
     }
 
     private function useCustomBlueprint()

--- a/tests/Tags/User/ProfileFormTest.php
+++ b/tests/Tags/User/ProfileFormTest.php
@@ -349,6 +349,19 @@ EOT
         $this->assertStringContainsString($expectedErrorRedirect, $output);
     }
 
+    #[Test]
+    public function it_does_not_redirect_to_external_url()
+    {
+        $this->actingAs(User::make()->id('1')->email('san@holo.com')->save());
+
+        $this
+            ->post('/!/auth/profile', [
+                'email' => 'san@holo.com',
+                '_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
     private function useCustomBlueprint()
     {
         $blueprint = Blueprint::make()->setContents([

--- a/tests/Tags/User/RegisterFormTest.php
+++ b/tests/Tags/User/RegisterFormTest.php
@@ -343,6 +343,29 @@ EOT
     }
 
     #[Test]
+    public function it_does_not_redirect_to_external_url()
+    {
+        $this
+            ->post('/!/auth/register', [
+                'email' => 'san@holo.com',
+                'password' => 'chewbacca',
+                'password_confirmation' => 'chewbacca',
+                '_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
+    public function it_does_not_redirect_to_external_url_on_error()
+    {
+        $this
+            ->post('/!/auth/register', [
+                '_error_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
     public function it_ensures_some_fields_arent_saved()
     {
         UserGroup::make('client')->title('Client')->save();

--- a/tests/Tags/User/RegisterFormTest.php
+++ b/tests/Tags/User/RegisterFormTest.php
@@ -324,6 +324,29 @@ EOT
     }
 
     #[Test]
+    public function it_wont_follow_redirect_to_external_url()
+    {
+        $this
+            ->post('/!/auth/register', [
+                'email' => 'san@holo.com',
+                'password' => 'chewbacca',
+                'password_confirmation' => 'chewbacca',
+                '_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
+    public function it_wont_follow_redirect_to_external_url_on_error()
+    {
+        $this
+            ->post('/!/auth/register', [
+                '_error_redirect' => 'https://evil.com',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
     public function it_will_use_redirect_query_param_off_url()
     {
         $this->get('/?redirect=registration-successful&error_redirect=registration-failure');
@@ -340,29 +363,6 @@ EOT
 
         $this->assertStringContainsString($expectedRedirect, $output);
         $this->assertStringContainsString($expectedErrorRedirect, $output);
-    }
-
-    #[Test]
-    public function it_does_not_redirect_to_external_url()
-    {
-        $this
-            ->post('/!/auth/register', [
-                'email' => 'san@holo.com',
-                'password' => 'chewbacca',
-                'password_confirmation' => 'chewbacca',
-                '_redirect' => 'https://evil.com',
-            ])
-            ->assertLocation('/');
-    }
-
-    #[Test]
-    public function it_does_not_redirect_to_external_url_on_error()
-    {
-        $this
-            ->post('/!/auth/register', [
-                '_error_redirect' => 'https://evil.com',
-            ])
-            ->assertLocation('/');
     }
 
     #[Test]

--- a/tests/Tags/User/ResetPasswordFormTest.php
+++ b/tests/Tags/User/ResetPasswordFormTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Tags\User;
 
+use Illuminate\Support\Facades\Password;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Parse;
+use Statamic\Facades\User;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -22,5 +24,76 @@ class ResetPasswordFormTest extends TestCase
         $output = $this->tag('{{ user:reset_password_form }}{{ /user:reset_password_form }}');
 
         $this->assertStringStartsWith('<form method="POST" action="http://localhost/!/auth/password/reset">', $output);
+    }
+
+    #[Test]
+    public function it_will_follow_custom_redirect_with_success()
+    {
+        $user = tap(User::make()->email('san@holo.com')->password('chewy'))->save();
+
+        $token = Password::createToken($user);
+
+        $this
+            ->post('/!/auth/password/reset', [
+                'token' => $token,
+                'email' => 'san@holo.com',
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+                'redirect' => '/password-reset-successful',
+            ])
+            ->assertLocation('/password-reset-successful');
+    }
+
+    #[Test]
+    public function it_wont_follow_redirect_to_external_url()
+    {
+        $user = tap(User::make()->email('san@holo.com')->password('chewy'))->save();
+
+        $token = Password::createToken($user);
+
+        $this
+            ->from('/reset-password')
+            ->post('/!/auth/password/reset', [
+                'token' => $token,
+                'email' => 'san@holo.com',
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+                'redirect' => 'https://external-site.com/phishing',
+            ])
+            ->assertLocation('/');
+    }
+
+    #[Test]
+    public function it_wont_follow_redirect_to_external_url_on_error()
+    {
+        $this
+            ->from('/reset-password')
+            ->post('/!/auth/password/reset', [
+                'token' => 'invalid-token',
+                'email' => 'invalid-email',
+                'password' => 'short',
+                'password_confirmation' => 'short',
+                '_error_redirect' => 'https://external-site.com/phishing',
+            ])
+            ->assertLocation('/reset-password');
+    }
+
+    #[Test]
+    public function it_will_use_redirect_query_param_off_url()
+    {
+        $this->get('/?redirect=password-reset-successful&error_redirect=password-reset-failure');
+
+        $expectedRedirect = '<input type="hidden" name="redirect" value="password-reset-successful" />';
+        $expectedErrorRedirect = '<input type="hidden" name="_error_redirect" value="password-reset-failure" />';
+
+        $output = $this->tag('{{ user:reset_password_form }}{{ /user:reset_password_form }}');
+
+        $this->assertStringNotContainsString($expectedRedirect, $output);
+        $this->assertStringNotContainsString($expectedErrorRedirect, $output);
+
+        $output = $this->tag('{{ user:reset_password_form allow_request_redirect="true" }}{{ /user:reset_password_form }}');
+
+        $this->assertStringContainsString($expectedRedirect, $output);
+        $this->assertStringContainsString($expectedErrorRedirect, $output);
     }
 }


### PR DESCRIPTION
This pull request fixes various issues around auth / user tag redirects. 

This PR also fixes an issue where `URL::isExternalToApplication()` wouldn't take protocol-relative URLs into account (eg. `//statamic.com/blog`).