### PR TITLE
[6.x] Acquire stache-warming lock in Duplicates::find

### DIFF
--- a/src/Stache/Duplicates.php
+++ b/src/Stache/Duplicates.php
@@ -79,12 +79,16 @@ class Duplicates
 
     public function find()
     {
+        $lock = tap($this->stache->lock('stache-warming'))->acquire(true);
+
         $this->stache->stores()->flatMap(function ($store) {
             return $store instanceof AggregateStore ? $store->discoverStores() : [$store];
         })->each(function ($store) {
             $store->clearCachedPaths();
             $store->paths();
         });
+
+        $lock->release();
 
         return $this;
     }

--- a/tests/Stache/DuplicatesTest.php
+++ b/tests/Stache/DuplicatesTest.php
@@ -192,8 +192,13 @@ class DuplicatesTest extends TestCase
         $store3 = $this->mock(AggregateStore::class);
         $store3->shouldReceive('discoverStores')->once()->andReturn([$childStore]);
 
+        $lock = $this->mock(\Symfony\Component\Lock\LockInterface::class);
+        $lock->shouldReceive('acquire')->with(true)->once()->andReturnSelf();
+        $lock->shouldReceive('release')->once();
+
         $stache = $this->mock(Stache::class);
         $stache->shouldReceive('stores')->andReturn(collect([$store1, $store2, $store3]));
+        $stache->shouldReceive('lock')->with('stache-warming')->once()->andReturn($lock);
 
         $duplicates = (new Duplicates($stache));
 

--- a/tests/Stache/DuplicatesTest.php
+++ b/tests/Stache/DuplicatesTest.php
@@ -193,7 +193,7 @@ class DuplicatesTest extends TestCase
         $store3->shouldReceive('discoverStores')->once()->andReturn([$childStore]);
 
         $lock = $this->mock(\Symfony\Component\Lock\LockInterface::class);
-        $lock->shouldReceive('acquire')->with(true)->once()->andReturnSelf();
+        $lock->shouldReceive('acquire')->with(true)->once()->andReturnTrue();
         $lock->shouldReceive('release')->once();
 
         $stache = $this->mock(Stache::class);


### PR DESCRIPTION
`Duplicates::find()` clears all store paths and rebuilds them from the filesystem without acquiring the stache-warming lock. Concurrent requests can encounter an inconsistent cache state during the rebuild, leading to cascading errors like "Call to a member function sites() on null".

This fix uses the same lock as `Stache::warm()`.

v5 Backport is already merged: https://github.com/statamic/cms/pull/14176