### PR TITLE
[5.x] Prevent term creation via fieldtype without permission

### DIFF
--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -485,9 +485,20 @@ class Terms extends Relationship
         $slug = Str::slug($string, '-', $lang);
 
         if (! $term = Facades\Term::find("{$taxonomy}::{$slug}")) {
+            $taxonomy = Facades\Taxonomy::findByHandle($taxonomy);
+
+            // Only enforce authorization when there's no parent context,
+            // e.g. when processing fields via the field-action-modal endpoint.
+            if (! $parent) {
+                throw_if(
+                    User::current()->cant('create', [TermContract::class, $taxonomy]),
+                    new AuthorizationException
+                );
+            }
+
             $term = Facades\Term::make()
                 ->slug($slug)
-                ->taxonomy(Facades\Taxonomy::findByHandle($taxonomy))
+                ->taxonomy($taxonomy)
                 ->set('title', $string);
 
             $term->save();

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -220,8 +220,13 @@ class Terms extends Relationship
                     $id = $this->createTermFromString($id, $taxonomy);
                 }
 
+                if (! $id) {
+                    return null;
+                }
+
                 return explode('::', $id, 2)[1];
             })
+                ->filter()
                 ->unique()
                 ->values()
                 ->all();
@@ -487,13 +492,8 @@ class Terms extends Relationship
         if (! $term = Facades\Term::find("{$taxonomy}::{$slug}")) {
             $taxonomy = Facades\Taxonomy::findByHandle($taxonomy);
 
-            // Only enforce authorization when there's no parent context,
-            // e.g. when processing fields via the field-action-modal endpoint.
-            if (! $parent) {
-                throw_if(
-                    User::current()->cant('create', [TermContract::class, $taxonomy]),
-                    new AuthorizationException
-                );
+            if (User::current()->cant('create', [TermContract::class, $taxonomy])) {
+                return null;
             }
 
             $term = Facades\Term::make()


### PR DESCRIPTION
This prevents terms being created via the fieldtype if you don't have permission to do so.