### PR TITLE
[6.x] Fix outline focus briefly showing as the stack comes in

### DIFF
--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -205,7 +205,7 @@ provide('closeStack', close);
             <FocusScope
 	            :trapped="isTopPortal"
 	            loop
-                class="stack-container"
+                class="stack-container outline-none"
                 :class="{ 'stack-is-current': isTopStack }"
                 :style="direction === 'ltr' ? { left: `${leftOffset}px` } : { right: `${leftOffset}px` }"
             >


### PR DESCRIPTION
## Description of the Problem

As stacks slide in, you can sometimes see a brief blue focus outline that has no use case and is distracting.
It's difficult to capture in a screenshot because it happens so quickly.

## What this PR Does

Removes the outline from the outer stack

## How to Reproduce

1. Go to edit a blueprint, click on existing field