### PR TITLE
[6.x] Fix $isNew detection after Asset::move()

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -618,7 +618,8 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function save()
     {
-        $isNew = is_null($this->container()->asset($this->path()));
+        $pathHasChanged = $this->getOriginal('path') !== $this->path();
+        $isNew = $pathHasChanged ? false : is_null($this->container()->asset($this->path()));
 
         $withEvents = $this->withEvents;
         $this->withEvents = true;

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1107,6 +1107,28 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    public function it_doesnt_dispatch_creating_or_created_events_when_moved()
+    {
+        Event::fake();
+        Storage::fake('local');
+        $disk = Storage::disk('local');
+        $disk->put('old/asset.txt', 'The asset contents');
+        $container = Facades\AssetContainer::make('test')->disk('local');
+        Facades\AssetContainer::shouldReceive('save')->with($container);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
+        $asset->save();
+
+        Event::fake();
+        $asset->move('new');
+
+        Event::assertDispatched(AssetSaving::class);
+        Event::assertDispatched(AssetSaved::class);
+        Event::assertNotDispatched(AssetCreating::class);
+        Event::assertNotDispatched(AssetCreated::class);
+    }
+
+    #[Test]
     public function it_can_be_moved_to_another_folder_quietly()
     {
         Storage::fake('local');


### PR DESCRIPTION
## Problem

When `Asset::move()` is called (e.g. by a listener on `AssetUploaded`), the subsequent `save()` incorrectly evaluates `$isNew = true` with the Eloquent driver. This causes `AssetCreating`/`AssetCreated` events to fire for what is actually a move — a semantic bug that can abort the save entirely if any `AssetCreating` listener returns `false`.

**Example:** An `AssetUploaded` listener that organizes uploads into date-based folders:

```php
class OrganizeArticleAssets
{
    public function handle(AssetUploaded $event): void
    {
        $asset = $event->asset;
        $asset->move(now()->format('Y/m/d'));
    }
}
```

This triggers `AssetCreating` on the internal `save()`, which can abort the move if any other listener returns `false` — even though the asset already exists and is simply being relocated.

**Root cause:** The `$isNew` check creates a fresh lookup at the current (post-move) path:

```php
$isNew = is_null($this->container()->asset($this->path()));
```

With the Eloquent driver, `exists()` checks the DB which still has the old path, returning `false` and making `$isNew = true`.

## Solution

Use `getOriginal('path')` to detect whether the path has changed since the last `syncOriginal()` call. If it has, the asset was moved — not created.

```php
$pathHasChanged = $this->getOriginal('path') !== $this->path();
$isNew = $pathHasChanged ? false : is_null($this->container()->asset($this->path()));
```

This works because `syncOriginal()` is called after every `save()`, storing the path at that point. After `move()` changes the path but before the next `save()`, `getOriginal('path')` returns the pre-move path — signaling a move.

## Test

Added a test that verifies after `move()`:
- `AssetSaving`/`AssetSaved` **are** dispatched
- `AssetCreating`/`AssetCreated` are **not** dispatched