### PR TITLE
[6.x] Performance: memoize outpost

### DIFF
--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -44,7 +44,7 @@ class Outpost
 
     public function response()
     {
-        return $this->response ?? $this->request();
+        return $this->response ??= $this->request();
     }
 
     private function request()


### PR DESCRIPTION
I was seeing about 15 Outpost cache reads per request in CP - this reduces that to 1 or 2.