### PR TITLE
[6.x] Fix 2FA setup modal not re-opening

### DIFF
--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -4,7 +4,7 @@ import TwoFactorRecoveryCodesModal from '@/components/two-factor/RecoveryCodesMo
 import axios from 'axios';
 import { Modal, ModalClose, Input, Button, Icon } from '@/components/ui';
 
-const emit = defineEmits(['setup-complete', 'cancel', 'close']);
+const emit = defineEmits(['setup-complete', 'close']);
 
 const props = defineProps({
     enableUrl: String,

--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -52,7 +52,7 @@ function complete() {
 </script>
 
 <template>
-    <Modal v-if="setupModalOpen" :title="__('Set up Two Factor Authentication')" blur open @update:model-value="$emit('cancel')">
+    <Modal v-if="setupModalOpen" :title="__('Set up Two Factor Authentication')" blur open @dismissed="$emit('close')">
         <div>
             <div v-if="loading" class="flex items-center justify-center text-center">
                 <Icon name="loading" />

--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -51,7 +51,7 @@ function complete() {
 }
 
 watch(setupModalOpen, (open) => {
-    if (!open) emit('close');
+    if (!open && !recoveryCodesModalOpen.value) emit('close');
 });
 </script>
 

--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import TwoFactorRecoveryCodesModal from '@/components/two-factor/RecoveryCodesModal.vue';
 import axios from 'axios';
-import { Modal, Input, Button, Icon } from '@/components/ui';
+import { Modal, ModalClose, Input, Button, Icon } from '@/components/ui';
 
 const emit = defineEmits(['setup-complete', 'cancel', 'close']);
 
@@ -49,10 +49,14 @@ function complete() {
     recoveryCodesModalOpen.value = false;
     emit('setup-complete');
 }
+
+watch(setupModalOpen, (open) => {
+    if (!open) emit('close');
+});
 </script>
 
 <template>
-    <Modal v-if="setupModalOpen" :title="__('Set up Two Factor Authentication')" blur open @dismissed="$emit('close')">
+    <Modal v-model:open="setupModalOpen" :title="__('Set up Two Factor Authentication')" blur>
         <div>
             <div v-if="loading" class="flex items-center justify-center text-center">
                 <Icon name="loading" />
@@ -88,11 +92,12 @@ function complete() {
 
         <template #footer>
             <div class="flex items-center justify-end space-x-3 pt-3 pb-1">
-                <Button
-                    variant="ghost"
-                    @click="$emit('close')"
-                    :text="__('Cancel')"
-                />
+                <ModalClose>
+                    <Button
+                        variant="ghost"
+                        :text="__('Cancel')"
+                    />
+                </ModalClose>
                 <Button
                     :disabled="!code"
                     variant="primary"


### PR DESCRIPTION
This pull request fixes an issue where the 2FA setup modal wouldn't re-open after dismissing it by clicking on the modal's overlay.

Noticed this yesterday while testing something.