### PR TITLE
[5.x] Config parsing exclusion

### DIFF
--- a/src/Facades/Endpoint/Parse.php
+++ b/src/Facades/Endpoint/Parse.php
@@ -109,6 +109,10 @@ class Parse
         return preg_replace_callback('/\{\{\s*config[\.:]([\w\.\:]+)\s*\}\}/', function ($matches) {
             $key = str_replace(':', '.', $matches[1]);
 
+            if (strtolower($key) === 'app.key') {
+                return '';
+            }
+
             return config($key, '');
         }, $value);
     }

--- a/tests/Facades/ParseTest.php
+++ b/tests/Facades/ParseTest.php
@@ -67,4 +67,18 @@ class ParseTest extends TestCase
             'null passthrough' => [null, null],
         ];
     }
+
+    #[Test]
+    public function app_key_is_banned_from_config_parsing()
+    {
+        config([
+            'app.key' => 'secret',
+            'foo.bar' => 'baz',
+        ]);
+
+        $this->assertSame('', Parse::config('{{ config:app:key }}'));
+        $this->assertSame('', Parse::config('{{ config.app.key }}'));
+        $this->assertSame('', Parse::config('{{ config.app:key }}'));
+        $this->assertSame('prefix  baz suffix', Parse::config('prefix {{ config:app:key }} {{ config:foo:bar }} suffix'));
+    }
 }


### PR DESCRIPTION
This builds on #14146 and explicitly disables app.key from being referenced.