### PR TITLE
[6.x] Ignore toolbar shortcuts while inside menus

### DIFF
--- a/resources/js/components/ui/Listing/BulkActionsFloatingToolbar.vue
+++ b/resources/js/components/ui/Listing/BulkActionsFloatingToolbar.vue
@@ -61,7 +61,7 @@ const actionsWithShortcuts = computed(() => {
 // ——— Keyboard handler: skip when overlays or form controls have focus ———
 function hasOpenOverlay() {
     return !!document.querySelector(
-        '[data-ui-modal-content], .stack-content, [role="dialog"]'
+        '[data-ui-modal-content], [data-ui-dropdown-menu], .stack-content, [role="dialog"]'
     );
 }
 
@@ -152,4 +152,3 @@ onUnmounted(() => document.removeEventListener('keydown', onKeydown, true));
         </div>
     </Motion>
 </template>
-


### PR DESCRIPTION
Fix #14110 by checking for open dropdown menus in addition to open modals to prevent triggering floating toolbar keyboard actions. Avoids issues with hitting `Esc` in an actions menu which would also clear the current selection.