### PR TITLE
[6.x] Critical updates visibility

### DIFF
--- a/resources/js/components/UpdatesBadge.vue
+++ b/resources/js/components/UpdatesBadge.vue
@@ -1,12 +1,13 @@
 <template>
-    <Badge v-if="count" :text="String(count)" color="amber" size="sm" pill />
+    <Badge v-if="count" :text="String(count)" :color="critical ? 'red' : 'amber'" size="sm" pill />
 </template>
 
 <script>
 import { ref } from 'vue';
 import { Badge } from '@/components/ui';
 
-const count = ref(null);
+const countRef = ref(null);
+const criticalRef = ref(false);
 const requested = ref(false);
 
 export default {
@@ -16,7 +17,10 @@ export default {
 
     computed: {
         count() {
-            return count.value;
+            return countRef.value;
+        },
+        critical() {
+            return criticalRef.value;
         },
     },
 
@@ -30,7 +34,10 @@ export default {
 
             this.$axios
                 .get(cp_url('updater/count'))
-                .then((response) => (count.value = !isNaN(response.data) ? response.data : 0));
+                .then((response) => {
+                    countRef.value = response.data.count;
+                    criticalRef.value = response.data.critical;
+                });
 
             requested.value = true;
         },

--- a/resources/js/components/UpdatesBadge.vue
+++ b/resources/js/components/UpdatesBadge.vue
@@ -35,8 +35,8 @@ export default {
             this.$axios
                 .get(cp_url('updater/count'))
                 .then((response) => {
-                    countRef.value = response.data.count;
-                    criticalRef.value = response.data.critical;
+                    countRef.value = response.data?.count ?? 0;
+                    criticalRef.value = response.data?.critical ?? false;
                 });
 
             requested.value = true;

--- a/resources/js/components/updater/Release.vue
+++ b/resources/js/components/updater/Release.vue
@@ -2,7 +2,10 @@
     <ui-panel>
         <ui-panel-header class="flex items-center justify-between">
             <div>
-                <ui-heading :text="release.version" />
+                <div class="flex items-center gap-2">
+                    <ui-heading :text="release.version" />
+                    <ui-badge v-if="release.critical" :text="__('Critical')" color="red" size="sm" />
+                </div>
                 <ui-subheading :text="`${__('Released on :date', { date })}`" />
             </div>
             <ui-modal :title="__('Update to :version', { version: release.version })" blur>

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -2,8 +2,10 @@
     <div class="max-w-page mx-auto">
         <ui-header :title="name" icon="updates">
             <template v-if="!gettingChangelog" #actions>
-                <ui-badge :prepend="__('Version')" :text="currentVersion" :color="onLatestVersion ? 'green' : 'amber'" size="lg" />
-                <div v-if="onLatestVersion" v-text="__('Up to date')" />
+                {{ currentVersion }}
+                <ui-badge v-if="onLatestVersion" :text="__('Up to date')" color="green" size="lg" icon="checkmark" />
+                <ui-badge v-else-if="criticalUpdateAvailable" :text="__('Critical update available')" color="red" size="lg" icon="alert-warning-exclamation-mark" />
+                <ui-badge v-else :text="__('Update available')" color="amber" size="lg" icon="alert-warning-exclamation-mark" />
             </template>
         </ui-header>
 
@@ -91,6 +93,12 @@ export default {
 
         onLatestVersion() {
             return this.currentVersion && this.currentVersion == this.latestVersion;
+        },
+
+        criticalUpdateAvailable() {
+            return this.currentVersion && this.changelog
+                .filter((release) => release.type === 'upgrade')
+                .some((release) => release.critical);
         },
 
         licensedReleases() {

--- a/resources/js/components/updater/UpdaterWidget.vue
+++ b/resources/js/components/updater/UpdaterWidget.vue
@@ -18,10 +18,12 @@ defineProps({
                             <Link :href="update.url" class="flex items-center gap-2" v-text="update.name" />
                         </td>
                         <td>
-                            <Badge pill :color="update.critical ? 'red' : 'amber'" :text="update.count" />
-                            <div class="inline-flex" v-tooltip="__('Critical')">
-                                <Icon v-if="update.critical" name="warning-diamond" color="red" />
-                            </div>
+                            <Badge
+                                pill
+                                :text="update.count"
+                                :color="update.critical ? 'red' : 'amber'"
+                                v-tooltip="update.critical ? __('Critical update available') : null"
+                            />
                         </td>
                     </tr>
                 </table>

--- a/resources/js/pages/updater/Index.vue
+++ b/resources/js/pages/updater/Index.vue
@@ -2,15 +2,22 @@
 import { Link } from '@inertiajs/vue3';
 import Head from '@/pages/layout/Head.vue';
 import { Header, Card, Panel, Table, TableRow, TableCell, Badge, Heading, Button, DocsCallout, CommandPaletteItem } from '@ui';
+import { computed } from 'vue';
 
-defineProps(['requestError', 'statamic', 'addons']);
+const props = defineProps(['requestError', 'statamic', 'addons']);
+
+const criticalUpdateAvailable = computed(() => props.statamic.critical || props.addons.some(addon => addon.critical));
 </script>
 
 <template>
     <Head :title="__('Updates')" />
 
     <div class="max-w-page mx-auto">
-        <Header :title="__('Updates')" icon="updates" />
+        <Header :title="__('Updates')" icon="updates">
+            <template #actions>
+                <Badge v-if="criticalUpdateAvailable" :text="__('Critical update available')" color="red" size="lg" icon="alert-warning-exclamation-mark" />
+            </template>
+        </Header>
 
         <Card v-if="requestError" class="w-full space-y-4 flex items-center justify-between">
             <Heading size="lg" class="mb-0!" :text="__('statamic::messages.outpost_issue_try_later')" icon="warning-diamond" />

--- a/resources/js/pages/updater/Index.vue
+++ b/resources/js/pages/updater/Index.vue
@@ -38,7 +38,11 @@ defineProps(['requestError', 'statamic', 'addons']);
                             </TableCell>
                             <TableCell>{{ statamic.currentVersion }}</TableCell>
                             <TableCell v-if="statamic.availableUpdatesCount" class="text-right">
-                                <Badge size="sm" color="amber">{{ __n('1 update|:count updates', statamic.availableUpdatesCount) }}</Badge>
+                                <Badge
+                                    size="sm"
+                                    :text="__n('1 update|:count updates', statamic.availableUpdatesCount)"
+                                    :color="statamic.critical ? 'red' : 'amber'"
+                                />
                             </TableCell>
                             <TableCell v-else class="text-right">{{ __('Up to date') }}</TableCell>
                         </TableRow>
@@ -63,7 +67,11 @@ defineProps(['requestError', 'statamic', 'addons']);
                             </TableCell>
                             <TableCell>{{ addon.version }}</TableCell>
                             <TableCell v-if="addon.availableUpdatesCount" class="text-right">
-                                <Badge size="sm" color="amber">{{ __n('1 update|:count updates', addon.availableUpdatesCount) }}</Badge>
+                                <Badge
+                                    size="sm"
+                                    :text="__n('1 update|:count updates', addon.availableUpdatesCount)"
+                                    :color="addon.critical ? 'red' : 'amber'"
+                                />
                             </TableCell>
                             <TableCell v-else class="text-right">{{ __('Up to date') }}</TableCell>
                         </TableRow>

--- a/resources/views/nav/updates.blade.php
+++ b/resources/views/nav/updates.blade.php
@@ -1,5 +1,5 @@
 <li>
-    <inertia-link href="{{ $item->url() }}" class="flex items-centerb gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
+    <inertia-link href="{{ $item->url() }}" class="flex items-center gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
         @cp_svg('icons/updates', 'size-4 shrink-0')
         <span v-pre>{{ __($item->name()) }}</span>
         <updates-badge class="-ml-1.5"></updates-badge>

--- a/src/Http/Controllers/CP/Updater/UpdaterController.php
+++ b/src/Http/Controllers/CP/Updater/UpdaterController.php
@@ -50,6 +50,6 @@ class UpdaterController extends CpController
     {
         $this->authorize('view updates');
 
-        return UpdatesOverview::count();
+        return UpdatesOverview::badge();
     }
 }

--- a/src/Http/Controllers/CP/Updater/UpdaterController.php
+++ b/src/Http/Controllers/CP/Updater/UpdaterController.php
@@ -33,12 +33,14 @@ class UpdaterController extends CpController
             'statamic' => [
                 'currentVersion' => $changelog->currentVersion(),
                 'availableUpdatesCount' => $changelog->availableUpdatesCount(),
+                'critical' => $changelog->hasCriticalUpdate(),
             ],
             'addons' => $addons->filter->existsOnMarketplace()->map(fn ($addon) => [
                 'name' => $addon->name(),
                 'slug' => $addon->slug(),
                 'version' => $addon->version(),
                 'availableUpdatesCount' => $addon->changelog()->availableUpdatesCount(),
+                'critical' => $addon->changelog()->hasCriticalUpdate(),
             ])->values()->all(),
         ]);
     }

--- a/src/Updater/Changelog.php
+++ b/src/Updater/Changelog.php
@@ -70,6 +70,7 @@ abstract class Changelog
                 'licensed' => $this->isLicensed($release['version']),
                 'date' => Carbon::parse($release['date'])->toIso8601String(),
                 'body' => $release['changelog'],
+                'critical' => $release['critical'] ?? false,
             ];
         });
     }

