### PR TITLE
[6.x] Add "Content Search" string to translator's `$additionalStrings` array

### DIFF
--- a/translator
+++ b/translator
@@ -36,6 +36,7 @@ $dontTranslate = [
 $additionalStrings = [
     'Author',
     'Content',
+    'Content Search',
     'Groups',
     'Tools',
     'Laptop',


### PR DESCRIPTION
This PR fixes #14225 by adding "Content Search" to the translator's `$additionalStrings` array. Translations already exist for the rest of the category strings.