### PR TITLE
[6.x] Skip laravel-vite-plugin during Vitest runs

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,7 @@ export default defineConfig(({ mode, command }) => {
     const isRunningBuild = command === 'build';
     const isProdBuild = isRunningBuild && mode === 'production';
     const isProdDevBuild = isRunningBuild && mode === 'development';
+    const isTesting = !!process.env.VITEST;
 
     return {
         base: './',
@@ -25,7 +26,7 @@ export default defineConfig(({ mode, command }) => {
         plugins: [
             tsconfigPaths(),
             tailwindcss(),
-            laravel({
+            !isTesting && laravel({
                 valetTls: env.VALET_TLS,
                 input: ['resources/css/app.css', 'resources/js/index.js'],
                 refresh: true,


### PR DESCRIPTION
## Summary

Running `npm run test` while the Vite dev server (`npm run dev`) is active causes a "Vite manifest not found" error. This happens because Vitest spins up its own internal Vite server using the same config, which initializes the `laravel-vite-plugin`. When Vitest's server shuts down, the plugin deletes the `hot` file that the real dev server depends on — and since `npm run dev` already deleted the build directory, Laravel can't find either the hot file or the manifest.

This PR conditionally excludes `laravel-vite-plugin` when the `VITEST` environment variable is set, since the plugin isn't needed for tests.

Related upstream issue: https://github.com/laravel/vite-plugin/issues/329

The [suggested fix](https://github.com/laravel/vite-plugin/issues/329#issuecomment-3046919469) from the `laravel-vite-plugin` maintainers is to use a dedicated `vitest.config.ts` file. We opted against that here because a separate config would need to either duplicate the entire Vite config (plugins, aliases, defines, etc.) or use `mergeConfig` and awkwardly strip the laravel plugin from the merged result. The conditional plugin approach keeps everything in one file with no duplication.

## Test plan

- Run `npm run dev` to start the Vite dev server
- In a separate terminal, run `npm run test`
- Confirm the dev server continues working after tests complete (no manifest error)
- Confirm `npm run build` still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)