### PR TITLE
[6.x] Hide "Duplicate Set" when max sets limit has been reached

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -290,6 +290,8 @@ export default {
         },
 
         duplicateSet(old_id) {
+            if (!this.canAddSet) return;
+
             const index = this.value.findIndex((v) => v._id === old_id);
             const old = this.value[index];
             const set = {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -190,7 +190,7 @@ reveal.use(rootEl, () => emit('expanded'));
                                 :text="__(collapsed ? __('Expand Set') : __('Collapse Set'))"
                                 @click="toggleCollapsedState"
                             />
-                            <DropdownItem :text="__('Duplicate Set')" @click="emit('duplicated')" />
+                            <DropdownItem v-if="canAddSet" :text="__('Duplicate Set')" @click="emit('duplicated')" />
                             <DropdownItem
                                 :text="__('Delete Set')"
                                 variant="destructive"


### PR DESCRIPTION
This pull request hides the "Duplicate Set" dropdown item when the `max_sets` limit has been reached.

Fixes #14267
