### PR TITLE
[6.x] Fix logo z-index in Outside.vue

### DIFF
--- a/resources/js/pages/layout/Outside.vue
+++ b/resources/js/pages/layout/Outside.vue
@@ -22,7 +22,7 @@ onMounted(() => {
 <template>
     <div class="relative mx-auto max-w-[400px] items-center justify-center">
         <div class="flex items-center justify-center py-6">
-            <div class="logo relative z-0 max-w-3/4 md:pt-18">
+            <div class="logo max-w-3/4 md:pt-18">
                 <template v-if="customLogo">
                     <img
                         :src="lightCustomLogo"

--- a/resources/js/pages/layout/Outside.vue
+++ b/resources/js/pages/layout/Outside.vue
@@ -22,7 +22,7 @@ onMounted(() => {
 <template>
     <div class="relative mx-auto max-w-[400px] items-center justify-center">
         <div class="flex items-center justify-center py-6">
-            <div class="logo relative z-10 max-w-3/4 md:pt-18 z-0">
+            <div class="logo relative z-0 max-w-3/4 md:pt-18">
                 <template v-if="customLogo">
                     <img
                         :src="lightCustomLogo"

--- a/resources/js/pages/layout/Outside.vue
+++ b/resources/js/pages/layout/Outside.vue
@@ -22,7 +22,7 @@ onMounted(() => {
 <template>
     <div class="relative mx-auto max-w-[400px] items-center justify-center">
         <div class="flex items-center justify-center py-6">
-            <div class="logo relative z-10 max-w-3/4 md:pt-18">
+            <div class="logo relative z-10 max-w-3/4 md:pt-18 z-0">
                 <template v-if="customLogo">
                     <img
                         :src="lightCustomLogo"


### PR DESCRIPTION
Fixes #14298

Before:

<img width="1768" height="1130" alt="CleanShot 2026-03-19 at 09 09 26@2x" src="https://github.com/user-attachments/assets/4e976b13-4d74-48ba-ab50-c60cabd16e7f" />

After:

<img width="1630" height="1150" alt="CleanShot 2026-03-19 at 09 09 08@2x" src="https://github.com/user-attachments/assets/912c85bd-fb0e-41bf-834b-8eb96625d41d" />
