### PR TITLE
[6.x] Performance: Reduce duplicate cache reads on nav

### DIFF
--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -17,6 +17,7 @@ class NavBuilder
 
     protected $items = [];
     protected $pendingItems = [];
+    protected $itemsKeyedById = null;
     protected $withHidden = false;
     protected $itemsWithChildrenClosures = [];
     protected $sections = [];
@@ -154,6 +155,7 @@ class NavBuilder
     protected function authorizeItems()
     {
         $this->items = $this->filterAuthorizedNavItems($this->items);
+        $this->itemsKeyedById = null;
 
         return $this;
     }
@@ -352,6 +354,7 @@ class NavBuilder
 
         if (! in_array($item->manipulations()['action'], ['@modify', '@hide'])) {
             $this->items[] = $item;
+            $this->itemsKeyedById = null;
         }
 
         return $item;
@@ -518,6 +521,16 @@ class NavBuilder
     }
 
     /**
+     * Get items keyed by ID
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    protected function getItemsKeyedById()
+    {
+        return $this->itemsKeyedById ??= collect($this->items)->keyBy->id();
+    }
+
+    /**
      * Find existing nav item by ID.
      *
      * @param  string  $id
@@ -534,7 +547,7 @@ class NavBuilder
             return $item;
         }
 
-        $items = collect($this->items)->keyBy->id();
+        $items = $this->getItemsKeyedById();
 
         if ($item = $items->get($id)) {
             return $item;
@@ -562,7 +575,7 @@ class NavBuilder
             $id = NavTransformer::removeUniqueIdHash($id);
         }
 
-        $items = collect($this->items)->keyBy->id();
+        $items = $this->getItemsKeyedById();
 
         $idParts = collect(explode('::', $id));
 
@@ -832,6 +845,7 @@ class NavBuilder
         $this->items = collect($this->items)
             ->reject(fn ($registeredItem) => $registeredItem->id() === $item->id())
             ->all();
+        $this->itemsKeyedById = null;
     }
 
     /**
@@ -1038,8 +1052,17 @@ class NavBuilder
      */
     public static function getUnresolvedChildrenUrlsForItem($item)
     {
-        return Blink::get(static::UNRESOLVED_CHILDREN_URLS_CACHE_KEY)?->get($item->id())
-            ?? Cache::get(static::UNRESOLVED_CHILDREN_URLS_CACHE_KEY)?->get($item->id());
+        if ($urls = Blink::get(static::UNRESOLVED_CHILDREN_URLS_CACHE_KEY)) {
+            return $urls->get($item->id());
+        }
+
+        if ($urls = Cache::get(static::UNRESOLVED_CHILDREN_URLS_CACHE_KEY)) {
+            Blink::put(static::UNRESOLVED_CHILDREN_URLS_CACHE_KEY, $urls);
+
+            return $urls->get($item->id());
+        }
+
+        return null;
     }
 
     /**
@@ -1049,9 +1072,15 @@ class NavBuilder
      */
     public static function getAllUrls()
     {
-        return Blink::get(static::ALL_URLS_CACHE_KEY)
-            ?? Cache::get(static::ALL_URLS_CACHE_KEY)
-            ?? collect();
+        if ($urls = Blink::get(static::ALL_URLS_CACHE_KEY)) {
+            return $urls;
+        }
+
+        $urls = Cache::get(static::ALL_URLS_CACHE_KEY) ?? collect();
+
+        Blink::put(static::ALL_URLS_CACHE_KEY, $urls);
+
+        return $urls;
     }
 
     /**


### PR DESCRIPTION
While debugging performance issues, I noticed many cache reads from `cp-nav-*` keys.

This PR reduces the amount of cache calls per request and resulted in a couple hundred ms gains for us on our project. It also reduces re-collections.