### PR TITLE
[6.x] Don't force an SVG aspect ratio in the asset preview thumbnails

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -76,13 +76,13 @@
                             <div v-else-if="asset.isSvg" class="flex h-full w-full flex-col shadow-ui-xl">
                                 <div class="grid grid-cols-3 gap-1">
                                     <div class="flex items-center justify-center p-3 aspect-square" :class="{ 'bg-checkerboard before:opacity-100': showCheckerboard }">
-                                        <img :src="asset.url" class="asset-thumb relative z-10 size-4" />
+                                        <img :src="asset.url" class="asset-thumb relative z-10 w-4" />
                                     </div>
                                     <div class="flex items-center justify-center p-3 aspect-square" :class="{ 'bg-checkerboard before:opacity-100': showCheckerboard }">
-                                        <img :src="asset.url" class="asset-thumb relative z-10 size-12" />
+                                        <img :src="asset.url" class="asset-thumb relative z-10 w-12" />
                                     </div>
                                     <div class="flex items-center justify-center p-3 aspect-square" :class="{ 'bg-checkerboard before:opacity-100': showCheckerboard }">
-                                        <img :src="asset.url" class="asset-thumb relative z-10 size-24" />
+                                        <img :src="asset.url" class="asset-thumb relative z-10 w-24" />
                                     </div>
                                 </div>
                                 <div class="h-full min-h-0 mt-1 flex items-center justify-center p-3 aspect-square" :class="{ 'bg-checkerboard before:opacity-100': showCheckerboard }">


### PR DESCRIPTION
## Description of the Problem

This is related to PR https://github.com/statamic/cms/pull/14003

- Currently `size-something` is applied to thumbnail sizes in the asset editor.
- This forces an aspect ratio on SVGs, which means if they're not square, they get squished—for example, here:

### Before

![2026-02-28 at 12 23 28@2x](https://github.com/user-attachments/assets/c8b1f51a-9089-41f8-95b3-8302523ddf71)

### After

![2026-02-28 at 12 23 14@2x](https://github.com/user-attachments/assets/4025c2e4-5fc5-42ee-a89a-623b1bd98e98)

## What this PR Does

Switches size for a width attribute so the height can be whatever ratio it is naturally

## How to Reproduce

1. Add a landscape logo as an SVG and open it in the asset preview