### PR TITLE
[6.x] Performance: optimize middleware

### DIFF
--- a/src/Http/Middleware/CP/BootPreferences.php
+++ b/src/Http/Middleware/CP/BootPreferences.php
@@ -9,6 +9,10 @@ class BootPreferences
 {
     public function handle($request, Closure $next)
     {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
         Preference::boot();
 
         return $next($request);

--- a/src/Http/Middleware/CP/BootUtilities.php
+++ b/src/Http/Middleware/CP/BootUtilities.php
@@ -9,6 +9,10 @@ class BootUtilities
 {
     public function handle($request, Closure $next)
     {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
         Utility::boot();
 
         return $next($request);

--- a/src/Http/Middleware/CP/ContactOutpost.php
+++ b/src/Http/Middleware/CP/ContactOutpost.php
@@ -16,6 +16,10 @@ class ContactOutpost
 
     public function handle($request, Closure $next)
     {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
         $this->outpost->radio();
 
         return $next($request);

--- a/src/Http/Middleware/CP/CountUsers.php
+++ b/src/Http/Middleware/CP/CountUsers.php
@@ -11,6 +11,10 @@ class CountUsers
 {
     public function handle($request, Closure $next, $guard = null)
     {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
         if (! Statamic::pro() && User::count() > 1) {
             throw new StatamicProRequiredException('Statamic Pro is required for multiple users.');
         }

--- a/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
@@ -19,6 +19,10 @@ class HandleAuthenticatedInertiaRequests
 {
     public function handle(Request $request, Closure $next)
     {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
         Inertia::share($this->share($request));
 
         return $next($request);

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Middleware\CP;
 
+use Closure;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
 use Statamic\CP\Toasts\Manager;
@@ -19,6 +20,15 @@ class HandleInertiaRequests extends Middleware
     public function __construct(private Manager $toasts)
     {
         //
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
+        return parent::handle($request, $next);
     }
 
     public function share(Request $request): array

--- a/src/Http/Middleware/DeleteTemporaryFileUploads.php
+++ b/src/Http/Middleware/DeleteTemporaryFileUploads.php
@@ -9,6 +9,10 @@ class DeleteTemporaryFileUploads
 {
     public function handle($request, Closure $next)
     {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
         $lottery = [2, 100];
 
         if (random_int(1, $lottery[1]) <= $lottery[0]) {

--- a/src/Http/Middleware/RedirectIfTwoFactorSetupIncomplete.php
+++ b/src/Http/Middleware/RedirectIfTwoFactorSetupIncomplete.php
@@ -10,6 +10,10 @@ class RedirectIfTwoFactorSetupIncomplete
 {
     public function handle(Request $request, Closure $next)
     {
+        if (! $request->inertia() && $request->ajax()) {
+            return $next($request);
+        }
+
         if (
             ($user = User::fromUser($request->user()))
             && $user->isTwoFactorAuthenticationRequired()


### PR DESCRIPTION
This PR attempts to optimize the AJAX calls a bit in CP - and locally, it has been *very* successful, cutting most AJAX requests by 50%. For example, listing pages were averaging ~4,000ms and now most are taking < 2,000ms.

The "trick" is not running all middleware on AJAX routes - for example, it's wasteful to be rendering CP nav on tree listings etc.

I assume this may be a bit controversial and may require more in-depth testing, but the Statamic team should consider trimming some middleware off routes that don't need it :)