### PR TITLE
[7.x] Add $unique argument to Asset::move()

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -745,11 +745,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function rename($filename, $unique = false)
     {
-        if ($unique) {
-            return $this->moveUnique($this->folder(), $filename);
-        }
-
-        return $this->move($this->folder(), $filename);
+        return $this->move($this->folder(), $filename, $unique);
     }
 
     /**
@@ -757,11 +753,13 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      *
      * @param  string  $folder  The folder relative to the container.
      * @param  string|null  $filename  The new filename, if renaming.
+     * @param  bool  $unique  Whether to ensure the filename is unique.
      * @return $this
      */
-    public function move($folder, $filename = null)
+    public function move($folder, $filename = null, $unique = false)
     {
         $filename = Uploader::getSafeFilename($filename ?: $this->filename());
+        $filename = $unique ? $this->ensureUniqueFilename($folder, $filename) : $filename;
         $oldPath = $this->path();
         $oldMetaPath = $this->metaPath();
         $newPath = Str::removeLeft(Path::tidy($folder.'/'.$filename.'.'.pathinfo($oldPath, PATHINFO_EXTENSION)), '/');
@@ -780,22 +778,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
         return $this;
     }
 
-    /**
-     * Move the asset to a different location with a unique filename.
-     *
-     * @param  string  $folder  The folder relative to the container.
-     * @param  string|null  $filename  The new filename, if renaming.
-     * @return $this
-     */
-    public function moveUnique($folder, $filename = null)
-    {
-        $filename = Uploader::getSafeFilename($filename ?: $this->filename());
-        $filename = $this->ensureUniqueFilename($folder, $filename);
-
-        return $this->move($folder, $filename);
-    }
-
-    public function moveQuietly($folder, $filename = null)
+    public function moveQuietly($folder, $filename = null, $unique = false)
     {
         $this->withEvents = false;
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1261,7 +1261,7 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    public function it_can_be_moved_uniquely_to_another_folder_when_conflict_exists()
+    public function it_can_be_moved_to_another_folder_with_a_unique_filename_when_conflict_exists()
     {
         Storage::fake('local');
         $disk = Storage::disk('local');
@@ -1274,7 +1274,7 @@ class AssetTest extends TestCase
         $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
         $asset->save();
 
-        $return = $asset->moveUnique('new');
+        $return = $asset->move('new', null, true);
 
         $this->assertEquals($asset, $return);
         $disk->assertMissing('old/asset.txt');
@@ -1283,7 +1283,7 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    public function it_can_be_moved_uniquely_to_another_folder_without_renaming_when_no_conflict()
+    public function it_can_be_moved_to_another_folder_with_a_unique_filename_without_renaming_when_no_conflict()
     {
         Storage::fake('local');
         $disk = Storage::disk('local');
@@ -1294,7 +1294,7 @@ class AssetTest extends TestCase
         $asset = $container->makeAsset('old/asset.txt')->data(['foo' => 'bar']);
         $asset->save();
 
-        $return = $asset->moveUnique('new');
+        $return = $asset->move('new', null, true);
 
         $this->assertEquals($asset, $return);
         $disk->assertMissing('old/asset.txt');


### PR DESCRIPTION
This is a follow-up to #14236, which added `Asset::moveUnique()` as a non-breaking addition for 6.x.

Since `master` allows breaking changes, this PR removes `moveUnique()` and adds a `$unique` parameter directly to `Asset::move()`, consistent with how `Asset::rename()` already works:

```php
$asset->move('folder', 'filename', unique: true);
```