### PR TITLE
[6.x] Fix error on `CreateForm` component in Storybook

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -37,6 +37,9 @@ setup(async (app) => {
                       lang: 'en',
                   }],
                   selectedSite: 'default',
+                  lang: 'en',
+                  asciiReplaceExtraSymbols: false,
+                  charmap: { currency: {}, currency_short: {} },
               };
 
               return config[key] ?? null;


### PR DESCRIPTION
This pull request fixes an issue where typing into the title input of a CreateForm component in Storybook throws an error: `Cannot read properties of null (reading 'en')`.

This was happening because the `Slug.js` class expects `Statamic.$config.get('charmap')` to return an object, but the Storybook mock was returning `null` for unmocked config keys.

This PR fixes it by adding the missing config values (`charmap`, `asciiReplaceExtraSymbols`, and `lang`) to the Storybook preview configuration.

Reported [on Discord](https://discord.com/channels/489818810157891584/489825364902805505/1477964053451112469)