### PR TITLE
[5.x] Relationship endpoint authorization

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -7,6 +7,7 @@ use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\CP\Column;
 use Statamic\CP\Columns;
+use Statamic\Exceptions\AuthorizationException;
 use Statamic\Exceptions\CollectionNotFoundException;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
@@ -132,12 +133,16 @@ class Entries extends Relationship
 
     public function getIndexItems($request)
     {
+        $configuredCollections = $this->getConfiguredCollections();
+        $requestedCollections = $this->getRequestedCollections($request, $configuredCollections);
+        $this->authorizeCollectionAccess($requestedCollections);
+
         $query = $this->getIndexQuery($request);
 
         $filters = $request->filters;
 
         if (! isset($filters['collection'])) {
-            $query->whereIn('collection', $this->getConfiguredCollections());
+            $query->whereIn('collection', $configuredCollections);
         }
 
         if ($blueprints = $this->config('blueprints')) {
@@ -155,6 +160,30 @@ class Entries extends Relationship
         $items = $results->map(fn ($item) => $item instanceof Result ? $item->getSearchable() : $item);
 
         return $paginate ? $results->setCollection($items) : $items;
+    }
+
+    private function getRequestedCollections($request, $configuredCollections)
+    {
+        $filteredCollections = collect($request->input('filters.collection.collections', []))
+            ->filter()
+            ->values()
+            ->all();
+
+        return empty($filteredCollections) ? $configuredCollections : $filteredCollections;
+    }
+
+    private function authorizeCollectionAccess($collections)
+    {
+        $user = User::current();
+
+        collect($collections)->each(function ($collectionHandle) use ($user) {
+            $collection = Collection::findByHandle($collectionHandle);
+
+            throw_if(
+                ! $collection || ! $user->can('view', $collection),
+                new AuthorizationException
+            );
+        });
     }
 
     public function getResourceCollection($request, $items)

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -7,6 +7,7 @@ use Statamic\Contracts\Data\Localization;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Taxonomies\Term as TermContract;
 use Statamic\CP\Column;
+use Statamic\Exceptions\AuthorizationException;
 use Statamic\Exceptions\TaxonomyNotFoundException;
 use Statamic\Exceptions\TermsFieldtypeBothOptionsUsedException;
 use Statamic\Exceptions\TermsFieldtypeTaxonomyOptionUsed;
@@ -257,6 +258,10 @@ class Terms extends Relationship
             return collect();
         }
 
+        $this->authorizeTaxonomyAccess(
+            $this->getRequestedTaxonomies($request, $this->getConfiguredTaxonomies())
+        );
+
         $query = $this->getIndexQuery($request);
 
         if ($sort = $this->getSortColumn($request)) {
@@ -264,6 +269,27 @@ class Terms extends Relationship
         }
 
         return $request->boolean('paginate', true) ? $query->paginate() : $query->get();
+    }
+
+    private function getRequestedTaxonomies($request, $configuredTaxonomies)
+    {
+        $requestedTaxonomies = collect($request->taxonomies)->filter()->values()->all();
+
+        return empty($requestedTaxonomies) ? $configuredTaxonomies : $requestedTaxonomies;
+    }
+
+    private function authorizeTaxonomyAccess($taxonomies)
+    {
+        $user = User::current();
+
+        collect($taxonomies)->each(function ($taxonomyHandle) use ($user) {
+            $taxonomy = Taxonomy::findByHandle($taxonomyHandle);
+
+            throw_if(
+                ! $taxonomy || ! $user->can('view', $taxonomy),
+                new AuthorizationException
+            );
+        });
     }
 
     public function getResourceCollection($request, $items)

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -5,6 +5,8 @@ namespace Tests\Feature\Fieldtypes;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
 use Statamic\Facades\User;
 use Statamic\Query\Scopes\Scope;
 use Tests\FakesRoles;
@@ -59,7 +61,7 @@ class RelationshipFieldtypeTest extends TestCase
     }
 
     #[Test]
