### PR TITLE
[6.x] Fix custom entry class test artifact

### DIFF
--- a/tests/Stache/Repositories/EntryRepositoryTest.php
+++ b/tests/Stache/Repositories/EntryRepositoryTest.php
@@ -275,6 +275,8 @@ class EntryRepositoryTest extends TestCase
             ->collection(Collection::findByHandle('custom_class'))
             ->slug('custom');
 
+        $this->unlinkAfter($this->directory.'/custom_class/custom.md');
+
         $this->repo->save($temp);
         $entry = $this->repo->find('custom');
 


### PR DESCRIPTION
This PR just cleans up a leftover file when running tests. Same as other methods in the same test class. No functionality change.
