### PR TITLE
[6.x] Bump reka-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "pusher-js": "^8.4.0-rc2",
         "qs": "^6.14.2",
         "read-time-estimate": "0.0.3",
-        "reka-ui": "^2.6.1",
+        "reka-ui": "^2.9.2",
         "resize-observer-polyfill": "^1.5.1",
         "semver": "^7.7.1",
         "speakingurl": "^14.0.1",


### PR DESCRIPTION
In #14259 we updated the `reka-ui` constraint to `^2.9.2` but the `package-lock.json` only received an update to `^2.6.1` (which was enough to fix the issue, but didn't match the intended fully updated version).
