### PR TITLE
[6.x] Fieldset editing improvements

### DIFF
--- a/resources/js/components/blueprints/ImportField.vue
+++ b/resources/js/components/blueprints/ImportField.vue
@@ -8,8 +8,7 @@
                         <div class="flex flex-1 items-center py-2">
                             <ui-icon class="size-4 me-2 text-ui-accent-text/80" name="fieldsets" />
                             <div class="flex items-center gap-2">
-                            <!-- @TODO: Show fieldset.title -->
-                                <button class="cursor-pointer overflow-hidden text-ellipsis text-sm text-ui-accent-text hover:text-ui-accent-text/80" v-text="field.fieldset" @click="$emit('edit')" />
+                                <button class="cursor-pointer overflow-hidden text-ellipsis text-sm text-ui-accent-text hover:text-ui-accent-text/80" v-text="fieldsetTitle" @click="$emit('edit')" />
                                 <ui-icon name="link" class="text-gray-400" />
                                 <span class="text-gray-500 font-mono text-2xs" v-text="__('Fieldset')" />
                             </div>
@@ -50,6 +49,12 @@ export default {
     },
 
     computed: {
+        fieldsetTitle() {
+            const title = this.$page?.props?.fieldsets?.[this.field.fieldset]?.title;
+
+            return title ? __(title) : this.field.fieldset;
+        },
+
         fieldConfig() {
             const { _id, type, ...config } = this.field;
             return config;

--- a/resources/js/components/blueprints/ImportField.vue
+++ b/resources/js/components/blueprints/ImportField.vue
@@ -8,13 +8,13 @@
                         <div class="flex flex-1 items-center py-2">
                             <ui-icon class="size-4 me-2 text-ui-accent-text/80" name="fieldsets" />
                             <div class="flex items-center gap-2">
-                                <a class="cursor-pointer overflow-hidden text-ellipsis text-sm text-ui-accent-text hover:text-ui-accent-text/80" :href="fieldsetEditUrl" v-text="fieldsetTitle" />
+                                <a class="cursor-pointer overflow-hidden text-ellipsis text-sm text-ui-accent-text hover:text-ui-accent-text/80" :href="fieldsetEditUrl" v-text="fieldsetTitle" v-tooltip="__('Edit fieldset')" />
                                 <ui-icon name="link" class="text-gray-400" />
                                 <span class="text-gray-500 font-mono text-2xs" v-text="__('Fieldset')" />
                             </div>
                         </div>
                         <div class="flex items-center">
-                            <ui-button size="sm" icon="cog" variant="subtle" inset @click.prevent="$emit('edit')" v-tooltip="__('Configure')" />
+                            <ui-button size="sm" icon="cog" variant="subtle" inset @click.prevent="$emit('edit')" v-tooltip="__('Configure import')" />
                             <ui-button size="sm" icon="trash" variant="subtle" inset @click.prevent="$emit('deleted')" v-tooltip="__('Remove')" />
                             <ui-stack :open="isEditing" @update:open="editorClosed" inset :show-close-button="false" :wrap-slot="false">
                                 <field-settings

--- a/resources/js/components/blueprints/ImportField.vue
+++ b/resources/js/components/blueprints/ImportField.vue
@@ -13,8 +13,9 @@
                                 <span class="text-gray-500 font-mono text-2xs" v-text="__('Fieldset')" />
                             </div>
                         </div>
-                        <div class="flex items-center gap-2">
-                            <ui-button size="sm" icon="trash" variant="subtle" @click.prevent="$emit('deleted')" v-tooltip="__('Remove')" />
+                        <div class="flex items-center">
+                            <ui-button size="sm" icon="edit" variant="subtle" inset :href="fieldsetEditUrl" v-tooltip="__('Edit')" />
+                            <ui-button size="sm" icon="trash" variant="subtle" inset @click.prevent="$emit('deleted')" v-tooltip="__('Remove')" />
                             <ui-stack :open="isEditing" @update:open="editorClosed" inset :show-close-button="false" :wrap-slot="false">
                                 <field-settings
                                     ref="settings"
@@ -53,6 +54,10 @@ export default {
             const title = this.$page?.props?.fieldsets?.[this.field.fieldset]?.title;
 
             return title ? __(title) : this.field.fieldset;
+        },
+
+        fieldsetEditUrl() {
+            return cp_url(`fields/fieldsets/${this.field.fieldset}/edit`);
         },
 
         fieldConfig() {

--- a/resources/js/components/blueprints/ImportField.vue
+++ b/resources/js/components/blueprints/ImportField.vue
@@ -11,6 +11,12 @@
                                 <a class="cursor-pointer overflow-hidden text-ellipsis text-sm text-ui-accent-text hover:text-ui-accent-text/80" :href="fieldsetEditUrl" v-text="fieldsetTitle" v-tooltip="__('Edit fieldset')" />
                                 <ui-icon name="link" class="text-gray-400" />
                                 <span class="text-gray-500 font-mono text-2xs" v-text="__('Fieldset')" />
+                                <ui-badge
+                                    v-if="field.prefix"
+                                    size="sm"
+                                    color="gray"
+                                    :text="`${__('Prefix')}: ${field.prefix}`"
+                                />
                             </div>
                         </div>
                         <div class="flex items-center">

--- a/resources/js/components/blueprints/ImportField.vue
+++ b/resources/js/components/blueprints/ImportField.vue
@@ -8,13 +8,13 @@
                         <div class="flex flex-1 items-center py-2">
                             <ui-icon class="size-4 me-2 text-ui-accent-text/80" name="fieldsets" />
                             <div class="flex items-center gap-2">
-                                <button class="cursor-pointer overflow-hidden text-ellipsis text-sm text-ui-accent-text hover:text-ui-accent-text/80" v-text="fieldsetTitle" @click="$emit('edit')" />
+                                <a class="cursor-pointer overflow-hidden text-ellipsis text-sm text-ui-accent-text hover:text-ui-accent-text/80" :href="fieldsetEditUrl" v-text="fieldsetTitle" />
                                 <ui-icon name="link" class="text-gray-400" />
                                 <span class="text-gray-500 font-mono text-2xs" v-text="__('Fieldset')" />
                             </div>
                         </div>
                         <div class="flex items-center">
-                            <ui-button size="sm" icon="edit" variant="subtle" inset :href="fieldsetEditUrl" v-tooltip="__('Edit')" />
+                            <ui-button size="sm" icon="cog" variant="subtle" inset @click.prevent="$emit('edit')" v-tooltip="__('Configure')" />
                             <ui-button size="sm" icon="trash" variant="subtle" inset @click.prevent="$emit('deleted')" v-tooltip="__('Remove')" />
                             <ui-stack :open="isEditing" @update:open="editorClosed" inset :show-close-button="false" :wrap-slot="false">
                                 <field-settings


### PR DESCRIPTION
Various improvements to importing a Fieldset in the Blueprint editor:
- Show imported fieldset title (fallbacks to handle).
- Make the fieldset label/title click through to edit the actual fieldset (href for now).
- Add a Configure (gear) button for import settings.
- Disambiguate tooltips
- Add a Prefix preview using `ui-badge` when a prefix is set.

<img width="1638" height="350" alt="CleanShot 2026-03-17 at 23 56 09@2x" src="https://github.com/user-attachments/assets/cd89a507-7560-4769-9673-dfb21ff92e6c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only changes to the blueprint fieldset import row (labels, links, buttons) with no backend or data model changes.
> 
> **Overview**
> Improves the Blueprint editor’s imported fieldset row by showing the *fieldset title* (falling back to the handle) and making it a direct link to the fieldset edit screen.
> 
> Adds clearer import controls: a dedicated **Configure import** (gear) action, disambiguated tooltips, and a small `ui-badge` preview of the configured prefix when present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39190ededa535895c40c9c454376c2dc670f1579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->