### PR TITLE
[6.x] Allow using SVGs from `vendor`/`node_modules` directories

### DIFF
--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -31,6 +31,7 @@ class Svg extends Tags
             public_path('svg'),
             public_path(),
             statamic_path('resources/svg/icons'),
+            base_path(),
         ];
 
         $svg = null;


### PR DESCRIPTION
This pull request updates the `{{ svg }}` tag to allow using icons from the `vendor`/`node_modules` directories, as well as anywhere else in your project.

The tag will still look at paths like `resources/svg`, `public/svg` first, but if it fails to find a match, it'll look from the base of the project.

Fixes #14253