### PR TITLE
[6.x] Fix pjpg format being used as file extension in AssetUploader

### DIFF
--- a/src/Assets/AssetUploader.php
+++ b/src/Assets/AssetUploader.php
@@ -71,6 +71,10 @@ class AssetUploader extends Uploader
             return null;
         }
 
+        if ($ext === 'pjpg') {
+            $ext = 'jpg';
+        }
+
         return $ext;
     }
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1913,6 +1913,36 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    public function it_normalizes_pjpg_format_to_jpg_extension_on_upload()
+    {
+        Event::fake();
+
+        config(['statamic.assets.image_manipulation.presets.progressive' => [
+            'fm' => 'pjpg',
+        ]]);
+
+        $this->container->sourcePreset('progressive');
+
+        $asset = (new Asset)->container($this->container)->path('path/to/asset.jpg')->syncOriginal();
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+        Storage::disk('test')->assertMissing('path/to/asset.jpg');
+
+        ImageValidator::partialMock()
+            ->shouldReceive('isValidImage')
+            ->with('jpg', 'image/jpeg')
+            ->andReturnTrue()
+            ->once();
+
+        $return = $asset->upload(UploadedFile::fake()->image('asset.jpg', 20, 30));
+
+        $this->assertEquals($asset, $return);
+        Storage::disk('test')->assertMissing('path/to/asset.pjpg');
+        Storage::disk('test')->assertExists('path/to/asset.jpg');
+        $this->assertEquals('path/to/asset.jpg', $asset->path());
+    }
+
+    #[Test]
     public function it_sanitizes_svgs_on_upload()
     {
         Event::fake();


### PR DESCRIPTION
When an asset container has a `source_preset` with `'fm' => 'pjpg'` (progressive JPEG), uploaded images get saved with a `.pjpg` file extension instead of `.jpg`.

This happens because `AssetUploader::getNewExtension()` returns the raw Glide format value without normalizing `pjpg` to `jpg`.

This normalization already exists in three other places:
- `league/glide` `Encoder.php` ([lines 68-71](https://github.com/thephpleague/glide/blob/3.0/src/Manipulators/Encode.php#L68-L71))
- `league/glide` `Server.php` ([line 400](https://github.com/thephpleague/glide/blob/3.0/src/Server.php#L400))
- Statamic `GlideManager.php` ([line 192](https://github.com/statamic/cms/blob/6.x/src/Imaging/GlideManager.php#L192))

This PR adds the same normalization to `AssetUploader::getNewExtension()`.