### PR TITLE
[5.x] Fix live preview token scope

### DIFF
--- a/src/Auth/Protect/Protectors/Password/PasswordProtector.php
+++ b/src/Auth/Protect/Protectors/Password/PasswordProtector.php
@@ -20,7 +20,7 @@ class PasswordProtector extends Protector
             throw new ForbiddenHttpException();
         }
 
-        if (request()->isLivePreview()) {
+        if (request()->isLivePreviewOf($this->data)) {
             return;
         }
 

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -75,7 +75,7 @@ class EntryQuery extends Query
 
         $entry = $query->limit(1)->get()->first();
 
-        if ($entry && $entry->published() === false && request()->isLivePreview() && ! request()->isLivePreviewOf($entry)) {
+        if ($entry && $entry->status() !== 'published' && request()->isLivePreview() && ! request()->isLivePreviewOf($entry)) {
             return null;
         }
 

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -75,7 +75,7 @@ class EntryQuery extends Query
 
         $entry = $query->limit(1)->get()->first();
 
-        if ($entry && $entry->published() === false && ! request()->isLivePreviewOf($entry)) {
+        if ($entry && $entry->published() === false && request()->isLivePreview() && ! request()->isLivePreviewOf($entry)) {
             return null;
         }
 

--- a/src/GraphQL/Queries/EntryQuery.php
+++ b/src/GraphQL/Queries/EntryQuery.php
@@ -75,6 +75,10 @@ class EntryQuery extends Query
 
         $entry = $query->limit(1)->get()->first();
 
+        if ($entry && $entry->published() === false && ! request()->isLivePreviewOf($entry)) {
+            return null;
+        }
+
         // The `AuthorizeSubResources` middleware will authorize when using `collection` arg,
         // but this is still required when the user queries entry using other args.
         if ($entry && ! in_array($collection = $entry->collection()->handle(), $this->allowedSubResources())) {

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -27,7 +27,7 @@ class ApiController extends Controller
      */
     protected function abortIfUnpublished($item)
     {
-        if (request()->isLivePreview()) {
+        if (request()->isLivePreviewOf($item)) {
             return;
         }
 

--- a/src/Http/Responses/DataResponse.php
+++ b/src/Http/Responses/DataResponse.php
@@ -112,7 +112,7 @@ class DataResponse implements Responsable
             return $this;
         }
 
-        throw_unless($this->request->isLivePreview(), new NotFoundHttpException);
+        throw_unless($this->isLivePreviewing(), new NotFoundHttpException);
 
         $this->headers['X-Statamic-Draft'] = true;
 
@@ -129,11 +129,16 @@ class DataResponse implements Responsable
             return $this;
         }
 
-        throw_unless($this->request->isLivePreview(), new NotFoundHttpException);
+        throw_unless($this->isLivePreviewing(), new NotFoundHttpException);
 
         $this->headers['X-Statamic-Private'] = true;
 
         return $this;
+    }
+
+    private function isLivePreviewing()
+    {
+        return $this->request->isLivePreviewOf($this->data);
     }
 
     protected function view()

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -96,6 +96,18 @@ class AppServiceProvider extends ServiceProvider
             return optional($this->statamicToken())->handler() === LivePreview::class;
         });
 
+        Request::macro('isLivePreviewOf', function ($item) {
+            $token = $this->statamicToken();
+
+            if (! $token || $token->handler() !== LivePreview::class) {
+                return false;
+            }
+
+            $previewItem = \Facades\Statamic\CP\LivePreview::item($token);
+
+            return $item && $previewItem && method_exists($item, 'reference') && $previewItem->reference() === $item->reference();
+        });
+
         TrimStrings::skipWhen(function (Request $request) {
             $route = config('statamic.cp.route');
 

--- a/src/Tokens/FileTokenRepository.php
+++ b/src/Tokens/FileTokenRepository.php
@@ -22,7 +22,15 @@ class FileTokenRepository extends TokenRepository
             return null;
         }
 
-        return $this->makeFromPath($path);
+        $token = $this->makeFromPath($path);
+
+        if ($token->hasExpired()) {
+            $this->delete($token);
+
+            return null;
+        }
+
+        return $token;
     }
 
     public function save(TokenContract $token): bool

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -502,6 +502,21 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function live_preview_token_for_different_entry_doesnt_bypass_status_check()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+        Facades\Collection::make('pages')->save();
+        tap(Facades\Entry::make()->collection('pages')->id('dance')->published(false)->set('title', 'Dance')->slug('dance'))->save();
+        $otherEntry = tap(Facades\Entry::make()->collection('pages')->id('sing')->published(true)->set('title', 'Sing')->slug('sing'))->save();
+
+        LivePreview::tokenize('test-token', $otherEntry);
+
+        $this->get('/api/collections/pages/entries/dance?token=test-token')->assertJson([
+            'message' => 'Not found.',
+        ]);
+    }
+
+    #[Test]
     public function it_replaces_terms_using_live_preview_token()
     {
         Facades\Config::set('statamic.api.resources.taxonomies', true);

--- a/tests/Auth/Protect/PasswordProtectionTest.php
+++ b/tests/Auth/Protect/PasswordProtectionTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Auth\Protect;
 
 use Facades\Statamic\Auth\Protect\Protectors\Password\Token;
+use Facades\Statamic\CP\LivePreview;
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Entry;
 
 class PasswordProtectionTest extends PageProtectionTestCase
 {
@@ -123,5 +126,45 @@ class PasswordProtectionTest extends PageProtectionTestCase
             ->get('/password-entry')
             ->assertOk()
             ->assertSee('Password form template');
+    }
+
+    #[Test]
+    public function live_preview_token_bypasses_password_protection()
+    {
+        config(['statamic.protect.schemes.password-scheme' => [
+            'driver' => 'password',
+            'allowed' => ['test'],
+        ]]);
+
+        $this->createPage('test', ['data' => ['protect' => 'password-scheme']]);
+
+        $entry = Entry::find('test');
+
+        LivePreview::tokenize('test-token', $entry);
+
+        $this
+            ->get('/test?token=test-token')
+            ->assertOk();
+    }
+
+    #[Test]
+    public function live_preview_token_for_different_entry_doesnt_bypass_password_protection()
+    {
+        config(['statamic.protect.schemes.password-scheme' => [
+            'driver' => 'password',
+            'allowed' => ['test'],
+        ]]);
+
+        $this->createPage('test', ['data' => ['protect' => 'password-scheme']]);
+
+        $other = EntryFactory::slug('other')->id('other')->collection('pages')->create();
+
+        LivePreview::tokenize('test-token', $other);
+
+        Token::shouldReceive('generate')->andReturn('pw-token');
+
+        $this
+            ->get('/test?token=test-token')
+            ->assertRedirect();
     }
 }

