### PR TITLE
[6.x] Handle validation rules on Files fieldtype

### DIFF
--- a/src/Fieldtypes/Files.php
+++ b/src/Fieldtypes/Files.php
@@ -3,6 +3,14 @@
 namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
+use Statamic\Fieldtypes\Assets\DimensionsRule;
+use Statamic\Fieldtypes\Assets\ImageRule;
+use Statamic\Fieldtypes\Assets\MaxRule;
+use Statamic\Fieldtypes\Assets\MimesRule;
+use Statamic\Fieldtypes\Assets\MimetypesRule;
+use Statamic\Fieldtypes\Assets\MinRule;
+use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 class Files extends Fieldtype
 {
@@ -48,5 +56,29 @@ class Files extends Fieldtype
         }
 
         return $rules;
+    }
+
+    public function fieldRules()
+    {
+        $classes = [
+            'dimensions' => DimensionsRule::class,
+            'image' => ImageRule::class,
+            'max_filesize' => MaxRule::class,
+            'mimes' => MimesRule::class,
+            'mimetypes' => MimetypesRule::class,
+            'min_filesize' => MinRule::class,
+        ];
+
+        return collect(parent::fieldRules())->map(function ($rule) use ($classes) {
+            $name = Str::before($rule, ':');
+
+            if ($class = Arr::get($classes, $name)) {
+                $parameters = explode(',', Str::after($rule, ':'));
+
+                return new $class($parameters);
+            }
+
+            return $rule;
+        })->all();
     }
 }

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -9,6 +9,14 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Assets\AssetContainer;
 use Statamic\Facades\User;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Assets\DimensionsRule;
+use Statamic\Fieldtypes\Assets\ImageRule;
+use Statamic\Fieldtypes\Assets\MaxRule;
+use Statamic\Fieldtypes\Assets\MimesRule;
+use Statamic\Fieldtypes\Assets\MimetypesRule;
+use Statamic\Fieldtypes\Assets\MinRule;
+use Statamic\Fieldtypes\Files;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -86,5 +94,82 @@ class FilesTest extends TestCase
             'non-image with container with no preset' => ['without_preset', false, '1671484636/test.txt', null, null],
             'non-image with container with preset' => ['with_preset', false, '1671484636/test.txt', null, null],
         ];
+    }
+
+    #[Test]
+    public function it_replaces_dimensions_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['dimensions:width=180,height=180']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertInstanceOf(DimensionsRule::class, $replaced[0]);
+    }
+
+    #[Test]
+    public function it_replaces_image_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['image']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertInstanceOf(ImageRule::class, $replaced[0]);
+    }
+
+    #[Test]
+    public function it_replaces_mimes_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['mimes:jpg,png']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertInstanceOf(MimesRule::class, $replaced[0]);
+    }
+
+    #[Test]
+    public function it_replaces_mimetypes_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['mimetypes:image/jpg,image/png']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertInstanceOf(MimetypesRule::class, $replaced[0]);
+    }
+
+    #[Test]
+    public function it_replaces_min_filesize_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['min_filesize:100']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertInstanceOf(MinRule::class, $replaced[0]);
+    }
+
+    #[Test]
+    public function it_replaces_max_filesize_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['max_filesize:100']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertInstanceOf(MaxRule::class, $replaced[0]);
+    }
+
+    #[Test]
+    public function it_doesnt_replace_non_file_related_rule()
+    {
+        $replaced = $this->fieldtype(['validate' => ['required']])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertEquals('required', $replaced[0]);
+    }
+
+    private function fieldtype($config = [])
+    {
+        return (new Files)->setField(new Field('test', array_merge([
+            'type' => 'files',
+        ], $config)));
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where the Files fieldtype would throw a 500 error when using `min_filesize` or `max_filesize` validation rules.

This was happening because the Files fieldtype doesn't have a `fieldRules()` method to map these custom validation rules to their corresponding Rule classes. When rules like `max_filesize:10240` were passed to Laravel's validator, it tried to find a `validateMaxFilesize` method which doesn't exist.

This PR fixes it by defending a `fieldRules()` method on the Files fieldtype, just like we do on the Assets fieldtype.

Fixes #14083