### PR TITLE
[5.x] Restrict markdown preview endpoint

### DIFF
--- a/src/Http/Controllers/CP/Fieldtypes/MarkdownFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/MarkdownFieldtypeController.php
@@ -12,7 +12,11 @@ class MarkdownFieldtypeController extends CpController
 {
     public function preview(Request $request)
     {
-        return $this->fieldtype($request->config)->augment($request->value);
+        $config = $request->config;
+
+        abort_unless(($config['type'] ?? null) === 'markdown', 400, 'Bad Request');
+
+        return $this->fieldtype($config)->augment($request->value);
     }
 
     protected function fieldtype($config)

--- a/tests/Feature/Fieldtypes/PreviewMarkdownTest.php
+++ b/tests/Feature/Fieldtypes/PreviewMarkdownTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Fieldtypes;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class PreviewMarkdownTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    private function request($payload)
+    {
+        return $this->postJson(cp_route('markdown.preview'), $payload);
+    }
+
+    #[Test]
+    public function it_parses_markdown()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->request(['config' => ['type' => 'markdown'], 'value' => '**Hello**'])
+            ->assertContent("<p><strong>Hello</strong></p>\n");
+    }
+
+    #[Test]
+    public function it_aborts_for_non_markdown()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->request(['config' => ['type' => 'text'], 'value' => '**Hello**'])
+            ->assertBadRequest()
+            ->assertJson(['message' => 'Bad Request']);
+    }
+
+    #[Test]
+    public function it_denies_access_without_control_panel_permission()
+    {
+        $this->setTestRoles(['test' => []]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->request(['config' => ['type' => 'markdown'], 'value' => '**Hello**'])
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
This PR ensures only markdown will ever be returned from the preview endpoint.
