### PR TITLE
[6.x] Set the header to relative so it appears above the architectural line…

### DIFF
--- a/resources/js/components/ui/Header.vue
+++ b/resources/js/components/ui/Header.vue
@@ -10,7 +10,7 @@ const props = defineProps({
 </script>
 
 <template>
-    <header class="flex flex-wrap items-center justify-between gap-4 px-2 sm:px-0 py-6 max-md:pb-8 md:py-8" data-ui-header>
+    <header class="relative flex flex-wrap items-center justify-between gap-4 px-2 sm:px-0 py-6 max-md:pb-8 md:py-8" data-ui-header>
         <h1 class="text-[25px] leading-[1.25] st-text-legibility font-medium antialiased flex items-center gap-2.5 md:flex-1">
             <!-- Wrap icon in a fixed size div (the same size as the icon) to prevent layout shift once it loads -->
             <div v-if="icon" class="size-5 relative">


### PR DESCRIPTION
## Description of the Problem

Sometimes the header component falls behind the absolutely positioned architectural lines pattern. This is noticeable when there are buttons like this

See top right
![2026-03-24 at 17 22 58@2x](https://github.com/user-attachments/assets/6ecadc45-eee5-454c-adc8-8f110ca4147e)

## What this PR Does

- Closes #14271 
- Simply adds `position: relative` to the header, which prevents it from falling behind absolutely positioned elements.

## How to Reproduce

1. Enable multi-site
2. Create a new navigation and configure it to accept multiple sites
3. Notice the dropdown falls behind the architectural lines