### PR TITLE
[6.x] Minor adjustment to label margin

### DIFF
--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -110,7 +110,7 @@ const hasErrors = computed(() => {
                 </slot>
                 <slot name="actions" />
             </div>
-            <div v-if="label || (instructions && !instructionsBelow) || ($slots.label && !$slots.actions)" data-ui-field-text :class="inline ? 'mb-0' : 'mb-1.5'">
+            <div v-if="label || (instructions && !instructionsBelow) || ($slots.label && !$slots.actions)" data-ui-field-text :class="inline ? 'mb-0' : 'mb-2'">
                 <slot v-if="!$slots.actions" name="label">
                     <Label v-if="label" v-bind="labelProps" class="flex-1" />
                 </slot>


### PR DESCRIPTION
## Description of the Problem

- While the margin on standard fields with text boxes feels fine, the title felt a little too close to the options for fields like radio and checkbox

![2026-03-03 at 13 21 57@2x](https://github.com/user-attachments/assets/e9b04632-f5d2-43e6-9b8a-e31d3554cb28)

## What this PR Does

Increases the margin between labels and fields a touch. This should be mostly imperceptible, but for certain fields the spacing feels more comfortable.

### After

![2026-03-03 at 13 20 57@2x](https://github.com/user-attachments/assets/ccca2a24-3d5a-4fea-ad97-fb93075adb31)