### PR TITLE
[6.x] Revert caching of parsed items during Stache warming

### DIFF
--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -328,8 +328,6 @@ abstract class Store
             return $isDuplicate ?? false;
         });
 
-        $items->each(fn ($item) => $this->cacheItem($item['item']));
-
         $paths = $items->pluck('path', 'key');
 
         $this->cachePaths($paths);


### PR DESCRIPTION
This reverts #14031 temporarily. It introduces bugs in addons. It'll be back!