### PR TITLE
[5.x] Relationship fieldtype authorization tweaks

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -147,8 +147,7 @@ class Entries extends Relationship
                 'collection',
                 collect($configuredCollections)
                     ->map(fn (string $collectionHandle) => Collection::findByHandle($collectionHandle))
-                    ->filter()
-                    ->filter(fn ($collection) => $user->can('view', $collection))
+                    ->filter(fn ($collection) => $collection && $user->can('view', $collection))
                     ->map->handle()
                     ->all()
             );

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -176,8 +176,7 @@ class Entries extends Relationship
 
         $authorizedCollections = collect($collections)
             ->map(fn (string $collectionHandle) => Collection::findByHandle($collectionHandle))
-            ->filter()
-            ->filter(fn ($collection) => $user->can('view', $collection));
+            ->filter(fn ($collection) => $collection && $user->can('view', $collection));
 
         throw_if($authorizedCollections->isEmpty(), new AuthorizationException);
     }

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -134,15 +134,24 @@ class Entries extends Relationship
     public function getIndexItems($request)
     {
         $configuredCollections = $this->getConfiguredCollections();
-        $requestedCollections = $this->getRequestedCollections($request, $configuredCollections);
-        $this->authorizeCollectionAccess($requestedCollections);
+        $this->authorizeCollectionAccess($configuredCollections);
 
         $query = $this->getIndexQuery($request);
 
         $filters = $request->filters;
 
         if (! isset($filters['collection'])) {
-            $query->whereIn('collection', $configuredCollections);
+            $user = User::current();
+
+            $query->whereIn(
+                'collection',
+                collect($configuredCollections)
+                    ->map(fn (string $collectionHandle) => Collection::findByHandle($collectionHandle))
+                    ->filter()
+                    ->filter(fn ($collection) => $user->can('view', $collection))
+                    ->map->handle()
+                    ->all()
+            );
         }
 
         if ($blueprints = $this->config('blueprints')) {
@@ -162,28 +171,16 @@ class Entries extends Relationship
         return $paginate ? $results->setCollection($items) : $items;
     }
 
-    private function getRequestedCollections($request, $configuredCollections)
-    {
-        $filteredCollections = collect($request->input('filters.collection.collections', []))
-            ->filter()
-            ->values()
-            ->all();
-
-        return empty($filteredCollections) ? $configuredCollections : $filteredCollections;
-    }
-
     private function authorizeCollectionAccess($collections)
     {
         $user = User::current();
 
-        collect($collections)->each(function ($collectionHandle) use ($user) {
-            $collection = Collection::findByHandle($collectionHandle);
+        $authorizedCollections = collect($collections)
+            ->map(fn (string $collectionHandle) => Collection::findByHandle($collectionHandle))
+            ->filter()
+            ->filter(fn ($collection) => $user->can('view', $collection));
 
-            throw_if(
-                ! $collection || ! $user->can('view', $collection),
-                new AuthorizationException
-            );
-        });
+        throw_if($authorizedCollections->isEmpty(), new AuthorizationException);
     }
 
     public function getResourceCollection($request, $items)

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -171,7 +171,7 @@ class Entries extends Relationship
         return $paginate ? $results->setCollection($items) : $items;
     }
 
-    private function authorizeCollectionAccess($collections)
+    private function authorizeCollectionAccess(array $collections): void
     {
         $user = User::current();
 

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -428,7 +428,7 @@ class Terms extends Relationship
         $taxonomies = collect($request->taxonomies ?? $this->getConfiguredTaxonomies())
             ->map(fn (string $taxonomyHandle) => Taxonomy::findByHandle($taxonomyHandle))
             ->filter()
-            ->filter(fn ($collection) => $user->can('view', $collection))
+            ->filter(fn ($taxonomy) => $user->can('view', $taxonomy))
             ->map->handle()
             ->all();
 

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -427,8 +427,7 @@ class Terms extends Relationship
 
         $taxonomies = collect($request->taxonomies ?? $this->getConfiguredTaxonomies())
             ->map(fn (string $taxonomyHandle) => Taxonomy::findByHandle($taxonomyHandle))
-            ->filter()
-            ->filter(fn ($taxonomy) => $user->can('view', $taxonomy))
+            ->filter(fn ($taxonomy) => $taxonomy && $user->can('view', $taxonomy))
             ->map->handle()
             ->all();
 

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -263,9 +263,7 @@ class Terms extends Relationship
             return collect();
         }
 