-    public function it_denies_access_when_theres_a_collection_the_user_cannot_view()
+    public function it_denies_access_to_entries_when_theres_a_collection_the_user_cannot_view()
     {
         Collection::make('secret')->save();
         Entry::make()->collection('secret')->slug('secret-one')->data(['title' => 'Secret One'])->save();
@@ -79,7 +81,7 @@ class RelationshipFieldtypeTest extends TestCase
     }
 
     #[Test]
-    public function it_forbids_access_when_filters_target_a_collection_the_user_cannot_view()
+    public function it_forbids_access_to_entries_when_filters_target_a_collection_the_user_cannot_view()
     {
         Collection::make('secret')->save();
         Entry::make()->collection('test')->slug('apple')->data(['title' => 'Apple'])->save();
@@ -101,6 +103,50 @@ class RelationshipFieldtypeTest extends TestCase
         $this
             ->actingAs($user)
             ->getJson("/cp/fieldtypes/relationship?config={$config}&filters={$filters}")
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_forbids_access_to_terms_when_config_contains_a_taxonomy_the_user_cannot_view()
+    {
+        Taxonomy::make('secret')->save();
+        Term::make('internal')->taxonomy('secret')->data([])->save();
+
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'terms',
+            'taxonomies' => ['secret'],
+        ]));
+
+        $this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=secret")
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_forbids_access_to_terms_when_requested_taxonomy_is_forbidden()
+    {
+        Taxonomy::make('topics')->save();
+        Taxonomy::make('secret')->save();
+        Term::make('public')->taxonomy('topics')->data([])->save();
+        Term::make('internal')->taxonomy('secret')->data([])->save();
+
+        $this->setTestRoles([
+            'test' => ['access cp', 'view topics terms'],
+        ]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'terms',
+            'taxonomies' => ['topics'],
+        ]));
+
+        $this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=secret")
             ->assertForbidden();
     }
 }

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -35,7 +35,7 @@ class RelationshipFieldtypeTest extends TestCase
         Entry::make()->collection('test')->slug('cherry')->data(['title' => 'Cherry'])->save();
         Entry::make()->collection('test')->slug('banana')->data(['title' => 'Banana'])->save();
 
-        $this->setTestRoles(['test' => ['access cp']]);
+        $this->setTestRoles(['test' => ['access cp', 'view test entries']]);
         $user = User::make()->assignRole('test')->save();
 
         $config = base64_encode(json_encode([
@@ -46,7 +46,7 @@ class RelationshipFieldtypeTest extends TestCase
 
         $response = $this
             ->actingAs($user)
-            ->get("/cp/fieldtypes/relationship?config={$config}&collections[0]=test")
+            ->get("/cp/fieldtypes/relationship?config={$config}")
             ->assertOk();
 
         $titles = collect($response->json('data'))->pluck('title')->all();
@@ -56,6 +56,52 @@ class RelationshipFieldtypeTest extends TestCase
         $this->assertContains('Cherry', $titles);
         $this->assertNotContains('Apple', $titles);
         $this->assertNotContains('Banana', $titles);
+    }
+
+    #[Test]
+    public function it_denies_access_when_theres_a_collection_the_user_cannot_view()
+    {
+        Collection::make('secret')->save();
+        Entry::make()->collection('secret')->slug('secret-one')->data(['title' => 'Secret One'])->save();
+
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'entries',
+            'collections' => ['secret'],
+        ]));
+
+        $this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship?config={$config}")
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_forbids_access_when_filters_target_a_collection_the_user_cannot_view()
+    {
+        Collection::make('secret')->save();
+        Entry::make()->collection('test')->slug('apple')->data(['title' => 'Apple'])->save();
+        Entry::make()->collection('secret')->slug('secret-one')->data(['title' => 'Secret One'])->save();
+
+        $this->setTestRoles([
+            'test' => ['access cp', 'view test entries'],
+        ]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'entries',
+            'collections' => ['test'],
+        ]));
+        $filters = base64_encode(json_encode([
+            'collection' => ['collections' => ['secret']],
+        ]));
+
+        $this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship?config={$config}&filters={$filters}")
+            ->assertForbidden();
     }
 }
 


### PR DESCRIPTION
This PR prevents access to unauthorized entries and terms via the relationship fieldtype endpoint.