### PR TITLE
[6.x] Prevent logging git dependabot errors

### DIFF
--- a/src/Console/Processes/Git.php
+++ b/src/Console/Processes/Git.php
@@ -90,6 +90,7 @@ class Git extends Process
             'Permanently added the ECDSA host key for IP address',
             'remote: Processed',
             'Auto packing the repository',
+            'remote: GitHub found',
         ];
 
         if (Str::contains($buffer, $ignore)) {

--- a/tests/Git/GitProcessTest.php
+++ b/tests/Git/GitProcessTest.php
@@ -161,6 +161,14 @@ EOT;
         $this->simulateLoggableErrorOutput('Error: Auto packing the repository in background for optimum performance.');
     }
 
+    #[Test]
+    public function it_doesnt_log_github_dependabot_warnings_as_error_output()
+    {
+        Log::shouldReceive('error')->never();
+
+        $this->simulateLoggableErrorOutput("remote: GitHub found 45 vulnerabilities on user/repo's default branch (1 critical, 17 high, 24 moderate, 3 low). To find out more, visit:\nremote: https://github.com/user/repo/security/dependabot");
+    }
+
     private function showLastCommit($path)
     {
         return Process::create($path)->run('git show');


### PR DESCRIPTION
The Git integration is throwing errors when pushing changes to a repo with open dependabot warnings. This PR ignores these errors and follows the same pattern as https://github.com/statamic/cms/pull/10332.

```log
Process Class: Git Command: 'git' 'push' '--porcelain' Error: remote: remote: GitHub found 45 vulnerabilities on user/repo's default branch (1 critical, 17 high, 24 moderate, 3 low). To find out more, visit: remote: https://github.com/user/repo/security/dependabot remote:
```