### PR TITLE
[6.x] Omit application name and URL from support:details

### DIFF
--- a/src/Console/Commands/SupportDetails.php
+++ b/src/Console/Commands/SupportDetails.php
@@ -2,30 +2,82 @@
 
 namespace Statamic\Console\Commands;
 
-use Illuminate\Console\Command;
+use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Support\Composer;
 use Statamic\Console\RunsInPlease;
+use Symfony\Component\Console\Attribute\AsCommand;
 
-class SupportDetails extends Command
+#[AsCommand(name: 'statamic:support:details')]
+class SupportDetails extends AboutCommand
 {
     use RunsInPlease;
 
-    protected $signature = 'statamic:support:details';
+    /**
+     * @var string
+     */
+    protected $signature = 'statamic:support:details
+                {--only= : The section to display}
+                {--json : Output the information as JSON}';
+
+    /**
+     * @var string
+     */
     protected $description = 'Outputs details helpful for support requests';
+
+    public function __construct(Composer $composer)
+    {
+        parent::__construct($composer);
+    }
 
     public function handle()
     {
         $this->replaceView();
 
         try {
-            $this->call('about');
+            return parent::handle();
         } finally {
             $this->restoreView();
         }
-
-        return static::SUCCESS;
     }
 
-    private function replaceView()
+    /**
+     * @param  \Illuminate\Support\Collection  $data
+     */
+    protected function displayDetail($data): void
+    {
+        $data->each(function ($data, $section) {
+            $this->newLine();
+
+            $this->components->twoColumnDetail('  <fg=green;options=bold>'.$section.'</>');
+
+            $data->pipe(fn ($data) => $section !== 'Environment' ? $data->sort() : $data)
+                ->reject(fn ($detail) => $this->shouldExcludeSupportDetail($detail[0]))
+                ->each(function ($detail) {
+                    [$label, $value] = $detail;
+
+                    $this->components->twoColumnDetail($label, value($value, false));
+                });
+        });
+    }
+
+    /**
+     * @param  \Illuminate\Support\Collection  $data
+     */
+    protected function displayJson($data): void
+    {
+        $data = $data->map(fn ($sectionData) => $sectionData
+            ->reject(fn ($detail) => $this->shouldExcludeSupportDetail($detail[0]))
+            ->values());
+
+        parent::displayJson($data);
+    }
+
+    private function shouldExcludeSupportDetail(string $label): bool
+    {
+        return in_array($label, ['Application Name', 'URL'], true);
+    }
+
+    private function replaceView(): void
     {
         $view = <<<'EOT'
 <div class="flex">
@@ -38,14 +90,14 @@ EOT;
         app('files')->put($dir.'/two-column-detail.php', $view);
     }
 
-    private function restoreView()
+    private function restoreView(): void
     {
         $dir = $this->viewDir();
         app('files')->delete($dir.'/two-column-detail.php');
         app('files')->move($dir.'/two-column-detail.php.bak', $dir.'/two-column-detail.php');
     }
 
-    private function viewDir()
+    private function viewDir(): string
     {
         return base_path('vendor/laravel/framework/src/Illuminate/Console/resources/views/components');
     }


### PR DESCRIPTION
`statamic:support:details` now extends Laravel's `AboutCommand` and runs the same `parent::handle()` flow inside the existing temporary two-column view swap, instead of delegating to `about`.

The Environment rows **Application Name** and **URL** are omitted from both normal and `--json` output so issue templates that ask for this command are less likely to expose branding or the site base URL.

See https://github.com/statamic/ideas/issues/1446.

Made with [Cursor](https://cursor.com)