### PR TITLE
[6.x] Fix error saving preferences when `theme` translations exist

### DIFF
--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -6,6 +6,8 @@ use Locale;
 use Statamic\Facades\Preference;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class CorePreferences
 {
     public function boot()


### PR DESCRIPTION
This pull request fixes an error saving preferences when a `lang/{locale}/theme.php` file exists in the app. This PR fixes it in a similar fashion as #11482.

Fixes #14039.