### PR TITLE
[6.x] Fix translator locale

### DIFF
--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -24,12 +24,9 @@ class Localize
         $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $site->locale());
 
-        // The sites lang is used for your translations. (eg. if you set your site's lang
-        // to "fr_FR", the translator will look for "fr_FR" files rather than "fr" files
-        // but if not set the translator will look for "fr" files rather than "fr_FR"
-        // files.) Again, we'll save the original locale so we can reset it later.
-        $originalAppLocale = app()->getLocale();
-        app()->setLocale($site->lang());
+        // Use the site's lang for translations.
+        $originalTranslatorLocale = app('translator')->getLocale();
+        app('translator')->setLocale($site->lang());
 
         // Get original Carbon format so it can be restored later.
         $originalToStringFormat = $this->getToStringFormat();
@@ -46,7 +43,7 @@ class Localize
         // Reset everything back to their originals. This allows everything
         // not within the scope of the request to be the "defaults".
         setlocale(LC_TIME, $originalLocale);
-        app()->setLocale($originalAppLocale);
+        app('translator')->setLocale($originalTranslatorLocale);
         Date::setToStringFormat($originalToStringFormat);
 
         return $response;

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -724,6 +724,8 @@ class FrontendTest extends TestCase
     #[Test]
     public function it_sets_the_locale()
     {
+        // Frontend localization sets PHP LC_TIME and the translator locale for the site;
+        // Laravel's configured app locale (app()->getLocale()) is left unchanged.
         // You can only set the locale to one that is actually installed on the server.
         // The names are a little different across jobs in the GitHub actions matrix.
         // We'll test against whichever was successfully applied. Finally, we will
@@ -751,16 +753,16 @@ class FrontendTest extends TestCase
 
         (new class extends Tags
         {
-            public static $handle = 'laravel_locale';
+            public static $handle = 'translator_locale';
 
             public function index()
             {
-                return app()->getLocale();
+                return app('translator')->getLocale();
             }
         })->register();
 
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
-        $this->viewShouldReturnRaw('some_template', 'PHP Locale: {{ php_locale }} App Locale: {{ laravel_locale }}');
+        $this->viewShouldReturnRaw('some_template', 'PHP Locale: {{ php_locale }} Translator Locale: {{ translator_locale }}');
 
         $this->makeCollection()->sites(['english', 'french'])->save();
         tap($this->makePage('about', ['with' => ['template' => 'some_template']])->locale('english'))->save();
@@ -771,7 +773,7 @@ class FrontendTest extends TestCase
 
         $this->get('/fr/le-about')->assertSeeInOrder([
             'PHP Locale: '.$frLocale,
-            'App Locale: fr',
+            'Translator Locale: fr',
         ]);
 
         $this->assertEquals('en', app()->getLocale());


### PR DESCRIPTION
This PR adjusts the localize middleware to update the locale of the translator directly rather than as a side-effect of updating the entire app locale.

Setting the entire app locale had side effects of its own, including altering behavior of certain Carbon features like `startOfWeek()`.
