### PR TITLE
[6.x] Fix various timezone issues

### DIFF
--- a/resources/js/components/entries/calendar/Calendar.vue
+++ b/resources/js/components/entries/calendar/Calendar.vue
@@ -7,7 +7,7 @@ import Month from './Month.vue';
 import Week from './Week.vue';
 import { Listing, StatusIndicator } from '@/components/ui';
 import DateFormatter from '@/components/DateFormatter.js';
-import { formatDateString, getWeekDates, getCurrentDateRange } from './calendar.js';
+import { getWeekDates, getCurrentDateRange } from './calendar.js';
 import { Link } from '@inertiajs/vue3';
 import { ToggleGroup, ToggleItem, Button, Popover, Label, Select, Heading } from '@ui';
 import { preferences } from '@api';
@@ -119,7 +119,7 @@ const yearOptions = computed(() => {
 const selectedDateEntries = computed(() => {
     if (!selectedDate.value) return [];
 
-    const dateStr = formatDateString(selectedDate.value);
+    const dateStr = selectedDate.value.toString();
 
     return entries.value.filter(entry => {
         const entryDate = new Date(entry.date?.date || entry.date);

--- a/resources/js/components/entries/calendar/Month.vue
+++ b/resources/js/components/entries/calendar/Month.vue
@@ -3,8 +3,9 @@ import { CalendarCell, CalendarCellTrigger, CalendarGrid, CalendarGridBody, Cale
 import CalendarEntry from './MonthEntry.vue';
 import CreateEntryButton from '../CreateEntryButton.vue';
 import { Button } from '@ui';
-import { formatDateString, isToday, getCreateUrlDateParam } from './calendar.js';
+import { isToday, getCreateUrlDateParam } from './calendar.js';
 import DateFormatter from '@/components/DateFormatter.js';
+import { parseAbsoluteToLocal } from '@internationalized/date';
 
 const props = defineProps({
     weekDays: { type: Array, required: true },
@@ -29,10 +30,10 @@ const isCurrentDay = (dayIndex) => {
 };
 
 const getEntriesForDate = (date) => {
-    const dateStr = formatDateString(date);
+    const dateStr = date.toString();
     return props.entries.filter(entry => {
-        const entryDate = new Date(entry.date?.date || entry.date);
-        return entryDate.toISOString().split('T')[0] === dateStr;
+        const entryDate = parseAbsoluteToLocal(entry.date?.date || entry.date);
+        return entryDate.toString().split('T')[0] === dateStr;
     });
 };
 

--- a/resources/js/components/entries/calendar/Week.vue
+++ b/resources/js/components/entries/calendar/Week.vue
@@ -6,9 +6,9 @@ import { Button } from '@ui';
 import {
     isToday,
     getCreateUrlDateParam,
-    formatDateString,
 } from './calendar.js';
 import DateFormatter from '@/components/DateFormatter.js';
+import { parseAbsoluteToLocal } from '@internationalized/date';
 
 const props = defineProps({
     weekDates: { type: Array, required: true },
@@ -25,13 +25,13 @@ const $date = new DateFormatter;
 const visibleHours = Array.from({ length: 24 }, (_, i) => i);
 
 function getEntriesForHour(date, hour) {
-    const dateStr = formatDateString(date);
+    const dateStr = date.toString();
     return props.entries.filter(entry => {
-        const entryDate = new Date(entry.date?.date || entry.date);
-        const entryDateStr = entryDate.toISOString().split('T')[0];
+        const entryDate = parseAbsoluteToLocal(entry.date?.date || entry.date);
+        const entryDateStr = entryDate.toString().split('T')[0];
         if (entryDateStr !== dateStr) return false;
 
-        const entryHour = entryDate.getHours();
+        const entryHour = entryDate.hour;
         return entryHour === hour;
     });
 }

--- a/resources/js/components/entries/calendar/calendar.js
+++ b/resources/js/components/entries/calendar/calendar.js
@@ -1,10 +1,6 @@
 import { CalendarDate, CalendarDateTime, fromDate, getLocalTimeZone, startOfWeek, endOfWeek } from '@internationalized/date';
 import DateFormatter from '@/components/DateFormatter.js';
 
-export function formatDateString(date) {
-    return new Date(date.year, date.month - 1, date.day).toISOString().split('T')[0];
-}
-
 export function getWeekDates(currentDate) {
     if (!currentDate) {
         throw new Error('getWeekDates called with undefined currentDate');

--- a/src/Console/Commands/MigrateDatesToUtc.php
+++ b/src/Console/Commands/MigrateDatesToUtc.php
@@ -45,6 +45,8 @@ class MigrateDatesToUtc extends Command
     {
         $this->currentTimezone = $this->argument('timezone');
 
+        config(['app.timezone' => 'UTC']);
+
         $this->components->warn('This command makes changes to content. Please make a backup before running.');
         $this->components->info('This operation converts content dates to UTC for storage purposes only. System functionality is identical whether you proceed or not – do so only if specifically desired.');
 

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -540,7 +540,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
                 $format .= 's';
             }
 
-            $prefix = $this->date->format($format).'.';
+            $prefix = $this->date->copy()->setTimezone(config('app.timezone'))->format($format).'.';
         }
 
         return vsprintf('%s/%s/%s%s%s.%s', [

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -203,12 +203,32 @@ class StoreEntryTest extends TestCase
         $this->assertEquals('auto-avada-kedavra', $entry->slug());
         $this->assertEquals('auto-avada-kedavra.md', pathinfo($entry->path(), PATHINFO_BASENAME));
     }
+    
+    #[Test]
+    public function date_is_saved_correctly_when_app_timezone_is_utc()
+    {
+        config()->set('app.timezone', 'UTC');
+
+        [$user, $collection] = $this->seedUserAndCollection();
+        $collection->dated(true)->save();
+
+        $this->assertCount(0, Entry::all());
+
+        $this
+            ->actingAs($user)
+            ->submit($collection, ['title' => 'My Entry', 'slug' => 'my-entry', 'date' => '2026-03-23T16:30:00.000Z'])
+            ->assertOk();
+
+        $this->assertCount(1, Entry::all());
+        $entry = Entry::all()->first();
+        $this->assertEquals('2026-03-23-1630.my-entry.md', Str::afterLast($entry->buildPath(), '/'));
+    }
 
     /**
      * @see https://github.com/statamic/cms/issues/14251
      **/
     #[Test]
-    public function date_in_path_is_saved_in_app_timezone_if_collection_is_dated()
+    public function date_is_saved_correctly_when_app_timezone_is_not_utc()
     {
         config()->set('app.timezone', 'Europe/Zurich');
 

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Events\EntrySaving;
@@ -207,7 +208,7 @@ class StoreEntryTest extends TestCase
      * @see https://github.com/statamic/cms/issues/14251
      **/
     #[Test]
-    public function date_is_saved_in_app_timezone_if_collection_is_dated()
+    public function date_in_path_is_saved_in_app_timezone_if_collection_is_dated()
     {
         config()->set('app.timezone', 'Europe/Zurich');
 
@@ -223,7 +224,7 @@ class StoreEntryTest extends TestCase
 
         $this->assertCount(1, Entry::all());
         $entry = Entry::all()->first();
-        $this->assertEquals('2026-03-23 17:30:00', $entry->date()->format('Y-m-d H:i:s')); // Should be saved in Europe/Zurich, so 17:30.
+        $this->assertEquals('2026-03-23-1730.my-entry.md', Str::afterLast($entry->buildPath(), '/')); // Should be saved in Europe/Zurich, so 17:30.
     }
 
     #[Test]

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -203,6 +203,29 @@ class StoreEntryTest extends TestCase
         $this->assertEquals('auto-avada-kedavra.md', pathinfo($entry->path(), PATHINFO_BASENAME));
     }
 
+    /**
+     * @see https://github.com/statamic/cms/issues/14251
+     **/
+    #[Test]
+    public function date_is_saved_in_app_timezone_if_collection_is_dated()
+    {
+        config()->set('app.timezone', 'Europe/Zurich');
+
+        [$user, $collection] = $this->seedUserAndCollection();
+        $collection->dated(true)->save();
+
+        $this->assertCount(0, Entry::all());
+
+        $this
+            ->actingAs($user)
+            ->submit($collection, ['title' => 'My Entry', 'slug' => 'my-entry', 'date' => '2026-03-23T16:30:00.000Z']) // 16:30 UTC is 17:30 in Zurich
+            ->assertOk();
+
+        $this->assertCount(1, Entry::all());
+        $entry = Entry::all()->first();
+        $this->assertEquals('2026-03-23 17:30:00', $entry->date()->format('Y-m-d H:i:s')); // Should be saved in Europe/Zurich, so 17:30.
+    }
+
     #[Test]
     public function it_can_validate_against_published_value()
     {

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Str;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Events\EntrySaving;
@@ -203,7 +202,7 @@ class StoreEntryTest extends TestCase
         $this->assertEquals('auto-avada-kedavra', $entry->slug());
         $this->assertEquals('auto-avada-kedavra.md', pathinfo($entry->path(), PATHINFO_BASENAME));
     }
-    
+
     #[Test]
     public function date_is_saved_correctly_when_app_timezone_is_utc()
     {
@@ -221,7 +220,7 @@ class StoreEntryTest extends TestCase
 
         $this->assertCount(1, Entry::all());
         $entry = Entry::all()->first();
-        $this->assertEquals('2026-03-23-1630.my-entry.md', Str::afterLast($entry->buildPath(), '/'));
+        $this->assertStringContainsString('2026-03-23-1630.my-entry.md', $entry->buildPath());
     }
 
     /**
@@ -244,7 +243,7 @@ class StoreEntryTest extends TestCase
 
         $this->assertCount(1, Entry::all());
         $entry = Entry::all()->first();
-        $this->assertEquals('2026-03-23-1730.my-entry.md', Str::afterLast($entry->buildPath(), '/')); // Should be saved in Europe/Zurich, so 17:30.
+        $this->assertStringContainsString('2026-03-23-1730.my-entry.md', $entry->buildPath()); // Should be saved in Europe/Zurich, so 17:30.
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes various timezone issues reported #14251.

- Fixes issue where an entry's date/time could change after saving.
  - Only affects apps where the app timezone _isn't_ `UTC`.
  - The date was returned correctly by `Date@process()` (returns a UTC date/time string). 
  - However, the date was later passed to `Date@augment()` which returns UTC `Carbon` instances. This UTC date was ultimately persisted in the entry's filename, causing the wrong date/time to be saved.
  - Re-saving the entry would cause the time to change again, by the app timezone's UTC offset.
  - This PR fixes it ensuring the date in entry filename is converted to the app timezone before persisting.
- Fixes entries showing under the wrong date in the collection calendar
  - We found that the `formatDateString()` helper was always returning the day _after_ the provided date, at least when my local timezone was set to `Europe/Zurich`.
  - It turns out that we don't need the helper anyway and can simply convert the passed `date` object to a string, which respects the local timezone and returns in the correct format.

Fixes #14251
