### PR TITLE
[6.x] Fix expanding Bard sets in localized entries

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -206,7 +206,7 @@ export default {
             json: [],
             fullScreenMode: false,
             buttons: [],
-            collapsed: clone(this.meta.collapsed),
+            collapsed: this.meta.collapsed,
             mounted: false,
             initError: null,
             pageHeader: null,
@@ -456,7 +456,9 @@ export default {
         },
 
         collapsed(collapsed) {
-            this.updateMeta({ ...this.meta, collapsed });
+            const meta = this.meta;
+            meta.collapsed = value;
+            this.updateMeta(meta);
         },
 
         fullScreenMode(fullScreenMode) {
@@ -624,7 +626,7 @@ export default {
 
         collapseSet(id) {
             if (!this.collapsed.includes(id)) {
-                this.collapsed = [...this.collapsed, id];
+                this.collapsed.push(id);
             }
         },
 
@@ -635,7 +637,8 @@ export default {
             }
 
             if (this.collapsed.includes(id)) {
-                this.collapsed = this.collapsed.filter((v) => v !== id);
+                var index = this.collapsed.indexOf(id);
+                this.collapsed.splice(index, 1);
             }
         },
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -206,7 +206,7 @@ export default {
             json: [],
             fullScreenMode: false,
             buttons: [],
-            collapsed: this.meta.collapsed,
+            collapsed: clone(this.meta.collapsed),
             mounted: false,
             initError: null,
             pageHeader: null,
@@ -455,10 +455,8 @@ export default {
             this.editor.setEditable(!this.readOnly);
         },
 
-        collapsed(value) {
-            const meta = this.meta;
-            meta.collapsed = value;
-            this.updateMeta(meta);
+        collapsed(collapsed) {
+            this.updateMeta({ ...this.meta, collapsed });
         },
 
         fullScreenMode(fullScreenMode) {
@@ -626,7 +624,7 @@ export default {
 
         collapseSet(id) {
             if (!this.collapsed.includes(id)) {
-                this.collapsed.push(id);
+                this.collapsed = [...this.collapsed, id];
             }
         },
 
@@ -637,8 +635,7 @@ export default {
             }
 
             if (this.collapsed.includes(id)) {
-                var index = this.collapsed.indexOf(id);
-                this.collapsed.splice(index, 1);
+                this.collapsed = this.collapsed.filter((v) => v !== id);
             }
         },
 

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -162,7 +162,7 @@ export default {
         },
 
         collapsed() {
-            return this.extension.options.bard.meta.collapsed.includes(this.node.attrs.id);
+            return this.extension.options.bard.collapsed.includes(this.node.attrs.id);
         },
 
         config() {


### PR DESCRIPTION
This pull request fixes an issue where clicking on a Bard set header wouldn't expand/collapse the set when viewing a localized entry with `collapse: true` and `localizable: true` configured on the field.

This was happening because Set.vue was reading the collapsed state from `bard.meta.collapsed` (the prop) instead of `bard.collapsed` (the reactive data property that gets modified by the expand/collapse methods).

This PR fixes it by reading from the `collapsed` data property instead.

Fixes #14131
