### PR TITLE
[6.x] Fix updated widget badge alignment

### DIFF
--- a/resources/js/components/updater/UpdaterWidget.vue
+++ b/resources/js/components/updater/UpdaterWidget.vue
@@ -17,7 +17,7 @@ defineProps({
                         <td class="py-1 pr-4 leading-tight">
                             <Link :href="update.url" class="flex items-center gap-2" v-text="update.name" />
                         </td>
-                        <td>
+                        <td class="text-right">
                             <Badge
                                 pill
                                 :text="update.count"


### PR DESCRIPTION
Before
<img width="1070" height="502" alt="CleanShot 2026-03-19 at 10 14 14@2x" src="https://github.com/user-attachments/assets/d081f752-245a-4939-a676-322c6c772d05" />


After
<img width="1082" height="250" alt="CleanShot 2026-03-19 at 10 14 00@2x" src="https://github.com/user-attachments/assets/e8cbadb4-7dc6-47de-b8c7-ac3847607480" />

Nuff said.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts table cell alignment without affecting update logic or data flow.
> 
> **Overview**
> Fixes the Updates widget layout by adding `text-right` to the badge `<td>`, right-aligning the update count/security badge column for consistent table alignment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1360b3dbd392a9e2a8406937e556dc4d9ac4a749. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->