### PR TITLE
[6.x] Ensure empty addon settings get default blueprint values

### DIFF
--- a/src/Addons/Settings.php
+++ b/src/Addons/Settings.php
@@ -19,8 +19,7 @@ abstract class Settings implements Contract
     public function __construct(Addon $addon, array $settings = [])
     {
         $this->addon = $addon;
-        $this->rawSettings = $settings;
-        $this->settings = $this->resolveAntlers($this->applyBlueprintDefaults($settings));
+        $this->setValues($settings);
     }
 
     public function addon(): Addon
@@ -59,7 +58,7 @@ abstract class Settings implements Contract
     private function setValues(array $values): self
     {
         $this->rawSettings = $values;
-        $this->settings = $this->resolveAntlers($values);
+        $this->settings = $this->resolveAntlers($this->applyBlueprintDefaults($values));
 
         return $this;
     }

--- a/src/Addons/Settings.php
+++ b/src/Addons/Settings.php
@@ -19,8 +19,8 @@ abstract class Settings implements Contract
     public function __construct(Addon $addon, array $settings = [])
     {
         $this->addon = $addon;
-        $this->settings = $this->resolveAntlers($settings);
         $this->rawSettings = $settings;
+        $this->settings = $this->resolveAntlers($this->applyBlueprintDefaults($settings));
     }
 
     public function addon(): Addon
@@ -80,6 +80,20 @@ abstract class Settings implements Contract
     public function delete(): bool
     {
         return app(SettingsRepository::class)->delete($this);
+    }
+
+    private function applyBlueprintDefaults(array $settings): array
+    {
+        if (! $blueprint = $this->addon->settingsBlueprint()) {
+            return $settings;
+        }
+
+        $defaults = $blueprint->fields()->all()
+            ->mapWithKeys(fn ($field) => [$field->handle() => $field->defaultValue()])
+            ->whereNotNull()
+            ->all();
+
+        return array_merge($defaults, $settings);
     }
 
     public function resolveAntlers($config)

--- a/tests/Addons/SettingsTest.php
+++ b/tests/Addons/SettingsTest.php
@@ -146,6 +146,22 @@ class SettingsTest extends TestCase
             'test' => ['a' => 'A', 'b' => 'B'],
             'statamic.system.view_config_allowlist' => ['@default', 'test.a', 'test.b'],
         ]);
+
+        $this->app->bind('statamic.addons.test-addon.settings_blueprint', fn () => [
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'fields' => [
+                                ['handle' => 'api_key', 'field' => ['type' => 'text', 'default' => 'my-default-key']],
+                                ['handle' => 'another_field', 'field' => ['type' => 'text', 'default' => 'default-value']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
         $addon = $this->makeFromPackage();
         $settings = new Settings($addon, ['foo' => 'bar']);
 
@@ -158,6 +174,8 @@ class SettingsTest extends TestCase
         ]);
 
         $this->assertEquals([
+            'api_key' => 'my-default-key',
+            'another_field' => 'default-value',
             'alfa' => 'bravo',
             'charlie' => 'A',
             'delta' => ['echo' => 'B'],

--- a/tests/Addons/SettingsTest.php
+++ b/tests/Addons/SettingsTest.php
@@ -166,6 +166,81 @@ class SettingsTest extends TestCase
     }
 
     #[Test]
+    public function it_applies_blueprint_defaults_to_resolved_settings()
+    {
+        $this->app->bind('statamic.addons.test-addon.settings_blueprint', fn () => [
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'fields' => [
+                                ['handle' => 'api_key', 'field' => ['type' => 'text', 'default' => 'my-default-key']],
+                                ['handle' => 'no_default_field', 'field' => ['type' => 'text']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $addon = $this->makeFromPackage();
+        $settings = new Settings($addon, []);
+
+        $this->assertEquals('my-default-key', $settings->get('api_key'));
+        $this->assertNull($settings->get('no_default_field'));
+    }
+
+    #[Test]
+    public function it_does_not_include_blueprint_defaults_in_raw_settings()
+    {
+        $this->app->bind('statamic.addons.test-addon.settings_blueprint', fn () => [
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'fields' => [
+                                ['handle' => 'api_key', 'field' => ['type' => 'text', 'default' => 'my-default-key']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $addon = $this->makeFromPackage();
+        $settings = new Settings($addon, []);
+
+        $this->assertArrayNotHasKey('api_key', $settings->raw());
+        $this->assertSame([], $settings->raw());
+    }
+
+    #[Test]
+    public function saved_settings_take_precedence_over_blueprint_defaults()
+    {
+        $this->app->bind('statamic.addons.test-addon.settings_blueprint', fn () => [
+            'tabs' => [
+                'main' => [
+                    'sections' => [
+                        [
+                            'fields' => [
+                                ['handle' => 'api_key', 'field' => ['type' => 'text', 'default' => 'my-default-key']],
+                                ['handle' => 'another_field', 'field' => ['type' => 'text', 'default' => 'default-value']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $addon = $this->makeFromPackage();
+        $settings = new Settings($addon, ['api_key' => 'saved-key']);
+
+        $this->assertEquals('saved-key', $settings->get('api_key'));
+        $this->assertEquals('default-value', $settings->get('another_field'));
+        $this->assertSame(['api_key' => 'saved-key'], $settings->raw());
+    }
+
+    #[Test]
     public function it_saves_settings()
     {
         Event::fake();


### PR DESCRIPTION
Closes https://github.com/statamic/cms/issues/14376