### PR TITLE
[6.x] When sets are expanded, add isolation to force a new stacking context.…

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -75,7 +75,7 @@
                 </div>
             </header>
 
-            <div v-if="index !== undefined" v-show="!collapsed" :class="{ 'contain-paint': collapsed }">
+            <div v-if="index !== undefined" v-show="!collapsed" :class="{ 'contain-paint': collapsed, 'isolate': !collapsed }">
                 <FieldsProvider
                     :fields="fields"
                     :as-config="false"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -200,7 +200,7 @@ reveal.use(rootEl, () => emit('expanded'));
                 </div>
             </header>
 
-            <div v-show="!collapsed" :class="{ 'contain-paint': collapsed }">
+            <div v-show="!collapsed" :class="{ 'contain-paint': collapsed, 'isolate': !collapsed }">
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
                     <FieldsProvider
                         :fields="config.fields"


### PR DESCRIPTION
## Description of the Problem

- Up until recently, we had `contain: paint` wrapped around sets.
  - `contain: paint` was originally used to prevent overflow in a performant way (it's more performant than simply hiding elements, because it also tells the browser not to even render anything outside the boundaries)
  - A side effect of using `contain: paint` is that it also creates a new stacking context

### Well, it turns out that `contain: paint` had both bad _and_ good side effects

- The bad side effect was that it also clipped Bard floating toolbars
  - I fixed this in https://github.com/statamic/cms/pull/14007 by conditionally applying `contain: paint` only when sets were closed.
- The good side effect was that it created a new stacking context. This inadvertently meant that even when you had a Bard fixed toolbar inside a Bard fixed toolbar, the inner Bard toolbar _would remain below_ the outer Bard toolbar, even though it had the same `z-index` value.

![2026-03-02 at 13 48 19@2x](https://github.com/user-attachments/assets/24abd9fa-0d36-493e-a662-93c560a9a5b6)

So… removing `contain: paint` for open sets to fix https://github.com/statamic/cms/pull/14007 means that we no longer have that "new stacking context" applied, which in turn means that inner Bard toolbars appear _above_ outer Bard toolbars

![2026-03-02 at 13 52 15@2x](https://github.com/user-attachments/assets/8c41bd31-4880-4465-a165-51ad348f08d5)

## What this PR Does

- This PR means we have the best of both worlds…
  - `contain: paint` is still conditionally applied when sets are closed, for maximum rendering performance
  - When sets are open we use [`isolation: isolate`](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/isolation), which creates a new stacking context.

## How to Reproduce

1. Add a Bard fieldtype within a Bard fieldtype (fixed toolbars)
2. Focus on the parent Bard fieldtype and scroll to see what happens when you go over the next Bard toolbar
  1. Before this fix the inner toolbar would overlap the outer toolbar
  2. But post-fix the outer toolbar stays on top until you switch focus to an inner Bard field