### PR TITLE
[6.x] Fields shouldn't be editable in read-only Group fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -17,6 +17,7 @@
                         <FieldsProvider
                             :fields="fields"
                             :as-config="false"
+                            :read-only="isReadOnly"
                             :field-path-prefix="fieldPathPrefix ? `${fieldPathPrefix}.${handle}` : handle"
                             :meta-path-prefix="metaPathPrefix ? `${metaPathPrefix}.${handle}` : handle"
                         >


### PR DESCRIPTION
This pull request fixes an issue where fields were editable in a read-only Group fieldtype.

Fixes #14280