### PR TITLE
[6.x] Fix Stache index re-entrancy causing null URIs on cold stache

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -11,7 +11,7 @@ abstract class Index
     protected $name;
     protected $items = [];
     protected $loaded = false;
-    private static ?string $currentlyLoading = null;
+    private static array $loadingStack = [];
 
     public function __construct($store, $name)
     {
@@ -66,9 +66,9 @@ abstract class Index
         }
 
         $loadingKey = $this->store->key().'/'.$this->name;
-        $currentlyLoadingThis = static::$currentlyLoading === $loadingKey;
+        $currentlyLoadingThis = in_array($loadingKey, static::$loadingStack);
 
-        static::$currentlyLoading = $loadingKey;
+        static::$loadingStack[] = $loadingKey;
 
         $this->loaded = true;
 
@@ -86,7 +86,7 @@ abstract class Index
 
         $this->store->cacheIndexUsage($this);
 
-        static::$currentlyLoading = null;
+        array_pop(static::$loadingStack);
 
         return $this;
     }
@@ -163,6 +163,11 @@ abstract class Index
 
     public static function currentlyLoading()
     {
-        return static::$currentlyLoading;
+        return end(static::$loadingStack) ?: null;
+    }
+
+    public static function isLoading(): bool
+    {
+        return ! empty(static::$loadingStack);
     }
 }

--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -235,9 +235,7 @@ class CollectionEntriesStore extends ChildStore
             return null;
         }
 
-        $isLoadingIds = Index::currentlyLoading() === $this->key().'/id';
-
-        if (! $isLoadingIds && $this->shouldBlinkEntryUris && ($uri = $this->resolveIndex('uri')->load()->get($entry->id()))) {
+        if (! Index::isLoading() && $this->shouldBlinkEntryUris && ($uri = $this->resolveIndex('uri')->load()->get($entry->id()))) {
             Blink::store('entry-uris')->put($entry->id(), $uri);
         }
 

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -328,6 +328,8 @@ abstract class Store
             return $isDuplicate ?? false;
         });
 
+        $items->each(fn ($item) => $this->cacheItem($item['item']));
+
         $paths = $items->pluck('path', 'key');
 
         $this->cachePaths($paths);

--- a/tests/Stache/ColdStacheUriTest.php
+++ b/tests/Stache/ColdStacheUriTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Stache;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blink;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ColdStacheUriTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    private function simulateColdStache(): void
+    {
+        Stache::clear();
+        Blink::flush();
+    }
+
+    #[Test]
+    public function entries_have_uris_on_cold_stache_with_single_site_structured_collection()
+    {
+        $collection = Collection::make('pages')
+            ->routes('{parent_uri}/{slug}')
+            ->structureContents(['root' => true]);
+        $collection->save();
+
+        EntryFactory::id('alfa-id')->collection('pages')->slug('alfa')->data(['title' => 'Alfa'])->create();
+        EntryFactory::id('bravo-id')->collection('pages')->slug('bravo')->data(['title' => 'Bravo'])->create();
+
+        $this->simulateColdStache();
+
+        // Loading a non-URI index first triggers re-entrant URI index loading via getCachedItem().
+        Stache::store('entries')->store('pages')->index('site')->load();
+
+        $entries = Entry::query()
+            ->where('collection', 'pages')
+            ->whereNotNull('uri')
+            ->whereStatus('published')
+            ->get();
+
+        $this->assertGreaterThanOrEqual(2, $entries->count(), 'Expected at least 2 entries with URI on cold stache');
+    }
+
+    #[Test]
+    public function entries_have_uris_on_cold_stache_with_multisite_structured_collection()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en_US'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr_FR'],
+        ]);
+
+        $collection = Collection::make('pages')
+            ->routes('{parent_uri}/{slug}')
+            ->structureContents(['root' => true])
+            ->sites(['en', 'fr']);
+        $collection->save();
+
+        EntryFactory::id('alfa-id')->locale('en')->collection('pages')->slug('alfa')->data(['title' => 'Alfa'])->create();
+        EntryFactory::id('bravo-id')->locale('fr')->collection('pages')->slug('bravo')->origin('alfa-id')->data(['title' => 'Bravo'])->create();
+
+        $this->simulateColdStache();
+
+        Stache::store('entries')->store('pages')->index('site')->load();
+
+        $entries = Entry::query()
+            ->where('collection', 'pages')
+            ->whereNotNull('uri')
+            ->whereStatus('published')
+            ->get();
+
+        $this->assertGreaterThanOrEqual(1, $entries->count(), 'Expected at least 1 entry with URI on cold stache');
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/statamic/seo-pro/issues/508

Deep Stache internals ahead. Please try to break or optimize this..  I did my best 👀

On a cold stache, building an index calls [getItem()](https://github.com/statamic/cms/blob/19256b5c634285d58647f54be3efbcfcd1489467/src/Stache/Stores/BasicStore.php#L18) for each entry, which hits [getCachedItem()](https://github.com/statamic/cms/blob/19256b5c634285d58647f54be3efbcfcd1489467/src/Stache/Stores/CollectionEntriesStore.php#L230). That method then triggers `->resolveIndex('uri')->load()` causing re-entrant index loading.

The issue: [validateTree()](https://github.com/statamic/cms/blob/19256b5c634285d58647f54be3efbcfcd1489467/src/Structures/CollectionStructure.php#L65) sees incomplete indexes, removes all entries from the structure tree, and all URIs become null. The broken index gets cached, poisoning subsequent requests. That's why the sitemap.xml is empty or `Entry::query()->whereNotNull('uri')` returns null 🕳️

My introduced caching from #14031 also triggers this in single-site setups, since cached items cause `getCachedItem()` to be called during index builds.

The main change is about tracking nested index loads, instead of storing the currently loading index in a string. ☀️
```diff                                                                                                                    
-private static ?string $currentlyLoading = null;
+private static array $loadingStack = [];
```

It seems also possible to just remove the URI blink from [getCachedItem()](https://github.com/statamic/cms/blob/19256b5c634285d58647f54be3efbcfcd1489467/src/Stache/Stores/CollectionEntriesStore.php#L240-L242) (or just use the base class function), but this would break the performance optimization which was introduced in https://github.com/statamic/cms/pull/9844

```diff
-  if (! Index::isLoading() && $this->shouldBlinkEntryUris && ($uri = $this->resolveIndex('uri')->load()->get($entry->id()))) {           
-      Blink::store('entry-uris')->put($entry->id(), $uri);                                                                             
-  }
```

If possible, it might be worth backporting this to 5.x? 🤗