### PR TITLE
[6.x] Refresh CodeMirror instance when switching tabs

### DIFF
--- a/resources/js/components/ui/CodeEditor.vue
+++ b/resources/js/components/ui/CodeEditor.vue
@@ -1,6 +1,6 @@
 <script setup>
 import CodeMirror from 'codemirror';
-import { computed, markRaw, nextTick, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue';
+import { computed, markRaw, nextTick, onBeforeUnmount, onMounted, ref, useAttrs, useTemplateRef, watch } from 'vue';
 import Select from './Select/Select.vue';
 import { colorMode as colorModeApi } from '@api';
 
@@ -99,6 +99,7 @@ const modes = ref([
 const codemirror = ref(null);
 const codemirrorElement = useTemplateRef('codemirrorElement');
 const fullScreenMode = ref(false);
+const visibilityObserver = ref(null);
 
 defineOptions({
     inheritAttrs: false,
@@ -110,7 +111,14 @@ defineExpose({
 });
 
 onMounted(() => {
-    nextTick(() => initCodeMirror());
+    nextTick(() => {
+        initCodeMirror();
+        initVisibilityObserver();
+    });
+});
+
+onBeforeUnmount(() => {
+    visibilityObserver.value?.disconnect();
 });
 
 function initCodeMirror() {
@@ -147,6 +155,21 @@ function initCodeMirror() {
             codemirror.value.getInputField().blur();
         }
     });
+}
+
+function initVisibilityObserver() {
+    visibilityObserver.value = new IntersectionObserver(
+        (entries) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    codemirror.value?.refresh();
+                }
+            });
+        },
+        { threshold: 0.01 },
+    );
+
+    visibilityObserver.value.observe(codemirrorElement.value);
 }
 
 watch(

--- a/resources/js/components/ui/CodeEditor.vue
+++ b/resources/js/components/ui/CodeEditor.vue
@@ -119,6 +119,11 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
     visibilityObserver.value?.disconnect();
+
+    if (codemirror.value) {
+        codemirror.value.getWrapperElement().remove();
+        codemirror.value = null;
+    }
 });
 
 function initCodeMirror() {


### PR DESCRIPTION
This pull request fixes an issue where the Code field doesn't render correctly when placed in a tab other than the main one. The field appears empty when switching to the tab, and focusing into it causes the content to be superimposed on the line numbers.

This was happening because CodeMirror initializes when the component is mounted, but if the element is hidden (in a non-active tab), it can't calculate its dimensions correctly. When the tab becomes visible, CodeMirror doesn't know it needs to recalculate its layout.

This PR fixes it by adding an `IntersectionObserver` to detect when the editor becomes visible and calling refresh() on the CodeMirror instance to recalculate its dimensions. It also adds proper cleanup of the CodeMirror instance in `onBeforeUnmount`.

## Before


https://github.com/user-attachments/assets/8b700f77-84a9-4c3d-89a1-0d5761701c94



## After


https://github.com/user-attachments/assets/3aa2179a-cf33-4df2-9464-7bbd658f9992


---

Fixes #14194