### PR TITLE
[5.x] Add additional `URL::isExternalToApplication()` tests

### DIFF
--- a/tests/Facades/Concerns/ProvidesExternalUrls.php
+++ b/tests/Facades/Concerns/ProvidesExternalUrls.php
@@ -67,6 +67,24 @@ trait ProvidesExternalUrls
             ['http://subdomain.this-site.com.au/some-slug', true],
             ['http://subdomain.this-site.com.au/some-slug?foo', true],
             ['http://subdomain.this-site.com.au/some-slug#anchor', true],
+
+            // URL credential injection attacks
+            // These use the userinfo@host syntax to trick naive URL parsing
+            ['http://this-site.com@evil.com', true],
+            ['http://this-site.com@evil.com/', true],
+            ['http://this-site.com@evil.com/path', true],
+            ['http://this-site.com@evil.com/path?query', true],
+            ['http://this-site.com:password@evil.com', true],
+            ['http://user:pass@evil.com', true],
+            ['http://absolute-url-resolved-from-request.com@evil.com', true],
+            ['http://absolute-url-resolved-from-request.com@evil.com/path', true],
+            ['http://subdomain.this-site.com@evil.com', true],
+            ['http://subdomain.this-site.com@evil.com/path', true],
+
+            // URL credential injection with port numbers
+            ['http://this-site.com:8000@evil.com', true],
+            ['http://this-site.com:8000@evil.com/path', true],
+            ['http://this-site.com:8000@webhook.site/token', true],
         ];
     }
 }

--- a/tests/Facades/Concerns/ProvidesExternalUrls.php
+++ b/tests/Facades/Concerns/ProvidesExternalUrls.php
@@ -68,8 +68,7 @@ trait ProvidesExternalUrls
             ['http://subdomain.this-site.com.au/some-slug?foo', true],
             ['http://subdomain.this-site.com.au/some-slug#anchor', true],
 
-            // URL credential injection attacks
-            // These use the userinfo@host syntax to trick naive URL parsing
+            // Credential injection
             ['http://this-site.com@evil.com', true],
             ['http://this-site.com@evil.com/', true],
             ['http://this-site.com@evil.com/path', true],
@@ -80,8 +79,6 @@ trait ProvidesExternalUrls
             ['http://absolute-url-resolved-from-request.com@evil.com/path', true],
             ['http://subdomain.this-site.com@evil.com', true],
             ['http://subdomain.this-site.com@evil.com/path', true],
-
-            // URL credential injection with port numbers
             ['http://this-site.com:8000@evil.com', true],
             ['http://this-site.com:8000@evil.com/path', true],
             ['http://this-site.com:8000@webhook.site/token', true],


### PR DESCRIPTION
This pull request adds additional test cases to the `ProvidesExternalUrls` trait to protect against URL credential injection. 

The issue only affects the implementation on`6.x`, but I thought it was worth adding tests to `5.x` just to be sure.

Related: #14287