### PR TITLE
[6.x] Collapse the assets fieldtype to its mobile layout at a higher breakpoint

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -29,7 +29,7 @@
                 <div
                     v-if="!isReadOnly && showPicker"
                     data-asset-picker
-                    class="not-[.link-fieldtype_&]:p-2 not-[.link-fieldtype_&]:border border-gray-300 dark:border-gray-700 dark:bg-gray-850 rounded-xl flex flex-col @2xs:flex-row items-center gap-2 sm:gap-3 gap-y-3"
+                    class="not-[.link-fieldtype_&]:p-2 not-[.link-fieldtype_&]:border border-gray-300 dark:border-gray-700 dark:bg-gray-850 rounded-xl flex flex-col @[22rem]:flex-row gap-2 sm:gap-3 gap-y-3"
                     :class="{
                         'rounded-b-none': expanded,
                         'bard-drag-handle': isInBardField,


### PR DESCRIPTION
## Description of the Problem

The Assets fieldtype includes a container query for when it gets squished into a small space.
However, this wasn't activating soon enough, so you could get layouts like this

<img width="1764" height="1414" alt="image" src="https://github.com/user-attachments/assets/d1b55fd5-c617-42e1-947a-7d810e5c8b29" />

## What this PR Does

Changes the flex-row activation to a custom container query unit (`xs`/`25rem` is too "soon" and `2xs/20rem` is too "late", but `22rem` feels about right)
Closes https://github.com/statamic/cms/issues/14192

## Before

![2026-03-11 at 12 39 09@2x](https://github.com/user-attachments/assets/f4a78784-6f0d-4d14-960c-0ea7efef2496)

## After

![2026-03-11 at 12 39 45@2x](https://github.com/user-attachments/assets/60c937ac-2ab4-432e-b306-938e163b5133)

## How to Reproduce

1. Add an assets fieldtype at 50% width and drag the viewport in