### PR TITLE
[6.x] Update bulk action selections when individual row is deleted

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,6 +14,7 @@ import FullscreenHeader from '@/components/publish/FullscreenHeader.vue';
 import Portal from '@/components/portals/Portal.vue';
 import PortalTargets from '@/components/portals/PortalTargets.vue';
 import {keys, portals, slug, stacks} from '@api';
+import useGlobalEventBus from '@/composables/global-event-bus';
 
 // Intercept Inertia navigation and log to Actions tab.
 router.on('before', (event) => {
@@ -46,6 +47,7 @@ setup(async (app) => {
               //
           }
       },
+      $events: useGlobalEventBus(),
       $progress: {
           loading(name, loading) {
               //

--- a/resources/js/bootstrap/App.vue
+++ b/resources/js/bootstrap/App.vue
@@ -49,6 +49,10 @@ export default {
                 document.body.querySelectorAll(`img[src='${url}']`).forEach((img) => (img.src = url));
             });
         });
+
+        Statamic.$callbacks.add('removeFromSelections', function (ids) {
+            Statamic.$events.$emit('removeFromSelections', ids);
+        });
     },
 
     methods: {

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -237,6 +237,10 @@ watch(
     }
 );
 
+const removeFromSelections = (ids) => selections.value = selections.value.filter(selection => !ids.includes(selection));
+Statamic.$events.$on('removeFromSelections', removeFromSelections);
+onBeforeUnmount(() => Statamic.$events.$off('removeFromSelections', removeFromSelections));
+
 const rawParameters = computed(() => ({
     page: currentPage.value,
     perPage: perPage.value,

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -86,7 +86,10 @@ class Delete extends Action
             }
         }
 
-        return trans_choice('Item deleted|Items deleted', $total);
+        return [
+            'message' => trans_choice('Item deleted|Items deleted', $total),
+            'callback' => ['removeFromSelections', $items->map->id()],
+        ];
     }
 
     public function redirect($items, $values)

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -88,7 +88,9 @@ class Delete extends Action
 
         return [
             'message' => trans_choice('Item deleted|Items deleted', $total),
-            'callback' => ['removeFromSelections', $items->map->id()],
+            'callback' => [
+                'removeFromSelections', $items->map(fn ($item) => method_exists($item, 'id') ? $item->id() : null),
+            ],
         ];
     }
 

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -89,7 +89,10 @@ class Delete extends Action
         return [
             'message' => trans_choice('Item deleted|Items deleted', $total),
             'callback' => [
-                'removeFromSelections', $items->map(fn ($item) => method_exists($item, 'id') ? $item->id() : null),
+                'removeFromSelections', $items
+                    ->map(fn ($item) => method_exists($item, 'id') ? $item->id() : null)
+                    ->filter()
+                    ->values(),
             ],
         ];
     }

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -86,14 +86,14 @@ class Delete extends Action
             }
         }
 
+        $ids = $items
+            ->map(fn ($item) => method_exists($item, 'id') ? $item->id() : null)
+            ->filter()
+            ->values();
+
         return [
             'message' => trans_choice('Item deleted|Items deleted', $total),
-            'callback' => [
-                'removeFromSelections', $items
-                    ->map(fn ($item) => method_exists($item, 'id') ? $item->id() : null)
-                    ->filter()
-                    ->values(),
-            ],
+            'callback' => $ids->isNotEmpty() ? ['removeFromSelections', $ids] : null,
         ];
     }
 


### PR DESCRIPTION
This pull request ensures the bulk action selections are updated when the "Delete" action is run on an individual row, fixing an issue where the "Deselect x items" counter becomes out-of-date.

Fixes #14188
