### PR TITLE
[6.x] Remove fixed height from SVGs in UI labels to prevent flickering

### DIFF
--- a/resources/js/components/ui/Label.vue
+++ b/resources/js/components/ui/Label.vue
@@ -18,7 +18,7 @@ const props = defineProps({
 
 <template>
     <label
-        class="flex justify-between mb-1.5 text-sm font-medium [&_button]:font-medium text-gray-925 select-none dark:text-gray-300"
+        class="flex justify-between mb-1.5 text-sm font-medium [&_button]:font-medium text-gray-925 select-none dark:text-gray-300 [&_button:has(svg)]:h-auto"
         data-ui-label
         :for="for"
     >


### PR DESCRIPTION
## Description of the Problem

When switching between multi-sites, the "sync" icon causes the label height to change slightly because it has a fixed height which is taller than the label, here:
![2026-03-24 at 20 13 14@2x](https://github.com/user-attachments/assets/5d588bf5-6247-4f8b-a157-f97cc94634ca)

## What this PR Does

- Sets the button height to `auto` for svgs in labels like the link icon so that label heights stay the same when switching between two different sites in multisite.
- Should close #14269

## How to Reproduce

1. In multi site switch between different locales and observe the label height changing slightly as the link icon appears