### PR TITLE
[6.x] Replicator fieldtype endpoint hardening

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -540,7 +540,7 @@ export default {
                 const field = this.bardFieldPath();
                 const setCacheKey = `${field}.${set}`;
                 const reference = this.publishContainer.reference;
-                const blueprint = this.publishContainer.blueprint.fqh;
+                const token = this.publishContainer.blueprint.token;
 
 	            if (this.meta.new?.hasOwnProperty(set)) {
 		            let meta = this.meta.new[set];
@@ -555,7 +555,7 @@ export default {
                     return;
                 }
 
-                this.$axios.post(cp_url('fieldtypes/replicator/set'), { blueprint, reference, field, set })
+                this.$axios.post(cp_url('fieldtypes/replicator/set'), { token, reference, field, set })
                     .then(response => {
                         this.setsCache[setCacheKey] = response.data;
                         resolve(response.data);

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -240,7 +240,7 @@ export default {
                 const field = this.replicatorFieldPath();
                 const setCacheKey = `${field}.${set}`;
                 const reference = this.publishContainer.reference;
-                const blueprint = this.publishContainer.blueprint.fqh;
+                const token = this.publishContainer.blueprint.token;
 
 				if (this.meta.new?.hasOwnProperty(set)) {
 					let meta = this.meta.new[set];
@@ -255,7 +255,7 @@ export default {
                     return;
                 }
 
-                this.$axios.post(cp_url('fieldtypes/replicator/set'), { blueprint, reference, field, set })
+                this.$axios.post(cp_url('fieldtypes/replicator/set'), { token, reference, field, set })
                     .then(response => {
                         this.setsCache[setCacheKey] = response.data;
                         resolve(response.data);

--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -27,6 +27,7 @@ use Statamic\Facades;
 use Statamic\Facades\Blink;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
+use Statamic\Facades\User;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -453,6 +454,10 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, QueryableValue
             'tabs' => $this->tabs()->map->toPublishArray()->values()->all(),
             'empty' => $this->isEmpty(),
             'fqh' => $this->fullyQualifiedHandle(),
+            'token' => encrypt([
+                'fqh' => $this->fullyQualifiedHandle(),
+                'user_id' => User::current()->id(),
+            ]),
         ];
     }
 

--- a/src/Http/Controllers/CP/Fieldtypes/ReplicatorSetController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/ReplicatorSetController.php
@@ -2,11 +2,13 @@
 
 namespace Statamic\Http\Controllers\CP\Fieldtypes;
 
+use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades;
 use Statamic\Facades\Data;
+use Statamic\Facades\User;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
@@ -18,13 +20,25 @@ class ReplicatorSetController extends CpController
     public function __invoke(Request $request)
     {
         $request->validate([
-            'blueprint' => ['required', 'string'],
+            'token' => ['required', 'string'],
             'reference' => ['nullable', 'string'],
             'field' => ['required', 'string'],
             'set' => ['required', 'string'],
         ]);
 
-        $blueprint = Facades\Blueprint::find($request->blueprint);
+        try {
+            $tokenPayload = decrypt($request->token);
+        } catch (DecryptException $e) {
+            abort(403);
+        }
+
+        if (! is_array($tokenPayload)
+            || ! is_string($tokenPayload['fqh'] ?? null)
+            || ($tokenPayload['user_id'] ?? null) !== User::current()?->id()) {
+            abort(403);
+        }
+
+        $blueprint = Facades\Blueprint::find($tokenPayload['fqh']);
 
         if (! $blueprint) {
             throw new NotFoundHttpException();

--- a/tests/Feature/Fieldtypes/ReplicatorSetControllerAuthorizationTest.php
+++ b/tests/Feature/Fieldtypes/ReplicatorSetControllerAuthorizationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature\Fieldtypes;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blueprint as BlueprintFacade;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ReplicatorSetControllerAuthorizationTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_allows_requests_with_a_valid_blueprint_token()
+    {
+        BlueprintFacade::partialMock();
+        BlueprintFacade::shouldReceive('find')
+            ->with('collections.pages.default')
+            ->andReturn($this->makeBlueprint());
+
+        $user = tap(User::make()->makeSuper())->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('replicator-fieldtype.set'), [
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $user->id(),
+                ]),
+                'field' => 'content',
+                'set' => 'text',
+            ])
+            ->assertOk()
+            ->assertJson([
+                'defaults' => [
+                    'a_text_field' => 'the default',
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function it_requires_a_blueprint_token()
+    {
+        $user = tap(User::make()->makeSuper())->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('replicator-fieldtype.set'), [
+                'field' => 'content',
+                'set' => 'text',
+            ])
+            ->assertStatus(422);
+    }
+
+    #[Test]
+    public function it_denies_requests_with_a_tampered_blueprint_token()
+    {
+        $user = tap(User::make()->makeSuper())->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('replicator-fieldtype.set'), [
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $user->id(),
+                ]).'tampered',
+                'field' => 'content',
+                'set' => 'text',
+            ])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_denies_requests_with_a_token_for_a_different_user()
+    {
+        $actingUser = tap(User::make()->makeSuper())->save();
+        $otherUser = tap(User::make()->makeSuper())->save();
+
+        $this
+            ->actingAs($actingUser)
+            ->postJson(cp_route('replicator-fieldtype.set'), [
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $otherUser->id(),
+                ]),
+                'field' => 'content',
+                'set' => 'text',
+            ])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_denies_requests_with_a_token_missing_the_blueprint_handle()
+    {
+        $user = tap(User::make()->makeSuper())->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson(cp_route('replicator-fieldtype.set'), [
+                'token' => encrypt([
+                    'user_id' => $user->id(),
+                ]),
+                'field' => 'content',
+                'set' => 'text',
+            ])
+            ->assertForbidden();
+    }
+
+    private function makeBlueprint()
+    {
+        $blueprint = BlueprintFacade::make()->setHandle('default')->setNamespace('collections.pages');
+        $blueprint->setContents([
+            'sections' => [
+                'main' => [
+                    'fields' => [
+                        [
+                            'handle' => 'content',
+                            'field' => [
+                                'type' => 'replicator',
+                                'sets' => [
+                                    'main' => [
+                                        'sets' => [
+                                            'text' => [
+                                                'fields' => [
+                                                    [
+                                                        'handle' => 'a_text_field',
+                                                        'field' => [
+                                                            'type' => 'text',
+                                                            'default' => 'the default',
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        return $blueprint;
+    }
+}

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -417,6 +417,17 @@ class BlueprintTest extends TestCase
             ],
         ]);
 
+        $user = tap(Facades\User::make()->makeSuper())->save();
+        $this->actingAs($user);
+
+        $publishArray = $blueprint->toPublishArray();
+
+        $this->assertSame([
+            'fqh' => 'test',
+            'user_id' => $user->id(),
+        ], decrypt($publishArray['token']));
+        $publishArray['token'] = '__token__';
+
         $this->assertSame([
             'title' => 'Test',
             'handle' => 'test',
@@ -496,7 +507,8 @@ class BlueprintTest extends TestCase
             ],
             'empty' => false,
             'fqh' => 'test',
-        ], $blueprint->toPublishArray());
+            'token' => '__token__',
+        ], $publishArray);
     }
 
     #[Test]
@@ -544,6 +556,17 @@ class BlueprintTest extends TestCase
                 ],
             ],
         ]);
+
+        $user = tap(Facades\User::make()->makeSuper())->save();
+        $this->actingAs($user);
+
+        $publishArray = $blueprint->toPublishArray();
+
+        $this->assertSame([
+            'fqh' => 'test',
+            'user_id' => $user->id(),
+        ], decrypt($publishArray['token']));
+        $publishArray['token'] = '__token__';
 
         $this->assertSame([
             'title' => 'Test',
@@ -617,7 +640,8 @@ class BlueprintTest extends TestCase
             ],
             'empty' => false,
             'fqh' => 'test',
-        ], $blueprint->toPublishArray());
+            'token' => '__token__',
+        ], $publishArray);
     }
 
     #[Test]

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -803,10 +803,15 @@ class ReplicatorTest extends TestCase
         Facades\Blueprint::partialMock();
         Facades\Blueprint::shouldReceive('find')->with('collections.pages.default')->andReturn($blueprint);
 
+        $user = tap(Facades\User::make()->makeSuper())->save();
+
         $response = $this
-            ->actingAs(tap(Facades\User::make()->makeSuper())->save())
+            ->actingAs($user)
             ->postJson(cp_route('replicator-fieldtype.set'), [
-                'blueprint' => 'collections.pages.default',
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $user->id(),
+                ]),
                 'field' => 'content',
                 'set' => 'text',
             ])
@@ -913,10 +918,15 @@ class ReplicatorTest extends TestCase
         Facades\Blueprint::partialMock();
         Facades\Blueprint::shouldReceive('find')->with('collections.pages.default')->andReturn($blueprint);
 
+        $user = tap(Facades\User::make()->makeSuper())->save();
+
         $response = $this
-            ->actingAs(tap(Facades\User::make()->makeSuper())->save())
+            ->actingAs($user)
             ->postJson(cp_route('replicator-fieldtype.set'), [
-                'blueprint' => 'collections.pages.default',
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $user->id(),
+                ]),
                 'field' => 'page_builder.article.bard_field.cards.cards',
                 'set' => 'card',
             ])
