### PR TITLE
[6.x] Handle cancelled requests when generating slugs

### DIFF
--- a/resources/js/components/slugs/Slug.js
+++ b/resources/js/components/slugs/Slug.js
@@ -116,7 +116,6 @@ export default class Slug {
             .catch((e) => {
                 if (axios.isCancel(e)) {
                     aborted = true;
-                    return;
                 }
                 throw e;
             })

--- a/resources/js/components/slugs/Slugify.vue
+++ b/resources/js/components/slugs/Slugify.vue
@@ -89,7 +89,10 @@ export default {
                         this.slug = slug;
                         resolve(slug);
                     })
-                    .catch((error) => reject(error));
+                    .catch((error) => {
+                        if (error.name === 'CanceledError') return;
+                        reject(error);
+                    });
             });
         },
     },


### PR DESCRIPTION
This pull request fixes an issue where the slug field would stop updating when typing on slow network connections.

This was happening because when a slug request was cancelled (due to the user continuing to type), the cancelled request's promise was resolving with `undefined`. This `undefined` value would then propagate through to `Slugify.vue`, setting `this.slug = undefined`. When the `to` watcher detected this mismatch between the parent's slug value and `this.slug`, it would set `shouldSlugify = false`, permanently disabling slug generation until the page is reloaded.

This PR fixes it by allowing cancelled requests to throw their error (instead of returning undefined) and ignoring CanceledError exceptions in `Slugify.vue` so cancelled requests don't interfere with the slug field state.

---

Fixes #14206