### PR TITLE
[6.x] Long dropdowns should be scrollable

### DIFF
--- a/resources/js/components/ui/Dropdown/Dropdown.vue
+++ b/resources/js/components/ui/Dropdown/Dropdown.vue
@@ -21,7 +21,8 @@ const props = defineProps({
 
 const dropdownContentClasses = cva({
     base: [
-        'rounded-xl min-w-64 bg-gray-50 dark:bg-gray-800 outline-hidden overflow-hidden group z-50',
+        'rounded-xl min-w-64 bg-gray-50 dark:bg-gray-800 outline-hidden overflow-y-auto group z-50',
+        'max-h-[calc(var(--reka-dropdown-menu-content-available-height,300px)-16px)]',
         'border border-gray-200 dark:border-black shadow-lg popoverAnimation',
     ],
 })({});


### PR DESCRIPTION
This pull request fixes an issue where dropdown menus with many options would overflow the viewport, making some options inaccessible.

This was happening because the `DropdownMenuContent` component had no max-height constraint, allowing it to grow indefinitely.

This PR fixes it by using reka-ui's `--reka-dropdown-menu-content-available-height` CSS variable to constrain the dropdown to the available viewport space (minus 16px for edge padding), with scrolling enabled when content exceeds that height.

## Before

<img width="389" height="736" alt="CleanShot 2026-03-24 at 11 47 13" src="https://github.com/user-attachments/assets/85372421-2661-421d-968a-c5f7f5e58ebc" />


## After


<img width="320" height="724" alt="CleanShot 2026-03-24 at 11 46 56" src="https://github.com/user-attachments/assets/615ad3f8-e917-4036-b6fa-6b46c79f84f3" />

---

Fixes #14320