### PR TITLE
[6.x] Blueprint button order changes

### DIFF
--- a/lang/ar.json
+++ b/lang/ar.json
@@ -99,6 +99,7 @@
     "Application Cache": "ذاكرة تخزين التطبيق",
     "Application cache cleared.": "تم مسح ذاكرة تخزين التطبيق.",
     "Apply": "تطبيق",
+    "Save All": "حفظ الكل",
     "Apply Link": "تطبيق الرابط",
     "Are you sure you want to delete this column?": "هل أنت متأكد أنك تريد حذف هذا العمود؟",
     "Are you sure you want to delete this entry?": "هل أنت متأكد أنك تريد حذف هذا الإدخال؟",

--- a/lang/az.json
+++ b/lang/az.json
@@ -99,6 +99,7 @@
     "Application Cache": "Tətbiqi Program Keşi",
     "Application cache cleared.": "Tətbiq Program keşi təmizləndi.",
     "Apply": "Tətbiq et",
+    "Save All": "Hamısını yadda saxla",
     "Apply Link": "Keçidi tətbiq et",
     "Are you sure you want to delete this column?": "Bu sütunu silmək istədiyinizə əminsinizmi?",
     "Are you sure you want to delete this entry?": "Bu girişi silmək istədiyinizə əminsinizmi?",

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -99,6 +99,7 @@
     "Application Cache": "Mezipaměť aplikace",
     "Application cache cleared.": "Mezipaměť aplikace vymazána.",
     "Apply": "Použít",
+    "Save All": "Uložit vše",
     "Apply Link": "Použít odkaz",
     "Are you sure you want to delete this column?": "Opravdu chcete smazat tento sloupec?",
     "Are you sure you want to delete this entry?": "Opravdu chcete smazat tento záznam?",

--- a/lang/da.json
+++ b/lang/da.json
@@ -99,6 +99,7 @@
     "Application Cache": "Applikationscache",
     "Application cache cleared.": "Applikationscache ryddet.",
     "Apply": "Anvende",
+    "Save All": "Gem alle",
     "Apply Link": "Anvend link",
     "Are you sure you want to delete this column?": "Er du sikker på, at du vil slette denne kolonne?",
     "Are you sure you want to delete this entry?": "Er du sikker på, at du vil slette denne?",

--- a/lang/de.json
+++ b/lang/de.json
@@ -109,6 +109,7 @@
     "Apply": "Übernehmen",
     "Apply & Close All": "Übernehmen & alle schließen",
     "Apply & Save": "Übernehmen & Speichern",
+    "Save All": "Alle speichern",
     "Apply Link": "Link übernehmen",
     "Apply Query Scopes": "Query-Scopes anwenden",
     "Archive": "Archiv",

--- a/lang/de_CH.json
+++ b/lang/de_CH.json
@@ -109,6 +109,7 @@
     "Apply": "Übernehmen",
     "Apply & Close All": "Übernehmen & alle schliessen",
     "Apply & Save": "Übernehmen & Speichern",
+    "Save All": "Alle speichern",
     "Apply Link": "Link übernehmen",
     "Apply Query Scopes": "Query-Scopes anwenden",
     "Archive": "Archiv",

--- a/lang/es.json
+++ b/lang/es.json
@@ -99,6 +99,7 @@
     "Application Cache": "Caché de aplicaciones",
     "Application cache cleared.": "Caché de la aplicación borrada.",
     "Apply": "Aplicar",
+    "Save All": "Guardar todo",
     "Apply Link": "Aplicar enlace",
     "Are you sure you want to delete this column?": "¿Realmente deseas eliminar esta columna?",
     "Are you sure you want to delete this entry?": "¿Estás seguro de que deseas eliminar esta entrada?",

--- a/lang/et.json
+++ b/lang/et.json
@@ -99,6 +99,7 @@
     "Application Cache": "Rakenduse vahemälu",
     "Application cache cleared.": "Rakenduse vahemälu tühjendati.",
     "Apply": "Rakenda",
