### PR TITLE
[6.x] Fix Replicator Drag & Drop when multiple fields share the same handle

### DIFF
--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -147,11 +147,11 @@ export default {
         },
 
         sortableItemClass() {
-            return `${this.name}-sortable-item`;
+            return `${this.fieldId}-sortable-item`;
         },
 
         sortableHandleClass() {
-            return `${this.name}-sortable-handle`;
+            return `${this.fieldId}-sortable-handle`;
         },
 
         replicatorPreview() {


### PR DESCRIPTION
This pull request fixes an issue where drag & drop in the Replicator fieldtype would become glitchy when multiple fields share the same handle.

This was due to them all outputting the same item/handle classes for the `SortableList` component. This PR fixes it by using the field ID instead, which takes the field's path into account.

## Before

https://github.com/user-attachments/assets/5601afb9-77b6-4091-84e1-077fd9b8a48b


## After

https://github.com/user-attachments/assets/21e91a5f-084f-4833-a33a-3d318812eda7



---

Fixes #14308