### PR TITLE
[6.x] Make stacks smoother

### DIFF
--- a/resources/css/components/stacks.css
+++ b/resources/css/components/stacks.css
@@ -23,11 +23,8 @@
     }
     .stack-container {
         @apply absolute inset-0;
-        transition: left 200ms ease-out;
-
-        [dir='rtl'] & {
-            transition: right 200ms ease-out;
-        }
+        transition: transform 200ms ease-out;
+        -webkit-backface-visibility: hidden;
     }
 
     .stack-overlay {
@@ -69,10 +66,14 @@
 @media all and (max-width: 980px) {
     .stacks-on-stacks .stack-container {
         left: 0 !important;
+        right: 0 !important;
+        width: 100% !important;
+        transform: translateX(0) !important;
 
         [dir='rtl'] & {
-            left: unset !important;
+            left: 0 !important;
             right: 0 !important;
+            transform: translateX(0) !important;
         }
     }
 }

--- a/resources/css/components/stacks.css
+++ b/resources/css/components/stacks.css
@@ -42,6 +42,7 @@
     .stack-slide-enter-active,
     .stack-slide-leave-active {
         transition: transform 200ms ease-out, opacity 200ms ease-out;
+        will-change: transform, opacity;
     }
 
     .stack-slide-enter-from {

--- a/resources/css/components/stacks.css
+++ b/resources/css/components/stacks.css
@@ -42,21 +42,9 @@
         @apply relative h-[calc(100svh-1rem)];
     }
 
-    .stack-overlay-fade-enter-active,
-    .stack-overlay-fade-leave-active {
-        transition: opacity 200ms ease-out;
-        will-change: opacity;
-    }
-
-    .stack-overlay-fade-enter-from,
-    .stack-overlay-fade-leave-to {
-        opacity: 0;
-    }
-
     .stack-slide-enter-active,
     .stack-slide-leave-active {
         transition: transform 200ms ease-out, opacity 200ms ease-out;
-        will-change: transform, opacity;
     }
 
     .stack-slide-enter-from {

--- a/resources/js/components/blueprints/Fields.vue
+++ b/resources/js/components/blueprints/Fields.vue
@@ -34,26 +34,25 @@
             <ui-button icon="add-circle" :text="__('Create Field')" @click="createField" />
         </div>
 
+        <!-- Single stack for picker → settings so selecting a field type swaps content without closing/reopening (no animation). -->
         <Stack
-            v-model:open="isSelectingNewFieldtype"
-            @closed="isSelectingNewFieldtype = false"
-            :title="__('Fieldtypes')"
-            icon="cog"
+            :open="isCreateFieldStackOpen"
+            @update:open="(value) => { if (!value) closeCreateFieldStack() }"
+            @closed="closeCreateFieldStack"
+            :title="isSelectingNewFieldtype ? __('Fieldtypes') : undefined"
+            :icon="isSelectingNewFieldtype ? 'cog' : null"
+            :inset="!!pendingCreatedField"
+            :show-close-button="isSelectingNewFieldtype"
+            :wrap-slot="!pendingCreatedField"
             v-slot="{ close }"
         >
-            <fieldtype-selector @closed="close" @selected="fieldtypeSelected" />
-        </Stack>
-
-        <Stack
-            :open="pendingCreatedField != null"
-            @update:open="(value) => { if (!value) pendingCreatedField = null }"
-            @closed="pendingCreatedField = null"
-            v-slot="{ close }"
-            inset
-            :show-close-button="false"
-            :wrap-slot="false"
-        >
+            <fieldtype-selector
+                v-if="isSelectingNewFieldtype"
+                @closed="onPickerClosed"
+                @selected="fieldtypeSelected"
+            />
             <field-settings
+                v-else-if="pendingCreatedField"
                 ref="settings"
                 :type="pendingCreatedField.config.type"
                 :root="true"
@@ -87,7 +86,7 @@ export default {
         LinkFields,
         FieldtypeSelector,
         FieldSettings,
-	    Stack,
+        Stack,
     },
 
     props: {
@@ -109,6 +108,12 @@ export default {
             isSelectingNewFieldtype: false,
             pendingCreatedField: null,
         };
+    },
+
+    computed: {
+        isCreateFieldStackOpen() {
+            return this.isSelectingNewFieldtype || this.pendingCreatedField != null;
+        },
     },
 
     mounted() {
@@ -141,6 +146,20 @@ export default {
 
         createField() {
             this.isSelectingNewFieldtype = true;
+        },
+
+        closeCreateFieldStack() {
+            this.isSelectingNewFieldtype = false;
+            this.pendingCreatedField = null;
+        },
+
+        // FieldtypeSelector emits 'closed' after 'selected'; only close stack when user cancelled (no selection).
+        onPickerClosed() {
+            if (this.pendingCreatedField == null) {
+                this.closeCreateFieldStack();
+            } else {
+                this.isSelectingNewFieldtype = false;
+            }
         },
 
         fieldCreated(created) {

--- a/resources/js/components/portals/PortalTargets.vue
+++ b/resources/js/components/portals/PortalTargets.vue
@@ -1,24 +1,61 @@
 <template>
-    <div class="portal-targets" :class="{ 'stacks-on-stacks': hasStacks, 'solo-narrow-stack': isSoloNarrowStack }">
+    <div class="portal-targets" :class="{ 'stacks-on-stacks': hasStacks, 'stack-entering': isStackEntering, 'solo-narrow-stack': isSoloNarrowStack }">
         <div v-for="(portal, i) in portals" :key="portal.id" :id="`portal-target-${portal.id}`" />
     </div>
 </template>
 
 <script>
+import { events } from '@/api';
+
 export default {
+    data() {
+        return {
+            isStackEntering: false,
+            stackEnteringTimeout: null,
+        };
+    },
+
     computed: {
         portals() {
             return this.$portals.all();
         },
 
+        stackCount() {
+            return this.$stacks.count();
+        },
+
         hasStacks() {
-            return this.$stacks.count() > 0;
+            return this.stackCount > 0;
         },
 
         isSoloNarrowStack() {
             const stacks = this.$stacks.stacks();
             return stacks.length === 1 && stacks[0]?.data?.vm?.size === 'narrow';
         },
+    },
+
+    watch: {
+        stackCount(newCount, oldCount) {
+            if (newCount <= oldCount) {
+                return;
+            }
+
+            clearTimeout(this.stackEnteringTimeout);
+            this.isStackEntering = true;
+            events.$emit('stacks.entering', true);
+
+            // Match the stack enter transition so CSS can ignore hover effects while a new stack slides in.
+            this.stackEnteringTimeout = setTimeout(() => {
+                this.isStackEntering = false;
+                this.stackEnteringTimeout = null;
+                events.$emit('stacks.entering', false);
+            }, 200);
+        },
+    },
+
+    beforeUnmount() {
+        clearTimeout(this.stackEnteringTimeout);
+        events.$emit('stacks.entering', false);
     },
 };
 </script>

--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -138,7 +138,7 @@ function open() {
     events.$on(`stacks.${depth.value}.hit-area-mouseenter`, () => (isHovering.value = true));
     events.$on(`stacks.${depth.value}.hit-area-mouseout`, () => (isHovering.value = false));
 
-    escBinding.value = keys.bindGlobal('esc', close);
+    escBinding.value = keys.bindGlobal('esc', runCloseCallback);
 
     window.addEventListener('resize', windowResized);
 
@@ -236,7 +236,6 @@ provide('closeStack', close);
                 class="stack-container outline-none"
                 :class="{ 'stack-is-current': isTopStack }"
                 :style="containerStyle"
-                @keydown.esc="isTopStack && runCloseCallback()"
             >
                 <div
                     class="stack-hit-area"

--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -202,6 +202,11 @@ provide('closeStack', close);
     </Primitive>
     <teleport :to="portal" :order="depth" v-if="mounted">
         <div class="vue-portal-target stack">
+            <div
+                class="stack-overlay fixed inset-0 bg-gray-800/20 dark:bg-gray-800/50 transition-opacity duration-200 ease-out"
+                :class="visible ? 'opacity-100' : 'opacity-0'"
+            />
+
             <FocusScope
 	            :trapped="isTopPortal"
 	            loop
@@ -209,14 +214,6 @@ provide('closeStack', close);
                 :class="{ 'stack-is-current': isTopStack }"
                 :style="direction === 'ltr' ? { left: `${leftOffset}px` } : { right: `${leftOffset}px` }"
             >
-                <transition name="stack-overlay-fade">
-                    <div
-                        v-if="visible"
-                        class="stack-overlay fixed inset-0 bg-gray-800/20 dark:bg-gray-800/50"
-                        :style="direction === 'ltr' ? { left: `-${leftOffset}px` } : { right: `-${leftOffset}px` }"
-                    />
-                </transition>
-
                 <div
                     class="stack-hit-area"
                     :style="direction === 'ltr' ? { left: `-${offset}px` } : { right: `-${offset}px` }"

--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -45,6 +45,7 @@ const stack = ref(null);
 const mounted = ref(false);
 const visible = ref(false);
 const isHovering = ref(false);
+const isStackEntering = ref(false);
 const escBinding = ref(null);
 const windowInnerWidth = ref(window.innerWidth);
 
@@ -123,6 +124,13 @@ const mouseOutHitArea = () => {
 };
 
 const windowResized = () => windowInnerWidth.value = window.innerWidth;
+const stackEnteringChanged = (entering) => {
+    isStackEntering.value = entering;
+
+    if (entering) {
+        isHovering.value = false;
+    }
+};
 
 function open() {
     if (!stack.value) stack.value = stacks.add(instance.proxy);
@@ -192,10 +200,13 @@ watch(
 );
 
 onMounted(() => {
+    events.$on('stacks.entering', stackEnteringChanged);
+
 	if (props.open) open();
 });
 
 onBeforeUnmount(() => {
+    events.$off('stacks.entering', stackEnteringChanged);
     cleanup();
 });
 
@@ -241,7 +252,7 @@ provide('closeStack', close);
                         class="stack-content fixed flex flex-col sm:end-1.5 bg-content-bg dark:bg-dark-content-bg overflow-hidden rounded-xl shadow-[0_8px_5px_-6px_rgba(0,0,0,0.1),_0_3px_8px_0_rgba(0,0,0,0.02),_0_30px_22px_-22px_rgba(39,39,42,0.15)] dark:shadow-[0_5px_20px_rgba(0,0,0,.5)] transition-transform duration-200 ease-out will-change-transform"
                         :class="[
                             size === 'full' ? 'inset-2 w-[calc(100svw-1rem)]' : 'inset-y-2',
-                            { '-translate-x-4 rtl:translate-x-4': isHovering }
+                            { '-translate-x-4 rtl:translate-x-4': isHovering && !isStackEntering }
                         ]"
                     >
                         <template v-if="shouldAddHeader">

--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -213,6 +213,7 @@ provide('closeStack', close);
                 class="stack-container outline-none"
                 :class="{ 'stack-is-current': isTopStack }"
                 :style="direction === 'ltr' ? { left: `${leftOffset}px` } : { right: `${leftOffset}px` }"
+                @keydown.esc="isTopStack && runCloseCallback()"
             >
                 <div
                     class="stack-hit-area"

--- a/resources/js/components/ui/Stack/Stack.vue
+++ b/resources/js/components/ui/Stack/Stack.vue
@@ -91,6 +91,18 @@ const leftOffset = computed(() => {
 const hasChild = computed(() => stacks.count() > depth.value);
 const direction = computed(() => config.get('direction', 'ltr'));
 
+const containerStyle = computed(() => {
+    if (props.size === 'full') {
+        return direction.value === 'ltr' ? { left: 0, transform: 'translateZ(0)' } : { right: 0, transform: 'translateZ(0)' };
+    }
+    const x = leftOffset.value;
+    const width = `calc(100% - ${x}px)`;
+    if (direction.value === 'ltr') {
+        return { left: 0, width, transform: `translateX(${x}px) translateZ(0)` };
+    }
+    return { right: 0, width, transform: `translateX(-${x}px) translateZ(0)` };
+});
+
 const clickedHitArea = () => {
     if (!visible.value) return;
     if (!runCloseCallback()) return;
@@ -212,7 +224,7 @@ provide('closeStack', close);
 	            loop
                 class="stack-container outline-none"
                 :class="{ 'stack-is-current': isTopStack }"
-                :style="direction === 'ltr' ? { left: `${leftOffset}px` } : { right: `${leftOffset}px` }"
+                :style="containerStyle"
                 @keydown.esc="isTopStack && runCloseCallback()"
             >
                 <div


### PR DESCRIPTION
## Description of the Problem

I noticed that stack-on-stack performance can degrade when you get a few layers deep and start playing with fields. This is especially noticeable when you open stack layers on a large viewport such as 2560px (5K monitor), where any performance shortcomings are laid bare.

For what it's worth, I'm noticing this on an M2 processor – stacks should perform better than they do on this machine.

## What this PR Does

Fixes overlay performance and flicker by…

- Moves the overlay outside the container
- Animates with `transform` rather than `left`/`right` – transform animations are usually handled by the GPU (compositor layer) and do not trigger layout recalculations.
- Stacks are no longer re-animated when a new field is picked. Picking a new field creates a lot of DOM movement as particular field options are loaded in—this, in addition to shuffling the stacks, seems to create performance issues
- Suppress hover during the new stack’s enter animation, to prevent the previous stack wobbling left then right as the hover effect is removed. This was creating extra movement as the new stack was animating in

- FYI Claude also recommended adding a `@keydown.esc handler for more reliable escape key handling`. I'm not sure about that, so feel free to remove if you disagree.

Here are some demos of before and after on a 27-inch 5K screen, so you can see the performance strains better

### Before Safari

You'll notice it's OK up until the third level deep (where I add a checkbox field)
Safari is particularly sluggish. It doesn't have the same render flashing behaviour that Chrome has, instead it just feels like it's struggling.

https://github.com/user-attachments/assets/56d65d44-32b6-4a42-987b-34fce42a065c

### Before Chrome

You'll notice it's OK up until the third level deep (where I add a checkbox field)
When I close the third-level stack and re-open it to re-add the checkbox, it's really bad, with multiple render flashes.
It seems to get progressively worse the more you interact with the stacks, and the deeper you go.

https://github.com/user-attachments/assets/f0c0bc0c-7bce-4b3c-8d48-244f0d4becca

### After Safari

https://github.com/user-attachments/assets/dc3dfa3e-33b1-4bc0-a9e4-3c002ad20878

### After Chrome

https://github.com/user-attachments/assets/a99620c2-5992-4921-9ce5-0d72c8a9cc9c

FYI, Firefox's performance is similar.

## How to Reproduce

1. Add a blueprint several layers deep. In the demo I have Bard > Replicator > Checkbox
2. Do this on a wide monitor so the browser has to work harder and expose any performance bottlenecks