--- a/src/Updater/Changelog.php
+++ b/src/Updater/Changelog.php
@@ -88,6 +88,18 @@ abstract class Changelog
     }
 
     /**
+     * Check if any available upgrade is marked as critical.
+     *
+     * @return bool
+     */
+    public function hasCriticalUpdate()
+    {
+        return $this->get()->contains(function ($release) {
+            return $release->type === 'upgrade' && $release->critical;
+        });
+    }
+
+    /**
      * Get latest release.
      *
      * @return \stdClass

--- a/src/Updater/UpdatesOverview.php
+++ b/src/Updater/UpdatesOverview.php
@@ -122,6 +122,8 @@ class UpdatesOverview
             ->values()
             ->all();
 
+        $this->count += count($this->addons);
+
         return $this;
     }
 

--- a/src/Updater/UpdatesOverview.php
+++ b/src/Updater/UpdatesOverview.php
@@ -15,6 +15,7 @@ class UpdatesOverview
 
     protected $count;
     protected $statamic;
+    protected $critical;
     protected $addons;
 
     /**
@@ -45,6 +46,29 @@ class UpdatesOverview
     public function updatableAddons()
     {
         return $this->getCached('updates-overview.addons');
+    }
+
+    /**
+     * Check if a critical update is available (Statamic or any addon).
+     *
+     * @return bool
+     */
+    public function hasCriticalUpdate()
+    {
+        return $this->getCached('updates-overview.critical');
+    }
+
+    /**
+     * Get badge data (count and whether there is a critical update).
+     *
+     * @return array{count: int, critical: bool}
+     */
+    public function badge()
+    {
+        return [
+            'count' => $this->count(),
+            'critical' => $this->hasCriticalUpdate(),
+        ];
     }
 
     /**
@@ -83,6 +107,7 @@ class UpdatesOverview
     {
         $this->count = 0;
         $this->statamic = false;
+        $this->critical = false;
         $this->addons = [];
 
         return $this;
@@ -106,6 +131,10 @@ class UpdatesOverview
             $this->count++;
         }
 
+        if ($this->statamic && Marketplace::statamic()->changelog()->hasCriticalUpdate()) {
+            $this->critical = true;
+        }
+
         return $this;
     }
 
@@ -116,12 +145,16 @@ class UpdatesOverview
      */
     protected function checkForAddonUpdates()
     {
-        $this->addons = Addon::all()
-            ->reject->isLatestVersion()
-            ->map->id()
-            ->values()
-            ->all();
+        $updatableAddons = Addon::all()->reject->isLatestVersion();
 
+        foreach ($updatableAddons as $addon) {
+            if ($addon->changelog()->hasCriticalUpdate()) {
+                $this->critical = true;
+                break;
+            }
+        }
+
+        $this->addons = $updatableAddons->map->id()->values()->all();
         $this->count += count($this->addons);
 
         return $this;
@@ -138,6 +171,7 @@ class UpdatesOverview
 
         Cache::put('updates-overview.count', $this->count, $expiry);
         Cache::put('updates-overview.statamic', $this->statamic, $expiry);
+        Cache::put('updates-overview.critical', $this->critical, $expiry);
         Cache::put('updates-overview.addons', $this->addons, $expiry);
 
         return $this;

--- a/src/Widgets/Updater.php
+++ b/src/Widgets/Updater.php
@@ -18,19 +18,22 @@ class Updater extends Widget
         $items = collect(UpdatesOverview::updatableAddons())->map(function ($id) {
             $addon = Addon::get($id);
 
+            $changelog = $addon->changelog();
+
             return [
                 'name' => $addon->name(),
-                'count' => $addon->changelog()->availableUpdatesCount(),
-                'critical' => false,
+                'count' => $changelog->availableUpdatesCount(),
+                'critical' => $changelog->hasCriticalUpdate(),
                 'url' => cp_route('updater.product', $addon->slug()),
             ];
         });
 
         if (UpdatesOverview::hasStatamicUpdate()) {
+            $changelog = Marketplace::statamic()->changelog();
             $items->push([
                 'name' => 'Statamic Core',
-                'count' => Marketplace::statamic()->changelog()->availableUpdatesCount(),
-                'critical' => false,
+                'count' => $changelog->availableUpdatesCount(),
+                'critical' => $changelog->hasCriticalUpdate(),
                 'url' => cp_route('updater.product', 'statamic'),
             ]);
         }

--- a/tests/Composer/ChangelogTests.php
+++ b/tests/Composer/ChangelogTests.php
@@ -22,6 +22,7 @@ trait ChangelogTests
 
         $this->assertCount(5, $contents);
         $this->assertEquals(3, $changelog->availableUpdatesCount());
+        $this->assertFalse($changelog->hasCriticalUpdate());
 
         $this->assertEquals('2.0.0', $contents[0]->version);
         $this->assertEquals('upgrade', $contents[0]->type);
@@ -80,6 +81,38 @@ trait ChangelogTests
 
         $this->assertSame([true, false, false, true, false], collect($contents)->map->critical->all());
         $this->assertTrue($this->changelog()->latest()->critical);
+        $this->assertTrue($this->changelog()->hasCriticalUpdate());
+    }
+
+    #[Test]
+    public function has_critical_update_false_when_no_upgrades_are_critical()
+    {
+        Client::shouldReceive('request')
+            ->andReturn($this->fakeMarketplaceReleasesResponse([
+                ['version' => '1.0.3', 'critical' => false],
+                ['version' => '1.0.2', 'critical' => false],
+                ['version' => '1.0.1', 'critical' => true], // current
+                ['version' => '1.0.0', 'critical' => true],
+            ]));
+
+        $this->assertFalse($this->changelog()->hasCriticalUpdate());
+    }
+
+    #[Test]
+    public function has_critical_update_true_when_upgrades_are_critical()
+    {
+        // An upgrade is marked as critical but intentionally not the latest.
+        // This ensures that we are checking for ANY upgrades and not just the latest.
+
+        Client::shouldReceive('request')
+            ->andReturn($this->fakeMarketplaceReleasesResponse([
+                ['version' => '1.0.3', 'critical' => false],
+                ['version' => '1.0.2', 'critical' => true],
+                ['version' => '1.0.1', 'critical' => false], // current
+                ['version' => '1.0.0', 'critical' => false],
+            ]));
+
+        $this->assertTrue($this->changelog()->hasCriticalUpdate());
     }
 
     private function fakeCoreChangelogResponse($versions)

