### PR TITLE
[6.x] Fix addon settings permissions

### DIFF
--- a/src/Auth/CorePermissions.php
+++ b/src/Auth/CorePermissions.php
@@ -227,7 +227,7 @@ class CorePermissions
         Addon::all()
             ->filter->hasSettingsBlueprint()
             ->each(function ($addon) {
-                Permission::register("edit {$addon->slug()} settings", function ($permission) use ($addon) {
+                Permission::register("edit {$addon->package()} settings", function ($permission) use ($addon) {
                     return $permission
                         ->label(__('statamic::permissions.edit_addon_settings', ['addon' => __($addon->name())]));
                 });


### PR DESCRIPTION
This pull request fixes the specific "edit [addon] settings" permissions. 

Initially, addon settings permissions used addon slugs, but this was changed during code review to use the addon's package (8820301). However, this change didn't make its way to the actual permission.

  Fixes #14117