### PR TITLE
[6.x] Resizable sidebar

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -155,7 +155,7 @@ main.nav-closed {
 /* GROUP RESIZEABLE NAVS / RESIZE NEEDLE
 =================================================== */
 .content-card-resize-handle {
-    --resize-width: 12px;
+    --resize-width: 10px;
     --needle-width: 5px;
 
     position: absolute;
@@ -166,20 +166,6 @@ main.nav-closed {
     height: 100%;
     cursor: col-resize;
     @apply hidden lg:block;
-
-    &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        inset-inline-start: 0;
-        width: var(--needle-width);
-        height: 100%;
-        @apply bg-transparent transition-colors rounded-lg;
-    }
-
-    &:hover::after {
-        background: var(--theme-color-global-header-bg);
-    }
 }
 
 .nav-resizing {
@@ -196,10 +182,6 @@ main.nav-closed {
     & .nav-main {
         /* Disables transitions while dragging, specifically to prevent jank/animated layout changes from the existing sidebar + main transitions in layout.css (the sidebar open/close transition and the main padding transition). */
         transition: none;
-    }
-
-    & .content-card-resize-handle::after {
-        background: var(--theme-color-global-header-bg);
     }
 }
 

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -4,7 +4,7 @@
 
 /* GROUP THE MAIN NAV (LEFT SIDEBAR)
 =================================================== */
-.nav-main {
+.cp-sidebar-start {
     @apply flex flex-col gap-6 py-6 px-2 sm:px-3 sm:pe-1 text-sm antialiased select-none;
     /* Same as the main element, accounting for the header with a class of h-14, which is the same as 3.5rem */
     @apply h-[calc(100vh-3.5rem)];
@@ -51,7 +51,7 @@
 
 /* GROUP THE MAIN NAV (LEFT SIDEBAR) / ACTIVE STATES
 =================================================== */
-.nav-main {
+.cp-sidebar-start {
     @supports not (anchor-name: --my-anchor) {
         ul li ul li {
             a.active {
@@ -117,13 +117,13 @@
 /* GROUP THE MAIN NAV (LEFT SIDEBAR) / MOBILE BEHAVIOR
 =================================================== */
 @media (width < theme(--breakpoint-lg)) {
-    .nav-main {
+    .cp-sidebar-start {
         /* Always visible but off-screen by default */
         @apply flex;
         @apply bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700;
     }
 
-    .nav-open .nav-main {
+    .nav-open .cp-sidebar-start {
         /* Slide in from the left */
         @apply start-0 shadow-2xl;
     }
@@ -142,7 +142,7 @@ main {
     }
 }
 
-.nav-closed .nav-main {
+.nav-closed .cp-sidebar-start {
     /* Start off-screen to the left */
     @apply -start-50;
 }
@@ -178,7 +178,8 @@ main.nav-closed {
     }
 
     & main,
-    & .nav-main {
+    & .cp-sidebar-start,
+    & .cp-sidebar-end {
         /* Disables transitions while dragging, specifically to prevent jank/animated layout changes from the existing sidebar + main transitions in layout.css (the sidebar open/close transition and the main padding transition). */
         transition: none;
     }

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -154,15 +154,14 @@ main.nav-closed {
 
 /* GROUP RESIZEABLE NAVS / RESIZE NEEDLE
 =================================================== */
-.nav-resize-handle {
-    --resize-width: 10px;
+.content-card-resize-handle {
+    --resize-width: 12px;
     --needle-width: 5px;
 
     position: absolute;
     z-index: var(--z-index-above);
     top: 0;
-    inset-inline-end: 0;
-    /* inset-inline-end: 0; */
+    inset-inline-start: 0;
     width: var(--resize-width);
     height: 100%;
     cursor: col-resize;
@@ -172,10 +171,10 @@ main.nav-closed {
         content: '';
         position: absolute;
         top: 0;
-        inset-inline-end: 0;
+        inset-inline-start: 0;
         width: var(--needle-width);
         height: 100%;
-        @apply bg-transparent transition-colors;
+        @apply bg-transparent transition-colors rounded-lg;
     }
 
     &:hover::after {
@@ -199,7 +198,7 @@ main.nav-closed {
         transition: none;
     }
 
-    & .nav-resize-handle::after {
+    & .content-card-resize-handle::after {
         background: var(--theme-color-global-header-bg);
     }
 }

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -156,12 +156,11 @@ main.nav-closed {
 =================================================== */
 .content-card-resize-handle {
     --resize-width: 10px;
-    --needle-width: 5px;
 
     position: absolute;
     z-index: var(--z-index-above);
     top: 0;
-    inset-inline-start: 0;
+    inset-inline-start: calc(0% - var(--resize-width) / 2);
     width: var(--resize-width);
     height: 100%;
     cursor: col-resize;

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -5,7 +5,7 @@
 /* GROUP THE MAIN NAV (LEFT SIDEBAR)
 =================================================== */
 .nav-main {
-    @apply flex flex-col gap-6 py-6 px-2 sm:px-3 text-sm antialiased select-none;
+    @apply flex flex-col gap-6 py-6 px-2 sm:px-3 sm:pe-1 text-sm antialiased select-none;
     /* Same as the main element, accounting for the header with a class of h-14, which is the same as 3.5rem */
     @apply h-[calc(100vh-3.5rem)];
     @apply overflow-y-auto fixed top-14 start-0;

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -1,5 +1,5 @@
 :root {
-    --nav-width: 12rem;
+    --nav-width: 11.5rem;
 }
 
 /* GROUP THE MAIN NAV (LEFT SIDEBAR)

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -152,7 +152,7 @@ main.nav-closed {
     @apply lg:ps-0;
 }
 
-/* GROUP RESIZEABLE NAVS / RESIZE NEEDLE
+/* GROUP RESIZABLE NAVS / RESIZE HANDLE
 =================================================== */
 .content-card-resize-handle {
     --resize-width: 10px;

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -1,10 +1,15 @@
+:root {
+    --nav-width: 12rem;
+}
+
 /* GROUP THE MAIN NAV (LEFT SIDEBAR)
 =================================================== */
 .nav-main {
     @apply flex flex-col gap-6 py-6 px-2 sm:px-3 text-sm antialiased select-none;
     /* Same as the main element, accounting for the header with a class of h-14, which is the same as 3.5rem */
     @apply h-[calc(100vh-3.5rem)];
-    @apply overflow-y-auto fixed top-14 start-0 w-48;
+    @apply overflow-y-auto fixed top-14 start-0;
+    width: var(--nav-width);
     @apply [&_svg]:text-gray-500 dark:[&_svg]:text-gray-500/85;
     /* Wait for the full page to load before allowing this transition otherwise you see the Sidebar animate in/out on load in Firefox (and sometimes Safari) */
     .page-fully-loaded & {
@@ -109,10 +114,8 @@
     }
 }
 
-
-
-
-/* Mobile nav behavior */
+/* GROUP THE MAIN NAV (LEFT SIDEBAR) / MOBILE BEHAVIOR
+=================================================== */
 @media (width < theme(--breakpoint-lg)) {
     .nav-main {
         /* Always visible but off-screen by default */
@@ -128,7 +131,10 @@
 
 
 main {
-    @apply ps-0 lg:ps-46;
+    padding-inline-start: 0;
+    @media (width >= theme(--breakpoint-lg)) {
+        padding-inline-start: var(--nav-width);
+    }
     /* Wait for the full page to load before allowing this transition otherwise you see the Sidebar animate in/out on load in Firefox (and sometimes Safari) */
     .page-fully-loaded & {
         /* Only padding because we don't wand to transition the color when we switch between light/dark mode */
@@ -144,6 +150,58 @@ main {
 main.nav-closed {
     @apply ps-0;
     @apply lg:ps-0;
+}
+
+/* GROUP RESIZEABLE NAVS / RESIZE NEEDLE
+=================================================== */
+.nav-resize-handle {
+    --resize-width: 10px;
+    --needle-width: 5px;
+
+    position: absolute;
+    z-index: var(--z-index-above);
+    top: 0;
+    inset-inline-end: 0;
+    /* inset-inline-end: 0; */
+    width: var(--resize-width);
+    height: 100%;
+    cursor: col-resize;
+    @apply hidden lg:block;
+
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        inset-inline-end: 0;
+        width: var(--needle-width);
+        height: 100%;
+        @apply bg-transparent transition-colors;
+    }
+
+    &:hover::after {
+        background: var(--theme-color-global-header-bg);
+    }
+}
+
+.nav-resizing {
+    cursor: col-resize;
+    /* Prevents any text selection while dragging (otherwise you could end up selecting menu text while dragging the resize handle). */
+    user-select: none;
+
+    & * {
+        /* Ensures that if you move the pointer over a child element inside the nav (icons, links, spans), the cursor doesn't revert back to the default pointer/hand. */
+        cursor: col-resize;
+    }
+
+    & main,
+    & .nav-main {
+        /* Disables transitions while dragging, specifically to prevent jank/animated layout changes from the existing sidebar + main transitions in layout.css (the sidebar open/close transition and the main padding transition). */
+        transition: none;
+    }
+
+    & .nav-resize-handle::after {
+        background: var(--theme-color-global-header-bg);
+    }
 }
 
 /* ==========================================================================

--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -151,44 +151,6 @@ Statamic.$keys.bind(['command+\\', ['[']], (e) => {
 });
 
 Statamic.$events.$on('nav.toggle', toggle);
-
-// Resizable sidebar
-const navWidthKey = 'statamic.nav.width';
-const MIN_NAV_WIDTH = 150;
-const MAX_NAV_WIDTH = 400;
-
-const savedNavWidth = localStorage.getItem(navWidthKey);
-if (savedNavWidth) {
-    document.documentElement.style.setProperty('--nav-width', savedNavWidth + 'px');
-}
-
-function startResize(event) {
-    const dir = getComputedStyle(document.documentElement).direction;
-    document.documentElement.classList.add('nav-resizing');
-
-    const onPointerMove = (e) => {
-        const rect = navRef.value.getBoundingClientRect();
-        const width = dir === 'rtl' ? rect.right - e.clientX : e.clientX - rect.left;
-        const clamped = Math.min(Math.max(width, MIN_NAV_WIDTH), MAX_NAV_WIDTH);
-        document.documentElement.style.setProperty('--nav-width', clamped + 'px');
-    };
-
-    const onPointerUp = () => {
-        document.documentElement.classList.remove('nav-resizing');
-        document.removeEventListener('pointermove', onPointerMove);
-        document.removeEventListener('pointerup', onPointerUp);
-        const currentWidth = Math.round(navRef.value.getBoundingClientRect().width);
-        localStorage.setItem(navWidthKey, currentWidth);
-    };
-
-    document.addEventListener('pointermove', onPointerMove);
-    document.addEventListener('pointerup', onPointerUp);
-}
-
-function resetWidth() {
-    localStorage.removeItem(navWidthKey);
-    document.documentElement.style.removeProperty('--nav-width');
-}
 </script>
 
 <template>
@@ -229,10 +191,5 @@ function resetWidth() {
                 </li>
             </ul>
         </div>
-        <div
-            class="nav-resize-handle"
-            @pointerdown.prevent="startResize"
-            @dblclick="resetWidth"
-        />
     </nav>
 </template>

--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -154,7 +154,7 @@ Statamic.$events.$on('nav.toggle', toggle);
 </script>
 
 <template>
-    <nav ref="navRef" class="nav-main">
+    <nav ref="navRef" class="cp-sidebar-start">
         <div v-for="(section, i) in nav" :key="i">
             <div
                 class="section-title"

--- a/resources/js/components/nav/Nav.vue
+++ b/resources/js/components/nav/Nav.vue
@@ -151,6 +151,44 @@ Statamic.$keys.bind(['command+\\', ['[']], (e) => {
 });
 
 Statamic.$events.$on('nav.toggle', toggle);
+
+// Resizable sidebar
+const navWidthKey = 'statamic.nav.width';
+const MIN_NAV_WIDTH = 150;
+const MAX_NAV_WIDTH = 400;
+
+const savedNavWidth = localStorage.getItem(navWidthKey);
+if (savedNavWidth) {
+    document.documentElement.style.setProperty('--nav-width', savedNavWidth + 'px');
+}
+
+function startResize(event) {
+    const dir = getComputedStyle(document.documentElement).direction;
+    document.documentElement.classList.add('nav-resizing');
+
+    const onPointerMove = (e) => {
+        const rect = navRef.value.getBoundingClientRect();
+        const width = dir === 'rtl' ? rect.right - e.clientX : e.clientX - rect.left;
+        const clamped = Math.min(Math.max(width, MIN_NAV_WIDTH), MAX_NAV_WIDTH);
+        document.documentElement.style.setProperty('--nav-width', clamped + 'px');
+    };
+
+    const onPointerUp = () => {
+        document.documentElement.classList.remove('nav-resizing');
+        document.removeEventListener('pointermove', onPointerMove);
+        document.removeEventListener('pointerup', onPointerUp);
+        const currentWidth = Math.round(navRef.value.getBoundingClientRect().width);
+        localStorage.setItem(navWidthKey, currentWidth);
+    };
+
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerup', onPointerUp);
+}
+
+function resetWidth() {
+    localStorage.removeItem(navWidthKey);
+    document.documentElement.style.removeProperty('--nav-width');
+}
 </script>
 
 <template>
@@ -191,5 +229,10 @@ Statamic.$events.$on('nav.toggle', toggle);
                 </li>
             </ul>
         </div>
+        <div
+            class="nav-resize-handle"
+            @pointerdown.prevent="startResize"
+            @dblclick="resetWidth"
+        />
     </nav>
 </template>

--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -6,7 +6,7 @@ import SessionExpiry from '@/components/SessionExpiry.vue';
 import LicensingAlert from '@/components/LicensingAlert.vue';
 import PortalTargets from '@/components/portals/PortalTargets.vue';
 import Tooltips from '@/components/Tooltips.vue';
-import { provide, watch, ref, onMounted, onUnmounted, nextTick, computed } from 'vue';
+import { provide, watch, ref, onMounted, onUnmounted, nextTick, computed, useTemplateRef } from 'vue';
 import { router, usePage } from '@inertiajs/vue3';
 import useBodyClasses from './body-classes.js';
 import useMaxWidthToggle from '@/composables/use-max-width-toggle.js';
@@ -44,10 +44,10 @@ const navWidthStorageKey = computed(() => {
 
 watch(navWidthStorageKey, () => restoreSavedNavWidth());
 
-const MIN_NAV_WIDTH = 150;
-const MAX_NAV_WIDTH = 400;
-const mainContentRef = ref(null);
-const contentCardRef = ref(null);
+const minNavWidth = 150;
+const maxNavWidth = 400;
+const mainContentRef = useTemplateRef('mainContent');
+const contentCardRef = useTemplateRef('contentCard');
 
 let isResizing = false;
 let currentWidthPx = null;
@@ -56,7 +56,7 @@ let pointerMoveListener = null;
 let pointerUpListener = null;
 
 function clampNavWidthPx(widthPx) {
-    return Math.min(Math.max(widthPx, MIN_NAV_WIDTH), MAX_NAV_WIDTH);
+    return Math.min(Math.max(widthPx, minNavWidth), maxNavWidth);
 }
 
 function setNavWidthPx(widthPx) {
@@ -72,6 +72,7 @@ function restoreSavedNavWidth() {
     }
 
     const widthPx = Number(saved);
+
     if (!Number.isFinite(widthPx)) {
         document.documentElement.style.removeProperty('--nav-width');
         return;
@@ -190,8 +191,8 @@ onUnmounted(() => {
         <main id="main" class="flex bg-body-bg dark:border-t dark:border-body-border rounded-t-2xl fixed top-14 inset-x-0 bottom-0 min-h-[calc(100vh-3.5rem)]">
             <Nav />
             <!-- The data attribute allows CSS to target elements when max-width is disabled. -->
-            <div ref="mainContentRef" id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
-                <div ref="contentCardRef" id="content-card" tabindex="-1" class="focus:outline-none relative content-card grid min-h-full mx-auto">
+            <div ref="mainContent" id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
+                <div ref="contentCard" id="content-card" tabindex="-1" class="focus:outline-none relative content-card grid min-h-full mx-auto">
                     <div
                         class="content-card-resize-handle"
                         @pointerdown.prevent="startResize"

--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -33,7 +33,8 @@ let navigationListener = null;
 
 // Resizable sidebar (handle lives on the left edge of the content card)
 const page = usePage();
-const isEditingForm = computed(() => page.url.includes('/forms/'));
+// const isEditingForm = computed(() => page.url.includes('/forms/'));
+const isEditingForm = computed(() => false);
 
 const navWidthStorageKey = computed(() => isEditingForm.value ? 'statamic.nav.width.forms' : 'statamic.nav.width');
 const minNavWidth = computed(() => isEditingForm.value ? 480 : 150);

--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -61,14 +61,14 @@ function restoreSavedNavWidth() {
     const saved = localStorage.getItem(navWidthStorageKey.value);
 
     if (!saved) {
-        document.documentElement.style.removeProperty('--nav-width');
+        setNavWidthPx(minNavWidth.value);
         return;
     }
 
     const widthPx = Number(saved);
 
     if (!Number.isFinite(widthPx)) {
-        document.documentElement.style.removeProperty('--nav-width');
+        setNavWidthPx(minNavWidth.value);
         return;
     }
 
@@ -129,7 +129,7 @@ function startResize(event) {
 function resetNavWidth() {
     stopResize({ persist: false });
     localStorage.removeItem(navWidthStorageKey.value);
-    document.documentElement.style.removeProperty('--nav-width');
+    setNavWidthPx(minNavWidth.value);
 }
 
 function focusMain() {

--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -33,21 +33,15 @@ let navigationListener = null;
 
 // Resizable sidebar (handle lives on the left edge of the content card)
 const page = usePage();
+const isEditingForm = computed(() => page.url.includes('/forms/'));
 
-const navWidthStorageKey = computed(() => {
-    // if (page.url.includes('/forms/')) {
-    //     return 'statamic.nav.width.forms';
-    // }
-
-    return 'statamic.nav.width';
-});
-
-watch(navWidthStorageKey, () => restoreSavedNavWidth());
-
-const minNavWidth = 150;
-const maxNavWidth = 400;
+const navWidthStorageKey = computed(() => isEditingForm.value ? 'statamic.nav.width.forms' : 'statamic.nav.width');
+const minNavWidth = computed(() => isEditingForm.value ? 480 : 150);
+const maxNavWidth = computed(() => isEditingForm.value ? 1000 : 300);
 const mainContentRef = useTemplateRef('mainContent');
 const contentCardRef = useTemplateRef('contentCard');
+
+watch(navWidthStorageKey, restoreSavedNavWidth);
 
 let isResizing = false;
 let currentWidthPx = null;
@@ -56,7 +50,7 @@ let pointerMoveListener = null;
 let pointerUpListener = null;
 
 function clampNavWidthPx(widthPx) {
-    return Math.min(Math.max(widthPx, minNavWidth), maxNavWidth);
+    return Math.min(Math.max(widthPx, minNavWidth.value), maxNavWidth.value);
 }
 
 function setNavWidthPx(widthPx) {

--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -6,10 +6,9 @@ import SessionExpiry from '@/components/SessionExpiry.vue';
 import LicensingAlert from '@/components/LicensingAlert.vue';
 import PortalTargets from '@/components/portals/PortalTargets.vue';
 import Tooltips from '@/components/Tooltips.vue';
-import { provide, watch, ref, onMounted, onUnmounted, nextTick } from 'vue';
-import { router } from '@inertiajs/vue3';
+import { provide, watch, ref, onMounted, onUnmounted, nextTick, computed } from 'vue';
+import { router, usePage } from '@inertiajs/vue3';
 import useBodyClasses from './body-classes.js';
-import useStatamicPageProps from '@/composables/page-props.js';
 import useMaxWidthToggle from '@/composables/use-max-width-toggle.js';
 
 useBodyClasses('bg-global-header-bg font-sans leading-normal text-gray-900 dark:text-white');
@@ -33,7 +32,18 @@ provide('layout', {
 let navigationListener = null;
 
 // Resizable sidebar (handle lives on the left edge of the content card)
-const navWidthStorageKey = 'statamic.nav.width';
+const page = usePage();
+
+const navWidthStorageKey = computed(() => {
+    // if (page.url.includes('/forms/')) {
+    //     return 'statamic.nav.width.forms';
+    // }
+
+    return 'statamic.nav.width';
+});
+
+watch(navWidthStorageKey, () => restoreSavedNavWidth());
+
 const MIN_NAV_WIDTH = 150;
 const MAX_NAV_WIDTH = 400;
 const mainContentRef = ref(null);
@@ -54,11 +64,18 @@ function setNavWidthPx(widthPx) {
 }
 
 function restoreSavedNavWidth() {
-    const saved = localStorage.getItem(navWidthStorageKey);
-    if (!saved) return;
+    const saved = localStorage.getItem(navWidthStorageKey.value);
+
+    if (!saved) {
+        document.documentElement.style.removeProperty('--nav-width');
+        return;
+    }
 
     const widthPx = Number(saved);
-    if (!Number.isFinite(widthPx)) return;
+    if (!Number.isFinite(widthPx)) {
+        document.documentElement.style.removeProperty('--nav-width');
+        return;
+    }
 
     setNavWidthPx(clampNavWidthPx(widthPx));
 }
@@ -75,7 +92,7 @@ function stopResize({ persist = true } = {}) {
     pointerUpListener = null;
 
     if (persist && currentWidthPx !== null) {
-        localStorage.setItem(navWidthStorageKey, Math.round(currentWidthPx));
+        localStorage.setItem(navWidthStorageKey.value, Math.round(currentWidthPx));
     }
 
     currentWidthPx = null;
@@ -116,7 +133,7 @@ function startResize(event) {
 
 function resetNavWidth() {
     stopResize({ persist: false });
-    localStorage.removeItem(navWidthStorageKey);
+    localStorage.removeItem(navWidthStorageKey.value);
     document.documentElement.style.removeProperty('--nav-width');
 }
 

--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -32,6 +32,94 @@ provide('layout', {
 // Focus management: focus main element if no input has auto-focus
 let navigationListener = null;
 
+// Resizable sidebar (handle lives on the left edge of the content card)
+const navWidthStorageKey = 'statamic.nav.width';
+const MIN_NAV_WIDTH = 150;
+const MAX_NAV_WIDTH = 400;
+const mainContentRef = ref(null);
+const contentCardRef = ref(null);
+
+let isResizing = false;
+let currentWidthPx = null;
+let contentInsetPx = 0;
+let pointerMoveListener = null;
+let pointerUpListener = null;
+
+function clampNavWidthPx(widthPx) {
+    return Math.min(Math.max(widthPx, MIN_NAV_WIDTH), MAX_NAV_WIDTH);
+}
+
+function setNavWidthPx(widthPx) {
+    document.documentElement.style.setProperty('--nav-width', `${widthPx}px`);
+}
+
+function restoreSavedNavWidth() {
+    const saved = localStorage.getItem(navWidthStorageKey);
+    if (!saved) return;
+
+    const widthPx = Number(saved);
+    if (!Number.isFinite(widthPx)) return;
+
+    setNavWidthPx(clampNavWidthPx(widthPx));
+}
+
+function stopResize({ persist = true } = {}) {
+    if (!isResizing) return;
+
+    isResizing = false;
+    document.documentElement.classList.remove('nav-resizing');
+
+    if (pointerMoveListener) document.removeEventListener('pointermove', pointerMoveListener);
+    if (pointerUpListener) document.removeEventListener('pointerup', pointerUpListener);
+    pointerMoveListener = null;
+    pointerUpListener = null;
+
+    if (persist && currentWidthPx !== null) {
+        localStorage.setItem(navWidthStorageKey, Math.round(currentWidthPx));
+    }
+
+    currentWidthPx = null;
+}
+
+function startResize(event) {
+    if (isResizing || !mainContentRef.value || !contentCardRef.value) return;
+
+    isResizing = true;
+    document.documentElement.classList.add('nav-resizing');
+
+    // Prevent losing the drag if the pointer leaves the handle.
+    event?.currentTarget?.setPointerCapture?.(event.pointerId);
+
+    const dir = getComputedStyle(document.documentElement).direction;
+    const isRtl = dir === 'rtl';
+
+    const mainContentRect = mainContentRef.value.getBoundingClientRect();
+    const contentCardRect = contentCardRef.value.getBoundingClientRect();
+    contentInsetPx = isRtl
+        ? (mainContentRect.right - contentCardRect.right)
+        : (contentCardRect.left - mainContentRect.left);
+
+    pointerMoveListener = (e) => {
+        const proposedWidth = isRtl
+            ? (window.innerWidth - e.clientX - contentInsetPx)
+            : (e.clientX - contentInsetPx);
+
+        currentWidthPx = clampNavWidthPx(proposedWidth);
+        setNavWidthPx(currentWidthPx);
+    };
+
+    pointerUpListener = () => stopResize({ persist: true });
+
+    document.addEventListener('pointermove', pointerMoveListener);
+    document.addEventListener('pointerup', pointerUpListener);
+}
+
+function resetNavWidth() {
+    stopResize({ persist: false });
+    localStorage.removeItem(navWidthStorageKey);
+    document.documentElement.style.removeProperty('--nav-width');
+}
+
 function focusMain() {
     // Wait for components to mount and autofocus to process
     nextTick(() => {
@@ -63,6 +151,7 @@ function focusMain() {
 
 onMounted(() => {
     navigationListener = router.on('success', focusMain);
+    restoreSavedNavWidth();
     focusMain();
 });
 
@@ -70,6 +159,8 @@ onUnmounted(() => {
     if (navigationListener) {
         navigationListener();
     }
+
+    stopResize({ persist: false });
 });
 </script>
 
@@ -82,8 +173,13 @@ onUnmounted(() => {
         <main id="main" class="flex bg-body-bg dark:border-t dark:border-body-border rounded-t-2xl fixed top-14 inset-x-0 bottom-0 min-h-[calc(100vh-3.5rem)]">
             <Nav />
             <!-- The data attribute allows CSS to target elements when max-width is disabled. -->
-            <div id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
-                <div id="content-card" tabindex="-1" class="focus:outline-none relative content-card grid min-h-full mx-auto">
+            <div ref="mainContentRef" id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
+                <div ref="contentCardRef" id="content-card" tabindex="-1" class="focus:outline-none relative content-card grid min-h-full mx-auto">
+                    <div
+                        class="content-card-resize-handle"
+                        @pointerdown.prevent="startResize"
+                        @dblclick="resetNavWidth"
+                    />
                     <!-- Data attribute used by the CSS style tag below to override max-width when disabled.-->
                     <div class="w-full min-w-0 mx-auto max-w-page" data-max-width-wrapper>
                         <slot />


### PR DESCRIPTION
## What this PR Does

This is part of the new forms experience, which has 2 resizable sidebars.
The "left" sidebar could be used anywhere in the CP at the moment, so I'm making this PR.

This PR:

- Renames `nav-main` to `cp-sidebar-start`. Since we'll have "left" and "right" sidebars, this makes more sense. I could have called it `cp-sidebar-left`, but I wanted to think ahead and use logical naming conventions for RTL support. FYI the second bar will be called `cp-sidebar-end`.
- Makes the sidebar resizable in Vue, with a sensible min/max width
- You can always double-click the resize bar to reset its size

## How to Reproduce

1. On any page hover over the line that divides the sidebar and the main content
2. Drag around to observe the min/max values in place
3. Double click to reset the navbar size