### PR TITLE
[6.x] Don't autofocus on non-root fields with "title" or "alt" name

### DIFF
--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -37,11 +37,14 @@ const {
 } = Fieldtype.use(emit, props);
 
 const shouldFocus = computed(() => {
-    if (props.config.focus === false) {
-        return false;
+    if (props.config.focus === false || props.config.focus === true) {
+        return props.config.focus;
     }
+    
+    const isRootField = !props.fieldPathPrefix;
+    const isImplicitAutofocusField = name.value === 'title' || name.value === 'alt';
 
-    return props.config.focus || name.value === 'title' || name.value === 'alt';
+    return isRootField && isImplicitAutofocusField;
 });
 
 function inputUpdated(value) {


### PR DESCRIPTION
I see how autofocusing on the field with the "title" name is useful, but it results in weird behavior in scenarios like:

<img width="1718" height="1574" alt="CleanShot 2026-03-24 at 13 55 21@2x" src="https://github.com/user-attachments/assets/d80a854e-a591-4836-818d-85acdb6a1e1c" />

Instead of focusing on the page title, it focuses on the title of the last feature, which is not ideal, especially when the pages are huge and it scrolls thousands of pixels down the page to the wrong title.

I think keeping autofocus for "title" and "alt" fields only for root fields would be a good solution to this problem, while preferring the explicitly set `focus` value if there is any. 