+    "Save All": "Salvesta kõik",
     "Apply Link": "Rakenda link",
     "Are you sure you want to delete this column?": "Oled kindel, et soovid selle veeru kustutada?",
     "Are you sure you want to delete this entry?": "Oled kindel, et soovid selle kirje kustutada?",

--- a/lang/fa.json
+++ b/lang/fa.json
@@ -99,6 +99,7 @@
     "Application Cache": "کش اپلیکیشن",
     "Application cache cleared.": "کش اپلیکیشن پاک شد.",
     "Apply": "اعمال",
+    "Save All": "ذخیره همه",
     "Apply Link": "اعمال پیوند",
     "Are you sure you want to delete this column?": "آیا از حذف این ستون اطمینان دارید؟",
     "Are you sure you want to delete this entry?": "آیا از حذف این مطلب اطمینان دارید؟",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -109,6 +109,7 @@
     "Apply": "Appliquer",
     "Apply & Close All": "Appliquer & Tout Fermer",
     "Apply & Save": "Appliquer & Enregistrer",
+    "Save All": "Tout enregistrer",
     "Apply Link": "Appliquer le lien",
     "Apply Query Scopes": "Appliquer les étendues de requête",
     "Archive": "Archive",

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -99,6 +99,7 @@
     "Application Cache": "Alkalmazás gyorsítótár",
     "Application cache cleared.": "Az alkalmazás gyorsítótára törölve.",
     "Apply": "Alkalmazni",
+    "Save All": "Összes mentése",
     "Apply Link": "Link alkalmazása",
     "Are you sure you want to delete this column?": "Biztosan törli ezt az oszlopot?",
     "Are you sure you want to delete this entry?": "Biztosan törli ezt a bejegyzést?",

--- a/lang/id.json
+++ b/lang/id.json
@@ -99,6 +99,7 @@
     "Application Cache": "Cache Aplikasi",
     "Application cache cleared.": "Cache aplikasi dihapus.",
     "Apply": "Menerapkan",
+    "Save All": "Simpan semua",
     "Apply Link": "Terapkan Tautan",
     "Are you sure you want to delete this column?": "Anda yakin ingin menghapus kolom ini?",
     "Are you sure you want to delete this entry?": "Anda yakin ingin menghapus entri ini?",

--- a/lang/it.json
+++ b/lang/it.json
@@ -99,6 +99,7 @@
     "Application Cache": "Cache dell'applicazione",
     "Application cache cleared.": "Cache dell'applicazione cancellata.",
     "Apply": "Applica",
+    "Save All": "Salva tutto",
     "Apply Link": "Applica collegamento",
     "Are you sure you want to delete this column?": "Sei sicuro di voler eliminare questa colonna?",
     "Are you sure you want to delete this entry?": "Sei sicuro di voler eliminare questa voce?",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -99,6 +99,7 @@
     "Application Cache": "アプリケーションキャッシュ",
     "Application cache cleared.": "アプリケーションキャッシュがクリアされました。",
     "Apply": "適用する",
+    "Save All": "すべて保存",
     "Apply Link": "リンクを適用する",
     "Are you sure you want to delete this column?": "この列を削除してもよろしいですか?",
     "Are you sure you want to delete this entry?": "このエントリを削除してもよろしいですか?",

--- a/lang/ms.json
+++ b/lang/ms.json
@@ -99,6 +99,7 @@
     "Application Cache": "Cache Aplikasi",
     "Application cache cleared.": "Cache aplikasi dihapus.",
     "Apply": "Mohon",
+    "Save All": "Simpan semua",
     "Apply Link": "Gunakan Pautan",
     "Are you sure you want to delete this column?": "Anda pasti ingin menghapus lajur ini?",
     "Are you sure you want to delete this entry?": "Anda pasti ingin menghapus entri ini?",

--- a/lang/nb.json
+++ b/lang/nb.json
@@ -102,6 +102,7 @@
     "Applied to all users by default.": "Standard preferanser for alle brukere.",
     "Applied to your account.": "Preferanser for din konto.",
     "Apply": "Bruk",
