### PR TITLE
[6.x] Only change date for localizations with an explicit date set

### DIFF
--- a/src/Console/Commands/MigrateDatesToUtc.php
+++ b/src/Console/Commands/MigrateDatesToUtc.php
@@ -120,6 +120,12 @@ class MigrateDatesToUtc extends Command
                     && empty($dottedPrefix)
                     && $field->handle() === 'date'
                 ) {
+                    // Skip localized entries that inherit their date from the origin.
+                    // The origin will be migrated separately and the inheritance will continue to work.
+                    if (! $item->hasExplicitDate()) {
+                        return;
+                    }
+
                     // When entries are constructed, the datestamp from the filename would be provided but treated as UTC.
                     // We need them to be adjusted back to the existing timezone.
                     $item->date(Carbon::createFromFormat(

--- a/tests/Console/Commands/MigrateDatesToUtcTest.php
+++ b/tests/Console/Commands/MigrateDatesToUtcTest.php
@@ -92,6 +92,88 @@ class MigrateDatesToUtcTest extends TestCase
     }
 
     #[Test]
+    public function it_skips_localized_entries_that_inherit_date_from_origin()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR', 'name' => 'French'],
+            'it' => ['url' => '/it/', 'locale' => 'it_IT', 'name' => 'Italian'],
+        ]);
+
+        $collection = tap(Collection::make('articles')->dated(true)->sites(['en', 'fr', 'it']))->save();
+
+        $collection->entryBlueprint()->setContents([
+            'fields' => [
+                ['handle' => 'date', 'field' => ['type' => 'date', 'time_enabled' => true]],
+            ],
+        ])->save();
+
+        $origin = Entry::make()->id('origin')->locale('en')->collection('articles')->date('2025-01-01-1200');
+        $origin->save();
+
+        $french = Entry::make()->id('fr-entry')->locale('fr')->collection('articles')->origin($origin);
+        $french->save();
+
+        $italian = Entry::make()->id('it-entry')->locale('it')->collection('articles')->origin($origin);
+        $italian->save();
+
+        // All entries should have the same date before migration
+        $this->assertEquals('2025-01-01T12:00:00+00:00', $origin->date()->toIso8601String());
+        $this->assertEquals('2025-01-01T12:00:00+00:00', $french->date()->toIso8601String());
+        $this->assertEquals('2025-01-01T12:00:00+00:00', $italian->date()->toIso8601String());
+
+        $this->migrateDatesToUtc();
+
+        $origin = Entry::find('origin');
+        $french = Entry::find('fr-entry');
+        $italian = Entry::find('it-entry');
+
+        // Origin should be migrated
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $origin->date()->toIso8601String());
+
+        // Localized entries should still have the same date as origin (inherited)
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $french->date()->toIso8601String());
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $italian->date()->toIso8601String());
+
+        $this->assertFalse($french->hasExplicitDate());
+        $this->assertFalse($italian->hasExplicitDate());
+    }
+
+    #[Test]
+    public function it_migrates_localized_entries_that_have_their_own_date()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR', 'name' => 'French'],
+        ]);
+
+        $collection = tap(Collection::make('articles')->dated(true)->sites(['en', 'fr']))->save();
+
+        $collection->entryBlueprint()->setContents([
+            'fields' => [
+                ['handle' => 'date', 'field' => ['type' => 'date', 'time_enabled' => true]],
+            ],
+        ])->save();
+
+        $origin = Entry::make()->id('origin')->locale('en')->collection('articles')->date('2025-01-01-1200');
+        $origin->save();
+
+        $french = Entry::make()->id('fr-entry')->locale('fr')->collection('articles')->origin($origin)->date('2025-01-02-1400');
+        $french->save();
+
+        $this->assertTrue($french->hasExplicitDate());
+
+        $this->migrateDatesToUtc();
+
+        $origin = Entry::find('origin');
+        $french = Entry::find('fr-entry');
+
+        // Both should be migrated
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $origin->date()->toIso8601String());
+        $this->assertEquals('2025-01-02T19:00:00+00:00', $french->date()->toIso8601String());
+    }
+
+    #[Test]
     #[DataProvider('dateFieldsProvider')]
     public function it_converts_date_fields_in_terms(string $fieldHandle, array $field, $original, $expected)
     {
@@ -255,95 +337,6 @@ class MigrateDatesToUtcTest extends TestCase
                 ]]],
             ],
         ];
