### PR TITLE
[6.x] Fix date formats

### DIFF
--- a/resources/js/components/DateFormatter.js
+++ b/resources/js/components/DateFormatter.js
@@ -1,7 +1,6 @@
 export default class DateFormatter {
     #date;
     #options;
-    #locale = navigator.language;
     #presets = {
         datetime: {
             year: 'numeric',
@@ -104,7 +103,7 @@ export default class DateFormatter {
     }
 
     get locale() {
-        return this.#locale;
+        return DateFormatter.defaultLocale ?? Intl.DateTimeFormat().resolvedOptions().locale;
     }
 
     #normalizeDate(date) {

--- a/resources/js/tests/components/DateFormatter.test.js
+++ b/resources/js/tests/components/DateFormatter.test.js
@@ -1,13 +1,6 @@
 import { beforeEach, describe, expect, test } from 'vitest';
 import DateFormatter from '@/components/DateFormatter.js';
 
-function setNavigatorLanguage(lang) {
-    Object.defineProperty(navigator, 'language', {
-        value: lang,
-        writable: true,
-    });
-}
-
 let originalDate;
 function setMockDate(dateString) {
     originalDate = Date; // Store the original Date object
@@ -24,7 +17,7 @@ function setMockDate(dateString) {
 
 beforeEach(() => {
     process.env.TZ = 'UTC';
-    setNavigatorLanguage('en-us');
+    DateFormatter.defaultLocale = 'en-us';
     setMockDate('2021-12-25T12:13:14Z');
 });
 
@@ -189,7 +182,7 @@ describe('dates can be provided in various ways', () => {
 
 test('it can get the locale', () => {
     expect(new DateFormatter().locale).toBe('en-us');
-    setNavigatorLanguage('fr');
+    DateFormatter.defaultLocale = 'fr';
     expect(new DateFormatter().locale).toBe('fr');
 });
 
@@ -201,7 +194,7 @@ test.each([
     ['de', 'time', '12:13'],
     ['de', 'datetime', '25.12.2021, 12:13'],
 ])('it has format presets (%s %s)', (locale, preset, expected) => {
-    setNavigatorLanguage(locale);
+    DateFormatter.defaultLocale = locale;
     expect(new DateFormatter().options(preset).toString()).toBe(expected);
 });
 
@@ -308,6 +301,6 @@ test.each([
         'December 20, 2021 at 12:13:14 PM UTC',
     ],
 ])('it can use relative format (%s)', (label, locale, options, date, expected) => {
-    setNavigatorLanguage(locale);
+    DateFormatter.defaultLocale = locale;
     expect(new DateFormatter().format(date, options)).toBe(expected);
 });

--- a/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
@@ -1,19 +1,13 @@
 import { mount } from '@vue/test-utils';
 import { test, expect, beforeEach } from 'vitest';
 import DateIndexFieldtype from '@/components/fieldtypes/DateIndexFieldtype.vue';
+import DateFormatter from '@/components/DateFormatter.js';
 
 window.__ = (key) => key;
 
 window.matchMedia = () => ({
     addEventListener: () => {},
 });
-
-function setNavigatorLanguage(lang) {
-    Object.defineProperty(navigator, 'language', {
-        value: lang,
-        writable: true,
-    });
-}
 
 const makeDateIndexField = (value = {}) => {
     return mount(DateIndexFieldtype, {
@@ -27,6 +21,7 @@ const makeDateIndexField = (value = {}) => {
 
 beforeEach(() => {
     process.env.TZ = 'UTC';
+    DateFormatter.defaultLocale = 'en';
 });
 
 test.each([
@@ -79,7 +74,7 @@ test.each([
     ['de', '25.12.2025'],
     ['fr', '25/12/2025'],
 ])('date is formatted to the users browser language (%s)', async (lang, expected) => {
-    setNavigatorLanguage(lang);
+    DateFormatter.defaultLocale = lang;
 
     const dateIndexField = makeDateIndexField({ date: '2025-12-25T13:29:00Z' });
 
@@ -91,7 +86,7 @@ test.each([
     ['de', '25.12.2025, 13:29'],
     ['fr', '25/12/2025 13:29'],
 ])('date and time is formatted to the users browser language (%s)', async (lang, expected) => {
-    setNavigatorLanguage(lang);
+    DateFormatter.defaultLocale = lang;
 
     const dateIndexField = makeDateIndexField({ date: '2025-12-25T13:29:00Z', time_enabled: true });
 
@@ -103,7 +98,7 @@ test.each([
     ['de', '25.12.2025 – 28.12.2025'],
     ['fr', '25/12/2025 – 28/12/2025'],
 ])('date range is formatted to the users browser language (%s)', async (lang, expected) => {
-    setNavigatorLanguage(lang);
+    DateFormatter.defaultLocale = lang;
 
     const dateIndexField = makeDateIndexField({
         start: '2025-12-25T02:13:00Z',


### PR DESCRIPTION
## What & Why

`DateFormatter` was using `navigator.language` as the default locale, which often returns a regionless tag like `en`. When passed to `Intl.DateTimeFormat`, this resolves to US formatting (MM/DD/YYYY) — affecting users in the UK, Australia, Europe, etc. who have their browser set to English without a region.

The fix uses `Intl.DateTimeFormat().resolvedOptions().locale` as the fallback instead, which returns a fully resolved locale from the system/OS regional settings (e.g. `en-GB` rather than `en`).

A static `DateFormatter.defaultLocale` property is also introduced, which takes priority when set. This is used in tests to keep assertions deterministic without mocking `navigator.language`, and could serve as a hook for overriding via a preference if necessary.

## Changes

- Removed `#locale = navigator.language` field initializer
- `locale` getter now returns `DateFormatter.defaultLocale ?? Intl.DateTimeFormat().resolvedOptions().locale`
- Tests swap `setNavigatorLanguage()` for `DateFormatter.defaultLocale` in `beforeEach`

Fixes #14074
This PR intentionally does *not* introduce a preference. I'd like to see if this resolves the issue before introducing another thing.