### PR TITLE
[6.x] Use resize observer for the floating toolbar

### DIFF
--- a/resources/js/components/ui/Button/Group.vue
+++ b/resources/js/components/ui/Button/Group.vue
@@ -71,8 +71,9 @@ onBeforeUnmount(() => {
         /* Split buttons apart when wrapped */
         &[data-wrapped] {
             gap: 0.25rem;
+            box-shadow: none;
 
-            & button {
+            button {
                 border-radius: 0.375rem !important;
             }
         }

--- a/resources/js/components/ui/Button/Group.vue
+++ b/resources/js/components/ui/Button/Group.vue
@@ -1,7 +1,40 @@
+<script setup>
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+
+const groupEl = ref(null);
+let resizeObserver = null;
+
+function checkWrapping() {
+    const el = groupEl.value;
+    if (!el) return;
+
+    el.removeAttribute('data-wrapped');
+
+    const firstChild = el.firstElementChild;
+    const lastChild = el.lastElementChild;
+
+    if (firstChild && lastChild && firstChild !== lastChild && lastChild.offsetTop > firstChild.offsetTop) {
+        el.setAttribute('data-wrapped', '');
+    }
+}
+
+onMounted(() => {
+    resizeObserver = new ResizeObserver(checkWrapping);
+    if (groupEl.value) {
+        resizeObserver.observe(groupEl.value);
+    }
+});
+
+onBeforeUnmount(() => {
+    resizeObserver?.disconnect();
+});
+</script>
+
 <template>
     <div
+        ref="groupEl"
         :class="[
-            'group/button inline-flex flex-wrap [[data-floating-toolbar]_&]:justify-center [[data-floating-toolbar]_&]:gap-1 [[data-floating-toolbar]_&]:lg:gap-x-0',
+            'group/button inline-flex flex-wrap [[data-floating-toolbar]_&]:justify-center',
             '[&>[data-ui-group-target]:not(:first-child):not(:last-child)]:rounded-none',
             '[&>[data-ui-group-target]:first-child:not(:last-child)]:rounded-e-none',
             '[&>[data-ui-group-target]:last-child:not(:first-child)]:rounded-s-none',
@@ -9,7 +42,6 @@
             '[&>*:first-child:not(:last-child)_[data-ui-group-target]]:rounded-e-none',
             '[&>*:last-child:not(:first-child)_[data-ui-group-target]]:rounded-s-none',
             'dark:[&_button]:ring-0',
-            'max-lg:[[data-floating-toolbar]_&_button]:rounded-md!',
             'shadow-ui-sm rounded-lg'
         ]"
         data-ui-button-group
@@ -19,7 +51,7 @@
 </template>
 
 <style>
-    /* GROUP FLOATING TOOLBAR / BUTTON GROUP BORDERS
+    /* GROUP BUTTON GROUP BORDERS
     =================================================== */
     [data-ui-button-group] [data-ui-group-target] {
         @apply shadow-none;
@@ -27,13 +59,21 @@
         &:not(:first-child):not([data-floating-toolbar] &) {
             border-inline-start: 0;
         }
+    }
+    /* GROUP BUTTON GROUP BORDERS / FLOATING TOOLBAR
+    =================================================== */
+    [data-floating-toolbar] [data-ui-button-group] {
+        /* Connected look when not wrapped */
+        &:not([data-wrapped]) [data-ui-group-target]:not(:first-child) {
+            border-inline-start: 0;
+        }
 
-        /* Account for button groups being split apart on small screens */
-        [data-floating-toolbar] & {
-            @media (width >= 1024px) {
-                &:not(:first-child) {
-                    border-inline-start: 0;
-                }
+        /* Split buttons apart when wrapped */
+        &[data-wrapped] {
+            gap: 0.25rem;
+
+            & button {
+                border-radius: 0.375rem !important;
             }
         }
     }


### PR DESCRIPTION
## Description of the Problem

We currently use a media query to switch to the "floating toolbar" layout for smaller viewports, where actions start to wrap.

While we could sort of get away with this before, the goal posts have changed now that we have keyboard shortcuts attached to items, resulting in the old layout persisting, even when items have wrapped.

Before fix
![2026-03-09 at 11 18 01@2x](https://github.com/user-attachments/assets/ca9283ac-2314-4a1a-9b1b-5efabf71c709)

## What this PR Does

- Unfortunately, it's not possible to detect height or flex row changes with CSS alone, so I've added JavaScript resize observer to effectively toggle the "wrapped" layout instead. This is a very similar implementation to the button group resize observer implementation.
- Also fix the row box-shadow when the layout is wrapped
- Closes https://github.com/statamic/cms/issues/14170

After fix
![2026-03-09 at 11 13 40@2x](https://github.com/user-attachments/assets/dbb0b066-987e-4d1c-950b-ed57faa41a39)

## How to Reproduce

1. Go to `cp/assets` and select something
2. Pull the window in so the floating actions wrap