### PR TITLE
[6.x] Improve tables in Bard fields, particularly dark mode

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -471,15 +471,18 @@
             .tableWrapper &,
             blockquote > .tableWrapper &,
             :is(ol, ul) li > .tableWrapper & {
-                @apply m-0 mb-4 w-full overflow-hidden bg-white text-sm dark:bg-gray-600 border-collapse table-fixed;
+                @apply m-0 mb-4 w-full overflow-hidden bg-white text-sm dark:bg-gray-900 border-collapse table-fixed;
 
                 th {
-                    @apply bg-gray-200 font-bold dark:bg-gray-600 text-start;
+                    @apply bg-gray-50 dark:bg-gray-925 text-start;
+                    p {
+                        @apply font-medium dark:font-semibold;
+                    }
                 }
 
                 td,
                 th {
-                    @apply relative border px-2 py-1 align-top dark:border-gray-600;
+                    @apply relative border px-2 py-1 align-top dark:border-gray-700/50;
                     min-width: 1em;
                 }
 

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -482,7 +482,7 @@
 
                 td,
                 th {
-                    @apply relative border px-2 py-1 align-top dark:border-gray-700/50;
+                    @apply relative border px-2 py-1 align-top dark:border-gray-700/75;
                     min-width: 1em;
                 }
 

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -474,7 +474,7 @@
                 @apply m-0 mb-4 w-full overflow-hidden bg-white text-sm dark:bg-gray-900 border-collapse table-fixed;
 
                 th {
-                    @apply bg-gray-50 dark:bg-gray-925 text-start;
+                    @apply bg-gray-50 dark:bg-gray-950/30 text-start;
                     p {
                         @apply font-medium dark:font-semibold;
                     }


### PR DESCRIPTION
## Description of the Problem

As per issue #14150, it looks like #14013 made the Bard tables worse in dark mode (not that they were great to begin with – think we might have missed properly styling those!).

## What this PR Does

- Makes Bard tables much better in dark mode
- Makes Bard tables better in light mode too
- Closes #14150

### Before - Tables in Dark Mode

![2026-03-05 at 11 20 23@2x](https://github.com/user-attachments/assets/4e3fc5e2-bb57-4aca-8338-5efa41892511)

### Before - Tables in Light Mode

![2026-03-05 at 11 13 20@2x](https://github.com/user-attachments/assets/f93b4ce2-34d7-4c26-b687-3910c7d3067e)

### After - Tables in Dark Mode

![2026-03-05 at 11 20 01@2x](https://github.com/user-attachments/assets/72eb9acd-ff8b-4a8d-9111-adfefd7388c7)

### After - Tables in Light Mode

![2026-03-05 at 11 10 44@2x](https://github.com/user-attachments/assets/41ea2524-e100-463b-a23b-bb10525145f3)

## How to Reproduce

1. Create a table inside a bard field. Add some content and multiple rows. Select multiple cells and use the "Toggle Header Cell" button in the formatting bar. In dark mode, you can't tell whether it's been enabled or not.