### PR TITLE
[6.x] Ability to select the date formatting locale

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -198,6 +198,7 @@ return [
     'phpinfo_utility_description' => 'Check PHP configuration settings and installed modules.',
     'plus_count_more' => '+ :count more',
     'preference_confirm_dirty_navigation_instructions' => 'Whether you should get a warning when trying to leave the page when there are unsaved changes.',
+    'preference_formatting_locale_instructions' => 'The locale used for formatting values in the control panel, such as dates and numbers.',
     'preference_locale_instructions' => 'The preferred language for the control panel.',
     'preference_start_page_instructions' => 'The page to be shown when logging into the control panel.',
     'preference_strict_accessibility_instructions' => 'We\'ve designed the control panel with accessibility in mind, aiming to meet WCAG 2.2 guidelines where possible. Enable this option to apply stricter accessibility rules by increasing form border contrast.',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -198,6 +198,7 @@ return [
     'phpinfo_utility_description' => 'Check PHP configuration settings and installed modules.',
     'plus_count_more' => '+ :count more',
     'preference_confirm_dirty_navigation_instructions' => 'Whether you should get a warning when trying to leave the page when there are unsaved changes.',
+    'preference_formatting_locale_invalid' => 'Please enter a valid locale code.',
     'preference_formatting_locale_instructions' => 'The locale used for formatting values in the control panel, such as dates and numbers.',
     'preference_locale_instructions' => 'The preferred language for the control panel.',
     'preference_start_page_instructions' => 'The page to be shown when logging into the control panel.',

--- a/resources/js/bootstrap/fieldtypes.js
+++ b/resources/js/bootstrap/fieldtypes.js
@@ -17,6 +17,7 @@ import Routes from '../components/collections/Routes.vue';
 import TitleFormats from '../components/collections/TitleFormats.vue';
 import ColorFieldtype from '../components/fieldtypes/ColorFieldtype.vue';
 import DateFieldtype from '../components/fieldtypes/DateFieldtype.vue';
+import FormattingLocalesFieldtype from '../components/fieldtypes/FormattingLocalesFieldtype.vue';
 import DateIndexFieldtype from '../components/fieldtypes/DateIndexFieldtype.vue';
 import DictionaryFieldtype from '../components/fieldtypes/DictionaryFieldtype.vue';
 import DictionaryIndexFieldtype from '../components/fieldtypes/DictionaryIndexFieldtype.vue';
@@ -88,6 +89,7 @@ export default function registerFieldtypes(app) {
     app.component('collection_title_formats-fieldtype', TitleFormats);
     app.component('color-fieldtype', ColorFieldtype);
     app.component('date-fieldtype', DateFieldtype);
+    app.component('formatting_locales-fieldtype', FormattingLocalesFieldtype);
     app.component('date-fieldtype-index', DateIndexFieldtype);
     app.component('dictionary-fieldtype', DictionaryFieldtype);
     app.component('dictionary-fieldtype-index', DictionaryIndexFieldtype);

--- a/resources/js/bootstrap/statamic.js
+++ b/resources/js/bootstrap/statamic.js
@@ -177,7 +177,7 @@ export default {
         preferences.initialize(this.initialConfig.user?.preferences, this.initialConfig.defaultPreferences);
 
         const formattingLocale = this.initialConfig.user?.preferences?.formatting_locale;
-        if (formattingLocale === 'locale') {
+        if (formattingLocale === 'language') {
             dateFormatter.setDefaultLocale(this.initialConfig.translationLocale);
         } else if (formattingLocale) {
             dateFormatter.setDefaultLocale(formattingLocale);

--- a/resources/js/bootstrap/statamic.js
+++ b/resources/js/bootstrap/statamic.js
@@ -176,6 +176,13 @@ export default {
         contrast.initialize(this.initialConfig.user?.preferences?.strict_accessibility);
         preferences.initialize(this.initialConfig.user?.preferences, this.initialConfig.defaultPreferences);
 
+        const formattingLocale = this.initialConfig.user?.preferences?.formatting_locale;
+        if (formattingLocale === 'locale') {
+            dateFormatter.setDefaultLocale(this.initialConfig.translationLocale);
+        } else if (formattingLocale) {
+            dateFormatter.setDefaultLocale(formattingLocale);
+        }
+
         bootingCallbacks.forEach((callback) => callback(this));
         bootingCallbacks = [];
 

--- a/resources/js/components/DateFormatter.js
+++ b/resources/js/components/DateFormatter.js
@@ -102,6 +102,21 @@ export default class DateFormatter {
         return this.date(date).options(options).toString();
     }
 
+    withLocale(locale, callback) {
+        const previousLocale = DateFormatter.defaultLocale;
+        this.setDefaultLocale(locale);
+
+        try {
+            return callback(this);
+        } finally {
+            this.setDefaultLocale(previousLocale);
+        }
+    }
+
+    setDefaultLocale(locale) {
+        DateFormatter.defaultLocale = locale;
+    }
+
     get locale() {
         return DateFormatter.defaultLocale ?? Intl.DateTimeFormat().resolvedOptions().locale;
     }

--- a/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
@@ -1,0 +1,59 @@
+<template>
+    <Combobox
+        clearable
+        taggable
+        :options="options"
+        :read-only="isReadOnly"
+        :placeholder="null"
+        :model-value="value"
+        @update:modelValue="comboboxUpdated"
+    />
+</template>
+
+<script setup>
+import Fieldtype from '@/components/fieldtypes/fieldtype.js';
+import { dateFormatter } from '@api';
+import { Combobox } from '@/components/ui';
+import { computed } from 'vue';
+
+const emit = defineEmits(Fieldtype.emits);
+const props = defineProps(Fieldtype.props);
+const { isReadOnly, update } = Fieldtype.use(emit, props);
+
+const candidateLocales = [
+    'ar', 'az', 'cs', 'da', 'de', 'de-CH', 'en', 'es', 'et', 'fa', 'fr',
+    'hu', 'id', 'it', 'ja', 'ms', 'nb', 'nl', 'pl', 'pt', 'pt-BR', 'ru',
+    'sl', 'sv', 'tr', 'uk', 'vi', 'zh-CN', 'zh-TW',
+];
+
+const displayNames = typeof Intl.DisplayNames !== 'undefined'
+    ? new Intl.DisplayNames([document.documentElement.lang || 'en'], { type: 'language' })
+    : null;
+
+const options = computed(() => {
+    const locales = Intl.DateTimeFormat.supportedLocalesOf(candidateLocales);
+    const now = new Date();
+
+    const formatted = locales.map((locale) => {
+        const language = locale.split('-')[0];
+        const display = displayNames?.of(language);
+        const sample = dateFormatter.withLocale(locale, (formatter) => formatter.format(now, 'datetime'));
+
+        return {
+            value: locale,
+            label: display
+                ? `${locale} (${display}) - ${sample}`
+                : `${locale} - ${sample}`,
+        };
+    });
+
+    return [
+        { value: 'locale', label: __('Same as locale') },
+        ...formatted,
+    ];
+});
+
+function comboboxUpdated(value) {
+    update(value || null);
+}
+</script>

--- a/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
@@ -7,12 +7,33 @@
         :placeholder="null"
         :model-value="value"
         @update:modelValue="comboboxUpdated"
-    />
+    >
+        <template #selected-option="{ option: { value, label, sample } }">
+            <template v-if="value === 'language'">{{ label }}</template>
+            <div v-else class="w-full flex justify-between">
+                <div class="text-start flex-1">
+                    {{ getLabel(value) }}
+                    <span class="ms-4 text-gray-500 dark:text-gray-400" v-text="value" />
+                </div>
+                <span class="text-gray-500 dark:text-gray-400" v-text="getSample(value)" />
+            </div>
+        </template>
+        <template #option="{ value, label, sample }">
+            <template v-if="value === 'language'">{{ label }}</template>
+            <div v-else class="w-full flex justify-between">
+                <div class="text-start flex-1">
+                    {{ label }}
+                    <span class="ms-4 text-gray-500 dark:text-gray-400" v-text="value" />
+                </div>
+                <span class="text-gray-500 dark:text-gray-400" v-text="sample" />
+            </div>
+        </template>
+    </Combobox>
 </template>
 
 <script setup>
 import Fieldtype from '@/components/fieldtypes/fieldtype.js';
-import { dateFormatter } from '@api';
+import { dateFormatter, toast } from '@api';
 import { Combobox } from '@/components/ui';
 import { computed } from 'vue';
 
@@ -32,20 +53,12 @@ const displayNames = typeof Intl.DisplayNames !== 'undefined'
 
 const options = computed(() => {
     const locales = Intl.DateTimeFormat.supportedLocalesOf(candidateLocales);
-    const now = new Date();
 
-    const formatted = locales.map((locale) => {
-        const language = locale.split('-')[0];
-        const display = displayNames?.of(language);
-        const sample = dateFormatter.withLocale(locale, (formatter) => formatter.format(now, 'datetime'));
-
-        return {
-            value: locale,
-            label: display
-                ? `${locale} (${display}) - ${sample}`
-                : `${locale} - ${sample}`,
-        };
-    });
+    const formatted = locales.map((locale) => ({
+        value: locale,
+        label: getLabel(locale),
+        sample: getSample(locale),
+    }));
 
     return [
         { value: 'language', label: __('Same as language') },
@@ -53,7 +66,33 @@ const options = computed(() => {
     ];
 });
 
+function getLabel(locale) {
+    return displayNames?.of(locale.split('-')[0]);
+}
+
+function getSample(locale) {
+    return dateFormatter.withLocale(locale, (formatter) => formatter.format(new Date, 'datetime'));
+}
+
 function comboboxUpdated(value) {
+    if (value && !isValidLocale(value)) {
+        update(null);
+        toast.error(__('statamic::messages.preference_formatting_locale_invalid'));
+        return;
+    }
+
     update(value || null);
+}
+
+function isValidLocale(value) {
+    if (value === 'language') {
+        return true;
+    }
+
+    try {
+        return Intl.DateTimeFormat.supportedLocalesOf([value]).length > 0;
+    } catch {
+        return false;
+    }
 }
 </script>

--- a/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
@@ -48,7 +48,7 @@ const options = computed(() => {
     });
 
     return [
-        { value: 'locale', label: __('Same as locale') },
+        { value: 'language', label: __('Same as language') },
         ...formatted,
     ];
 });

--- a/resources/js/tests/components/DateFormatter.test.js
+++ b/resources/js/tests/components/DateFormatter.test.js
@@ -47,6 +47,27 @@ test('it can statically format', () => {
     expect(DateFormatter.format('1995-03-13T22:45:19Z', { year: 'numeric' })).toBe('1995');
 });
 
+test('it can temporarily format with locale using callback', () => {
+    const formatter = new DateFormatter();
+    DateFormatter.defaultLocale = 'en-us';
+
+    const result = formatter.withLocale('de', (instance) => instance.format('2021-12-25T12:13:14Z', 'datetime'));
+
+    expect(result).toBe('25.12.2021, 12:13');
+    expect(DateFormatter.defaultLocale).toBe('en-us');
+});
+
+test('it resets locale after withLocale callback throws', () => {
+    const formatter = new DateFormatter();
+    DateFormatter.defaultLocale = 'en-us';
+
+    expect(() => formatter.withLocale('de', () => {
+        throw new Error('boom');
+    })).toThrow('boom');
+
+    expect(DateFormatter.defaultLocale).toBe('en-us');
+});
+
 test('it can format on the instance', () => {
     expect(new DateFormatter().format('1995-03-13T22:45:19Z')).toBe('3/13/1995, 10:45 PM');
     expect(new DateFormatter().format('1995-03-13T22:45:19Z', { year: 'numeric' })).toBe('1995');
@@ -184,6 +205,12 @@ test('it can get the locale', () => {
     expect(new DateFormatter().locale).toBe('en-us');
     DateFormatter.defaultLocale = 'fr';
     expect(new DateFormatter().locale).toBe('fr');
+});
+
+test('it can set the default locale via setDefaultLocale', () => {
+    new DateFormatter().setDefaultLocale('de');
+    expect(DateFormatter.defaultLocale).toBe('de');
+    expect(new DateFormatter().locale).toBe('de');
 });
 
 test.each([

--- a/src/Fieldtypes/FormattingLocales.php
+++ b/src/Fieldtypes/FormattingLocales.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Statamic\Fieldtypes;
+
+use Statamic\Fields\Fieldtype;
+
+class FormattingLocales extends Fieldtype
+{
+    protected $selectable = false;
+}

--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -14,7 +14,7 @@ class CorePreferences
     {
         Preference::register('locale', [
             'type' => 'select',
-            'display' => __('Locale'),
+            'display' => __('Language'),
             'instructions' => __('statamic::messages.preference_locale_instructions'),
             'clearable' => true,
             'label_html' => true,

--- a/src/Preferences/CorePreferences.php
+++ b/src/Preferences/CorePreferences.php
@@ -21,6 +21,12 @@ class CorePreferences
             'options' => $this->localeOptions(),
         ]);
 
+        Preference::register('formatting_locale', [
+            'type' => 'formatting_locales',
+            'display' => __('Formatting Locale'),
+            'instructions' => __('statamic::messages.preference_formatting_locale_instructions'),
+        ]);
+
         Preference::register('start_page', [
             'type' => 'text',
             'display' => __('Start Page'),

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -83,6 +83,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Fieldtypes\FieldDisplay::class,
         Fieldtypes\Files::class,
         Fieldtypes\Floatval::class,
+        Fieldtypes\FormattingLocales::class,
         Fieldtypes\GlobalSetSites::class,
         Fieldtypes\Grid::class,
         Fieldtypes\Group::class,


### PR DESCRIPTION
- add a new `formatting_locale` user preference for locale-sensitive Control Panel formatting
- show a live date/time sample for each locale and include a `Same as language` inheritance option (`language`)
- wire the preference into CP bootstrap so `dateFormatter` uses either the explicit locale or the translation locale when inheriting from language
- leaving the preference blank keep the read-from-browser behavior
- add `DateFormatter.withLocale(locale, callback)` for safe temporary locale-scoped formatting (auto-resets locale after callback)
- rename the existing `locale` preference label from `Locale` to `Language` for clarity (handle remains `locale`)

<img width="1051" height="557" alt="CleanShot 2026-03-26 at 15 06 57" src="https://github.com/user-attachments/assets/84ed37b9-eee0-4d7f-bb8a-b6f8dfdabd8e" />

Closes https://github.com/statamic/ideas/issues/1447
References https://github.com/statamic/cms/issues/14074