-        $this->authorizeTaxonomyAccess(
-            $this->getRequestedTaxonomies($request, $this->getConfiguredTaxonomies())
-        );
+        $this->authorizeTaxonomyAccess($this->getConfiguredTaxonomies());
 
         $query = $this->getIndexQuery($request);
 
@@ -276,25 +274,16 @@ class Terms extends Relationship
         return $request->boolean('paginate', true) ? $query->paginate() : $query->get();
     }
 
-    private function getRequestedTaxonomies($request, $configuredTaxonomies)
-    {
-        $requestedTaxonomies = collect($request->taxonomies)->filter()->values()->all();
-
-        return empty($requestedTaxonomies) ? $configuredTaxonomies : $requestedTaxonomies;
-    }
-
-    private function authorizeTaxonomyAccess($taxonomies)
+    private function authorizeTaxonomyAccess(array $taxonomies): void
     {
         $user = User::current();
 
-        collect($taxonomies)->each(function ($taxonomyHandle) use ($user) {
-            $taxonomy = Taxonomy::findByHandle($taxonomyHandle);
+        $authorizedTaxonomies = collect($taxonomies)
+            ->map(fn (string $taxonomyHandle) => Taxonomy::findByHandle($taxonomyHandle))
+            ->filter()
+            ->filter(fn ($taxonomy) => $user->can('view', $taxonomy));
 
-            throw_if(
-                ! $taxonomy || ! $user->can('view', $taxonomy),
-                new AuthorizationException
-            );
-        });
+        throw_if($authorizedTaxonomies->isEmpty(), new AuthorizationException);
     }
 
     public function getResourceCollection($request, $items)
@@ -434,10 +423,16 @@ class Terms extends Relationship
     protected function getIndexQuery($request)
     {
         $query = Term::query();
+        $user = User::current();
 
-        if ($taxonomies = $request->taxonomies) {
-            $query->whereIn('taxonomy', $taxonomies);
-        }
+        $taxonomies = collect($request->taxonomies ?? $this->getConfiguredTaxonomies())
+            ->map(fn (string $taxonomyHandle) => Taxonomy::findByHandle($taxonomyHandle))
+            ->filter()
+            ->filter(fn ($collection) => $user->can('view', $collection))
+            ->map->handle()
+            ->all();
+
+        $query->whereIn('taxonomy', $taxonomies);
 
         if ($search = $request->search) {
             $query->where('title', 'like', '%'.$search.'%');

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -300,9 +300,7 @@ class Terms extends Relationship
 
     protected function getFirstTaxonomyFromRequest($request)
     {
-        return $request->taxonomies
-            ? Facades\Taxonomy::findByHandle($request->taxonomies[0])
-            : Facades\Taxonomy::all()->first();
+        return Facades\Taxonomy::all()->first();
     }
 
     public function getSortColumn($request)
@@ -425,7 +423,7 @@ class Terms extends Relationship
         $query = Term::query();
         $user = User::current();
 
-        $taxonomies = collect($request->taxonomies ?? $this->getConfiguredTaxonomies())
+        $taxonomies = collect($this->getConfiguredTaxonomies())
             ->map(fn (string $taxonomyHandle) => Taxonomy::findByHandle($taxonomyHandle))
             ->filter(fn ($taxonomy) => $taxonomy && $user->can('view', $taxonomy))
             ->map->handle()

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -300,7 +300,13 @@ class Terms extends Relationship
 
     protected function getFirstTaxonomyFromRequest($request)
     {
-        return Facades\Taxonomy::all()->first();
+        $taxonomies = $this->getConfiguredTaxonomies();
+
+        $taxonomy = Taxonomy::findByHandle($taxonomyHandle = Arr::first($taxonomies));
+
+        throw_if(! $taxonomy, new TaxonomyNotFoundException($taxonomyHandle));
+
+        return $taxonomy;
     }
 
     public function getSortColumn($request)

--- a/src/Query/Scopes/Filters/Collection.php
+++ b/src/Query/Scopes/Filters/Collection.php
@@ -52,7 +52,7 @@ class Collection extends Filter
 
         return collect($this->context['collections'])
             ->map(fn ($collection) => Facades\Collection::findByHandle($collection))
-            ->filter(fn ($collection) => $user->can('view', $collection))
+            ->filter(fn ($collection) => $collection && $user->can('view', $collection))
             ->mapWithKeys(fn ($collection) => [$collection->handle() => $collection->title()]);
     }
 

--- a/src/Query/Scopes/Filters/Collection.php
+++ b/src/Query/Scopes/Filters/Collection.php
@@ -56,11 +56,11 @@ class Collection extends Filter
             ->mapWithKeys(fn ($collection) => [$collection->handle() => $collection->title()]);
     }
 
