### PR TITLE
[6.x] Fix sync/desync on localizable nested fields

### DIFF
--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -182,13 +182,14 @@ const isSyncable = computed(() => {
 
 const isSynced = computed(() => isSyncable.value && !localizedFields.value.includes(fullPath.value));
 const isNested = computed(() => fullPath.value.includes('.'));
+const rootFieldPath = computed(() => isNested.value ? fullPath.value.split('.')[0] : fullPath.value);
 
 function sync() {
-    syncField(fullPath.value);
+    syncField(rootFieldPath.value);
 }
 
 function desync() {
-    desyncField(fullPath.value);
+    desyncField(rootFieldPath.value);
 }
 
 const fieldtypeComponentProps = computed(() => ({


### PR DESCRIPTION
This pull request fixes syncing/desyncing nested fields (like grid, group, replicator, etc) when `localizable: true`.

In v5, when a nested field's value was updated, it would emit events which would eventually make their way back up to the respective fieldtype component (eg. `Grid.vue`), which would emit an event of its own, and eventually update the container, causing the `localizedFields` state to be updated.

Publish Containers were completely rewritten in v6 — methods/state can be accessed by child components via injection, doing away with the need for emitting events all the way up the chain.

When a nested field's value is updated, its value is updated directly in the container's state without needing to go up the chain to the nested fieldtype component. However, this meant that the nested key was being added to the `localizedFields` array, rather than the key of the "root" field.

This PR ensures we pass the path of the "root" field to `syncField()` and `desyncField()` instead of the nested field's full path. Not 100% sure if it's the right solution, so if you can think of an alternative, let me know!

Fixes #13822
