### PR TITLE
[6.x] Use amber for update badges

### DIFF
--- a/resources/js/components/UpdatesBadge.vue
+++ b/resources/js/components/UpdatesBadge.vue
@@ -1,5 +1,5 @@
 <template>
-    <Badge v-if="count" :text="String(count)" color="red" size="sm" pill />
+    <Badge v-if="count" :text="String(count)" color="amber" size="sm" pill />
 </template>
 
 <script>

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -2,7 +2,7 @@
     <div class="max-w-page mx-auto">
         <ui-header :title="name" icon="updates">
             <template v-if="!gettingChangelog" #actions>
-                <ui-badge :prepend="__('Version')" :text="currentVersion" color="green" size="lg" />
+                <ui-badge :prepend="__('Version')" :text="currentVersion" :color="onLatestVersion ? 'green' : 'amber'" size="lg" />
                 <div v-if="onLatestVersion" v-text="__('Up to date')" />
             </template>
         </ui-header>

--- a/resources/js/components/updater/UpdaterWidget.vue
+++ b/resources/js/components/updater/UpdaterWidget.vue
@@ -18,7 +18,7 @@ defineProps({
                             <Link :href="update.url" class="flex items-center gap-2" v-text="update.name" />
                         </td>
                         <td>
-                            <Badge pill :color="update.critical ? 'red' : 'green'" :text="update.count" />
+                            <Badge pill :color="update.critical ? 'red' : 'amber'" :text="update.count" />
                             <div class="inline-flex" v-tooltip="__('Critical')">
                                 <Icon v-if="update.critical" name="warning-diamond" color="red" />
                             </div>

--- a/resources/js/pages/updater/Index.vue
+++ b/resources/js/pages/updater/Index.vue
@@ -38,7 +38,7 @@ defineProps(['requestError', 'statamic', 'addons']);
                             </TableCell>
                             <TableCell>{{ statamic.currentVersion }}</TableCell>
                             <TableCell v-if="statamic.availableUpdatesCount" class="text-right">
-                                <Badge size="sm" color="green">{{ __n('1 update|:count updates', statamic.availableUpdatesCount) }}</Badge>
+                                <Badge size="sm" color="amber">{{ __n('1 update|:count updates', statamic.availableUpdatesCount) }}</Badge>
                             </TableCell>
                             <TableCell v-else class="text-right">{{ __('Up to date') }}</TableCell>
                         </TableRow>
@@ -63,7 +63,7 @@ defineProps(['requestError', 'statamic', 'addons']);
                             </TableCell>
                             <TableCell>{{ addon.version }}</TableCell>
                             <TableCell v-if="addon.availableUpdatesCount" class="text-right">
-                                <Badge size="sm" color="green">{{ __n('1 update|:count updates', addon.availableUpdatesCount) }}</Badge>
+                                <Badge size="sm" color="amber">{{ __n('1 update|:count updates', addon.availableUpdatesCount) }}</Badge>
                             </TableCell>
                             <TableCell v-else class="text-right">{{ __('Up to date') }}</TableCell>
                         </TableRow>


### PR DESCRIPTION
This pull request fixes a UX inconsistency where update badges used green, which typically indicates "everything is OK", even when updates were available.

This PR fixes it by using amber for update badges, which better conveys "attention needed" without being as alarming as red.

- Widget: Non-critical updates now use amber instead of green
- Updates listing page: Statamic and addon update badges now use amber
- Version details page: Badge is now dynamic - green when up to date, amber when updates are available

Fixes #14169