### PR TITLE
[6.x] External URLs in the nav should render as `<a>` elements

### DIFF
--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -134,9 +134,10 @@ function handleChildClick(event, item, child) {
     }
 }
 
+const cpBaseUrl = Statamic.$config.get('cpUrl');
+
 function isUrlWithinControlPanel(url) {
-    const cpBase = Statamic.$config.get('cpUrl');
-    return url && (url === cpBase || url.startsWith(cpBase + '/'));
+    return url && (url === cpBaseUrl || url.startsWith(cpBaseUrl + '/'));
 }
 
 function shouldRenderAsInertiaLink(item) {

--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -134,11 +134,14 @@ function handleChildClick(event, item, child) {
     }
 }
 
+function isUrlWithinControlPanel(url) {
+    const cpBase = Statamic.$config.get('cpUrl');
+    return url && (url === cpBase || url.startsWith(cpBase + '/'));
+}
+
 function shouldRenderAsInertiaLink(item) {
     if (item.attributes?.target === '_blank') return false;
-    if (item.url?.startsWith('http://') || item.url?.startsWith('https://')) return false;
-
-    return true;
+    return isUrlWithinControlPanel(item.url);
 }
 
 Statamic.$keys.bind(['command+\\', ['[']], (e) => {

--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -134,6 +134,13 @@ function handleChildClick(event, item, child) {
     }
 }
 
+function shouldRenderAsInertiaLink(item) {
+    if (item.attributes?.target === '_blank') return false;
+    if (item.url?.startsWith('http://') || item.url?.startsWith('https://')) return false;
+
+    return true;
+}
+
 Statamic.$keys.bind(['command+\\', ['[']], (e) => {
     e.preventDefault();
     toggle();
@@ -155,7 +162,7 @@ Statamic.$events.$on('nav.toggle', toggle);
                     <DynamicHtmlRenderer v-if="item.view" :html="item.view" />
                     <template v-else>
                         <component
-                            :is="item.attributes?.target === '_blank' ? 'a' : Link"
+                            :is="shouldRenderAsInertiaLink(item) ? Link : 'a'"
                             :href="item.url"
                             v-bind="item.attributes"
                             :class="{ 'active': item.active }"
@@ -167,7 +174,7 @@ Statamic.$events.$on('nav.toggle', toggle);
                         <ul v-if="item.children.length && item.active">
                             <li v-for="(child, i) in item.children" :key="i">
                                 <component
-                                    :is="child.attributes?.target === '_blank' ? 'a' : Link"
+                                    :is="shouldRenderAsInertiaLink(child) ? Link : 'a'"
                                     :href="child.url"
                                     v-bind="child.attributes"
                                     v-text="__(child.display)"


### PR DESCRIPTION
This pull request ensures that external URLs in the nav are rendered as `<a>` elements, as opposed to Inertia `<Link>` components which may triggers CORS errors.