### PR TITLE
[6.x] Fix copy to clipboard input in light mode

### DIFF
--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -108,7 +108,7 @@ onUnmounted(() => {
             @confirm="$root.copyToClipboardModalUrl = null"
         >
             <div class="prose">
-                <ui-input :model-value="$root.copyToClipboardModalUrl" readonly copyable class="font-mono text-sm dark" />
+                <ui-input :model-value="$root.copyToClipboardModalUrl" readonly copyable class="font-mono text-sm" />
             </div>
         </confirmation-modal>
 


### PR DESCRIPTION
This pull request fixes an issue where the input in the copy to clipboard modal was always dark, regardless of the actual colour mode.

This was happening because the `<ui-input>` component had a hardcoded `dark` class. This PR fixes it by removing that class.

## Before

<img width="688" height="206" alt="CleanShot 2026-03-10 at 10 13 07" src="https://github.com/user-attachments/assets/8b6d8535-d7fd-4490-8db5-30682aa5ad64" />


## After

<img width="688" height="206" alt="CleanShot 2026-03-10 at 10 12 51" src="https://github.com/user-attachments/assets/b061856d-d92f-4c4a-b456-05e2a8ebe6c7" />


---

Fixes #14184