### PR TITLE
[6.x] Fix set picker position

### DIFF
--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -1,6 +1,6 @@
 <template>
     <template v-if="!hasMultipleSets">
-        <Primitive @click="singleButtonClicked">
+        <Primitive as-child @click="singleButtonClicked">
             <slot name="trigger" />
         </Primitive>
     </template>
@@ -14,7 +14,7 @@
         class="xl:max-w-3xl 2xl:max-w-page"
     >
         <template #trigger>
-            <Primitive @click.capture="onTriggerClick">
+            <Primitive as-child @click.capture="onTriggerClick">
                 <slot name="trigger" />
             </Primitive>
         </template>
@@ -92,7 +92,7 @@
         inset
     >
         <template #trigger>
-            <Primitive @click.capture="onTriggerClick">
+            <Primitive as-child @click.capture="onTriggerClick">
                 <slot name="trigger" />
             </Primitive>
         </template>


### PR DESCRIPTION
This pull request fixes an issue where creating a Set inside Bard would cause the set picker menu to appear at the very top of the content, instead of inline where the + button was clicked.

This was happening because the `Primitive` component (introduced in #14290) was rendering a default wrapper element (a `<span>`) around the trigger slot. This extra element became the popover's trigger reference for floating-ui positioning, instead of the actual transformed trigger element (the absolute div with `translateY`). Since the span was at its default position (top of the editor), the popover appeared there.

This PR fixes it by adding `as-child` to the `Primitive` components, which prevents them from rendering their own DOM element and instead merges props and event handlers with the child element, preserving correct trigger positioning for floating-ui.

Fixes #14311
Caused by #14290