### PR TITLE
[6.x] Revert "Fix translator locale"

### DIFF
--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -17,17 +17,19 @@ class Localize
     {
         $site = Site::current();
 
-        // Dates, Carbon, etc expect the full locale. (eg. "fr_FR" or whatever is
+        // PHP date-formatting functions expect the full locale. (eg. "fr_FR" or whatever is
         // installed on your actual server. You can check by running `locale -a`).
         // We'll save the original locale so we can reset it later. Of course,
         // you can get the locale by calling the setlocale method. Logical.
         $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $site->locale());
 
-        // The sites lang is used for your translations. (eg. if you set your site's lang
-        // to "fr_FR", the translator will look for "fr_FR" files rather than "fr" files
-        // but if not set the translator will look for "fr" files rather than "fr_FR"
-        // files.) Again, we'll save the original locale so we can reset it later.
+        // The sites lang is used for your translations.
+        // e.g. If you set your lang to "fr" it'll look for "fr" translations.
+        // If not explicitly set, a site's lang will fall back to the "short locale"
+        // e.g. If your site's locale is "fr_FR", the lang would be "fr".
+        // Note that Carbon does also use this for some things.
+        // Again, we'll save the original locale so we can reset it later.
         $originalAppLocale = app()->getLocale();
         app()->setLocale($site->lang());
 

--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -24,9 +24,12 @@ class Localize
         $originalLocale = setlocale(LC_TIME, 0);
         setlocale(LC_TIME, $site->locale());
 
-        // Use the site's lang for translations.
-        $originalTranslatorLocale = app('translator')->getLocale();
-        app('translator')->setLocale($site->lang());
+        // The sites lang is used for your translations. (eg. if you set your site's lang
+        // to "fr_FR", the translator will look for "fr_FR" files rather than "fr" files
+        // but if not set the translator will look for "fr" files rather than "fr_FR"
+        // files.) Again, we'll save the original locale so we can reset it later.
+        $originalAppLocale = app()->getLocale();
+        app()->setLocale($site->lang());
 
         // Get original Carbon format so it can be restored later.
         $originalToStringFormat = $this->getToStringFormat();
@@ -43,7 +46,7 @@ class Localize
         // Reset everything back to their originals. This allows everything
         // not within the scope of the request to be the "defaults".
         setlocale(LC_TIME, $originalLocale);
-        app('translator')->setLocale($originalTranslatorLocale);
+        app()->setLocale($originalAppLocale);
         Date::setToStringFormat($originalToStringFormat);
 
         return $response;

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -739,8 +739,6 @@ class FrontendTest extends TestCase
     #[Test]
     public function it_sets_the_locale()
     {
-        // Frontend localization sets PHP LC_TIME and the translator locale for the site;
-        // Laravel's configured app locale (app()->getLocale()) is left unchanged.
         // You can only set the locale to one that is actually installed on the server.
         // The names are a little different across jobs in the GitHub actions matrix.
         // We'll test against whichever was successfully applied. Finally, we will
@@ -768,16 +766,16 @@ class FrontendTest extends TestCase
 
         (new class extends Tags
         {
-            public static $handle = 'translator_locale';
+            public static $handle = 'laravel_locale';
 
             public function index()
             {
-                return app('translator')->getLocale();
+                return app()->getLocale();
             }
         })->register();
 
         $this->viewShouldReturnRaw('layout', '{{ template_content }}');
-        $this->viewShouldReturnRaw('some_template', 'PHP Locale: {{ php_locale }} Translator Locale: {{ translator_locale }}');
+        $this->viewShouldReturnRaw('some_template', 'PHP Locale: {{ php_locale }} App Locale: {{ laravel_locale }}');
 
         $this->makeCollection()->sites(['english', 'french'])->save();
         tap($this->makePage('about', ['with' => ['template' => 'some_template']])->locale('english'))->save();
@@ -788,7 +786,7 @@ class FrontendTest extends TestCase
 
         $this->get('/fr/le-about')->assertSeeInOrder([
             'PHP Locale: '.$frLocale,
-            'Translator Locale: fr',
+            'App Locale: fr',
         ]);
 
         $this->assertEquals('en', app()->getLocale());


### PR DESCRIPTION
This PR reverts #14323.

It turns out it was a breaking change. Things were relying on the config.

For example, https://github.com/statamic/cms/issues/14346

Looking into it, Carbon uses the app locale for more than purely translation related things.

Maybe this can change in v7.

I've also updated the comments in the middleware for clarity while in here.

Fixes #14346