### PR TITLE
[5.x] Allow external redirects from Form::getSubmissionRedirect

### DIFF
--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -154,9 +154,7 @@ class FormController extends Controller
             ]);
         }
 
-        $response = $redirect && ! \Statamic\Facades\URL::isExternalToApplication($redirect)
-            ? redirect($redirect)
-            : back();
+        $response = $redirect ? redirect($redirect) : back();
 
         if (! \Statamic\Facades\URL::isExternal($redirect)) {
             session()->flash("form.{$submission->form()->handle()}.success", __('Submission successful.'));
@@ -171,6 +169,10 @@ class FormController extends Controller
     {
         if (! $redirect = Form::getSubmissionRedirect($submission)) {
             $redirect = Arr::get($params, '_redirect');
+
+            if ($redirect && \Statamic\Facades\URL::isExternalToApplication($redirect)) {
+                return null;
+            }
         }
 
         return $redirect;

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -167,12 +167,14 @@ class FormController extends Controller
 
     private function formSuccessRedirect($params, $submission)
     {
-        if (! $redirect = Form::getSubmissionRedirect($submission)) {
-            $redirect = Arr::get($params, '_redirect');
+        if ($redirect = Form::getSubmissionRedirect($submission)) {
+            return $redirect;
+        }
 
-            if ($redirect && \Statamic\Facades\URL::isExternalToApplication($redirect)) {
-                return null;
-            }
+        $redirect = Arr::get($params, '_redirect');
+
+        if ($redirect && \Statamic\Facades\URL::isExternalToApplication($redirect)) {
+            return null;
         }
 
         return $redirect;


### PR DESCRIPTION
## Summary

- Moves the external URL check from `formSuccess` into `formSuccessRedirect` so it only blocks user-controlled `_redirect` params
- Trusted developer-defined redirects via `Form::getSubmissionRedirect` are now allowed to redirect to external URLs (e.g. payment providers)

Fixes #14317

🤖 Generated with [Claude Code](https://claude.com/claude-code)