### PR TITLE
[6.x] Show "Drop to Upload" on top when dragging file onto Asset field

### DIFF
--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -13,7 +13,7 @@
             <div>
                 <div
                     v-show="dragging"
-                    class="absolute inset-0 z-10 flex gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg"
+                    class="absolute inset-0 z-(--z-index-above) flex gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg"
                 >
                     <ui-icon name="upload-cloud" class="size-5 text-gray-500" />
                     <div class="text-sm text-gray-600 dark:text-gray-400">{{ __('Drop to Upload') }}</div>

--- a/resources/js/components/fieldtypes/FilesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FilesFieldtype.vue
@@ -13,7 +13,7 @@
             <div>
                 <div
                     v-show="dragging"
-                    class="absolute inset-0 flex  gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg"
+                    class="absolute inset-0 z-10 flex gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg"
                 >
                     <ui-icon name="upload-cloud" class="size-5 text-gray-500" />
                     <div class="text-sm text-gray-600 dark:text-gray-400">{{ __('Drop to Upload') }}</div>

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -20,7 +20,7 @@
                 <div
                     v-if="config.allow_uploads"
                     v-show="dragging && !showSelector"
-                    class="absolute inset-0 z-10 flex gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg text-gray-700"
+                    class="absolute inset-0 z-(--z-index-above) flex gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg text-gray-700"
                 >
                     <ui-icon name="upload-cloud" class="size-5" />
                     <span class="text-sm">{{ __('Drop to Upload') }}</span>

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -20,7 +20,7 @@
                 <div
                     v-if="config.allow_uploads"
                     v-show="dragging && !showSelector"
-                    class="absolute inset-0 flex gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg text-gray-700"
+                    class="absolute inset-0 z-10 flex gap-2 items-center justify-center bg-white/80 border border-gray-400 border-dashed rounded-lg text-gray-700"
                 >
                     <ui-icon name="upload-cloud" class="size-5" />
                     <span class="text-sm">{{ __('Drop to Upload') }}</span>


### PR DESCRIPTION
This pull request ensures the "Drop on Upload" text shows on top of everything else when dragging a file onto the Assets / Files fieldtypes.

## Before

<img width="634" height="318" alt="CleanShot 2026-03-13 at 15 31 05@2x" src="https://github.com/user-attachments/assets/0989c1dd-853a-4466-a4da-459b406d4e7a" />


## After

<img width="632" height="304" alt="CleanShot 2026-03-13 at 15 27 41@2x" src="https://github.com/user-attachments/assets/02261716-8826-4dbd-9692-202d7f4bbba4" />


---

Fixes #14224
