### PR TITLE
[6.x] Remove z-index from replicator. I think the `z-2` class is unnecessar…

### DIFF
--- a/resources/js/components/fieldtypes/replicator/AddSetButton.vue
+++ b/resources/js/components/fieldtypes/replicator/AddSetButton.vue
@@ -4,7 +4,7 @@
             <template #trigger>
                 <div class="inline-flex relative pt-2" :class="{ 'pt-6': showConnector }">
                     <div v-if="showConnector" class="absolute group-hover:opacity-0 transition-opacity delay-25 duration-125 inset-y-0 h-full left-3.5 border-l-1 border-gray-400 dark:border-gray-600 border-dashed z-0 dark:bg-gray-850" />
-                    <Button v-if="enabled" size="sm" :text="label" icon="plus" class="relative z-2" />
+                    <Button v-if="enabled" size="sm" :text="label" icon="plus" class="relative" />
                 </div>
             </template>
         </set-picker>

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -128,7 +128,7 @@ reveal.use(rootEl, () => emit('expanded'));
         <div
             layout
             data-replicator-set
-            class="relative z-2 w-full rounded-lg border border-gray-300 text-base dark:border-white/10 bg-white dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black shadow-ui-sm dark:[&_[data-ui-switch]]:border-gray-600 dark:[&_[data-ui-switch]]:border-1"
+            class="relative w-full rounded-lg border border-gray-300 text-base dark:border-white/10 bg-white dark:bg-gray-900 dark:inset-shadow-2xs dark:inset-shadow-black shadow-ui-sm dark:[&_[data-ui-switch]]:border-gray-600 dark:[&_[data-ui-switch]]:border-1"
             :class="{
                 'border-red-500': hasError
             }"


### PR DESCRIPTION
## Description of the Problem

As per https://github.com/statamic/cms/issues/14105 under certain circumstances, replicators can appear above sticky Bard toolbars (a Bard field with another Bard field inside, with a replicator set).

## What this PR Does

- This removes the z-index value from replicators.
  - `z-2` was added during the very initial draft of v6, likely as a safety value(?), and I don't think it needs to be there. Therefore, I think it's safe to remove it.
- Closes https://github.com/statamic/cms/issues/14105

### Before

![2026-02-28 at 12 54 26@2x](https://github.com/user-attachments/assets/8ef360a9-7d68-48e9-8954-f2004bcd5d13)

### After

![2026-02-28 at 12 53 56@2x](https://github.com/user-attachments/assets/33e16c87-dfaa-4d07-82fb-99bcdf6905c8)

## How to Reproduce

1. Add a Bard field with another Bard field inside, with a replicator set
2. Scroll downwards so the sticky toolbar rolls over the replicator set, where you can see the replicator appears above it.