### PR TITLE
[6.x] Force full width on asset grid to account for smaller SVGs

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -18,7 +18,7 @@
         >
         </asset-editor>
 
-        <div class="flex h-full rounded-b-md relative" :class="{ 'bg-checkerboard rounded-lg!': canBeTransparent, 'border-b dark:border-gray-700': showFilename }">
+        <div class="flex h-full w-full justify-center rounded-b-md relative" :class="{ 'bg-checkerboard rounded-lg!': canBeTransparent, 'border-b dark:border-gray-700': showFilename }">
             <div class="p-1 flex flex-col items-center justify-center h-full">
                 <!-- Solo Bard -->
                 <template v-if="isImage && isInBardField && !isInAssetBrowser">


### PR DESCRIPTION
## Description of the Problem

When you have small SVGs in the asset grid the shadow container does not expand to take up the container width, like this:

Notice the shadows underneath the SVGs
![2026-03-06 at 12 37 43@2x](https://github.com/user-attachments/assets/7eca24c7-f928-4292-b432-087e253ee5af)

## What this PR Does

Expands the parent container of the SVG that contains the shadow

Here it is with the fix:
![2026-03-06 at 12 39 04@2x](https://github.com/user-attachments/assets/e36d6641-000b-4169-90ad-51e3f8e8086d)


## How to Reproduce

1. Upload a small logo such as the Facebook "F" to an assets field with a grid UI