### PR TITLE
[6.x] Avoid sanitizing `target` attribute in `markdown()` helper

### DIFF
--- a/resources/js/util/markdown.js
+++ b/resources/js/util/markdown.js
@@ -15,6 +15,7 @@ export default function (markdown, options = {}) {
     }
 
     return DOMPurify.sanitize(
-        marked.parse(markdown, { renderer })
+        marked.parse(markdown, { renderer }),
+        { ADD_ATTR: ['target'] }
     );
 }


### PR DESCRIPTION
This pull request avoids the `target` attribute being sanitised in the `markdown()` helper - fixing an issue where links in field instructions weren't opening in a new tab as expected.

Fixes #14115