@@ -1006,10 +1016,15 @@ class ReplicatorTest extends TestCase
         Facades\Blueprint::partialMock();
         Facades\Blueprint::shouldReceive('find')->with('collections.pages.default')->andReturn($blueprint);
 
+        $user = tap(Facades\User::make()->makeSuper())->save();
+
         $response = $this
-            ->actingAs(tap(Facades\User::make()->makeSuper())->save())
+            ->actingAs($user)
             ->postJson(cp_route('replicator-fieldtype.set'), [
-                'blueprint' => 'collections.pages.default',
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $user->id(),
+                ]),
                 'field' => 'page_builder.cards_slider.cards_slider.slider.cards',
                 'set' => 'card',
             ])
@@ -1086,10 +1101,15 @@ class ReplicatorTest extends TestCase
         Facades\Blueprint::partialMock();
         Facades\Blueprint::shouldReceive('find')->with('collections.pages.default')->andReturn($blueprint);
 
+        $user = tap(Facades\User::make()->makeSuper())->save();
+
         $response = $this
-            ->actingAs(tap(Facades\User::make()->makeSuper())->save())
+            ->actingAs($user)
             ->postJson(cp_route('replicator-fieldtype.set'), [
-                'blueprint' => 'collections.pages.default',
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $user->id(),
+                ]),
                 'field' => 'page_builder.cards_slider.cards_slider.cards',
                 'set' => 'card',
             ])
@@ -1138,10 +1158,15 @@ class ReplicatorTest extends TestCase
         Facades\Blueprint::partialMock();
         Facades\Blueprint::shouldReceive('find')->with('collections.pages.default')->andReturn($blueprint);
 
+        $user = tap(Facades\User::make()->makeSuper())->save();
+
         $response = $this
-            ->actingAs(tap(Facades\User::make()->makeSuper())->save())
+            ->actingAs($user)
             ->postJson(cp_route('replicator-fieldtype.set'), [
-                'blueprint' => 'collections.pages.default',
+                'token' => encrypt([
+                    'fqh' => 'collections.pages.default',
+                    'user_id' => $user->id(),
+                ]),
                 'field' => 'content',
                 'set' => 'video',
             ])


### PR DESCRIPTION
This PR ensures that the endpoint for getting replicator set metadata doesn't return information for blueprints that you don't have access to.

The endpoint accepted the fully-qualified blueprint handle to look up the field from the respective blueprint. This PR encrypts/decrypts it so you can't just request any blueprint.