### PR TITLE
[6.x] Fix collection whereStatus logic

### DIFF
--- a/src/Stache/Query/QueriesEntryStatus.php
+++ b/src/Stache/Query/QueriesEntryStatus.php
@@ -45,6 +45,18 @@ trait QueriesEntryStatus
             return;
         }
 
+        if ($status === 'scheduled' && $collection->futureDateBehavior() !== 'private') {
+            $query->where('date', 'invalid'); // intentionally trigger no results.
+
+            return;
+        }
+
+        if ($status === 'expired' && $collection->pastDateBehavior() !== 'private') {
+            $query->where('date', 'invalid'); // intentionally trigger no results.
+
+            return;
+        }
+
         if ($collection->futureDateBehavior() === 'private') {
             $status === 'scheduled'
                 ? $query->where('date', '>', now())

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -1215,6 +1215,18 @@ class EntryQueryBuilderTest extends TestCase
         EntryFactory::collection('calendar')->id('calendar-past')->published(true)->date(now()->subDay())->create();
         EntryFactory::collection('calendar')->id('calendar-past-draft')->published(false)->date(now()->subDay())->create();
 
+        Collection::make('news')->dated(true)->futureDateBehavior('unlisted')->pastDateBehavior('public')->save();
+        EntryFactory::collection('news')->id('news-future')->published(true)->date(now()->addDay())->create();
+        EntryFactory::collection('news')->id('news-future-draft')->published(false)->date(now()->addDay())->create();
+        EntryFactory::collection('news')->id('news-past')->published(true)->date(now()->subDay())->create();
+        EntryFactory::collection('news')->id('news-past-draft')->published(false)->date(now()->subDay())->create();
+
+        Collection::make('alerts')->dated(true)->futureDateBehavior('public')->pastDateBehavior('unlisted')->save();
+        EntryFactory::collection('alerts')->id('alerts-future')->published(true)->date(now()->addDay())->create();
+        EntryFactory::collection('alerts')->id('alerts-future-draft')->published(false)->date(now()->addDay())->create();
+        EntryFactory::collection('alerts')->id('alerts-past')->published(true)->date(now()->subDay())->create();
+        EntryFactory::collection('alerts')->id('alerts-past-draft')->published(false)->date(now()->subDay())->create();
+
         // Undated, but with customized date behavior. Nonsensical situation, but it can happen.
         // See https://github.com/statamic/eloquent-driver/issues/288
         Collection::make('undated')->dated(false)->futureDateBehavior('private')->pastDateBehavior('private')->save();
@@ -1235,6 +1247,10 @@ class EntryQueryBuilderTest extends TestCase
                 'event-past-draft',
                 'calendar-future-draft',
                 'calendar-past-draft',
+                'news-future-draft',
+                'news-past-draft',
+                'alerts-future-draft',
+                'alerts-past-draft',
                 'undated-draft',
             ]],
             'published' => ['published', [
@@ -1243,6 +1259,10 @@ class EntryQueryBuilderTest extends TestCase
                 'event-future',
                 'calendar-future',
                 'calendar-past',
+                'news-future',
+                'news-past',
+                'alerts-future',
+                'alerts-past',
                 'undated',
             ]],
             'scheduled' => ['scheduled', [


### PR DESCRIPTION
Closes #13341


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes status-filtering query logic for dated collections, which can affect what entries appear as `scheduled`/`expired` in listings and badges. Risk is moderate due to potential behavior changes across collections with different date visibility settings.
> 
> **Overview**
> Fixes `whereStatus('scheduled'|'expired')` filtering so dated collections only return results when their corresponding date behavior is `private`; collections with `public` or `unlisted` future/past behaviors now intentionally return no matches for those statuses.
> 
> Extends `EntryQueryBuilderTest::it_filters_by_status` with new `news` and `alerts` collections to validate status results when future or past date behavior is `unlisted`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0d9404ca20da0e74f47cbcb5d4be3030ee98547. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->