### PR TITLE
[6.x] Asset cropper fixes

### DIFF
--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -440,7 +440,7 @@ function close() {
 
 <template>
     <Stack size="full" :open="open" inset @update:open="$emit('update:open', $event)" @opened="initCropper" :show-close-button="false">
-        <div class="min-h-0 flex h-full flex-col bg-gray-100 dark:bg-dark-800">
+        <div class="min-h-0 flex h-full flex-col bg-gray-100 dark:bg-gray-850">
             <!-- Header -->
             <header class="relative flex w-full items-center justify-between px-4 py-3 border-b dark:border-gray-700">
                 <Heading size="lg">{{ __('Crop Image') }}</Heading>
@@ -448,7 +448,7 @@ function close() {
             </header>
 
             <!-- Content -->
-            <div class="bg-gray-300 p-3 inset-shadow-xs dark:bg-gray-800 flex flex-1 flex-col overflow-auto relative min-h-0 w-full items-center justify-center" role="img" :aria-label="__('Image crop area')">
+            <div class="bg-gray-300 p-3 inset-shadow-xs dark:bg-gray-850 flex flex-1 flex-col overflow-auto relative min-h-0 w-full items-center justify-center" role="img" :aria-label="__('Image crop area')">
                 <div class="h-full w-full min-h-0 flex items-center justify-center overflow-hidden">
                     <img ref="image" :src="asset.preview" :crossorigin="crossOrigin" :alt="__('Image to crop')" class="max-w-full max-h-full" @error="onImageError" />
                 </div>

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -455,7 +455,7 @@ function close() {
             </div>
 
             <!-- Footer -->
-            <div class="flex items-center justify-between gap-3 border-t dark:border-gray-700 px-4 py-3">
+            <div class="flex flex-wrap items-center justify-between gap-3 border-t dark:border-gray-700 px-4 py-3">
                 <div class="flex gap-3">
                     <Select
                         clearable


### PR DESCRIPTION
## Description of the Problem

There were a couple of small issues with the asset cropper:

- Dark mode used the old `-dark-` syntax
- The toolbar grew and caused overflow on mobile when an aspect ratio was picked

## What this PR Does

- Use correct dark color syntax and make the color consistent with the other modals
- Use `flex-wrap` to avoid overflow on smaller viewports
- Fixes https://github.com/statamic/cms/issues/14159 and https://github.com/statamic/cms/issues/14154

## How to Reproduce

1. Switch to dark mode with the cropping modal open
2. Choose an aspect ratio to bring up more actions on a small viewport to see the overflow