### PR TITLE
[6.x] Handle more cases in external url detection

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -280,8 +280,10 @@ class URL
             return false;
         }
 
+        $cacheKey = $url;
+
         if (! Str::startsWith($url, ['/', 'http://', 'https://', '#', '?']) || Str::startsWith($url, '//')) {
-            return self::$externalAppUrlsCache[$url] = true;
+            return self::$externalAppUrlsCache[$cacheKey] = true;
         }
 
         // Normalize backslashes to forward slashes.
@@ -293,7 +295,7 @@ class URL
         $url = Str::ensureRight($url, '/');
 
         if (Str::startsWith($url, ['/', '?', '#'])) {
-            return self::$externalAppUrlsCache[$url] = false;
+            return self::$externalAppUrlsCache[$cacheKey] = false;
         }
 
         $urlWithoutQuery = Str::of($url)->before('?')->before('#');
@@ -304,12 +306,12 @@ class URL
             ->isEmpty();
 
         if (! $this->hasRelativeSite()) {
-            return self::$externalAppUrlsCache[$url] = $isExternalToSites;
+            return self::$externalAppUrlsCache[$cacheKey] = $isExternalToSites;
         }
 
         $isExternalToCurrentRequestDomain = $urlDomain !== self::getDomainFromAbsolute(url()->to('/'));
 
