### PR TITLE
[6.x] Fix `translator` error with Symfony Console 8

### DIFF
--- a/src/Translator/Commands/Generate.php
+++ b/src/Translator/Commands/Generate.php
@@ -40,7 +40,7 @@ class Generate extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('generate')

--- a/src/Translator/Commands/Review.php
+++ b/src/Translator/Commands/Review.php
@@ -24,7 +24,7 @@ class Review extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('review')

--- a/src/Translator/Commands/Stats.php
+++ b/src/Translator/Commands/Stats.php
@@ -24,7 +24,7 @@ class Stats extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('stats')

--- a/src/Translator/Commands/Translate.php
+++ b/src/Translator/Commands/Translate.php
@@ -30,7 +30,7 @@ class Translate extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('translate')

--- a/translator
+++ b/translator
@@ -124,9 +124,9 @@ $excludedKeys = [
 ];
 
 $app = new Symfony\Component\Console\Application('Statamic Translator');
-$app->add(new Statamic\Translator\Commands\Stats($discovery, $ignoredSubstrings));
-$app->add(new Statamic\Translator\Commands\Generate($discovery, $files, $manualFiles, $ignoredSubstrings, $additionalStrings, $additionalKeys, $excludedKeys));
-$app->add(new Statamic\Translator\Commands\Translate($files, $dontTranslate));
-$app->add(new Statamic\Translator\Commands\Review($files));
+$app->addCommand(new Statamic\Translator\Commands\Stats($discovery, $ignoredSubstrings));
+$app->addCommand(new Statamic\Translator\Commands\Generate($discovery, $files, $manualFiles, $ignoredSubstrings, $additionalStrings, $additionalKeys, $excludedKeys));
+$app->addCommand(new Statamic\Translator\Commands\Translate($files, $dontTranslate));
+$app->addCommand(new Statamic\Translator\Commands\Review($files));
 
 $app->run();


### PR DESCRIPTION
This pull request fixes an issue where the `translator` script throws an error when running on Symfony Console 8.0.

This was happening because Symfony Console 8.0 removed the `Application::add()` method, which was [deprecated in 7.4](https://github.com/symfony/symfony/blob/fe9786597d19021defcd6017db7448fca018caa1/src/Symfony/Component/Console/Application.php#L553-L561).

This PR fixes it by using the replacement `Application::addCommand()` method instead.

Fixes #14324