### PR TITLE
[6.x] Add `outside` class to outside layout

### DIFF
--- a/resources/js/pages/layout/Outside.vue
+++ b/resources/js/pages/layout/Outside.vue
@@ -6,7 +6,7 @@ import { onMounted } from 'vue';
 import { colorMode } from '@api';
 import PortalTargets from "@/components/portals/PortalTargets.vue";
 
-useBodyClasses('bg-gray-50 dark:bg-gray-900 font-sans leading-normal scheme-light p-2');
+useBodyClasses('bg-gray-50 dark:bg-gray-900 font-sans leading-normal scheme-light p-2 outside');
 const { logos, cmsName } = useStatamicPageProps();
 const customLogo = logos?.light?.outside ?? logos?.dark?.outside ?? null;
 const lightCustomLogo = logos?.light?.outside ?? null;


### PR DESCRIPTION
This pull request adds the `outside` class to the `<body>` of the outside (auth) layout.