### PR TITLE
[5.x] Fix Antlers parser state restoration

### DIFF
--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -1104,6 +1104,9 @@ class PathDataManager
         GlobalRuntimeState::$isEvaluatingData = true;
 
         if ($value instanceof Model) {
+            GlobalRuntimeState::$isEvaluatingUserData = $prevIsEvaluatingUserData;
+            GlobalRuntimeState::$isEvaluatingData = $prevIsEvaluatingData;
+
             return $value;
         }
 

--- a/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
+++ b/src/View/Antlers/Language/Runtime/Sandbox/Environment.php
@@ -1393,24 +1393,28 @@ class Environment
         if ($value instanceof Value) {
             $prevIsEvaluatingUserData = GlobalRuntimeState::$isEvaluatingUserData;
             GlobalRuntimeState::$isEvaluatingUserData = true;
-            if ($value->shouldParseAntlers()) {
-                if (! $hasModifiers || ($modifierChain != null && $modifierChain[0]->nameNode->name != 'raw')) {
-                    GlobalRuntimeState::$userContentEvalState = [
-                        $value,
-                        $this->nodeProcessor->getActiveNode(),
-                    ];
-                    try {
-                        $value = $value->antlersValue($this->nodeProcessor->getAntlersParser(), $this->data);
-                    } finally {
-                        GlobalRuntimeState::$userContentEvalState = null;
+
+            try {
+                if ($value->shouldParseAntlers()) {
+                    if (! $hasModifiers || ($modifierChain != null && $modifierChain[0]->nameNode->name != 'raw')) {
+                        GlobalRuntimeState::$userContentEvalState = [
+                            $value,
+                            $this->nodeProcessor->getActiveNode(),
+                        ];
+                        try {
+                            $value = $value->antlersValue($this->nodeProcessor->getAntlersParser(), $this->data);
+                        } finally {
+                            GlobalRuntimeState::$userContentEvalState = null;
+                        }
+                    }
+                } else {
+                    if (! $hasModifiers) {
+                        $value = $value->value();
                     }
                 }
-            } else {
-                if (! $hasModifiers) {
-                    $value = $value->value();
-                }
+            } finally {
+                GlobalRuntimeState::$isEvaluatingUserData = $prevIsEvaluatingUserData;
             }
-            GlobalRuntimeState::$isEvaluatingUserData = $prevIsEvaluatingUserData;
         }
 
         return $value;

--- a/tests/Antlers/ScratchTest.php
+++ b/tests/Antlers/ScratchTest.php
@@ -122,7 +122,6 @@ EOT;
 
             $env = new Environment();
             $method = new \ReflectionMethod($env, 'checkForFieldValue');
-            $method->setAccessible(true);
 
             try {
                 $method->invoke($env, $throwingValue);
@@ -165,7 +164,6 @@ class TriggerValueExceptionTag extends \Statamic\Tags\Tags
         $env = new Environment();
         $env->setData($this->context->all());
         $method = new \ReflectionMethod($env, 'checkForFieldValue');
-        $method->setAccessible(true);
         try {
             $method->invoke($env, $throwingValue);
         } catch (\Throwable $e) {

--- a/tests/Antlers/ScratchTest.php
+++ b/tests/Antlers/ScratchTest.php
@@ -6,8 +6,10 @@ use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Antlers;
+use Statamic\Fields\Value;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 use Statamic\View\Antlers\Language\Runtime\PathDataManager;
+use Statamic\View\Antlers\Language\Runtime\Sandbox\Environment;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -104,5 +106,82 @@ EOT;
             GlobalRuntimeState::$isEvaluatingUserData = $prevUserData;
             GlobalRuntimeState::$isEvaluatingData = $prevData;
         }
+    }
+
+    #[Test]
+    public function check_for_field_value_restores_state_when_value_throws()
+    {
+        $prev = GlobalRuntimeState::$isEvaluatingUserData;
+
+        try {
+            GlobalRuntimeState::$isEvaluatingUserData = false;
+
+            $throwingValue = new Value(function () {
+                throw new \RuntimeException('Intentional field value failure');
+            });
+
+            $env = new Environment();
+            $method = new \ReflectionMethod($env, 'checkForFieldValue');
+            $method->setAccessible(true);
+
+            try {
+                $method->invoke($env, $throwingValue);
+            } catch (\Throwable $e) {
+                $this->assertSame('Intentional field value failure', $e->getMessage());
+            }
+
+            $this->assertFalse(
+                GlobalRuntimeState::$isEvaluatingUserData,
+                'isEvaluatingUserData should be restored after exception in checkForFieldValue'
+            );
+        } finally {
+            GlobalRuntimeState::$isEvaluatingUserData = $prev;
+        }
+    }
+
+    #[Test]
+    public function view_with_condition_on_throwing_field_value_restores_state_so_later_output_is_correct()
+    {
+        app('statamic.tags')['trigger_value_exception'] = TriggerValueExceptionTag::class;
+        app('statamic.modifiers')['scratch_test_upper'] = ScratchTestUppercaseModifier::class;
+
+        $template = '{{ trigger_value_exception }} {{ title | scratch_test_upper }}';
+        $data = ['title' => 'hello'];
+
+        $output = (string) Antlers::parse($template, $data, true);
+
+        $this->assertSame('trusted HELLO', $output, 'Trusted state was not restored');
+    }
+}
+
+class TriggerValueExceptionTag extends \Statamic\Tags\Tags
+{
+    public function index()
+    {
+        $throwingValue = new Value(function () {
+            throw new \RuntimeException('Intentional field value failure');
+        });
+
+        $env = new Environment();
+        $env->setData($this->context->all());
+        $method = new \ReflectionMethod($env, 'checkForFieldValue');
+        $method->setAccessible(true);
+        try {
+            $method->invoke($env, $throwingValue);
+        } catch (\Throwable $e) {
+            //
+        }
+
+        $trusted = ! \Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState::$isEvaluatingUserData;
+
+        return $trusted ? 'trusted' : 'untrusted';
+    }
+}
+
+class ScratchTestUppercaseModifier extends \Statamic\Modifiers\Modifier
+{
+    public function index($value, $params, $context)
+    {
+        return is_string($value) ? strtoupper($value) : $value;
     }
 }

--- a/tests/Antlers/ScratchTest.php
+++ b/tests/Antlers/ScratchTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Antlers;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Database\Eloquent\Model;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Antlers;
+use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
+use Statamic\View\Antlers\Language\Runtime\PathDataManager;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -74,5 +77,32 @@ next line
 EOT;
 
         $this->assertSame($expected, (string) Antlers::parse($template, $data));
+    }
+
+    #[Test]
+    public function reduce_for_antlers_restores_global_runtime_state_when_early_returning_with_model()
+    {
+        $prevUserData = GlobalRuntimeState::$isEvaluatingUserData;
+        $prevData = GlobalRuntimeState::$isEvaluatingData;
+
+        try {
+            GlobalRuntimeState::$isEvaluatingUserData = false;
+            GlobalRuntimeState::$isEvaluatingData = false;
+
+            $model = new class extends Model
+            {
+                //
+            };
+            $parser = Antlers::parser();
+
+            $result = PathDataManager::reduceForAntlers($model, $parser, [], true);
+
+            $this->assertSame($model, $result);
+            $this->assertFalse(GlobalRuntimeState::$isEvaluatingUserData, 'isEvaluatingUserData should be restored after Model early return');
+            $this->assertFalse(GlobalRuntimeState::$isEvaluatingData, 'isEvaluatingData should be restored after Model early return');
+        } finally {
+            GlobalRuntimeState::$isEvaluatingUserData = $prevUserData;
+            GlobalRuntimeState::$isEvaluatingData = $prevData;
+        }
     }
 }


### PR DESCRIPTION
There were a couple of places in #14092 that unintentionally caused trusted templates to be left in an untrusted state, preventing guarded tags/modifiers from working.

This PR fixes a couple of those so that the trusted state is restored.

If you are still noticing tags and/or modifiers not working correctly from your templates - or `Runtime Access Violation` warnings in your logs, please let us know.