### PR TITLE
[6.x] Prevent opening set picker when `max_sets` limit has been reached

### DIFF
--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -14,7 +14,9 @@
         class="xl:max-w-3xl 2xl:max-w-page"
     >
         <template #trigger>
-            <slot name="trigger" />
+            <Primitive @click.capture="onTriggerClick">
+                <slot name="trigger" />
+            </Primitive>
         </template>
 
         <template #default>
@@ -90,7 +92,9 @@
         inset
     >
         <template #trigger>
-            <slot name="trigger" />
+            <Primitive @click.capture="onTriggerClick">
+                <slot name="trigger" />
+            </Primitive>
         </template>
 
         <template #default>
@@ -447,6 +451,13 @@ export default {
 
         open() {
             this.isOpen = true;
+        },
+
+        onTriggerClick(e) {
+            if (!this.enabled) {
+                e.stopPropagation();
+                e.preventDefault();
+            }
         },
 
         getStoredMode() {


### PR DESCRIPTION
This pull request fixes an issue where users could bypass the Replicator's set limit by clicking on a hidden clickable area between sets.

This was happening because the SetPicker's modal and popover triggers remained interactive even when the `enabled` prop was `false`. While the visible buttons were conditionally hidden, the underlying trigger slots were still capturing clicks and opening the picker.

This PR fixes it by wrapping the trigger slots in a `Primitive` component with a capture-phase click handler that stops event propagation when `enabled` is `false`, preventing the modal/popover from opening.

Fixes #14285