### PR TITLE
[5.x] Removed a comment from the js code output of the StaticCacher

### DIFF
--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -278,7 +278,7 @@ class FileCacher extends AbstractCacher
     })
     .then((response) => response.json())
     .then((data) => {
-        map = createMap(); // Recreate map in case the DOM changed.
+        map = createMap();
 
         const regions = data.regions;
         for (var key in regions) {


### PR DESCRIPTION
This is a small change, just removing the comment from the JS code output. This is a problem when the site code is minified down to one line, as the comment ends up causing everything after it to be commented out also. 

eg:
<img width="1245" height="92" alt="Screenshot_20260312_110345" src="https://github.com/user-attachments/assets/a03514ed-32e2-4ac8-ae54-cc0e0dfc492e" />
