### PR TITLE
[6.x] Various drag & drop fixes

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -23,7 +23,9 @@
                     'bg-gray-200/50 dark:bg-gray-950/35 rounded-b-none border-b-gray-300! dark:border-b-white/10!': !collapsed
                 }"
             >
-                <Icon data-drag-handle name="handles" class="size-4 cursor-grab text-gray-400" v-if="!isReadOnly" />
+                <span v-if="!isReadOnly" draggable="true" data-drag-handle class="flex cursor-grab">
+                    <Icon name="handles" class="size-4 text-gray-400" />
+                </span>
                 <button type="button" class="show-focus-within_target flex flex-1 items-center gap-4 p-2 min-w-0 focus:outline-none cursor-pointer" @click="toggleCollapsedState">
                     <Badge size="lg" :pill="true" color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -286,6 +286,14 @@ export default {
             if (this.initializing) return;
             this.$emit('item-data-updated', data);
         },
+
+        items(items, oldItems) {
+            if (items.length > 0 && oldItems.length === 0) {
+                if (this.canReorder) {
+                    this.$nextTick(() => this.makeSortable());
+                }
+            }
+        },
     },
 
     methods: {


### PR DESCRIPTION
This pull request fixes various drag & drop issues:

- Fixes Bard sets not being draggable
  - This was happening because our workaround for a Firefox bug (#14021) set `draggable="false"` on the `node-view-wrapper` element, preventing the native `dragstart` events from firing, which TipTap needs to handle drag and drop.
  - This PR fixes it by adding `draggable="true"` directly to the drag handle element, allowing the native `dragstart` event to fire from the handle and bubble up to TipTap's event handler, while the wrapper remains `draggable="false"` to preserve the Firefox text selection fix.
  - Fixes #14191
- Fixes relationship items not being draggable when going from "0 -> some" items
  - This was happening because `makeSortable()` is only run when the `ref="items"` element exists, but it's wrapped inside a `v-if` which evaluates to false when there aren't any items.
  - I've fixed it by calling `makeSortable()` when items are added to an empty relationship field.
  - Fixes #14124

