### PR TITLE
[5.x] Sanitize password reset form redirect value

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -444,7 +444,7 @@ class UserTags extends Tags
         $html .= '<input type="hidden" name="token" value="'.$token.'" />';
 
         if ($redirect) {
-            $html .= '<input type="hidden" name="redirect" value="'.$redirect.'" />';
+            $html .= '<input type="hidden" name="redirect" value="'.e($redirect).'" />';
         }
 
         $html .= $this->parse($data);


### PR DESCRIPTION
This sanitizes the hidden redirect field value. 

It doesn't do it the same way other front-end form tags do, as that would be a breaking change. The others all expect `_redirect` where this form uses `redirect`. Blade-authored templates might be hardcoding `redirect`.

We could clean this up with a small breaking change for v7.