### PR TITLE
[6.x] GraphQL API Authentication

### DIFF
--- a/config/graphql.php
+++ b/config/graphql.php
@@ -29,6 +29,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Authentication
+    |--------------------------------------------------------------------------
+    |
+    | By default, the GraphQL API will be publicly accessible. However, you
+    | may define an API token here which will be used to authenticate requests.
+    |
+    */
+
+    'auth_token' => env('STATAMIC_GRAPHQL_AUTH_TOKEN'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Queries
     |--------------------------------------------------------------------------
     |

--- a/resources/views/graphql/graphiql.blade.php
+++ b/resources/views/graphql/graphiql.blade.php
@@ -66,13 +66,11 @@
 
             const introspectionEnabled = {{ \Statamic\Support\Str::bool($introspection) }};
 
+            const authToken = {{ Js::from($authToken) }};
+
             const fetcher = createGraphiQLFetcher({
                 url: '{{ $url }}',
-                @if ($authToken)
-                headers: {
-                    'Authorization': 'Bearer {{ $authToken }}',
-                },
-                @endif
+                ...(authToken ? { headers: { 'Authorization': `Bearer ${authToken}` } } : {}),
             });
 
             let plugins = [HISTORY_PLUGIN];

--- a/resources/views/graphql/graphiql.blade.php
+++ b/resources/views/graphql/graphiql.blade.php
@@ -68,6 +68,11 @@
 
             const fetcher = createGraphiQLFetcher({
                 url: '{{ $url }}',
+                @if ($authToken)
+                headers: {
+                    'Authorization': 'Bearer {{ $authToken }}',
+                },
+                @endif
             });
 
             let plugins = [HISTORY_PLUGIN];

--- a/src/GraphQL/DefaultSchema.php
+++ b/src/GraphQL/DefaultSchema.php
@@ -6,6 +6,7 @@ use Facades\Statamic\API\ResourceAuthorizer;
 use Rebing\GraphQL\Support\Contracts\ConfigConvertible;
 use Statamic\Facades\GraphQL;
 use Statamic\GraphQL\Middleware\CacheResponse;
+use Statamic\GraphQL\Middleware\HandleAuthentication;
 use Statamic\GraphQL\Queries\AssetContainerQuery;
 use Statamic\GraphQL\Queries\AssetContainersQuery;
 use Statamic\GraphQL\Queries\AssetQuery;
@@ -77,7 +78,7 @@ class DefaultSchema implements ConfigConvertible
     private function getMiddleware()
     {
         return array_merge(
-            [CacheResponse::class],
+            [HandleAuthentication::class, CacheResponse::class],
             config('statamic.graphql.middleware', []),
             GraphQL::getExtraMiddleware()
         );

--- a/src/GraphQL/Middleware/HandleAuthentication.php
+++ b/src/GraphQL/Middleware/HandleAuthentication.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\GraphQL\Middleware;
+
+use Closure;
+
+class HandleAuthentication
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        if (
+            ($token = config('statamic.graphql.auth_token'))
+            && ($request->bearerToken() !== $token)
+        ) {
+            abort(401);
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Http/Controllers/CP/GraphQLController.php
+++ b/src/Http/Controllers/CP/GraphQLController.php
@@ -24,6 +24,7 @@ class GraphQLController extends CpController
         return view('statamic::graphql.graphiql', [
             'url' => '/'.config('graphql.route.prefix'),
             'introspection' => GraphQL::introspectionEnabled(),
+            'authToken' => config('statamic.graphql.auth_token'),
         ]);
     }
 }

--- a/tests/Feature/GraphQL/AuthenticationTest.php
+++ b/tests/Feature/GraphQL/AuthenticationTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Tests\Feature\GraphQL;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Config;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+#[Group('graphql')]
+class AuthenticationTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_can_authenticate_using_auth_token()
+    {
+        Config::set('statamic.graphql.auth_token', 'foobar');
+
+        $this
+            ->withToken('foobar')
+            ->postJson('/graphql', ['query' => '{ping}'])
+            ->assertOk();
+    }
+
+    #[Test]
+    public function it_cant_authenticate_with_invalid_auth_token()
+    {
+        Config::set('statamic.graphql.auth_token', 'foobar');
+
+        $this
+            ->withToken($token = 'invalid')
+            ->postJson($url = '/graphql', ['query' => '{ping}'])
+            ->assertUnauthorized();
+
+        $this
+            ->withToken($token)
+            ->post($url, ['query' => '{ping}'])
+            ->assertUnauthorized();
+    }
+
+    #[Test]
+    public function it_cant_authenticate_without_auth_token()
+    {
+        Config::set('statamic.graphql.auth_token', 'foobar');
+
+        $this
+            ->postJson($url = '/graphql', ['query' => '{ping}'])
+            ->assertUnauthorized();
+
+        $this
+            ->post($url, ['query' => '{ping}'])
+            ->assertUnauthorized();
+    }
+
+    #[Test]
+    public function authentication_only_required_when_auth_token_is_set()
+    {
+        Config::set('statamic.graphql.auth_token', null);
+
+        $this
+            ->postJson($url = '/graphql', ['query' => '{ping}'])
+            ->assertOk();
+
+        $this
+            ->post($url, ['query' => '{ping}'])
+            ->assertOk();
+    }
+
+    #[Test]
+    public function authenticated_responses_are_not_served_to_unauthenticated_requests()
+    {
+        Config::set('statamic.graphql.auth_token', 'foobar');
+        Config::set('statamic.graphql.cache', ['expiry' => 60]);
+
+        // First, make an authenticated request that gets cached
+        $this
+            ->withToken('foobar')
+            ->postJson('/graphql', ['query' => '{ping}'])
+            ->assertOk()
+            ->assertJsonPath('data.ping', 'pong');
+
+        // Now make an unauthenticated request - should get 401, not cached response
+        // This verifies auth happens before caching
+        $this
+            ->withoutToken()
+            ->postJson('/graphql', ['query' => '{ping}'])
+            ->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
This pull request adds authentication to the GraphQL API.

To enable, add the `STATAMIC_GRAPHQL_AUTH_TOKEN` key to your `.env`:

```
STATAMIC_GRAPHQL_AUTH_TOKEN=some-random-string
```

Then, when making requests to the GraphQL API, include the API token as a header:

```bash
curl -X GET "https://example.com/graphql" \
  -H "Authorization: Bearer some-random-string" \
  -H "Accept: application/json"
  -d '{"query": "{ping}"}'
```

If you need full-on user authentication, we recommend using something like [Laravel Sanctum](https://laravel.com/docs/master/sanctum) instead. 

We added authentication to the REST API in #12051, and ever since then I've been meaning to add it to GraphQL too for feature parity, so here we are!