-    }
-
-    #[Test]
-    public function it_skips_localized_entries_that_inherit_date_from_origin()
-    {
-        $this->setSites([
-            'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
-            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR', 'name' => 'French'],
-            'it' => ['url' => '/it/', 'locale' => 'it_IT', 'name' => 'Italian'],
-        ]);
-
-        $collection = tap(Collection::make('articles')->dated(true)->sites(['en', 'fr', 'it']))->save();
-
-        $collection->entryBlueprint()->setContents([
-            'fields' => [
-                ['handle' => 'date', 'field' => ['type' => 'date', 'time_enabled' => true]],
-            ],
-        ])->save();
-
-        // Create origin entry in English
-        $origin = Entry::make()->id('origin')->locale('en')->collection('articles')->date('2025-01-01-1200');
-        $origin->save();
-
-        // Create localized entries that inherit the date from origin
-        $frEntry = Entry::make()->id('fr-entry')->locale('fr')->collection('articles')->origin($origin);
-        $frEntry->save();
-
-        $itEntry = Entry::make()->id('it-entry')->locale('it')->collection('articles')->origin($origin);
-        $itEntry->save();
-
-        // All entries should have the same date before migration
-        $this->assertEquals('2025-01-01T12:00:00+00:00', $origin->date()->toIso8601String());
-        $this->assertEquals('2025-01-01T12:00:00+00:00', $frEntry->date()->toIso8601String());
-        $this->assertEquals('2025-01-01T12:00:00+00:00', $itEntry->date()->toIso8601String());
-
-        $this->migrateDatesToUtc();
-
-        // Refresh entries
-        $origin = Entry::find('origin');
-        $frEntry = Entry::find('fr-entry');
-        $itEntry = Entry::find('it-entry');
-
-        // Origin should be migrated
-        $this->assertEquals('2025-01-01T17:00:00+00:00', $origin->date()->toIso8601String());
-
-        // Localized entries should still have the same date as origin (inherited)
-        $this->assertEquals('2025-01-01T17:00:00+00:00', $frEntry->date()->toIso8601String());
-        $this->assertEquals('2025-01-01T17:00:00+00:00', $itEntry->date()->toIso8601String());
-
-        // Localized entries should not have their own date set
-        $this->assertFalse($frEntry->hasExplicitDate());
-        $this->assertFalse($itEntry->hasExplicitDate());
-    }
-
-    #[Test]
-    public function it_migrates_localized_entries_that_have_their_own_date()
-    {
-        $this->setSites([
-            'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
-            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR', 'name' => 'French'],
-        ]);
-
-        $collection = tap(Collection::make('articles')->dated(true)->sites(['en', 'fr']))->save();
-
-        $collection->entryBlueprint()->setContents([
-            'fields' => [
-                ['handle' => 'date', 'field' => ['type' => 'date', 'time_enabled' => true]],
-            ],
-        ])->save();
-
-        // Create origin entry
-        $origin = Entry::make()->id('origin')->locale('en')->collection('articles')->date('2025-01-01-1200');
-        $origin->save();
-
-        // Create localized entry with its own explicit date
-        $frEntry = Entry::make()->id('fr-entry')->locale('fr')->collection('articles')->origin($origin)->date('2025-01-02-1400');
-        $frEntry->save();
-
-        $this->assertTrue($frEntry->hasExplicitDate());
-
-        $this->migrateDatesToUtc();
-
-        // Refresh entries
-        $origin = Entry::find('origin');
-        $frEntry = Entry::find('fr-entry');
-
-        // Both should be migrated
-        $this->assertEquals('2025-01-01T17:00:00+00:00', $origin->date()->toIso8601String());
-        $this->assertEquals('2025-01-02T19:00:00+00:00', $frEntry->date()->toIso8601String());
     }
 
     private function migrateDatesToUtc(): void

--- a/tests/Console/Commands/MigrateDatesToUtcTest.php
+++ b/tests/Console/Commands/MigrateDatesToUtcTest.php
@@ -257,6 +257,95 @@ class MigrateDatesToUtcTest extends TestCase
         ];
     }
 
