### PR TITLE
[6.x] Revert floating toolbar buttons which were inadvertently affected by https://github.com/statamic/cms/pull/14036

### DIFF
--- a/resources/js/components/fieldtypes/bard/ToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/ToolbarButton.vue
@@ -4,12 +4,11 @@
         :class="{ active, group: variant === 'floating' }"
         :variant="variant === 'floating' ? 'subtle' : 'ghost'"
         size="sm"
-        :aria-label="tooltipText"
-        v-tooltip="tooltipText"
+        :aria-label="button.text"
+        v-tooltip="button.text"
         @click="button.command(editor, button.args)"
     >
         <ui-icon :name="button.svg" v-if="button.svg" class="size-3.5! " :class="{ 'group-hover:text-white text-yellow-300!': active && variant === 'floating' }" />
-        <span v-if="variant === 'floating' && (button.text || button.shortcutKey)" class="ml-1 text-xs">{{ button.text }}{{ button.shortcutKey ? ` ${button.shortcutKey}` : '' }}</span>
         <div class="flex items-center" v-html="button.html" v-if="button.html" />
     </Button>
 </template>
@@ -28,15 +27,6 @@ export default {
         config: Object,
         bard: {},
         editor: {},
-    },
-    computed: {
-        tooltipText() {
-            const label = this.button?.text ?? '';
-            if (this.button?.shortcutKey) {
-                return label ? `${label} (${this.button.shortcutKey})` : this.button.shortcutKey;
-            }
-            return label;
-        },
     },
 };
 </script>


### PR DESCRIPTION
## Description of the Problem

The recent PR for floating toolbar buttons (https://github.com/statamic/cms/pull/14036) unintentionally modified the Bard floating toolbar – you can see the text exposed below.

![2026-03-02 at 11 55 25@2x](https://github.com/user-attachments/assets/abfbc450-44f4-4150-9c25-34304f3dc102)

## What this PR Does

Reverts ToolbarButton.vue back to pre- https://github.com/statamic/cms/pull/14036

## How to Reproduce

1. Add a Bard floating toolbar
2. Select text to get the floating toolbar to appear
3. The button text appears, unintentionally