### PR TITLE
[6.x] Normalise prose mirror content before setting editor content

### DIFF
--- a/src/Fieldtypes/Bard/Augmentor.php
+++ b/src/Fieldtypes/Bard/Augmentor.php
@@ -172,11 +172,27 @@ class Augmentor
     {
         static::$currentBardConfig = $this->fieldtype->config();
 
-        $html = $this->editor()->setContent($value)->getHTML();
+        $html = $this->editor()->setContent($this->normalizeProsemirrorContent($value))->getHTML();
 
         static::$currentBardConfig = [];
 
         return $html;
+    }
+
+    private function normalizeProsemirrorContent(array $node): array
+    {
+        if (isset($node['content'])) {
+            if (! is_array($node['content'])) {
+                unset($node['content']);
+            } else {
+                $node['content'] = array_values(array_map(
+                    fn ($child) => $this->normalizeProsemirrorContent($child),
+                    $node['content']
+                ));
+            }
+        }
+
+        return $node;
     }
 
     private function editor()

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -989,6 +989,47 @@ EOT;
     }
 
     #[Test]
+    public function it_pre_processes_index_with_string_node_content()
+    {
+        $bard = $this->bard(['sets' => null]);
+
+        // A node with a string "content" value (e.g. empty string) instead of an array
+        // should not throw a foreach error when rendered to HTML.
+        $data = [
+            [
+                'type' => 'paragraph',
+                'content' => '',
+            ],
+        ];
+
+        $this->assertEquals('<p></p>', $bard->preProcessIndex($data));
+    }
+
+    #[Test]
+    public function it_pre_processes_index_with_deeply_nested_string_node_content()
+    {
+        $bard = $this->bard(['sets' => null]);
+
+        $data = [
+            [
+                'type' => 'paragraph',
+                'content' => [
+                    [
+                        'type' => 'text',
+                        'text' => 'Hello',
+                    ],
+                ],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => '',
+            ],
+        ];
+
+        $this->assertEquals('<p>Hello</p><p></p>', $bard->preProcessIndex($data));
+    }
+
+    #[Test]
     public function it_converts_tiptap_v1_snake_case_types_to_v2_camel_case_types()
     {
         $data = [


### PR DESCRIPTION
Not sure if this is the right fix, or is too generic, but this PR normalises prose mirror content before setting it, which means if you try to apply a replicator content to bard, it won't error out.

For context, see related issue which this closes:
https://github.com/statamic/cms/issues/14293

Closes https://github.com/statamic/cms/issues/14293