+    "Save All": "Lagre alle",
     "Apply & Save": "Bruk & lagre",
     "Apply Link": "Bruk lenke",
     "Are you sure you want to delete this column?": "Er du sikker på at du vil slette denne kolonnen?",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -109,6 +109,7 @@
     "Apply": "Toepassen",
     "Apply & Close All": "Toepassen & alles sluiten",
     "Apply & Save": "Toepassen & opslaan",
+    "Save All": "Alles opslaan",
     "Apply Link": "Link bevestigen",
     "Apply Query Scopes": "Query-scopes toepassen",
     "Are you sure you want to delete this column?": "Weet je zeker dat je deze kolom wilt verwijderen?",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -99,6 +99,7 @@
     "Application Cache": "Pamięć cache aplikacji",
     "Application cache cleared.": "Pamięć cache aplikacji usunięta.",
     "Apply": "Stosować",
+    "Save All": "Zapisz wszystko",
     "Apply Link": "Zastosuj link",
     "Are you sure you want to delete this column?": "Czy na pewno chcesz usunąć tę kolumnę?",
     "Are you sure you want to delete this entry?": "Czy na pewno chcesz usunąć ten rekord?",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -99,6 +99,7 @@
     "Application Cache": "Cache da aplicação",
     "Application cache cleared.": "Cache da aplicação limpo",
     "Apply": "Aplicar",
+    "Save All": "Guardar tudo",
     "Apply Link": "Aplicar Link",
     "Are you sure you want to delete this column?": "Tem a certeza de que deseja eliminar esta coluna?",
     "Are you sure you want to delete this entry?": "Tem certeza de que deseja eliminar esta entrada?",

--- a/lang/pt_BR.json
+++ b/lang/pt_BR.json
@@ -99,6 +99,7 @@
     "Application Cache": "Cache da Aplicação",
     "Application cache cleared.": "Cache da aplicação limpo.",
     "Apply": "Aplicar",
+    "Save All": "Salvar tudo",
     "Apply Link": "Aplicar link",
     "Are you sure you want to delete this column?": "Tem certeza que deseja excluir esta coluna?",
     "Are you sure you want to delete this entry?": "Tem certeza que deseja excluir esta entrada?",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -116,6 +116,7 @@
     "Apply": "Применить",
     "Apply & Close All": "Применить и закрыть все",
     "Apply & Save": "Применить и сохранить",
+    "Save All": "Сохранить все",
     "Apply Link": "Применить ссылку",
     "Apply Query Scopes": "Применить области запроса",
     "Are you sure you want to delete this column?": "Хотите удалить этот столбец?",

--- a/lang/sl.json
+++ b/lang/sl.json
@@ -99,6 +99,7 @@
     "Application Cache": "Predpomnilnik aplikacije",
     "Application cache cleared.": "Predpomnilnik aplikacije je bil očiščen.",
     "Apply": "Prijavite se",
+    "Save All": "Shrani vse",
     "Apply Link": "Uporabi povezavo",
     "Are you sure you want to delete this column?": "Ali ste prepričani, da želite izbrisati ta stolpec?",
     "Are you sure you want to delete this entry?": "Ali ste prepričani, da želite izbrisati ta vnos?",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -99,6 +99,7 @@
     "Application Cache": "Applikationscache",
     "Application cache cleared.": "Applikationscachen rensades.",
     "Apply": "Verkställ",
+    "Save All": "Spara alla",
     "Apply Link": "Använd länk",
     "Are you sure you want to delete this column?": "Är du säker på att du vill radera den här kolumnen?",
     "Are you sure you want to delete this entry?": "Är du säker på att du vill radera det här inlägget?",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -99,6 +99,7 @@
     "Application Cache": "Uygulama Önbelleği",
     "Application cache cleared.": "Uygulama önbelleği temizlendi.",
     "Apply": "Uygula",
