### PR TITLE
[6.x] Fix closure validation rules with Files fieldtype

### DIFF
--- a/src/Fieldtypes/Files.php
+++ b/src/Fieldtypes/Files.php
@@ -70,6 +70,10 @@ class Files extends Fieldtype
         ];
 
         return collect(parent::fieldRules())->map(function ($rule) use ($classes) {
+            if (! is_string($rule)) {
+                return $rule;
+            }
+
             $name = Str::before($rule, ':');
 
             if ($class = Arr::get($classes, $name)) {

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -166,6 +166,20 @@ class FilesTest extends TestCase
         $this->assertEquals('required', $replaced[0]);
     }
 
+    #[Test]
+    public function it_passes_through_closure_rules()
+    {
+        $closure = function ($attribute, $value, $fail) {
+            // custom validation
+        };
+
+        $replaced = $this->fieldtype(['validate' => [$closure]])->fieldRules();
+
+        $this->assertIsArray($replaced);
+        $this->assertCount(1, $replaced);
+        $this->assertSame($closure, $replaced[0]);
+    }
+
     private function fieldtype($config = [])
     {
         return (new Files)->setField(new Field('test', array_merge([


### PR DESCRIPTION
This pull request fixes an issue when using closure validation rules with the Files fieldtype.

Fixes #14313
Caused by #14262