+    #[Test]
+    public function it_skips_localized_entries_that_inherit_date_from_origin()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR', 'name' => 'French'],
+            'it' => ['url' => '/it/', 'locale' => 'it_IT', 'name' => 'Italian'],
+        ]);
+
+        $collection = tap(Collection::make('articles')->dated(true)->sites(['en', 'fr', 'it']))->save();
+
+        $collection->entryBlueprint()->setContents([
+            'fields' => [
+                ['handle' => 'date', 'field' => ['type' => 'date', 'time_enabled' => true]],
+            ],
+        ])->save();
+
+        // Create origin entry in English
+        $origin = Entry::make()->id('origin')->locale('en')->collection('articles')->date('2025-01-01-1200');
+        $origin->save();
+
+        // Create localized entries that inherit the date from origin
+        $frEntry = Entry::make()->id('fr-entry')->locale('fr')->collection('articles')->origin($origin);
+        $frEntry->save();
+
+        $itEntry = Entry::make()->id('it-entry')->locale('it')->collection('articles')->origin($origin);
+        $itEntry->save();
+
+        // All entries should have the same date before migration
+        $this->assertEquals('2025-01-01T12:00:00+00:00', $origin->date()->toIso8601String());
+        $this->assertEquals('2025-01-01T12:00:00+00:00', $frEntry->date()->toIso8601String());
+        $this->assertEquals('2025-01-01T12:00:00+00:00', $itEntry->date()->toIso8601String());
+
+        $this->migrateDatesToUtc();
+
+        // Refresh entries
+        $origin = Entry::find('origin');
+        $frEntry = Entry::find('fr-entry');
+        $itEntry = Entry::find('it-entry');
+
+        // Origin should be migrated
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $origin->date()->toIso8601String());
+
+        // Localized entries should still have the same date as origin (inherited)
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $frEntry->date()->toIso8601String());
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $itEntry->date()->toIso8601String());
+
+        // Localized entries should not have their own date set
+        $this->assertFalse($frEntry->hasExplicitDate());
+        $this->assertFalse($itEntry->hasExplicitDate());
+    }
+
+    #[Test]
+    public function it_migrates_localized_entries_that_have_their_own_date()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US', 'name' => 'English'],
+            'fr' => ['url' => '/fr/', 'locale' => 'fr_FR', 'name' => 'French'],
+        ]);
+
+        $collection = tap(Collection::make('articles')->dated(true)->sites(['en', 'fr']))->save();
+
+        $collection->entryBlueprint()->setContents([
+            'fields' => [
+                ['handle' => 'date', 'field' => ['type' => 'date', 'time_enabled' => true]],
+            ],
+        ])->save();
+
+        // Create origin entry
+        $origin = Entry::make()->id('origin')->locale('en')->collection('articles')->date('2025-01-01-1200');
+        $origin->save();
+
+        // Create localized entry with its own explicit date
+        $frEntry = Entry::make()->id('fr-entry')->locale('fr')->collection('articles')->origin($origin)->date('2025-01-02-1400');
+        $frEntry->save();
+
+        $this->assertTrue($frEntry->hasExplicitDate());
+
+        $this->migrateDatesToUtc();
+
+        // Refresh entries
+        $origin = Entry::find('origin');
+        $frEntry = Entry::find('fr-entry');
+
+        // Both should be migrated
+        $this->assertEquals('2025-01-01T17:00:00+00:00', $origin->date()->toIso8601String());
+        $this->assertEquals('2025-01-02T19:00:00+00:00', $frEntry->date()->toIso8601String());
+    }
+
     private function migrateDatesToUtc(): void
     {
         $this


### PR DESCRIPTION
This pull request fixes an issue where the `migrate-dates-to-utc` command would result in incorrect dates for localized entries in multisite setups.

This was happening because when a localized entry inherits its date from an origin entry, calling `$item->date()` returns the origin's date. If the origin was processed first, this date would already be in UTC, but the command would treat it as being in the current timezone and convert it again, causing double-conversion.

This PR fixes it by checking `hasExplicitDate()` before migrating entry dates. Entries that don't have an explicit date (they inherit from the origin) are now skipped, since the origin will be migrated separately and the inheritance will continue to work correctly.

Fixes #14343