-        return self::$externalAppUrlsCache[$url] = $isExternalToSites && $isExternalToCurrentRequestDomain;
+        return self::$externalAppUrlsCache[$cacheKey] = $isExternalToSites && $isExternalToCurrentRequestDomain;
     }
 
     /**

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -43,7 +43,7 @@ class URL
         $url = Path::tidy($url);
 
         // If URL is external to this Statamic application, we'll leave leading/trailing slashes by default.
-        if (! $external && self::isAbsolute($url) && self::isExternalToApplication($url)) {
+        if (! $external && $this->shouldLeaveExternalAbsoluteUrlUntouched($url)) {
             return $url;
         }
 
@@ -106,7 +106,7 @@ class URL
      */
     public function parent(?string $url): string
     {
-        $trailingSlash = self::isAbsolute($url) && self::isExternalToApplication($url)
+        $trailingSlash = $this->shouldLeaveExternalAbsoluteUrlUntouched($url)
             ? self::hasTrailingSlash($url)
             : self::$enforceTrailingSlashes;
 
@@ -190,7 +190,7 @@ class URL
     public function makeAbsolute(?string $url): string
     {
         // If URL is external to this Statamic application, we'll just leave it as-is.
-        if (self::isAbsolute($url) && self::isExternalToApplication($url)) {
+        if ($this->shouldLeaveExternalAbsoluteUrlUntouched($url)) {
             return $url;
         }
 
@@ -210,6 +210,27 @@ class URL
     public function getCurrent(): string
     {
         return self::tidy(request()->path());
+    }
+
+    private function shouldLeaveExternalAbsoluteUrlUntouched(?string $url): bool
+    {
+        if (! self::isAbsolute($url) || ! self::isExternalToApplication($url)) {
+            return false;
+        }
+
+        return ! $this->hostMatchesConfiguredAppUrl($url);
+    }
+
+    private function hostMatchesConfiguredAppUrl(?string $url): bool
+    {
+        if (! $url || ! self::isAbsolute($url)) {
+            return false;
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+        $appHost = parse_url((string) config('app.url'), PHP_URL_HOST);
+
+        return $host && $appHost && strtolower($host) === strtolower($appHost);
     }
 
     /**
@@ -265,6 +286,7 @@ class URL
         // Browsers treat \ as / for special schemes (http/https), which can
         // cause parse_url() to extract a different host than the browser uses.
         $url = str_replace('\\', '/', $url);
+        $url = preg_replace('/%5c/i', '/', $url);
 
         $url = Str::ensureRight($url, '/');
 
@@ -278,6 +300,14 @@ class URL
         $isExternalToSites = self::getAbsoluteSiteUrls()
             ->filter(fn ($siteUrl) => $urlDomain === $siteUrl)
             ->isEmpty();
+
+        $hasRelativeSite = Site::all()->contains(
+            fn ($site) => Str::startsWith((string) ($site->rawConfig()['url'] ?? ''), '/')
+        );
+
+        if (! $hasRelativeSite) {
+            return self::$externalAppUrlsCache[$url] = $isExternalToSites;
+        }
 
         $isExternalToCurrentRequestDomain = $urlDomain !== self::getDomainFromAbsolute(url()->to('/'));
 

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -15,6 +15,8 @@ class URL
 {
     private static $enforceTrailingSlashes = false;
     private static $absoluteSiteUrlsCache;
+    private static $hasRelativeSiteCache;
+    private static $siteCachesLoaded = false;
     private static $externalSiteUrlsCache;
     private static $externalAppUrlsCache;
 
@@ -301,11 +303,7 @@ class URL
             ->filter(fn ($siteUrl) => $urlDomain === $siteUrl)
             ->isEmpty();
 
-        $hasRelativeSite = Site::all()->contains(
-            fn ($site) => Str::startsWith((string) ($site->rawConfig()['url'] ?? ''), '/')
-        );
-
-        if (! $hasRelativeSite) {
+        if (! $this->hasRelativeSite()) {
             return self::$externalAppUrlsCache[$url] = $isExternalToSites;
         }
 
@@ -369,7 +367,9 @@ class URL
      */
     public function clearUrlCache(): void
     {
+        self::$siteCachesLoaded = false;
         self::$absoluteSiteUrlsCache = null;
+        self::$hasRelativeSiteCache = null;
         self::$externalSiteUrlsCache = null;
         self::$externalAppUrlsCache = null;
     }
@@ -402,18 +402,46 @@ class URL
     }
 
     /**
+     * Warm site-derived caches from a single Site::all() call
+     */
+    private function ensureSiteCaches(): void
+    {
+        if (self::$siteCachesLoaded) {
+            return;
+        }
+
+        $sites = Site::all();
+
+        self::$hasRelativeSiteCache = $sites->contains(
+            fn ($site) => Str::startsWith((string) ($site->rawConfig()['url'] ?? ''), '/')
+        );
+
+        self::$absoluteSiteUrlsCache = $sites
+            ->map(fn ($site) => $site->rawConfig()['url'] ?? null)
+            ->filter(fn ($siteUrl) => self::isAbsolute($siteUrl))
+            ->map(fn ($siteUrl) => self::getDomainFromAbsolute($siteUrl));
+
+        self::$siteCachesLoaded = true;
+    }
+
+    /**
      * Get and cache absolute site URLs for external checks.
      */
     private function getAbsoluteSiteUrls(): Collection
     {
-        if (self::$absoluteSiteUrlsCache) {
-            return self::$absoluteSiteUrlsCache;
-        }
+        $this->ensureSiteCaches();
 
-        return self::$absoluteSiteUrlsCache = Site::all()
-            ->map(fn ($site) => $site->rawConfig()['url'] ?? null)
-            ->filter(fn ($siteUrl) => self::isAbsolute($siteUrl))
-            ->map(fn ($siteUrl) => self::getDomainFromAbsolute($siteUrl));
+        return self::$absoluteSiteUrlsCache;
+    }
+
+    /**
+     * Checks whether there is a site configured with a relative URL.
+     */
+    private function hasRelativeSite(): bool
+    {
+        $this->ensureSiteCaches();
+
+        return self::$hasRelativeSiteCache;
     }
 
     /**

--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -257,9 +257,14 @@ class URL
             return false;
         }
 
-        if (Str::startsWith($url, '//')) {
+        if (! Str::startsWith($url, ['/', 'http://', 'https://', '#', '?']) || Str::startsWith($url, '//')) {
             return self::$externalAppUrlsCache[$url] = true;
         }
+
+        // Normalize backslashes to forward slashes.
+        // Browsers treat \ as / for special schemes (http/https), which can
+        // cause parse_url() to extract a different host than the browser uses.
+        $url = str_replace('\\', '/', $url);
 
         $url = Str::ensureRight($url, '/');
 

--- a/tests/Facades/Concerns/ProvidesExternalUrls.php
+++ b/tests/Facades/Concerns/ProvidesExternalUrls.php
@@ -88,6 +88,36 @@ trait ProvidesExternalUrls
             'http://this-site.com:8000@evil.com',
             'http://this-site.com:8000@evil.com/path',
             'http://this-site.com:8000@webhook.site/token',
+
+            // Backslash bypass
+            'http://evil.com\@this-site.com',
+            'http://evil.com\@this-site.com/',
+            'http://evil.com\@this-site.com/path',
+            'http://evil.com\@subdomain.this-site.com',
+            'http://evil.com\@absolute-url-resolved-from-request.com',
+            'https://evil.com\@this-site.com',
+            'http://evil.com\\@this-site.com',
+            'http://evil.com\\\@this-site.com',
+
+            // Dangerous URL schemes
+            'javascript:alert(1)',
+            'javascript:alert(document.cookie)',
+            'javascript://this-site.com/%0aalert(1)',
+            'JAVASCRIPT:alert(1)',
+            'data:text/html,<script>alert(1)</script>',
+            'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+            'DATA:text/html,test',
+            'vbscript:msgbox(1)',
+            'file:///etc/passwd',
+
+            // Whitespace bypass
+            ' http://this-site.com',
+            ' http://evil.com',
+            '  http://evil.com',
+            "\thttp://evil.com",
+            "\nhttp://evil.com",
+            "\rhttp://evil.com",
+            "\r\nhttp://evil.com",
         ];
     }
 

--- a/tests/Facades/Concerns/ProvidesExternalUrls.php
+++ b/tests/Facades/Concerns/ProvidesExternalUrls.php
@@ -99,6 +99,22 @@ trait ProvidesExternalUrls
             'http://evil.com\\@this-site.com',
             'http://evil.com\\\@this-site.com',
 
+            // Percent-encoded backslash bypass
+            'http://evil.com%5c@this-site.com',
+            'http://evil.com%5c@this-site.com/',
+            'http://evil.com%5c@this-site.com/path',
+            'http://evil.com%5c@subdomain.this-site.com',
+            'http://evil.com%5c@absolute-url-resolved-from-request.com',
+            'https://evil.com%5C@this-site.com',
+
+            // Absolute-looking URL with no host (parse_url() returns false)
+            'http:///path',
+
+            // Percent-encoded whitespace bypass
+            '%20http://evil.com',
+            '%09http://evil.com',
+            '%0ahttp://evil.com',
+
             // Dangerous URL schemes
             'javascript:alert(1)',
             'javascript:alert(document.cookie)',

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -248,7 +248,7 @@ class UrlTest extends TestCase
     }
 
     #[Test]
-    public function it_determines_if_external_url_to_application_when_only_current_request_domain_matches()
+    public function it_determines_if_external_url_to_application_when_only_current_request_domain_matches_when_theres_a_relative_site_url()
     {
         $this->setSites([
             'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -252,9 +252,22 @@ class UrlTest extends TestCase
     {
         $this->setSites([
             'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
+            'b' => ['name' => 'B', 'locale' => 'en_GB', 'url' => '/'],
         ]);
 
         $this->assertFalse(URL::isExternalToApplication('http://absolute-url-resolved-from-request.com/some-slug'));
+    }
+
+    #[Test]
+    public function it_does_not_trust_current_request_domain_when_no_sites_are_relative()
+    {
+        $this->setSites([
+            'a' => ['name' => 'A', 'locale' => 'en_US', 'url' => 'http://this-site.com/'],
+            'b' => ['name' => 'B', 'locale' => 'en_US', 'url' => 'http://subdomain.this-site.com/'],
+        ]);
+
+        $this->assertTrue(URL::isExternalToApplication('http://absolute-url-resolved-from-request.com/'));
+        $this->assertFalse(URL::isExternalToApplication('http://this-site.com/'));
     }
 
     #[Test]


### PR DESCRIPTION
This adds improved handling for more cases in the isExternalToApplication method.

`http://current-site.com` will now only be considered internal if there's a site defined with a relative url.
Otherwise the current domain could be forged via a header, and trusted if you have trusted proxies set to `'*'`.
Typically trusted proxies are only set to `'*'` on load balanced or cloud based hosts which would have their site urls defined as absolute.

Related: #14312 