### PR TITLE
[6.x] Add Asset::moveUnique() method

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -744,7 +744,11 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function rename($filename, $unique = false)
     {
-        return $this->move($this->folder(), $filename, $unique);
+        if ($unique) {
+            return $this->moveUnique($this->folder(), $filename);
+        }
+
+        return $this->move($this->folder(), $filename);
     }
 
     /**
@@ -754,10 +758,9 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      * @param  string|null  $filename  The new filename, if renaming.
      * @return $this
      */
-    public function move($folder, $filename = null, $unique = false)
+    public function move($folder, $filename = null)
     {
         $filename = Uploader::getSafeFilename($filename ?: $this->filename());
-        $filename = $unique ? $this->ensureUniqueFilename($folder, $filename) : $filename;
         $oldPath = $this->path();
         $oldMetaPath = $this->metaPath();
         $newPath = Str::removeLeft(Path::tidy($folder.'/'.$filename.'.'.pathinfo($oldPath, PATHINFO_EXTENSION)), '/');
@@ -774,6 +777,21 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
         $this->disk()->rename($oldMetaPath, $this->metaPath());
 
         return $this;
+    }
+
+    /**
+     * Move the asset to a different location with a unique filename.
+     *
+     * @param  string  $folder  The folder relative to the container.
+     * @param  string|null  $filename  The new filename, if renaming.
+     * @return $this
+     */
+    public function moveUnique($folder, $filename = null)
+    {
+        $filename = Uploader::getSafeFilename($filename ?: $this->filename());
+        $filename = $this->ensureUniqueFilename($folder, $filename);
+
+        return $this->move($folder, $filename);
     }
 
     public function moveQuietly($folder, $filename = null)

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -744,9 +744,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function rename($filename, $unique = false)
     {
-        $filename = $unique ? $this->ensureUniqueFilename($this->folder(), $filename) : $filename;
-
-        return $this->move($this->folder(), $filename);
+        return $this->move($this->folder(), $filename, $unique);
     }
 
     /**
@@ -756,9 +754,10 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      * @param  string|null  $filename  The new filename, if renaming.
      * @return $this
      */
-    public function move($folder, $filename = null)
+    public function move($folder, $filename = null, $unique = false)
     {
         $filename = Uploader::getSafeFilename($filename ?: $this->filename());
+        $filename = $unique ? $this->ensureUniqueFilename($folder, $filename) : $filename;
         $oldPath = $this->path();
         $oldMetaPath = $this->metaPath();
         $newPath = Str::removeLeft(Path::tidy($folder.'/'.$filename.'.'.pathinfo($oldPath, PATHINFO_EXTENSION)), '/');

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1261,6 +1261,70 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    public function it_can_be_moved_to_another_folder_with_a_unique_filename_when_conflict_exists()
+    {
+        Storage::fake('local');
+        $disk = Storage::disk('local');
+        $disk->put('old/asset.txt', 'The asset contents');
+        $disk->put('new/asset.txt', 'Existing asset');
+        $disk->put('new/asset-1.txt', 'Another existing asset');
+        $container = Facades\AssetContainer::make('test')->disk('local');
+        Facades\AssetContainer::shouldReceive('save')->with($container);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
+        $asset->save();
+
+        $return = $asset->move('new', null, true);
+
+        $this->assertEquals($asset, $return);
+        $disk->assertMissing('old/asset.txt');
+        $disk->assertExists('new/asset-2.txt');
+        $this->assertEquals('new/asset-2.txt', $asset->path());
+    }
+
+    #[Test]
+    public function it_can_be_moved_to_another_folder_with_unique_flag_without_renaming_when_no_conflict()
+    {
+        Storage::fake('local');
+        $disk = Storage::disk('local');
+        $disk->put('old/asset.txt', 'The asset contents');
+        $container = Facades\AssetContainer::make('test')->disk('local');
+        Facades\AssetContainer::shouldReceive('save')->with($container);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
+        $asset->save();
+
+        $return = $asset->move('new', null, true);
+
+        $this->assertEquals($asset, $return);
+        $disk->assertMissing('old/asset.txt');
+        $disk->assertExists('new/asset.txt');
+        $this->assertEquals('new/asset.txt', $asset->path());
+    }
+
+    #[Test]
+    public function it_does_not_ensure_unique_filename_when_moving_by_default()
+    {
+        Storage::fake('local');
+        $disk = Storage::disk('local');
+        $disk->put('old/asset.txt', 'The asset contents');
+        $disk->put('new/asset.txt', 'Existing asset');
+        $container = Facades\AssetContainer::make('test')->disk('local');
+        Facades\AssetContainer::shouldReceive('save')->with($container);
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test')->andReturn($container);
+        $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
+        $asset->save();
+
+        $return = $asset->move('new');
+
+        $this->assertEquals($asset, $return);
+        $disk->assertMissing('old/asset.txt');
+        // Without unique flag, it overwrites the existing file
+        $disk->assertExists('new/asset.txt');
+        $this->assertEquals('new/asset.txt', $asset->path());
+    }
+
+    #[Test]
     public function it_renames()
     {
         Event::fake();

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1261,7 +1261,7 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    public function it_can_be_moved_to_another_folder_with_a_unique_filename_when_conflict_exists()
+    public function it_can_be_moved_uniquely_to_another_folder_when_conflict_exists()
     {
         Storage::fake('local');
         $disk = Storage::disk('local');
@@ -1274,7 +1274,7 @@ class AssetTest extends TestCase
         $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
         $asset->save();
 
-        $return = $asset->move('new', null, true);
+        $return = $asset->moveUnique('new');
 
         $this->assertEquals($asset, $return);
         $disk->assertMissing('old/asset.txt');
@@ -1283,7 +1283,7 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    public function it_can_be_moved_to_another_folder_with_unique_flag_without_renaming_when_no_conflict()
+    public function it_can_be_moved_uniquely_to_another_folder_without_renaming_when_no_conflict()
     {
         Storage::fake('local');
         $disk = Storage::disk('local');
@@ -1294,7 +1294,7 @@ class AssetTest extends TestCase
         $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
         $asset->save();
 
-        $return = $asset->move('new', null, true);
+        $return = $asset->moveUnique('new');
 
         $this->assertEquals($asset, $return);
         $disk->assertMissing('old/asset.txt');


### PR DESCRIPTION
`Asset::rename($filename, $unique = false)` supports automatic unique filename generation via `ensureUniqueFilename()`, but there is no equivalent for `Asset::move()`. When moving an asset to a folder where a filename collision exists, developers must implement their own uniqueness logic.

This PR adds a dedicated `moveUnique()` method as a non-breaking addition, and updates `rename()` to delegate to it when `$unique = true`.

### Changes

- **`Asset::moveUnique($folder, $filename)`** — new method that calls `ensureUniqueFilename()` before delegating to `move()`.
- **`Asset::rename()`** — updated to delegate to `moveUnique()` when `$unique = true`, instead of handling uniqueness directly.
- **`Asset::move()`** — signature unchanged, no breaking change.
- **Tests** — three new test cases covering moveUnique (conflict, no conflict, and default move behavior).