### PR TITLE
[6.x] Ensure images are refreshed properly after cropping

### DIFF
--- a/resources/js/bootstrap/App.vue
+++ b/resources/js/bootstrap/App.vue
@@ -43,11 +43,15 @@ export default {
             }
         });
 
-        Statamic.$callbacks.add('bustAndReloadImageCaches', function (urls) {
-            urls.forEach(async (url) => {
+        Statamic.$callbacks.add('bustAndReloadImageCaches', async function (urls) {
+            for (const url of urls) {
+                if (!url) continue;
                 await fetch(url, { cache: 'reload', mode: 'no-cors' });
-                document.body.querySelectorAll(`img[src='${url}']`).forEach((img) => (img.src = url));
-            });
+                document.body.querySelectorAll(`img[src='${url}']`).forEach((img) => {
+                    img.removeAttribute('src');
+                    img.src = url;
+                });
+            }
         });
 
         Statamic.$callbacks.add('removeFromSelections', function (ids) {


### PR DESCRIPTION
This pull request fixes an issue where cropped images weren't updating in the asset editor after replacing the original file.

This was happening because the `bustAndReloadImageCaches` callback had two problems:
1. Using `forEach` with an `async` callback doesn't actually await the operations - the callback returns immediately while fetches happen in the background
2. Reassigning `img.src = url` to the same value doesn't reliably trigger a re-fetch since browsers may optimize this as a no-op

This PR fixes it by:
- Using a `for...of` loop instead of `forEach` to properly await each fetch operation
- Calling `removeAttribute('src')` before reassigning the src, which forces the browser to re-fetch from the (now updated) HTTP cache

## Before

https://github.com/user-attachments/assets/2174d287-05c8-4a2e-828e-c791b101de10


## After

https://github.com/user-attachments/assets/1c853910-c1c0-43c0-8811-3468d86fc6e6


---

Fixes #14155

_Note: I could only reproduce this issue in Safari - Chrome refreshed images as expected._