### PR TITLE
[6.x] Fixed incorrect variable in return doc

### DIFF
--- a/src/Auth/Permission.php
+++ b/src/Auth/Permission.php
@@ -45,7 +45,7 @@ class Permission
     }
 
     /**
-     * @return ($value is null ? string|null : static)
+     * @return ($label is null ? string|null : static)
      */
     public function label(?string $label = null)
     {


### PR DESCRIPTION
This PR fixes a misnamed variable of a return doc in the Permission class.
This would cause static analysis to fail while the real return value is correct.