--- a/tests/Feature/GraphQL/EntryTest.php
+++ b/tests/Feature/GraphQL/EntryTest.php
@@ -796,4 +796,41 @@ GQL;
                 'title' => 'That was so rad!',
             ]]]);
     }
+
+    #[Test]
+    public function it_does_not_show_unpublished_entries_with_token_for_different_entry()
+    {
+        FilterAuthorizer::shouldReceive('allowedForSubResources')
+            ->andReturn(['published', 'status']);
+
+        EntryFactory::collection('blog')
+            ->id('6')
+            ->slug('that-was-so-rad')
+            ->data(['title' => 'That was so rad!'])
+            ->published(false)
+            ->create();
+
+        $other = EntryFactory::collection('blog')
+            ->id('7')
+            ->slug('other')
+            ->data(['title' => 'Other'])
+            ->create();
+
+        LivePreview::tokenize('test-token', $other);
+
+        $query = <<<'GQL'
+{
+    entry(id: "6") {
+        id
+        title
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql?token=test-token', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => ['entry' => null]]);
+    }
 }

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -255,6 +255,21 @@ class FrontendTest extends TestCase
     }
 
     #[Test]
+    public function drafts_are_not_visible_if_using_live_preview_token_for_different_entry()
+    {
+        $this->withStandardFakeErrorViews();
+
+        $page = tap($this->createPage('about')->published(false)->set('content', 'Testing 123'))->save();
+        $other = $this->createPage('other');
+
+        LivePreview::tokenize('test-token', $other);
+
+        $this
+            ->get('/about?token=test-token')
+            ->assertStatus(404);
+    }
+
+    #[Test]
     public function drafts_dont_get_statically_cached()
     {
         $this->markTestIncomplete();

--- a/tests/Tokens/TokenRepositoryTest.php
+++ b/tests/Tokens/TokenRepositoryTest.php
@@ -87,6 +87,8 @@ YAML;
     #[Test]
     public function it_finds_a_token()
     {
+        Carbon::setTestNow(Carbon::create(2020, 1, 1, 0, 0, 0));
+
         $contents = <<<YAML
 handler: 'The\Test\Class'
 expires_at: 1577849700
@@ -110,6 +112,18 @@ YAML;
     }
 
     #[Test]
+    public function it_returns_null_and_deletes_expired_token_on_find()
+    {
+        Carbon::setTestNow(Carbon::create(2020, 1, 1, 3, 0, 0));
+
+        $this->tokens->make('expired-token', 'test')->expireAt(Carbon::now()->subMinute())->save();
+
+        $this->assertFileExists(storage_path('statamic/tokens/expired-token.yaml'));
+        $this->assertNull($this->tokens->find('expired-token'));
+        $this->assertFileDoesNotExist(storage_path('statamic/tokens/expired-token.yaml'));
+    }
+
+    #[Test]
     public function attempting_to_find_a_non_existent_token_returns_null()
     {
         $this->assertNull($this->tokens->find('missing-token'));
@@ -125,16 +139,16 @@ YAML;
         $this->tokens->make('c', 'test')->expireAt(Carbon::now()->subHour())->save();
         $this->tokens->make('d', 'test')->expireAt(Carbon::now()->addMinute())->save();
 
-        $this->assertNotNull($this->tokens->find('a'));
-        $this->assertNotNull($this->tokens->find('b'));
-        $this->assertNotNull($this->tokens->find('c'));
-        $this->assertNotNull($this->tokens->find('d'));
+        $this->assertFileExists(storage_path('statamic/tokens/a.yaml'));
+        $this->assertFileExists(storage_path('statamic/tokens/b.yaml'));
+        $this->assertFileExists(storage_path('statamic/tokens/c.yaml'));
+        $this->assertFileExists(storage_path('statamic/tokens/d.yaml'));
 
         $this->tokens->collectGarbage();
 
-        $this->assertNotNull($this->tokens->find('a'));
-        $this->assertNull($this->tokens->find('b'));
-        $this->assertNull($this->tokens->find('c'));
-        $this->assertNotNull($this->tokens->find('d'));
+        $this->assertFileExists(storage_path('statamic/tokens/a.yaml'));
+        $this->assertFileDoesNotExist(storage_path('statamic/tokens/b.yaml'));
+        $this->assertFileDoesNotExist(storage_path('statamic/tokens/c.yaml'));
+        $this->assertFileExists(storage_path('statamic/tokens/d.yaml'));
     }
 }


### PR DESCRIPTION
This PR makes sure that a live preview url/token can only be used for the entry that it was created for.

It also fixes the token expiry logic. If an expired token is used, it'll get deleted and return null. It won't wait for garbage collection.
