### PR TITLE
[6.x] Correct the Bard full-screen width. The usual max-w-page is based on …

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -264,7 +264,7 @@
         @apply fixed inset-0 min-h-screen overflow-scroll border-none rounded-none bg-gray-100 pt-14 dark:bg-gray-850;
 
         & > .bard-editor {
-            @apply relative mx-auto my-6 max-w-page rounded-lg bg-white px-8 shadow-ui-md dark:bg-gray-925 dark:shadow-lg;
+            @apply relative mx-auto my-6 max-w-[64rem] rounded-lg bg-white px-8 shadow-ui-md dark:bg-gray-925 dark:shadow-lg;
         }
         .bard-content {
             @apply dark:bg-gray-925;

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -264,7 +264,7 @@
         @apply fixed inset-0 min-h-screen overflow-scroll border-none rounded-none bg-gray-100 pt-14 dark:bg-gray-850;
 
         & > .bard-editor {
-            @apply relative mx-auto my-6 max-w-[64rem] rounded-lg bg-white px-8 shadow-ui-md dark:bg-gray-925 dark:shadow-lg;
+            @apply relative mx-auto my-6 max-w-[65rem] rounded-lg bg-white px-8 shadow-ui-md dark:bg-gray-925 dark:shadow-lg;
         }
         .bard-content {
             @apply dark:bg-gray-925;


### PR DESCRIPTION
## Description of the Problem

When Bard is full-screen, the `max-width` is set to `max-w-page`, the same as the publish form, which theoretically should work well.
However, the publish form has a sidebar and a grid layout, which means the actual width of a Bard field is narrower, at ~65rem, leaving an ideal, readable width.

## What this PR Does

- Sets the Bard max-width to `65rem` in full-screen mode, matching the reading width in non-full-screen mode.
- Closes #14229

## Bard reading standard reading width
![2026-03-25 at 10 05 54@2x](https://github.com/user-attachments/assets/85c49e5b-0e2e-4cab-94b9-28e084a984be)

## Full-screen (before)
![2026-03-25 at 10 10 32@2x](https://github.com/user-attachments/assets/8d6daad1-6f3d-4f7d-a025-357f1ca28686)

## Full-screen (after)
Note how the line breaks at the same point
![2026-03-25 at 10 09 45@2x](https://github.com/user-attachments/assets/f6b77cbf-d80b-4dd4-b950-25a48e85b410)

---

I considered adding an Expand Layout toggle control here, but then I reasoned it's unlikely to be useful when writing prose.

## How to Reproduce

1. Observe that Bard's reading width is slightly wider in full-screen mode.