### PR TITLE
[6.x] Fix CP Nav active state when trailing slashes are enforced

### DIFF
--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -149,6 +149,7 @@ class NavItem
         $cpUrl = url(config('statamic.cp.route')).'/';
 
         $relativeUrl = str_replace($cpUrl, '', URL::removeQueryAndFragment($url));
+        $relativeUrl = rtrim($relativeUrl, '/');
 
         return $relativeUrl.'(/(.*)?|$)';
     }

--- a/tests/CP/Navigation/ActiveNavItemTest.php
+++ b/tests/CP/Navigation/ActiveNavItemTest.php
@@ -12,6 +12,7 @@ use Statamic\CP\Navigation\NavBuilder;
 use Statamic\Facades;
 use Statamic\Facades\Blink;
 use Statamic\Facades\CP\Nav;
+use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -33,6 +34,13 @@ class ActiveNavItemTest extends TestCase
 
         // TODO: Other tests are leaving behind forms without titles that are causing failures here?
         Facades\Form::shouldReceive('all')->andReturn(collect());
+    }
+
+    public function tearDown(): void
+    {
+        URL::enforceTrailingSlashes(false);
+
+        parent::tearDown();
     }
 
     protected function resolveApplicationConfiguration($app)
@@ -406,6 +414,34 @@ class ActiveNavItemTest extends TestCase
         $this->assertInstanceOf(Collection::class, $seoPro->children());
         $this->assertFalse($this->getItemByDisplay($seoPro->children(), 'Reports')->isActive());
         $this->assertTrue($this->getItemByDisplay($seoPro->children(), 'Section Defaults')->isActive());
+    }
+
+    #[Test]
+    public function it_properly_handles_is_active_checks_when_trailing_slashes_are_enforced()
+    {
+        URL::enforceTrailingSlashes();
+
+        Nav::clearCachedUrls();
+
+        $parent = Nav::create('parent')
+            ->section('test')
+            ->url('http://localhost/cp/parent')
+            ->children([
+                $hello = Nav::create('hello')->url('http://localhost/cp/hello'),
+                $world = Nav::create('world')->url('http://localhost/cp/world'),
+            ]);
+
+        // Test active status with trailing slash in request URL
+        Request::swap(Request::create('http://localhost/cp/hello/'));
+        $this->assertTrue($parent->isActive());
+        $this->assertTrue($hello->isActive());
+        $this->assertFalse($world->isActive());
+
+        // Test active status on descendant with trailing slash
+        Request::swap(Request::create('http://localhost/cp/hello/nested/path/'));
+        $this->assertTrue($parent->isActive());
+        $this->assertTrue($hello->isActive());
+        $this->assertFalse($world->isActive());
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where enforcing trailing slashes would break the CP nav active state and breadcrumbs on nested pages (eg. entry edit page, asset browser).

This was happening because the `generateActivePatternForCpUrl()` method generates a regex pattern for active state detection, but when trailing slashes are enforced, the `$relativeUrl` contains a trailing slash, which breaks the regex.

This PR fixes it by stripping trailing slashes from the relative URL before generating the regex pattern.

Note: I couldn't replicate this locally w/ Herd, but I could on a Forge-provisioned server with our [recommended Nginx rules](https://statamic.dev/knowledge-base/tips/trailing-slashes#nginx).

Fixes #14126