--- a/tests/Composer/ChangelogTests.php
+++ b/tests/Composer/ChangelogTests.php
@@ -46,6 +46,7 @@ trait ChangelogTests
         collect($contents)->each(function ($release) {
             $this->assertEquals('2018-11-06T00:00:00+00:00', $release->date);
             $this->assertIsString($release->body);
+            $this->assertFalse($release->critical);
         });
     }
 
@@ -60,6 +61,25 @@ trait ChangelogTests
         $this->assertEquals('1.0.2', $latest->version);
         $this->assertEquals('upgrade', $latest->type);
         $this->assertTrue($latest->latest);
+        $this->assertFalse($latest->critical);
+    }
+
+    #[Test]
+    public function it_exposes_critical_flag_from_marketplace()
+    {
+        Client::shouldReceive('request')
+            ->andReturn($this->fakeMarketplaceReleasesResponse([
+                ['version' => '2.0.0', 'critical' => true],
+                ['version' => '1.0.3', 'critical' => false],
+                '1.0.2',
+                ['version' => '1.0.1', 'critical' => true],
+                '1.0.0',
+            ]));
+
+        $contents = $this->changelog()->get();
+
+        $this->assertSame([true, false, false, true, false], collect($contents)->map->critical->all());
+        $this->assertTrue($this->changelog()->latest()->critical);
     }
 
     private function fakeCoreChangelogResponse($versions)
