### PR TITLE
[6.x] Clarify that `character_limit` option is only a recommendation

### DIFF
--- a/lang/en/fieldtypes.php
+++ b/lang/en/fieldtypes.php
@@ -196,7 +196,7 @@ return [
     'terms.title' => 'Taxonomy Terms',
     'text.config.append' => 'Add text after (to the right of) the input.',
     'text.config.autocomplete' => 'Set the autocomplete attribute.',
-    'text.config.character_limit' => 'Set the maximum number of enterable characters.',
+    'text.config.character_limit' => 'Set the recommended maximum number of enterable characters. To enforce a hard limit, use the [`max`](https://laravel.com/docs/master/validation#rule-max) validation rule.',
     'text.config.input_type' => 'Set the HTML5 input type.',
     'text.config.placeholder' => 'Set placeholder text.',
     'text.config.prepend' => 'Add text before (to the left of) the input.',


### PR DESCRIPTION
This pull request tweaks the instructions for the `character_limit` config option on text fieldtypes, clarifying that its only a recommendation and not a hard limit.

We already mention this [on the docs](https://statamic.dev/fieldtypes/text#options):

<img width="804" height="202" alt="CleanShot 2026-02-27 at 17 26 53" src="https://github.com/user-attachments/assets/3a10f3d0-99b7-4dbc-bc87-fb1f8341e890" />
