### PR TITLE
[6.x] Fix dated entries not syncing with origin revisions

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -773,7 +773,9 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             ->slug($attrs['slug']);
 
         if ($this->collection()->dated() && ($date = Arr::get($attrs, 'date'))) {
-            $entry->date(Carbon::createFromTimestamp($date, config('app.timezone')));
+            if ($this->isRoot() || $this->blueprint()->field('date')->isLocalizable()) {
+                $entry->date(Carbon::createFromTimestamp($date, config('app.timezone')));
+            }
         }
 
         return $entry;

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -394,6 +394,155 @@ class EntryRevisionsTest extends TestCase
         return $this->post($entry->restoreRevisionUrl(), $payload);
     }
 
+    #[Test]
+    public function localized_entry_with_non_localizable_date_gets_origin_date_when_reconstructed_from_revision()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+
+        $this->setTestBlueprint('test', [
+            'foo' => ['type' => 'text'],
+            'date' => ['type' => 'date', 'localizable' => false],
+        ]);
+        $this->setTestRoles(['test' => ['access cp', 'publish blog entries']]);
+        $user = User::make()->id('user-1')->assignRole('test')->save();
+
+        $this->collection->sites(['en', 'fr'])->save();
+
+        $origin = EntryFactory::id('1')
+            ->slug('test')
+            ->collection('blog')
+            ->locale('en')
+            ->published(true)
+            ->date('2010-12-25')
+            ->data([
+                'blueprint' => 'test',
+                'title' => 'Title',
+                'foo' => 'bar',
+            ])->create();
+
+        $localized = EntryFactory::id('2')
+            ->slug('test')
+            ->collection('blog')
+            ->locale('fr')
+            ->origin($origin)
+            ->published(true)
+            ->data(['blueprint' => 'test'])
+            ->create();
+
+        $this->assertEquals('2010-12-25', $origin->date()->format('Y-m-d'));
+        $this->assertEquals('2010-12-25', $localized->date()->format('Y-m-d'));
+
+        tap($localized->makeWorkingCopy(), function ($copy) {
+            $attrs = $copy->attributes();
+            $attrs['data']['foo'] = 'foo modified in localized working copy';
+            $copy->attributes($attrs);
+        })->save();
+
+        $this->assertTrue($localized->hasWorkingCopy());
+        $this->assertEquals('2010-12-25', $localized->fromWorkingCopy()->date()->format('Y-m-d'));
+
+        tap($origin->makeWorkingCopy(), function ($copy) {
+            $attrs = $copy->attributes();
+            $attrs['date'] = Carbon::parse('2020-06-15')->timestamp;
+            $copy->attributes($attrs);
+        })->save();
+
+        $this
+            ->actingAs($user)
+            ->publish($origin, ['message' => 'Publish origin with new date'])
+            ->assertOk();
+
+        $origin = Entry::find('1');
+        $this->assertEquals('2020-06-15', $origin->date()->format('Y-m-d'));
+
+        $localized = Entry::find('2');
+        $this->assertEquals('2020-06-15', $localized->date()->format('Y-m-d'));
+
+        $this->assertEquals(
+            '2020-06-15',
+            $localized->fromWorkingCopy()->date()->format('Y-m-d'),
+            'Localized entry reconstructed from working copy should use origin\'s current date when date field is not localizable'
+        );
+    }
+
+    #[Test]
+    public function localized_entry_with_localizable_date_keeps_its_own_date_when_reconstructed_from_revision()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+
+        $this->setTestBlueprint('test', [
+            'foo' => ['type' => 'text'],
+            'date' => ['type' => 'date', 'localizable' => true],
+        ]);
+        $this->setTestRoles(['test' => ['access cp', 'publish blog entries']]);
+        $user = User::make()->id('user-1')->assignRole('test')->save();
+
+        $this->collection->sites(['en', 'fr'])->save();
+
+        $origin = EntryFactory::id('1')
+            ->slug('test')
+            ->collection('blog')
+            ->locale('en')
+            ->published(true)
+            ->date('2010-12-25')
+            ->data([
+                'blueprint' => 'test',
+                'title' => 'Title',
+                'foo' => 'bar',
+            ])->create();
+
+        $localized = EntryFactory::id('2')
+            ->slug('test')
+            ->collection('blog')
+            ->locale('fr')
+            ->origin($origin)
+            ->published(true)
+            ->date('2015-03-10')
+            ->data(['blueprint' => 'test'])
+            ->create();
+
+        $this->assertEquals('2010-12-25', $origin->date()->format('Y-m-d'));
+        $this->assertEquals('2015-03-10', $localized->date()->format('Y-m-d'));
+
+        tap($localized->makeWorkingCopy(), function ($copy) {
+            $attrs = $copy->attributes();
+            $attrs['data']['foo'] = 'foo modified in localized working copy';
+            $copy->attributes($attrs);
+        })->save();
+
+        $this->assertTrue($localized->hasWorkingCopy());
+        $this->assertEquals('2015-03-10', $localized->fromWorkingCopy()->date()->format('Y-m-d'));
+
+        tap($origin->makeWorkingCopy(), function ($copy) {
+            $attrs = $copy->attributes();
+            $attrs['date'] = Carbon::parse('2020-06-15')->timestamp;
+            $copy->attributes($attrs);
+        })->save();
+
+        $this
+            ->actingAs($user)
+            ->publish($origin, ['message' => 'Publish origin with new date'])
+            ->assertOk();
+
+        $origin = Entry::find('1');
+        $this->assertEquals('2020-06-15', $origin->date()->format('Y-m-d'));
+
+        $localized = Entry::find('2');
+        $this->assertEquals('2015-03-10', $localized->date()->format('Y-m-d'));
+
+        $this->assertEquals(
+            '2015-03-10',
+            $localized->fromWorkingCopy()->date()->format('Y-m-d'),
+            'Localized entry reconstructed from working copy should keep its own date when date field is localizable'
+        );
+    }
+
     private function setTestBlueprint($handle, $fields)
     {
         $blueprint = Blueprint::makeFromFields($fields)->setHandle($handle);


### PR DESCRIPTION
This pull request fixes an issue where dated entries with non-localizable date fields become unsynced with their origin when using revisions.

This happens because when a localized entry is reconstructed from its working copy (via `makeFromRevision()`), it would use the stale date stored in the revision instead of the current date from the origin entry. 

This meant that when the origin's date was changed and published, localized entries with working copies would continue showing the old date.

This PR fixes it by adding a check in `makeFromRevision()` to determine whether the entry is the root, and whether the date field is marked as localizable. When an entry is a localization and the date field isn't localizable, the revision's date will be skipped, allowing the entry to inherit the date from the origin.

Fixes #14132