@@ -78,11 +98,16 @@ trait ChangelogTests
 
     private function fakeReleasesData($versions)
     {
-        return collect($versions)->map(function ($version) {
+        return collect($versions)->map(function ($release) {
+            if (is_string($release)) {
+                $release = ['version' => $release];
+            }
+
             return [
-                'version' => $version,
+                'version' => $release['version'],
                 'date' => '2018-11-06',
                 'changelog' => '- [new] Stuff.',
+                'critical' => $release['critical'] ?? false,
             ];
         })->all();
     }

--- a/tests/Updater/UpdatesOverviewTest.php
+++ b/tests/Updater/UpdatesOverviewTest.php
@@ -26,6 +26,7 @@ class UpdatesOverviewTest extends TestCase
     {
         Cache::forget('updates-overview.count');
         Cache::forget('updates-overview.statamic');
+        Cache::forget('updates-overview.critical');
         Cache::forget('updates-overview.addons');
     }
 
@@ -38,12 +39,28 @@ class UpdatesOverviewTest extends TestCase
     public function it_shows_statamic_update()
     {
         $this->setDefaultVersion();
-        $this->mockMarketplaceStatamicChangelogLatest('upgrade');
+        $this->mockMarketplaceStatamicChangelog('upgrade');
         Addon::shouldReceive('all')->andReturn(collect());
 
         $overview = new UpdatesOverview;
 
         $this->assertSame(1, $overview->count());
+        $this->assertSame(['count' => 1, 'critical' => false], $overview->badge());
+        $this->assertTrue($overview->hasStatamicUpdate());
+        $this->assertSame([], $overview->updatableAddons());
+    }
+
+    #[Test]
+    public function it_shows_critical_statamic_update()
+    {
+        $this->setDefaultVersion();
+        $this->mockMarketplaceStatamicChangelog('upgrade', hasCriticalUpdate: true);
+        Addon::shouldReceive('all')->andReturn(collect());
+
+        $overview = new UpdatesOverview;
+
+        $this->assertSame(1, $overview->count());
+        $this->assertSame(['count' => 1, 'critical' => true], $overview->badge());
         $this->assertTrue($overview->hasStatamicUpdate());
         $this->assertSame([], $overview->updatableAddons());
     }
@@ -52,7 +69,7 @@ class UpdatesOverviewTest extends TestCase
     public function it_shows_no_statamic_update()
     {
         $this->setDefaultVersion();
-        $this->mockMarketplaceStatamicChangelogLatest('current');
+        $this->mockMarketplaceStatamicChangelog('current');
         Addon::shouldReceive('all')->andReturn(collect());
 
         $overview = new UpdatesOverview;
@@ -67,7 +84,7 @@ class UpdatesOverviewTest extends TestCase
     public function it_does_not_increment_count_or_offer_statamic_update_for_dev_versions(string $version)
     {
         Version::shouldReceive('get')->andReturn($version);
-        $this->mockMarketplaceStatamicChangelogLatest('upgrade');
+        $this->mockMarketplaceStatamicChangelog('upgrade');
         Addon::shouldReceive('all')->andReturn(collect());
 
         $overview = new UpdatesOverview;
@@ -89,15 +106,34 @@ class UpdatesOverviewTest extends TestCase
     public function it_shows_addon_updates()
     {
         $this->setDefaultVersion();
-        $this->mockMarketplaceStatamicChangelogLatest('current');
-        $addon1 = $this->mockAddon('vendor/one', isLatestVersion: false);
-        $addon2 = $this->mockAddon('vendor/two', isLatestVersion: true);
-        $addon3 = $this->mockAddon('vendor/three', isLatestVersion: false);
+        $this->mockMarketplaceStatamicChangelog('current');
+        $addon1 = $this->mockAddon('vendor/one', isLatestVersion: false, hasCriticalUpdate: false);
+        $addon2 = $this->mockAddon('vendor/two', isLatestVersion: true, hasCriticalUpdate: false);
+        $addon3 = $this->mockAddon('vendor/three', isLatestVersion: false, hasCriticalUpdate: false);
         Addon::shouldReceive('all')->andReturn(collect([$addon1, $addon2, $addon3]));
 
         $overview = new UpdatesOverview;
 
         $this->assertSame(2, $overview->count());
+        $this->assertSame(['count' => 2, 'critical' => false], $overview->badge());
+        $this->assertFalse($overview->hasStatamicUpdate());
+        $this->assertSame(['vendor/one', 'vendor/three'], $overview->updatableAddons());
+    }
+
+    #[Test]
+    public function it_shows_critical_addon_updates()
+    {
+        $this->setDefaultVersion();
+        $this->mockMarketplaceStatamicChangelog('current');
+        $addon1 = $this->mockAddon('vendor/one', isLatestVersion: false, hasCriticalUpdate: false);
+        $addon2 = $this->mockAddon('vendor/two', isLatestVersion: true, hasCriticalUpdate: true);
+        $addon3 = $this->mockAddon('vendor/three', isLatestVersion: false, hasCriticalUpdate: false);
+        Addon::shouldReceive('all')->andReturn(collect([$addon1, $addon2, $addon3]));
+
+        $overview = new UpdatesOverview;
+
+        $this->assertSame(2, $overview->count());
+        $this->assertSame(['count' => 2, 'critical' => true], $overview->badge());
         $this->assertFalse($overview->hasStatamicUpdate());
         $this->assertSame(['vendor/one', 'vendor/three'], $overview->updatableAddons());
     }
@@ -107,10 +143,12 @@ class UpdatesOverviewTest extends TestCase
     {
         $cachedCount = 2;
         $cachedStatamic = true;
+        $cachedCritical = true;
         $cachedAddons = ['vendor/one', 'vendor/two'];
 
         Cache::forever('updates-overview.count', $cachedCount);
         Cache::forever('updates-overview.statamic', $cachedStatamic);
+        Cache::forever('updates-overview.critical', $cachedCritical);
         Cache::forever('updates-overview.addons', $cachedAddons);
 
         Marketplace::shouldReceive('statamic')->never();
@@ -120,26 +158,30 @@ class UpdatesOverviewTest extends TestCase
 
         $this->assertSame($cachedCount, $overview->count());
         $this->assertSame($cachedStatamic, $overview->hasStatamicUpdate());
+        $this->assertSame($cachedCritical, $overview->hasCriticalUpdate());
         $this->assertSame($cachedAddons, $overview->updatableAddons());
+        $this->assertSame(['count' => $cachedCount, 'critical' => $cachedCritical], $overview->badge());
     }
 
-    protected function mockMarketplaceStatamicChangelogLatest(string $type): void
+    protected function mockMarketplaceStatamicChangelog(string $latestType, bool $hasCriticalUpdate = false): void
     {
-        $latest = (object) ['type' => $type];
+        $latest = (object) ['type' => $latestType];
         $changelog = \Mockery::mock();
         $changelog->shouldReceive('latest')->andReturn($latest);
+        $changelog->shouldReceive('hasCriticalUpdate')->andReturn($hasCriticalUpdate);
         $statamic = \Mockery::mock();
         $statamic->shouldReceive('changelog')->andReturn($changelog);
         Marketplace::shouldReceive('statamic')->andReturn($statamic);
     }
 
-    protected function mockAddon(string $id, bool $isLatestVersion)
+    protected function mockAddon(string $id, bool $isLatestVersion, bool $hasCriticalUpdate = false)
     {
-        return new class($id, $isLatestVersion)
+        return new class($id, $isLatestVersion, $hasCriticalUpdate)
         {
             public function __construct(
                 private readonly string $addonId,
-                private readonly bool $isLatest
+                private readonly bool $isLatest,
+                private readonly bool $hasCriticalUpdate
             ) {
             }
 
@@ -151,6 +193,14 @@ class UpdatesOverviewTest extends TestCase
             public function isLatestVersion(): bool
             {
                 return $this->isLatest;
+            }
+
+            public function changelog()
+            {
+                $changelog = \Mockery::mock();
+                $changelog->shouldReceive('hasCriticalUpdate')->andReturn($this->hasCriticalUpdate);
+
+                return $changelog;
             }
         };
     }

--- a/tests/Updater/UpdatesOverviewTest.php
+++ b/tests/Updater/UpdatesOverviewTest.php
@@ -125,8 +125,8 @@ class UpdatesOverviewTest extends TestCase
     {
         $this->setDefaultVersion();
         $this->mockMarketplaceStatamicChangelog('current');
-        $addon1 = $this->mockAddon('vendor/one', isLatestVersion: false, hasCriticalUpdate: false);
-        $addon2 = $this->mockAddon('vendor/two', isLatestVersion: true, hasCriticalUpdate: true);
+        $addon1 = $this->mockAddon('vendor/one', isLatestVersion: false, hasCriticalUpdate: true);
+        $addon2 = $this->mockAddon('vendor/two', isLatestVersion: true, hasCriticalUpdate: false);
         $addon3 = $this->mockAddon('vendor/three', isLatestVersion: false, hasCriticalUpdate: false);
         Addon::shouldReceive('all')->andReturn(collect([$addon1, $addon2, $addon3]));
 

--- a/tests/Updater/UpdatesOverviewTest.php
+++ b/tests/Updater/UpdatesOverviewTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Updater;
+
+use Facades\Statamic\Marketplace\Marketplace;
+use Facades\Statamic\Version;
+use Illuminate\Support\Facades\Cache;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Addon;
+use Statamic\Updater\UpdatesOverview;
+use Tests\TestCase;
+
+class UpdatesOverviewTest extends TestCase
+{
+    protected $shouldFakeVersion = false;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->clearUpdatesOverviewCache();
+    }
+
+    protected function clearUpdatesOverviewCache(): void
+    {
+        Cache::forget('updates-overview.count');
+        Cache::forget('updates-overview.statamic');
+        Cache::forget('updates-overview.addons');
+    }
+
+    protected function setDefaultVersion(): void
+    {
+        Version::shouldReceive('get')->andReturn('3.0.0-testing');
+    }
+
+    #[Test]
+    public function it_shows_statamic_update()
+    {
+        $this->setDefaultVersion();
+        $this->mockMarketplaceStatamicChangelogLatest('upgrade');
+        Addon::shouldReceive('all')->andReturn(collect());
+
+        $overview = new UpdatesOverview;
+
+        $this->assertSame(1, $overview->count());
+        $this->assertTrue($overview->hasStatamicUpdate());
+        $this->assertSame([], $overview->updatableAddons());
+    }
+
+    #[Test]
+    public function it_shows_no_statamic_update()
+    {
+        $this->setDefaultVersion();
+        $this->mockMarketplaceStatamicChangelogLatest('current');
+        Addon::shouldReceive('all')->andReturn(collect());
+
+        $overview = new UpdatesOverview;
+
+        $this->assertSame(0, $overview->count());
+        $this->assertFalse($overview->hasStatamicUpdate());
+        $this->assertSame([], $overview->updatableAddons());
+    }
+
+    #[Test]
+    #[DataProvider('devVersionProvider')]
+    public function it_does_not_increment_count_or_offer_statamic_update_for_dev_versions(string $version)
+    {
+        Version::shouldReceive('get')->andReturn($version);
+        $this->mockMarketplaceStatamicChangelogLatest('upgrade');
+        Addon::shouldReceive('all')->andReturn(collect());
+
+        $overview = new UpdatesOverview;
+
+        $this->assertSame(0, $overview->count());
+        $this->assertFalse($overview->hasStatamicUpdate());
+        $this->assertSame([], $overview->updatableAddons());
+    }
+
+    public static function devVersionProvider(): array
+    {
+        return [
+            'version starts with dev' => ['dev-main'],
+            'version ends with dev' => ['3.0.0-dev'],
+        ];
+    }
+
+    #[Test]
+    public function it_shows_addon_updates()
+    {
+        $this->setDefaultVersion();
+        $this->mockMarketplaceStatamicChangelogLatest('current');
+        $addon1 = $this->mockAddon('vendor/one', isLatestVersion: false);
+        $addon2 = $this->mockAddon('vendor/two', isLatestVersion: true);
+        $addon3 = $this->mockAddon('vendor/three', isLatestVersion: false);
+        Addon::shouldReceive('all')->andReturn(collect([$addon1, $addon2, $addon3]));
+
+        $overview = new UpdatesOverview;
+
+        $this->assertSame(2, $overview->count());
+        $this->assertFalse($overview->hasStatamicUpdate());
+        $this->assertSame(['vendor/one', 'vendor/three'], $overview->updatableAddons());
+    }
+
+    #[Test]
+    public function it_returns_cached_values_without_calling_marketplace_or_addons()
+    {
+        $cachedCount = 2;
+        $cachedStatamic = true;
+        $cachedAddons = ['vendor/one', 'vendor/two'];
+
+        Cache::forever('updates-overview.count', $cachedCount);
+        Cache::forever('updates-overview.statamic', $cachedStatamic);
+        Cache::forever('updates-overview.addons', $cachedAddons);
+
+        Marketplace::shouldReceive('statamic')->never();
+        Addon::shouldReceive('all')->never();
+
+        $overview = new UpdatesOverview;
+
+        $this->assertSame($cachedCount, $overview->count());
+        $this->assertSame($cachedStatamic, $overview->hasStatamicUpdate());
+        $this->assertSame($cachedAddons, $overview->updatableAddons());
+    }
+
+    protected function mockMarketplaceStatamicChangelogLatest(string $type): void
+    {
+        $latest = (object) ['type' => $type];
+        $changelog = \Mockery::mock();
+        $changelog->shouldReceive('latest')->andReturn($latest);
+        $statamic = \Mockery::mock();
+        $statamic->shouldReceive('changelog')->andReturn($changelog);
+        Marketplace::shouldReceive('statamic')->andReturn($statamic);
+    }
+
+    protected function mockAddon(string $id, bool $isLatestVersion)
+    {
+        return new class($id, $isLatestVersion)
+        {
+            public function __construct(
+                private readonly string $addonId,
+                private readonly bool $isLatest
+            ) {
+            }
+
+            public function id(): string
+            {
+                return $this->addonId;
+            }
+
+            public function isLatestVersion(): bool
+            {
+                return $this->isLatest;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR makes improvements throughout the Control Panel with regards to critical updates.

Following up from #14175 which makes badges amber when an update is available, this PR makes critical updates appear as red.

_Note that this requires some implementation from statamic.com so you won't see any changes at the moment. This PR just implements it so it'll start working once completed._

The nav item will now be red when there's a critical update:

<p><img width="184" height="120" alt="CleanShot 2026-03-10 at 15 25 35" src="https://github.com/user-attachments/assets/ae9740a4-a129-4557-863a-a8e26e81a020" /></p>

The listing will show a big badge at the top if something has a critical update, and then the items themselves will be red if critical:

<p><img width="694" height="412" alt="CleanShot 2026-03-10 at 15 28 25" src="https://github.com/user-attachments/assets/b08fb3bd-0278-4e54-b261-10646d99af1c" /></p>

Changelog pages will show a big badge at the top, and the individual changelog entry will be marked:

<p><img width="707" height="248" alt="CleanShot 2026-03-10 at 15 29 32" src="https://github.com/user-attachments/assets/cdbedd88-28ea-4f1f-beb3-4f613413f3af" /></p>

The updater dashboard widget:

<p><img width="355" height="313" alt="CleanShot 2026-03-10 at 15 35 12" src="https://github.com/user-attachments/assets/c7a7aacd-97fa-4465-84f9-328041999e95" /></p>
