### PR TITLE
[5.x] Remove pdf css

### DIFF
--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script>
-import 'pdfjs-dist/web/pdf_viewer.css';
 import * as pdfjsLib from 'pdfjs-dist/build/pdf.mjs';
 import pdfjsWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?worker&url';
 import { AnnotationLayerBuilder, EventBus, PDFLinkService } from 'pdfjs-dist/web/pdf_viewer.mjs';


### PR DESCRIPTION
The pdf.js css file added in #14045 was not even necessary. It was just adding filesize and caused #14138.

Fixes #14138
Fixes #14116