### PR TITLE
[6.x] Fix undefined variable in Bard fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -455,7 +455,7 @@ export default {
             this.editor.setEditable(!this.readOnly);
         },
 
-        collapsed(collapsed) {
+        collapsed(value) {
             const meta = this.meta;
             meta.collapsed = value;
             this.updateMeta(meta);


### PR DESCRIPTION
This pull request fixes an undefined variable from the Bard fieldtype's `collapsed` method. I reverted some unnecessary changes in https://github.com/statamic/cms/pull/14214, but obviously forgot to rename the argument 😬

Fixes #14228
Related: https://github.com/statamic/cms/pull/14214#issuecomment-4046924837