### PR TITLE
[6.x] Fix create entry translations

### DIFF
--- a/src/Entries/Collection.php
+++ b/src/Entries/Collection.php
@@ -465,7 +465,7 @@ class Collection implements Arrayable, ArrayAccess, AugmentableContract, Contrac
 
     public function createLabel()
     {
-        $key = "statamic::messages.{$this->handle()}_collection_create_entry";
+        $key = "messages.{$this->handle()}_collection_create_entry";
 
         $translation = __($key);
 


### PR DESCRIPTION
This pull request fixes an issue where it wasn't possible to customize the "Create Entry" translation.

This was due to the `statamic::` prefix being added in #12598, causing it to look at Statamic's translations instead of the app's translations. I'm not sure why it was added but the custom translation shows fine in card view 🤷‍♂️

Fixes #14078
