### PR TITLE
[5.x] Fix PHP sanitization edge cases

### DIFF
--- a/src/View/Antlers/Language/Utilities/StringUtilities.php
+++ b/src/View/Antlers/Language/Utilities/StringUtilities.php
@@ -81,6 +81,10 @@ class StringUtilities
     {
         $text = str_ireplace('<?php', '&lt;?php', $text);
 
+        // Always replace short echo tags (<?=) — enabled since PHP 5.4
+        // regardless of short_open_tag setting.
+        $text = str_replace('<?=', '&lt;?=', $text);
+
         // Also replace short tags if they're enabled.
         if (ini_get('short_open_tag')) {
             $xmlPlaceholder = '__XML_PLACEHOLDER'.Str::uuid();

--- a/src/View/Antlers/Language/Utilities/StringUtilities.php
+++ b/src/View/Antlers/Language/Utilities/StringUtilities.php
@@ -79,19 +79,10 @@ class StringUtilities
      */
     public static function sanitizePhp($text)
     {
-        $text = str_ireplace('<?php', '&lt;?php', $text);
-
-        // Always replace short echo tags (<?=) — enabled since PHP 5.4
-        // regardless of short_open_tag setting.
-        $text = str_replace('<?=', '&lt;?=', $text);
-
-        // Also replace short tags if they're enabled.
-        if (ini_get('short_open_tag')) {
-            $xmlPlaceholder = '__XML_PLACEHOLDER'.Str::uuid();
-            $text = str_replace('<?xml', $xmlPlaceholder, $text);
-            $text = str_replace('<?', '&lt;?', $text);
-            $text = str_replace($xmlPlaceholder, '<?xml', $text);
-        }
+        $xmlPlaceholder = '__XML_PLACEHOLDER'.Str::uuid();
+        $text = str_replace('<?xml', $xmlPlaceholder, $text);
+        $text = str_replace('<?', '&lt;?', $text);
+        $text = str_replace($xmlPlaceholder, '<?xml', $text);
 
         return $text;
     }

--- a/src/View/Antlers/Language/Utilities/StringUtilities.php
+++ b/src/View/Antlers/Language/Utilities/StringUtilities.php
@@ -79,7 +79,7 @@ class StringUtilities
      */
     public static function sanitizePhp($text)
     {
-        $text = str_replace('<?php', '&lt;?php', $text);
+        $text = str_ireplace('<?php', '&lt;?php', $text);
 
         // Also replace short tags if they're enabled.
         if (ini_get('short_open_tag')) {

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -617,9 +617,10 @@ TEXT;
         $this->assertSame('&lt;?pHp echo "test"; ?>', StringUtilities::sanitizePhp('<?pHp echo "test"; ?>'));
     }
 
-    public function test_sanitize_php_handles_short_echo_tag()
+    public function test_sanitize_php_handles_short_tags()
     {
         $this->assertSame('&lt;?= $var ?>', StringUtilities::sanitizePhp('<?= $var ?>'));
         $this->assertSame('&lt;?="test"?>', StringUtilities::sanitizePhp('<?="test"?>'));
+        $this->assertSame("&lt;? echo 'test' ?>", StringUtilities::sanitizePhp("<? echo 'test' ?>"));
     }
 }

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -608,4 +608,12 @@ TEXT;
 
         GlobalRuntimeState::$allowPhpInContent = false;
     }
+
+    public function test_sanitize_php_is_case_insensitive()
+    {
+        $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?php echo "test"; ?>'));
+        $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?PHP echo "test"; ?>'));
+        $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?Php echo "test"; ?>'));
+        $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?pHp echo "test"; ?>'));
+    }
 }

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -612,9 +612,9 @@ TEXT;
     public function test_sanitize_php_is_case_insensitive()
     {
         $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?php echo "test"; ?>'));
-        $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?PHP echo "test"; ?>'));
-        $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?Php echo "test"; ?>'));
-        $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?pHp echo "test"; ?>'));
+        $this->assertSame('&lt;?PHP echo "test"; ?>', StringUtilities::sanitizePhp('<?PHP echo "test"; ?>'));
+        $this->assertSame('&lt;?Php echo "test"; ?>', StringUtilities::sanitizePhp('<?Php echo "test"; ?>'));
+        $this->assertSame('&lt;?pHp echo "test"; ?>', StringUtilities::sanitizePhp('<?pHp echo "test"; ?>'));
     }
 
     public function test_sanitize_php_handles_short_echo_tag()

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -616,4 +616,10 @@ TEXT;
         $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?Php echo "test"; ?>'));
         $this->assertSame('&lt;?php echo "test"; ?>', StringUtilities::sanitizePhp('<?pHp echo "test"; ?>'));
     }
+
+    public function test_sanitize_php_handles_short_echo_tag()
+    {
+        $this->assertSame('&lt;?= $var ?>', StringUtilities::sanitizePhp('<?= $var ?>'));
+        $this->assertSame('&lt;?="test"?>', StringUtilities::sanitizePhp('<?="test"?>'));
+    }
 }


### PR DESCRIPTION
This pull request fixes edge cases in `StringUtilities::sanitizePhp()` where certain PHP opening tag variants were not being sanitized.