### PR TITLE
[6.x] Handle CarbonInterval instances in Localize middleware

### DIFF
--- a/src/Http/Middleware/CP/Localize.php
+++ b/src/Http/Middleware/CP/Localize.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Middleware\CP;
 
 use Carbon\CarbonInterface;
+use Carbon\CarbonInterval;
 use Closure;
 use DateTime;
 use Illuminate\Support\Facades\Date;
@@ -24,7 +25,11 @@ class Localize
 
         // Get original Carbon format so it can be restored later.
         $originalToStringFormat = $this->getToStringFormat();
-        Date::setToStringFormat(function (CarbonInterface $date) {
+        Date::setToStringFormat(function (CarbonInterface|CarbonInterval $date) {
+            if ($date instanceof CarbonInterval) {
+                return $date->forHumans();
+            }
+
             return $date->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
         });
 

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Middleware;
 
 use Carbon\CarbonInterface;
+use Carbon\CarbonInterval;
 use Closure;
 use Illuminate\Support\Facades\Date;
 use ReflectionClass;
@@ -32,7 +33,11 @@ class Localize
 
         // Get original Carbon format so it can be restored later.
         $originalToStringFormat = $this->getToStringFormat();
-        Date::setToStringFormat(function (CarbonInterface $date) {
+        Date::setToStringFormat(function (CarbonInterface|CarbonInterval $date) {
+            if ($date instanceof CarbonInterval) {
+                return $date->forHumans();
+            }
+
             return $date->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
         });
 


### PR DESCRIPTION
This pull request fixes an error from the `Localize` middleware(s) when outputting a `CarbonInterval` instance from a Blade view.

Fixes #14203
