### PR TITLE
[6.x] Only remove Bard set when backspace key is hit

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.js
+++ b/resources/js/components/fieldtypes/bard/Set.js
@@ -75,35 +75,6 @@ export const Set = Node.create({
         };
     },
 
-    addKeyboardShortcuts() {
-        const shortcuts = {};
-        const type = this.type;
-
-        const isSetSelected = (state) => {
-            const { selection } = state;
-            return selection instanceof NodeSelection && selection.node.type === type;
-        };
-
-        const blockCharacterKey = () => isSetSelected(this.editor.state);
-
-        // Letters a-z
-        for (let i = 97; i <= 122; i++) {
-            shortcuts[String.fromCharCode(i)] = blockCharacterKey;
-        }
-
-        // Numbers 0-9
-        for (let i = 0; i <= 9; i++) {
-            shortcuts[String(i)] = blockCharacterKey;
-        }
-
-        // Common punctuation/symbols
-        [' ', '-', '=', '[', ']', '\\', ';', "'", ',', '.', '/', '`'].forEach(
-            (key) => (shortcuts[key] = blockCharacterKey),
-        );
-
-        return shortcuts;
-    },
-
     addProseMirrorPlugins() {
         const bard = this.options.bard;
         const type = this.type;
@@ -115,6 +86,21 @@ export const Set = Node.create({
             return found;
         };
         return [
+            new Plugin({
+                key: new PluginKey('setBlockCharacterInput'),
+                props: {
+                    handleKeyDown(view, event) {
+                        const { selection } = view.state;
+                        if (!(selection instanceof NodeSelection) || selection.node.type !== type) return false;
+
+                        const key = event.key;
+                        if (['Backspace', 'Delete', 'Enter', 'Escape', 'Tab'].includes(key)) return false;
+                        if (key.length === 1) return true;
+
+                        return false;
+                    },
+                },
+            }),
             new Plugin({
                 key: new PluginKey('setSelectionDecorator'),
                 props: {

--- a/resources/js/components/fieldtypes/bard/Set.js
+++ b/resources/js/components/fieldtypes/bard/Set.js
@@ -1,5 +1,5 @@
 import { Node } from '@tiptap/core';
-import { Plugin, PluginKey } from '@tiptap/pm/state';
+import { Plugin, PluginKey, NodeSelection } from '@tiptap/pm/state';
 import { Slice, Fragment } from '@tiptap/pm/model';
 import { Decoration, DecorationSet } from '@tiptap/pm/view';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
@@ -73,6 +73,35 @@ export const Set = Node.create({
                     }
                 },
         };
+    },
+
+    addKeyboardShortcuts() {
+        const shortcuts = {};
+        const type = this.type;
+
+        const isSetSelected = (state) => {
+            const { selection } = state;
+            return selection instanceof NodeSelection && selection.node.type === type;
+        };
+
+        const blockCharacterKey = () => isSetSelected(this.editor.state);
+
+        // Letters a-z
+        for (let i = 97; i <= 122; i++) {
+            shortcuts[String.fromCharCode(i)] = blockCharacterKey;
+        }
+
+        // Numbers 0-9
+        for (let i = 0; i <= 9; i++) {
+            shortcuts[String(i)] = blockCharacterKey;
+        }
+
+        // Common punctuation/symbols
+        [' ', '-', '=', '[', ']', '\\', ';', "'", ',', '.', '/', '`'].forEach(
+            (key) => (shortcuts[key] = blockCharacterKey),
+        );
+
+        return shortcuts;
     },
 
     addProseMirrorPlugins() {


### PR DESCRIPTION
This pull request fixes an issue where pressing any character key while a Bard set is selected would delete the set.

This was happening because TipTap/ProseMirror's default behavior for selected nodes is to replace them when typing.

This PR fixes it by adding keyboard shortcuts that intercept printable character keys (letters, numbers, punctuation) when a set node is selected, preventing accidental deletion.

Backspace and Delete keys still work normally for intentional removal.

---

Partially fixes #14185