### PR TITLE
[6.x] Make image manipulation presets more readable

### DIFF
--- a/src/Http/Controllers/CP/Assets/AssetContainersController.php
+++ b/src/Http/Controllers/CP/Assets/AssetContainersController.php
@@ -257,7 +257,7 @@ class AssetContainersController extends CpController
 
         $params = collect($params)
             ->map(function ($value, $param) {
-                return sprintf('<code class="hidden-outside">%s: %s</code>', $param, $value);
+                return sprintf('<code class="hidden-outside">%s:&hairsp;%s</code>', $param, $value);
             })
             ->implode(' ');
 

--- a/src/Http/Controllers/CP/Assets/AssetContainersController.php
+++ b/src/Http/Controllers/CP/Assets/AssetContainersController.php
@@ -257,7 +257,7 @@ class AssetContainersController extends CpController
 
         $params = collect($params)
             ->map(function ($value, $param) {
-                return sprintf('<code class="hidden-outside">%s:&hairsp;%s</code>', $param, $value);
+                return sprintf('<code class="hidden-outside me-1.5 text-[0.95rem] rounded-xs">%s:&hairsp;%s</code>', $param, $value);
             })
             ->implode(' ');
 

--- a/src/Http/Controllers/CP/Assets/AssetContainersController.php
+++ b/src/Http/Controllers/CP/Assets/AssetContainersController.php
@@ -257,7 +257,7 @@ class AssetContainersController extends CpController
 
         $params = collect($params)
             ->map(function ($value, $param) {
-                return sprintf('<code class="hidden-outside me-1.5 text-[0.95rem] rounded-xs">%s:&hairsp;%s</code>', $param, $value);
+                return sprintf('<code class="hidden-outside me-1.5 rounded-xs">%s:&hairsp;%s</code>', $param, $value);
             })
             ->implode(' ');
 


### PR DESCRIPTION
## Description of the Problem

Text spaces in image manipulation presets are difficult to read, partly due to the way monospaced fonts work, as described in this issue https://github.com/statamic/cms/issues/14222

## What this PR Does

- Use a hairspace to make the space more subtle/readable
- Increase the gap between the presets slightly for readability
- Closes https://github.com/statamic/cms/issues/14222

### Before

![2026-03-11 at 18 27 23@2x](https://github.com/user-attachments/assets/1bd78853-cb2b-4ec6-a24d-8c6d0bb0720d)

### After

![2026-03-11 at 18 26 53@2x](https://github.com/user-attachments/assets/8a17139b-e18a-4033-9ecc-661932d2d17b)

## How to Reproduce

1. Add image manipulations to assets