+    "Save All": "Tümünü kaydet",
     "Apply Link": "Bağlantı Uygula",
     "Are you sure you want to delete this column?": "Bu sütunu silmek istediğinizden emin misiniz?",
     "Are you sure you want to delete this entry?": "Bu girdiyi silmek istediğinizden emin misiniz?",

--- a/lang/uk.json
+++ b/lang/uk.json
@@ -99,6 +99,7 @@
     "Application Cache": "Кеш додатків",
     "Application cache cleared.": "Кеш додатків очищено.",
     "Apply": "Застосувати",
+    "Save All": "Зберегти все",
     "Apply Link": "Застосувати посилання",
     "Are you sure you want to delete this column?": "Ви впевнені, що хочете видалити цей стовпець?",
     "Are you sure you want to delete this entry?": "Ви впевнені, що хочете видалити цей запис?",

--- a/lang/vi.json
+++ b/lang/vi.json
@@ -99,6 +99,7 @@
     "Application Cache": "Bộ nhớ tạm ứng dụng",
     "Application cache cleared.": "Bộ nhớ tạm ứng dụng đã được bật.",
     "Apply": "Áp dụng",
+    "Save All": "Lưu tất cả",
     "Apply Link": "Áp dụng liên kết",
     "Are you sure you want to delete this column?": "Bạn có chắc muốn xoá cột này không?",
     "Are you sure you want to delete this entry?": "Bạn có chắc muốn xoá mục này không?",

--- a/lang/zh_CN.json
+++ b/lang/zh_CN.json
@@ -99,6 +99,7 @@
     "Application Cache": "应用缓存",
     "Application cache cleared.": "应用程序缓存已清除。",
     "Apply": "申请",
+    "Save All": "全部保存",
     "Apply Link": "应用链接",
     "Are you sure you want to delete this column?": "您确定要删除此列吗？",
     "Are you sure you want to delete this entry?": "您确定要删除此条目吗？",

--- a/lang/zh_TW.json
+++ b/lang/zh_TW.json
@@ -99,6 +99,7 @@
     "Application Cache": "應用程式快取",
     "Application cache cleared.": "已清除應用程式快取。",
     "Apply": "申请",
+    "Save All": "全部儲存",
     "Apply Link": "套用連結",
     "Are you sure you want to delete this column?": "確定要刪除此一欄位？",
     "Are you sure you want to delete this entry?": "確定要刪除此一條目？",

--- a/resources/js/components/blueprints/Fields.vue
+++ b/resources/js/components/blueprints/Fields.vue
@@ -60,6 +60,7 @@
                 :config="pendingCreatedField.config"
                 :suggestable-condition-fields="suggestableConditionFields"
                 :is-inside-set="isInsideSet"
+                :show-save-only-at-top-level="true"
                 @committed="fieldCreated"
                 @closed="close"
             />

--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -42,6 +42,7 @@
                             :overrides="field.config_overrides || []"
                             :suggestable-condition-fields="suggestableConditionFields"
                             :is-inside-set="isInsideSet"
+                            :show-save-only-at-top-level="true"
                             @committed="settingsUpdated"
                             @closed="editorClosed"
                         />

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -7,8 +7,8 @@
         <template #actions>
             <Button v-if="!showSaveOnlyAtTopLevel" variant="default" @click.prevent="commit" :text="__('Apply')" />
             <Button v-if="!(isNestedField)" variant="primary" @click.prevent="commitAndSave" icon="save" :text="showSaveOnlyAtTopLevel ? __('Save') : __('Apply & Save')" />
-            <Button v-if="isNestedField" variant="default" @click.prevent="commitAndCloseAll" :text="__('Apply & Close All')" />
-            <Button v-if="isNestedField" variant="primary" @click.prevent="commitAndSaveAll" icon="save" :text="__('Save & Close All')" />
+            <Button v-if="isNestedField" variant="default" @click.prevent="commitAndSaveAll" :text="__('Save All')" />
+            <Button v-if="isNestedField" variant="primary" @click.prevent="commitAndSaveTopStack" icon="save" :text="__('Save')" />
         </template>
     </StackHeader>
 