-    private function authorizeCollectionAccess(array $collections)
+    private function authorizeCollectionAccess(array $collections): void
     {
         $user = User::current();
 
-        collect($collections)->each(function ($collectionHandle) use ($user) {
+        collect($collections)->each(function (string $collectionHandle) use ($user) {
             $collection = Facades\Collection::findByHandle($collectionHandle);
 
             throw_if(

--- a/src/Query/Scopes/Filters/Collection.php
+++ b/src/Query/Scopes/Filters/Collection.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Query\Scopes\Filters;
 
+use Statamic\Exceptions\AuthorizationException;
 use Statamic\Facades;
+use Statamic\Facades\User;
 use Statamic\Query\Scopes\Filter;
 
 class Collection extends Filter
@@ -29,6 +31,8 @@ class Collection extends Filter
 
     public function apply($query, $values)
     {
+        $this->authorizeCollectionAccess($values['collections']);
+
         $query->whereIn('collection', $values['collections']);
     }
 
@@ -44,8 +48,25 @@ class Collection extends Filter
 
     protected function options()
     {
-        return collect($this->context['collections'])->mapWithKeys(function ($collection) {
-            return [$collection => Facades\Collection::findByHandle($collection)->title()];
+        $user = User::current();
+
+        return collect($this->context['collections'])
+            ->map(fn ($collection) => Facades\Collection::findByHandle($collection))
+            ->filter(fn ($collection) => $user->can('view', $collection))
+            ->mapWithKeys(fn ($collection) => [$collection->handle() => $collection->title()]);
+    }
+
+    private function authorizeCollectionAccess(array $collections)
+    {
+        $user = User::current();
+
+        collect($collections)->each(function ($collectionHandle) use ($user) {
+            $collection = Facades\Collection::findByHandle($collectionHandle);
+
+            throw_if(
+                ! $collection || ! $user->can('view', $collection),
+                new AuthorizationException
+            );
         });
     }
 }

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -115,9 +115,6 @@ class RelationshipFieldtypeTest extends TestCase
     #[Test]
     public function it_forbids_access_to_entries_when_filters_target_collections_the_user_cannot_view()
     {
-        Collection::make('pages')->save();
-        Entry::make()->collection('pages')->slug('home')->data(['title' => 'Home'])->save();
-
         Collection::make('secret')->save();
         Entry::make()->collection('test')->slug('apple')->data(['title' => 'Apple'])->save();
         Entry::make()->collection('secret')->slug('secret-one')->data(['title' => 'Secret One'])->save();

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -61,8 +61,40 @@ class RelationshipFieldtypeTest extends TestCase
     }
 
     #[Test]
-    public function it_denies_access_to_entries_when_theres_a_collection_the_user_cannot_view()
+    public function it_limits_access_to_entries_from_collections_the_user_can_view()
     {
+        Collection::make('pages')->save();
+        Entry::make()->collection('pages')->slug('home')->data(['title' => 'Home'])->save();
+
+        Collection::make('secret')->save();
+        Entry::make()->collection('secret')->slug('secret-one')->data(['title' => 'Secret One'])->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view pages entries']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'entries',
+            'collections' => ['pages', 'secret'],
+        ]));
+
+        $this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship?config={$config}")
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJson([
+                'data' => [
+                    ['slug' => 'home'],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function it_denies_access_to_entries_when_user_cannot_view_any_of_the_collections()
+    {
+        Collection::make('pages')->save();
+        Entry::make()->collection('pages')->slug('home')->data(['title' => 'Home'])->save();
+
         Collection::make('secret')->save();
         Entry::make()->collection('secret')->slug('secret-one')->data(['title' => 'Secret One'])->save();
 
@@ -71,7 +103,7 @@ class RelationshipFieldtypeTest extends TestCase
 
         $config = base64_encode(json_encode([
             'type' => 'entries',
-            'collections' => ['secret'],
+            'collections' => ['pages', 'secret'],
         ]));
 
         $this
@@ -81,8 +113,11 @@ class RelationshipFieldtypeTest extends TestCase
     }
 
     #[Test]
-    public function it_forbids_access_to_entries_when_filters_target_a_collection_the_user_cannot_view()
+    public function it_forbids_access_to_entries_when_filters_target_collections_the_user_cannot_view()
     {
+        Collection::make('pages')->save();
+        Entry::make()->collection('pages')->slug('home')->data(['title' => 'Home'])->save();
+
         Collection::make('secret')->save();
         Entry::make()->collection('test')->slug('apple')->data(['title' => 'Apple'])->save();
         Entry::make()->collection('secret')->slug('secret-one')->data(['title' => 'Secret One'])->save();

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -142,9 +142,39 @@ class RelationshipFieldtypeTest extends TestCase
     }
 
     #[Test]
-    public function it_forbids_access_to_terms_when_config_contains_a_taxonomy_the_user_cannot_view()
+    public function it_limits_access_to_terms_from_taxonomies_the_user_can_view()
     {
+        Taxonomy::make('topics')->save();
         Taxonomy::make('secret')->save();
+        Term::make('public')->taxonomy('topics')->data([])->save();
+        Term::make('internal')->taxonomy('secret')->data([])->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view topics terms']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'terms',
+            'taxonomies' => ['topics', 'secret'],
+        ]));
+
+        $this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=topics&taxonomies[1]=secret")
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJson([
+                'data' => [
+                    ['slug' => 'public'],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function it_forbids_access_to_terms_when_the_user_cannot_view_any_of_the_taxonomies()
+    {
+        Taxonomy::make('topics')->save();
+        Taxonomy::make('secret')->save();
+        Term::make('public')->taxonomy('topics')->data([])->save();
         Term::make('internal')->taxonomy('secret')->data([])->save();
 
         $this->setTestRoles(['test' => ['access cp']]);
@@ -152,36 +182,12 @@ class RelationshipFieldtypeTest extends TestCase
 
         $config = base64_encode(json_encode([
             'type' => 'terms',
-            'taxonomies' => ['secret'],
+            'taxonomies' => ['topics', 'secret'],
         ]));
 
         $this
             ->actingAs($user)
-            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=secret")
-            ->assertForbidden();
-    }
-
-    #[Test]
-    public function it_forbids_access_to_terms_when_requested_taxonomy_is_forbidden()
-    {
-        Taxonomy::make('topics')->save();
-        Taxonomy::make('secret')->save();
-        Term::make('public')->taxonomy('topics')->data([])->save();
-        Term::make('internal')->taxonomy('secret')->data([])->save();
-
-        $this->setTestRoles([
-            'test' => ['access cp', 'view topics terms'],
-        ]);
-        $user = User::make()->assignRole('test')->save();
-
-        $config = base64_encode(json_encode([
-            'type' => 'terms',
-            'taxonomies' => ['topics'],
-        ]));
-
-        $this
-            ->actingAs($user)
-            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=secret")
+            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=topics&taxonomies[1]=secret")
             ->assertForbidden();
     }
 }

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -159,7 +159,7 @@ class RelationshipFieldtypeTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=topics&taxonomies[1]=secret")
+            ->getJson("/cp/fieldtypes/relationship?config={$config}")
             ->assertOk()
             ->assertJsonCount(1, 'data')
             ->assertJson([
@@ -187,7 +187,7 @@ class RelationshipFieldtypeTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->getJson("/cp/fieldtypes/relationship?config={$config}&taxonomies[0]=topics&taxonomies[1]=secret")
+            ->getJson("/cp/fieldtypes/relationship?config={$config}")
             ->assertForbidden();
     }
 }


### PR DESCRIPTION
In #14254, we added authorization to the entry and term fieldtypes to ensure users couldn't select items they don't have permission to view.

## Current behaviour
This meant that in the entries fieldtype, the user had to have permission to view entries in _all_ of the configured collections, otherwise they'd see an authorization error.

https://github.com/user-attachments/assets/e72a15b2-49bc-42e8-ba9e-28f26d1297d0

## Updated behaviour
This PR changes the behaviour slightly — instead of throwing an error when the user can't view one of the collections, we now limit the selections to only the collections the user is authorised to view.

The collection filter will now also only show the collections the user has permission to view.

https://github.com/user-attachments/assets/2aa66667-137e-41ca-be5b-7715e89cee33

_^ Everything I've mentioned above about collections and entries is true of taxonomies and terms too._

---

Fixes #14302