### PR TITLE
[6.x] Memoize marketplace cache

### DIFF
--- a/src/Marketplace/Marketplace.php
+++ b/src/Marketplace/Marketplace.php
@@ -11,12 +11,14 @@ use Statamic\Statamic;
 
 class Marketplace
 {
+    private static $packagesCache = [];
+
     public function packages(array $packages)
     {
         $uri = 'packages';
         $hash = md5(json_encode($packages));
 
-        return Cache::rememberWithExpiration("marketplace-$uri-$hash", function () use ($uri, $packages) {
+        return static::$packagesCache[$hash] ??= Cache::rememberWithExpiration("marketplace-$uri-$hash", function () use ($uri, $packages) {
             try {
                 $response = Client::post($uri, ['packages' => $packages]);
 


### PR DESCRIPTION
For the Statamic team - I've been trying to identify all memoization opportunities due to the excessive cache activity in the CMS:
<img width="1730" height="1060" alt="CleanShot 2026-03-09 at 15 05 03@2x" src="https://github.com/user-attachments/assets/b320ef57-5171-4a96-bfc6-cd4994cd85c6" />

A lot are small, but they add up!