@@ -318,6 +318,13 @@ export default {
             });
         },
 
+        // Nested field: saves and closes only the current stack.
+        commitAndSaveTopStack() {
+            this.commit({
+                shouldSaveRoot: true,
+            });
+        },
+
         saveRootForm() {
             // The "root form" could be the blueprint or fieldset forms.
             this.$events.$emit('root-form-save');
@@ -325,7 +332,7 @@ export default {
 
         handleSaveShortcut() {
             this.isNestedField
-                ? this.commitAndSaveAll()
+                ? this.commitAndSaveTopStack()
                 : this.commitAndSave();
         },
 

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -7,7 +7,7 @@
         <template #actions>
             <Button v-if="!showSaveOnlyAtTopLevel" variant="default" @click.prevent="commit" :text="__('Apply')" />
             <Button v-if="!(isNestedField)" variant="primary" @click.prevent="commitAndSave" icon="save" :text="showSaveOnlyAtTopLevel ? __('Save') : __('Apply & Save')" />
-            <Button v-if="isNestedField" variant="default" @click.prevent="commitAndSaveAll" :text="__('Save All')" v-tooltip="saveAllTooltipText" />
+            <Button v-if="isNestedField" variant="default" @click.prevent="commitAndSaveAll" :text="__('Save All')" v-tooltip="saveAllShortcutLabel" />
             <Button v-if="isNestedField" variant="primary" @click.prevent="commitAndSaveTopStack" icon="save" :text="__('Save')" />
         </template>
     </StackHeader>
@@ -197,10 +197,6 @@ export default {
             return this.isInsideSet || this.isInsideConfigFields;
         },
 
-        saveAllTooltipText() {
-            return this.saveAllShortcutLabel;
-        },
-
         saveAllShortcutLabel() {
             const platform = typeof navigator !== 'undefined'
                 ? (navigator.userAgentData?.platform || navigator.platform || '')
@@ -326,13 +322,13 @@ export default {
         // Nested field: saves and closes only the current stack.
         commitAndSaveTopStack() {
             this.commit({
-                shouldSaveRoot: true,
+                shouldSaveRoot: !this.isNestedField,
             });
         },
 
         softSave() {
             this.commit({
-                shouldSaveRoot: true,
+                shouldSaveRoot: !this.isNestedField,
                 shouldClose: false,
             });
         },

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -7,7 +7,7 @@
         <template #actions>
             <Button v-if="!showSaveOnlyAtTopLevel" variant="default" @click.prevent="commit" :text="__('Apply')" />
             <Button v-if="!(isNestedField)" variant="primary" @click.prevent="commitAndSave" icon="save" :text="showSaveOnlyAtTopLevel ? __('Save') : __('Apply & Save')" />
-            <Button v-if="isNestedField" variant="default" @click.prevent="commitAndSaveAll" :text="__('Save All')" />
+            <Button v-if="isNestedField" variant="default" @click.prevent="commitAndSaveAll" :text="__('Save All')" v-tooltip="saveAllTooltipText" />
             <Button v-if="isNestedField" variant="primary" @click.prevent="commitAndSaveTopStack" icon="save" :text="__('Save')" />
         </template>
     </StackHeader>
@@ -196,18 +196,27 @@ export default {
         isNestedField() {
             return this.isInsideSet || this.isInsideConfigFields;
         },
+
+        saveAllTooltipText() {
+            return this.saveAllShortcutLabel;
+        },
+
+        saveAllShortcutLabel() {
+            const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
+            return isMac ? 'Cmd+Shift+S' : 'Ctrl+Shift+S';
+        },
     },
 
     created() {
         this.load();
 
-        // Add keyboard shortcut for Cmd+S / Ctrl+S only when this component is focused
-        this.saveBinding = this.$keys.bindGlobal(['mod+s'], (e) => {
+        // Add keyboard shortcuts only when this component is focused.
+        this.saveBinding = this.$keys.bindGlobal(['mod+s', 'mod+shift+s'], (e) => {
             // Only handle if this component is currently visible/focused
             if (this.$el && this.$el.offsetParent !== null) {
                 e.preventDefault();
                 e.stopPropagation();
-                this.handleSaveShortcut();
+                this.handleSaveShortcut(e);
             }
         });
     },
@@ -337,8 +346,19 @@ export default {
             this.$events.$emit('root-form-save');
         },
 
-        handleSaveShortcut() {
+        handleSaveShortcut(event) {
+            if (event?.key?.toLowerCase() === 's' && event?.shiftKey) {
+                this.saveAllShortcut();
+                return;
+            }
+
             this.softSave();
+        },
+
+        saveAllShortcut() {
+            this.isNestedField
+                ? this.commitAndSaveAll()
+                : this.commitAndSave();
         },
 
         handleAxiosError(e) {

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -110,7 +110,7 @@ export default {
             default: false
         },
         commitParentField: {
-            default: () => {}
+            default: null
         }
     },
 
@@ -270,7 +270,7 @@ export default {
         },
 
         commit(params = {}) {
-            let { shouldCommitParent, shouldSaveRoot, shouldClose = true } = params;
+            let { shouldCommitParent, shouldSaveRoot, shouldClose = true, shouldEmitCommitted = true } = params;
 
             this.clearErrors();
 
@@ -284,7 +284,10 @@ export default {
                 })
                 .then((response) => {
                     this.$refs.container?.clearDirtyState();
-                    this.$emit('committed', response.data, this.editedFields);
+
+                    if (shouldEmitCommitted) {
+                        this.$emit('committed', response.data, this.editedFields);
+                    }
 
                     if (shouldCommitParent && this.commitParentField) {
 						this.$nextTick(() => {
@@ -327,8 +330,14 @@ export default {
         },
 
         softSave() {
+            if (this.config.isNew) {
+                this.isNestedField ? this.commitAndSaveTopStack() : this.commitAndSave();
+                return;
+            }
+
             this.commit({
-                shouldSaveRoot: !this.isNestedField,
+                shouldCommitParent: this.isNestedField,
+                shouldSaveRoot: true,
                 shouldClose: false,
             });
         },

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -270,7 +270,7 @@ export default {
         },
 
         commit(params = {}) {
-            let { shouldCommitParent, shouldSaveRoot, shouldClose = true, shouldEmitCommitted = true } = params;
+            let { shouldCommitParent, shouldSaveRoot, shouldClose = true } = params;
 
             this.clearErrors();
 
@@ -284,10 +284,7 @@ export default {
                 })
                 .then((response) => {
                     this.$refs.container?.clearDirtyState();
-
-                    if (shouldEmitCommitted) {
-                        this.$emit('committed', response.data, this.editedFields);
-                    }
+                    this.$emit('committed', response.data, this.editedFields);
 
                     if (shouldCommitParent && this.commitParentField) {
 						this.$nextTick(() => {

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -262,7 +262,7 @@ export default {
         },
 
         commit(params = {}) {
-            let { shouldCommitParent, shouldSaveRoot } = params;
+            let { shouldCommitParent, shouldSaveRoot, shouldClose = true } = params;
 
             this.clearErrors();
 
@@ -281,7 +281,7 @@ export default {
                     if (shouldCommitParent && this.commitParentField) {
 						this.$nextTick(() => {
 							this.commitParentField(params);
-							this.close();
+							if (shouldClose) this.close();
 						});
 
                         return;
@@ -291,7 +291,7 @@ export default {
                         this.saveRootForm();
                     }
 
-                    this.close();
+                    if (shouldClose) this.close();
                 })
                 .catch((e) => this.handleAxiosError(e));
         },
@@ -325,15 +325,20 @@ export default {
             });
         },
 
+        softSave() {
+            this.commit({
+                shouldSaveRoot: true,
+                shouldClose: false,
+            });
+        },
+
         saveRootForm() {
             // The "root form" could be the blueprint or fieldset forms.
             this.$events.$emit('root-form-save');
         },
 
         handleSaveShortcut() {
-            this.isNestedField
-                ? this.commitAndSaveTopStack()
-                : this.commitAndSave();
+            this.softSave();
         },
 
         handleAxiosError(e) {

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -202,7 +202,10 @@ export default {
         },
 
         saveAllShortcutLabel() {
-            const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/i.test(navigator.platform);
+            const platform = typeof navigator !== 'undefined'
+                ? (navigator.userAgentData?.platform || navigator.platform || '')
+                : '';
+            const isMac = /Mac|iPhone|iPad|iPod/i.test(platform);
             return isMac ? 'Cmd+Shift+S' : 'Ctrl+Shift+S';
         },
     },
@@ -309,13 +312,6 @@ export default {
         commitAndSave() {
             this.commit({
                 shouldSaveRoot: true,
-            });
-        },
-
-        // Nested field: saves the current field and any parents.
-        commitAndCloseAll() {
-            this.commit({
-                shouldCommitParent: true,
             });
         },
 

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -5,8 +5,8 @@
 
     <StackHeader v-if="!loading" :title="__(values.display) || __(config.display) || config.handle" :icon="fieldtype.icon">
         <template #actions>
-            <Button variant="default" @click.prevent="commit" :text="__('Apply')" />
-            <Button v-if="!(isNestedField)" variant="primary" @click.prevent="commitAndSave" icon="save" :text="__('Apply & Save')" />
+            <Button v-if="!showSaveOnlyAtTopLevel" variant="default" @click.prevent="commit" :text="__('Apply')" />
+            <Button v-if="!(isNestedField)" variant="primary" @click.prevent="commitAndSave" icon="save" :text="showSaveOnlyAtTopLevel ? __('Save') : __('Apply & Save')" />
             <Button v-if="isNestedField" variant="default" @click.prevent="commitAndCloseAll" :text="__('Apply & Close All')" />
             <Button v-if="isNestedField" variant="primary" @click.prevent="commitAndSaveAll" icon="save" :text="__('Save & Close All')" />
         </template>
@@ -90,6 +90,10 @@ export default {
         fields: Array,
         suggestableConditionFields: Array,
         isInsideSet: Boolean,
+        showSaveOnlyAtTopLevel: {
+            type: Boolean,
+            default: false,
+        },
     },
 
     provide() {


### PR DESCRIPTION
## Description of the Problem

Related to https://github.com/statamic/cms/discussions/12093, There's been ongoing discussion about how the button row should behave for blueprints—see the [feedback thread](https://github.com/statamic/cms/discussions/12093#discussioncomment-15911746) for full context.

In short:

- Users expect the primary button to save and close the *current* stack, so they can move on to the next one.
- The current primary button closes *everything*—so if you press it without noticing, you lose your place and have to navigate back through all stacks.
- Too many buttons increase cognitive load.

## What this PR Does

Simplifies the button row to a maximum of two buttons, with consistent keyboard shortcuts throughout.

**Single-level stacks** show one button:
- **Save**—saves and closes the stack.

![2026-03-26 at 11 22 23@2x](https://github.com/user-attachments/assets/96c83ace-cac9-48ec-8492-328a175d0d11)

**Multi-level stacks** show two buttons:
- **Save** (primary)—saves and closes the current stack.
- **Save All**—saves and closes all stacks.

![2026-03-26 at 11 22 37@2x](https://github.com/user-attachments/assets/fb80e4eb-dc5b-4bb8-8861-834088dbde5a)

**Keyboard shortcuts** (available everywhere):
- `cmd+s`—soft-save, keeping the stack open (consistent with behaviour elsewhere in the control panel).
- `cmd+shift+s`—save all, closing every open stack. Works on single stacks too.

A tooltip on the **Save All** button aids discoverability for users who haven't encountered the shortcut yet.

## How to Reproduce

1. Open a stack for a field like replicator
2. Add a further field to a set and open that to simulate two stacks