### PR TITLE
[6.x] Ensure moved/removed entries are statically invalidated

### DIFF
--- a/src/Events/CollectionTreeEntriesMovedOrRemoved.php
+++ b/src/Events/CollectionTreeEntriesMovedOrRemoved.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Statamic\Events;
+
+class CollectionTreeEntriesMovedOrRemoved extends Event
+{
+    public function __construct(
+        public array $removed,
+        public array $moved,
+    ) {
+    }
+}

--- a/src/Events/CollectionTreeEntriesMovedOrRemoved.php
+++ b/src/Events/CollectionTreeEntriesMovedOrRemoved.php
@@ -2,11 +2,39 @@
 
 namespace Statamic\Events;
 
+use Statamic\Facades\Entry;
+
 class CollectionTreeEntriesMovedOrRemoved extends Event
 {
+    public array $removedUrls;
+    public array $movedUrls;
+
     public function __construct(
         public array $removed,
         public array $moved,
     ) {
+        $this->removedUrls = $this->resolveUrls($removed);
+        $this->movedUrls = $this->resolveUrls($moved);
+    }
+
+    private function resolveUrls(array $ids): array
+    {
+        return collect($ids)
+            ->flatMap(function ($id) {
+                if (! $entry = Entry::find($id)) {
+                    return [];
+                }
+
+                return $entry->descendants()
+                    ->merge([$entry])
+                    ->reject->isRedirect()
+                    ->map->absoluteUrl()
+                    ->filter()
+                    ->values()
+                    ->all();
+            })
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -23,12 +23,12 @@ use Statamic\Events\NavDeleted;
 use Statamic\Events\NavSaved;
 use Statamic\Events\NavTreeDeleted;
 use Statamic\Events\NavTreeSaved;
-use Statamic\Facades\Entry;
 use Statamic\Facades\Form;
 
 class Invalidate implements ShouldQueue
 {
     protected $invalidator;
+    protected $cacher;
 
     protected $events = [
         AssetSaved::class => 'refreshAsset',
@@ -53,9 +53,10 @@ class Invalidate implements ShouldQueue
         BlueprintDeleted::class => 'invalidateByBlueprint',
     ];
 
-    public function __construct(Invalidator $invalidator)
+    public function __construct(Invalidator $invalidator, Cacher $cacher)
     {
         $this->invalidator = $invalidator;
+        $this->cacher = $cacher;
     }
 
     public function subscribe($dispatcher)
@@ -127,10 +128,8 @@ class Invalidate implements ShouldQueue
 
     public function invalidateMovedOrRemovedEntries($event)
     {
-        foreach (array_merge($event->removed, $event->moved) as $id) {
-            if ($entry = Entry::find($id)) {
-                $this->invalidator->invalidate($entry);
-            }
+        if ($urls = array_merge($event->removedUrls, $event->movedUrls)) {
+            $this->cacher->invalidateUrls($urls);
         }
     }
 

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -9,6 +9,7 @@ use Statamic\Events\BlueprintDeleted;
 use Statamic\Events\BlueprintSaved;
 use Statamic\Events\CollectionTreeDeleted;
 use Statamic\Events\CollectionTreeSaved;
+use Statamic\Events\CollectionTreeSaving;
 use Statamic\Events\EntryDeleting;
 use Statamic\Events\EntrySaved;
 use Statamic\Events\EntryScheduleReached;
@@ -22,6 +23,7 @@ use Statamic\Events\NavDeleted;
 use Statamic\Events\NavSaved;
 use Statamic\Events\NavTreeDeleted;
 use Statamic\Events\NavTreeSaved;
+use Statamic\Facades\Entry;
 use Statamic\Facades\Form;
 
 class Invalidate implements ShouldQueue
@@ -42,6 +44,7 @@ class Invalidate implements ShouldQueue
         NavDeleted::class => 'invalidateNav',
         FormSaved::class => 'refreshForm',
         FormDeleted::class => 'invalidateForm',
+        CollectionTreeSaving::class => 'invalidateMovedOrRemovedEntries',
         CollectionTreeSaved::class => 'invalidateCollectionByTree',
         CollectionTreeDeleted::class => 'invalidateCollectionByTree',
         NavTreeSaved::class => 'refreshNavByTree',
@@ -120,6 +123,19 @@ class Invalidate implements ShouldQueue
     public function refreshForm($event)
     {
         $this->invalidator->refresh($event->form);
+    }
+
+    public function invalidateMovedOrRemovedEntries($event)
+    {
+        $diff = $event->tree->diff();
+
+        $entryIds = array_merge($diff->removed(), $diff->ancestryChanged());
+
+        foreach ($entryIds as $id) {
+            if ($entry = Entry::find($id)) {
+                $this->invalidator->invalidate($entry);
+            }
+        }
     }
 
     public function invalidateCollectionByTree($event)

--- a/src/StaticCaching/Invalidate.php
+++ b/src/StaticCaching/Invalidate.php
@@ -8,8 +8,8 @@ use Statamic\Events\AssetSaved;
 use Statamic\Events\BlueprintDeleted;
 use Statamic\Events\BlueprintSaved;
 use Statamic\Events\CollectionTreeDeleted;
+use Statamic\Events\CollectionTreeEntriesMovedOrRemoved;
 use Statamic\Events\CollectionTreeSaved;
-use Statamic\Events\CollectionTreeSaving;
 use Statamic\Events\EntryDeleting;
 use Statamic\Events\EntrySaved;
 use Statamic\Events\EntryScheduleReached;
@@ -44,7 +44,7 @@ class Invalidate implements ShouldQueue
         NavDeleted::class => 'invalidateNav',
         FormSaved::class => 'refreshForm',
         FormDeleted::class => 'invalidateForm',
-        CollectionTreeSaving::class => 'invalidateMovedOrRemovedEntries',
+        CollectionTreeEntriesMovedOrRemoved::class => 'invalidateMovedOrRemovedEntries',
         CollectionTreeSaved::class => 'invalidateCollectionByTree',
         CollectionTreeDeleted::class => 'invalidateCollectionByTree',
         NavTreeSaved::class => 'refreshNavByTree',
@@ -127,11 +127,7 @@ class Invalidate implements ShouldQueue
 
     public function invalidateMovedOrRemovedEntries($event)
     {
-        $diff = $event->tree->diff();
-
-        $entryIds = array_merge($diff->removed(), $diff->ancestryChanged());
-
-        foreach ($entryIds as $id) {
+        foreach (array_merge($event->removed, $event->moved) as $id) {
             if ($entry = Entry::find($id)) {
                 $this->invalidator->invalidate($entry);
             }

--- a/src/Structures/CollectionTree.php
+++ b/src/Structures/CollectionTree.php
@@ -49,6 +49,10 @@ class CollectionTree extends Tree implements TreeContract
 
     protected function dispatchSavingEvent()
     {
+        if (CollectionTreeSaving::dispatch($this) === false) {
+            return false;
+        }
+
         $diff = $this->diff();
         $removed = $diff->removed();
         $moved = $diff->ancestryChanged();
@@ -56,8 +60,6 @@ class CollectionTree extends Tree implements TreeContract
         if ($removed || $moved) {
             CollectionTreeEntriesMovedOrRemoved::dispatch($removed, $moved);
         }
-
-        return CollectionTreeSaving::dispatch($this);
     }
 
     protected function dispatchDeletedEvent()

--- a/src/Structures/CollectionTree.php
+++ b/src/Structures/CollectionTree.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Structures\CollectionTreeDiff;
 use Statamic\Contracts\Structures\CollectionTree as TreeContract;
 use Statamic\Contracts\Structures\CollectionTreeRepository;
 use Statamic\Events\CollectionTreeDeleted;
+use Statamic\Events\CollectionTreeEntriesMovedOrRemoved;
 use Statamic\Events\CollectionTreeSaved;
 use Statamic\Events\CollectionTreeSaving;
 use Statamic\Facades\Blink;
@@ -48,6 +49,14 @@ class CollectionTree extends Tree implements TreeContract
 
     protected function dispatchSavingEvent()
     {
+        $diff = $this->diff();
+        $removed = $diff->removed();
+        $moved = $diff->ancestryChanged();
+
+        if ($removed || $moved) {
+            CollectionTreeEntriesMovedOrRemoved::dispatch($removed, $moved);
+        }
+
         return CollectionTreeSaving::dispatch($this);
     }
 

--- a/tests/Data/Structures/CollectionTreeTest.php
+++ b/tests/Data/Structures/CollectionTreeTest.php
@@ -4,9 +4,11 @@ namespace Tests\Data\Structures;
 
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Events\CollectionTreeEntriesMovedOrRemoved;
 use Statamic\Events\CollectionTreeSaving;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
 use Statamic\Structures\CollectionTree;
 use Statamic\Structures\CollectionTreeDiff;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -141,5 +143,113 @@ class CollectionTreeTest extends TestCase
         $tree->save();
 
         $this->assertFileDoesNotExist($tree->path());
+    }
+
+    #[Test]
+    public function it_fires_entries_moved_or_removed_event_when_entries_are_removed()
+    {
+        Event::fake();
+        Entry::shouldReceive('find')->andReturn(null);
+
+        $collection = Collection::make('test')->structureContents(['root' => true]);
+        Collection::shouldReceive('findByHandle')->with('test')->andReturn($collection);
+
+        $tree = $collection->structure()->makeTree('en', [
+            ['entry' => '1.0'],
+            ['entry' => '2.0'],
+        ]);
+
+        $tree->tree([
+            ['entry' => '1.0'],
+        ]);
+
+        $tree->save();
+
+        Event::assertDispatched(CollectionTreeEntriesMovedOrRemoved::class, function ($event) {
+            return $event->removed === ['2.0'] && $event->moved === [];
+        });
+    }
+
+    #[Test]
+    public function it_fires_entries_moved_or_removed_event_when_entries_change_ancestry()
+    {
+        Event::fake();
+        Entry::shouldReceive('find')->andReturn(null);
+
+        $collection = Collection::make('test')->structureContents(['root' => true]);
+        Collection::shouldReceive('findByHandle')->with('test')->andReturn($collection);
+
+        $tree = $collection->structure()->makeTree('en', [
+            ['entry' => '1.0', 'children' => [
+                ['entry' => '1.1'],
+            ]],
+            ['entry' => '2.0'],
+        ]);
+
+        $tree->tree([
+            ['entry' => '1.0'],
+            ['entry' => '2.0', 'children' => [
+                ['entry' => '1.1'],
+            ]],
+        ]);
+
+        $tree->save();
+
+        Event::assertDispatched(CollectionTreeEntriesMovedOrRemoved::class, function ($event) {
+            return $event->removed === [] && $event->moved === ['1.1'];
+        });
+    }
+
+    #[Test]
+    public function it_does_not_fire_entries_moved_or_removed_event_when_entries_are_only_reordered()
+    {
+        Event::fake();
+
+        $collection = Collection::make('test')->structureContents(['root' => true]);
+        Collection::shouldReceive('findByHandle')->with('test')->andReturn($collection);
+
+        $tree = $collection->structure()->makeTree('en', [
+            ['entry' => '1.0', 'children' => [
+                ['entry' => '1.1'],
+                ['entry' => '1.2'],
+            ]],
+        ]);
+
+        $tree->tree([
+            ['entry' => '1.0', 'children' => [
+                ['entry' => '1.2'],
+                ['entry' => '1.1'],
+            ]],
+        ]);
+
+        $tree->save();
+
+        Event::assertNotDispatched(CollectionTreeEntriesMovedOrRemoved::class);
+    }
+
+    #[Test]
+    public function it_does_not_fire_entries_moved_or_removed_event_when_saving_is_halted()
+    {
+        Event::fake([CollectionTreeEntriesMovedOrRemoved::class]);
+
+        Event::listen(CollectionTreeSaving::class, function () {
+            return false;
+        });
+
+        $collection = Collection::make('test')->structureContents(['root' => true]);
+        Collection::shouldReceive('findByHandle')->with('test')->andReturn($collection);
+
+        $tree = $collection->structure()->makeTree('en', [
+            ['entry' => '1.0'],
+            ['entry' => '2.0'],
+        ]);
+
+        $tree->tree([
+            ['entry' => '1.0'],
+        ]);
+
+        $tree->save();
+
+        Event::assertNotDispatched(CollectionTreeEntriesMovedOrRemoved::class);
     }
 }

--- a/tests/StaticCaching/InvalidateTest.php
+++ b/tests/StaticCaching/InvalidateTest.php
@@ -60,7 +60,7 @@ class InvalidateTest extends TestCase
 
         $invalidate = new Invalidate($invalidator);
 
-        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
+        $invalidate->invalidateMovedOrRemovedEntries($event);
     }
 
     #[Test]
@@ -84,7 +84,7 @@ class InvalidateTest extends TestCase
 
         $invalidate = new Invalidate($invalidator);
 
-        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
+        $invalidate->invalidateMovedOrRemovedEntries($event);
     }
 
     #[Test]
@@ -104,7 +104,7 @@ class InvalidateTest extends TestCase
 
         $invalidate = new Invalidate($invalidator);
 
-        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
+        $invalidate->invalidateMovedOrRemovedEntries($event);
     }
 
     #[Test]
@@ -126,6 +126,6 @@ class InvalidateTest extends TestCase
 
         $invalidate = new Invalidate($invalidator);
 
-        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
+        $invalidate->invalidateMovedOrRemovedEntries($event);
     }
 }

--- a/tests/StaticCaching/InvalidateTest.php
+++ b/tests/StaticCaching/InvalidateTest.php
@@ -9,6 +9,7 @@ use Statamic\Events\BlueprintSaved;
 use Statamic\Events\CollectionTreeEntriesMovedOrRemoved;
 use Statamic\Facades\Entry as EntryFacade;
 use Statamic\Facades\Form;
+use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\Invalidate;
 use Statamic\StaticCaching\Invalidator;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -29,27 +30,35 @@ class InvalidateTest extends TestCase
             return $form->handle() === 'contact';
         })->getMock();
 
-        $invalidate = new Invalidate($invalidator);
+        $invalidate = new Invalidate($invalidator, Mockery::mock(Cacher::class));
 
         $invalidate->invalidateByBlueprint($event);
+    }
+
+    private function mockEntry(string $url): Entry
+    {
+        $entry = Mockery::mock(Entry::class);
+        $entry->shouldReceive('descendants')->andReturn(collect());
+        $entry->shouldReceive('isRedirect')->andReturn(false);
+        $entry->shouldReceive('absoluteUrl')->andReturn($url);
+
+        return $entry;
     }
 
     #[Test]
     public function it_invalidates_removed_entries_when_collection_tree_is_saving()
     {
-        $entry1 = Mockery::mock(Entry::class);
-        $entry2 = Mockery::mock(Entry::class);
-
-        EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($entry1);
-        EntryFacade::shouldReceive('find')->with('entry-2')->andReturn($entry2);
+        EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($this->mockEntry('http://example.com/entry-1'));
+        EntryFacade::shouldReceive('find')->with('entry-2')->andReturn($this->mockEntry('http://example.com/entry-2'));
 
         $event = new CollectionTreeEntriesMovedOrRemoved(removed: ['entry-1', 'entry-2'], moved: []);
 
-        $invalidator = Mockery::mock(Invalidator::class);
-        $invalidator->shouldReceive('invalidate')->with($entry1)->once();
-        $invalidator->shouldReceive('invalidate')->with($entry2)->once();
+        $cacher = Mockery::mock(Cacher::class);
+        $cacher->shouldReceive('invalidateUrls')
+            ->with(['http://example.com/entry-1', 'http://example.com/entry-2'])
+            ->once();
 
-        $invalidate = new Invalidate($invalidator);
+        $invalidate = new Invalidate(Mockery::mock(Invalidator::class), $cacher);
 
         $invalidate->invalidateMovedOrRemovedEntries($event);
     }
@@ -57,16 +66,16 @@ class InvalidateTest extends TestCase
     #[Test]
     public function it_invalidates_entries_with_changed_ancestry_when_collection_tree_is_saving()
     {
-        $entry = Mockery::mock(Entry::class);
-
-        EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($entry);
+        EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($this->mockEntry('http://example.com/entry-1'));
 
         $event = new CollectionTreeEntriesMovedOrRemoved(removed: [], moved: ['entry-1']);
 
-        $invalidator = Mockery::mock(Invalidator::class);
-        $invalidator->shouldReceive('invalidate')->with($entry)->once();
+        $cacher = Mockery::mock(Cacher::class);
+        $cacher->shouldReceive('invalidateUrls')
+            ->with(['http://example.com/entry-1'])
+            ->once();
 
-        $invalidate = new Invalidate($invalidator);
+        $invalidate = new Invalidate(Mockery::mock(Invalidator::class), $cacher);
 
         $invalidate->invalidateMovedOrRemovedEntries($event);
     }
@@ -76,10 +85,10 @@ class InvalidateTest extends TestCase
     {
         $event = new CollectionTreeEntriesMovedOrRemoved(removed: [], moved: []);
 
-        $invalidator = Mockery::mock(Invalidator::class);
-        $invalidator->shouldNotReceive('invalidate');
+        $cacher = Mockery::mock(Cacher::class);
+        $cacher->shouldNotReceive('invalidateUrls');
 
-        $invalidate = new Invalidate($invalidator);
+        $invalidate = new Invalidate(Mockery::mock(Invalidator::class), $cacher);
 
         $invalidate->invalidateMovedOrRemovedEntries($event);
     }
@@ -91,10 +100,10 @@ class InvalidateTest extends TestCase
 
         $event = new CollectionTreeEntriesMovedOrRemoved(removed: ['missing-entry'], moved: []);
 
-        $invalidator = Mockery::mock(Invalidator::class);
-        $invalidator->shouldNotReceive('invalidate');
+        $cacher = Mockery::mock(Cacher::class);
+        $cacher->shouldNotReceive('invalidateUrls');
 
-        $invalidate = new Invalidate($invalidator);
+        $invalidate = new Invalidate(Mockery::mock(Invalidator::class), $cacher);
 
         $invalidate->invalidateMovedOrRemovedEntries($event);
     }

--- a/tests/StaticCaching/InvalidateTest.php
+++ b/tests/StaticCaching/InvalidateTest.php
@@ -4,10 +4,15 @@ namespace Tests\StaticCaching;
 
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Entries\Entry;
 use Statamic\Events\BlueprintSaved;
+use Statamic\Events\CollectionTreeSaving;
+use Statamic\Facades\Entry as EntryFacade;
 use Statamic\Facades\Form;
 use Statamic\StaticCaching\Invalidate;
 use Statamic\StaticCaching\Invalidator;
+use Statamic\Structures\CollectionTree;
+use Statamic\Structures\CollectionTreeDiff;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -29,5 +34,98 @@ class InvalidateTest extends TestCase
         $invalidate = new Invalidate($invalidator);
 
         $invalidate->invalidateByBlueprint($event);
+    }
+
+    #[Test]
+    public function it_invalidates_removed_entries_when_collection_tree_is_saving()
+    {
+        $entry1 = Mockery::mock(Entry::class);
+        $entry2 = Mockery::mock(Entry::class);
+
+        EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($entry1);
+        EntryFacade::shouldReceive('find')->with('entry-2')->andReturn($entry2);
+
+        $diff = Mockery::mock(CollectionTreeDiff::class);
+        $diff->shouldReceive('removed')->andReturn(['entry-1', 'entry-2']);
+        $diff->shouldReceive('ancestryChanged')->andReturn([]);
+
+        $tree = Mockery::mock(CollectionTree::class);
+        $tree->shouldReceive('diff')->andReturn($diff);
+
+        $event = new CollectionTreeSaving($tree);
+
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldReceive('invalidate')->with($entry1)->once();
+        $invalidator->shouldReceive('invalidate')->with($entry2)->once();
+
+        $invalidate = new Invalidate($invalidator);
+
+        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
+    }
+
+    #[Test]
+    public function it_invalidates_entries_with_changed_ancestry_when_collection_tree_is_saving()
+    {
+        $entry = Mockery::mock(Entry::class);
+
+        EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($entry);
+
+        $diff = Mockery::mock(CollectionTreeDiff::class);
+        $diff->shouldReceive('removed')->andReturn([]);
+        $diff->shouldReceive('ancestryChanged')->andReturn(['entry-1']);
+
+        $tree = Mockery::mock(CollectionTree::class);
+        $tree->shouldReceive('diff')->andReturn($diff);
+
+        $event = new CollectionTreeSaving($tree);
+
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldReceive('invalidate')->with($entry)->once();
+
+        $invalidate = new Invalidate($invalidator);
+
+        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
+    }
+
+    #[Test]
+    public function it_does_not_invalidate_entries_only_reordered_within_same_parent_when_collection_tree_is_saving()
+    {
+        $diff = Mockery::mock(CollectionTreeDiff::class);
+        $diff->shouldReceive('removed')->andReturn([]);
+        $diff->shouldReceive('ancestryChanged')->andReturn([]);
+
+        $tree = Mockery::mock(CollectionTree::class);
+        $tree->shouldReceive('diff')->andReturn($diff);
+
+        $event = new CollectionTreeSaving($tree);
+
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldNotReceive('invalidate');
+
+        $invalidate = new Invalidate($invalidator);
+
+        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
+    }
+
+    #[Test]
+    public function it_skips_entries_that_cannot_be_found_when_collection_tree_is_saving()
+    {
+        EntryFacade::shouldReceive('find')->with('missing-entry')->andReturn(null);
+
+        $diff = Mockery::mock(CollectionTreeDiff::class);
+        $diff->shouldReceive('removed')->andReturn(['missing-entry']);
+        $diff->shouldReceive('ancestryChanged')->andReturn([]);
+
+        $tree = Mockery::mock(CollectionTree::class);
+        $tree->shouldReceive('diff')->andReturn($diff);
+
+        $event = new CollectionTreeSaving($tree);
+
+        $invalidator = Mockery::mock(Invalidator::class);
+        $invalidator->shouldNotReceive('invalidate');
+
+        $invalidate = new Invalidate($invalidator);
+
+        $invalidate->invalidateMovedOrRemovedCollectionEntries($event);
     }
 }

--- a/tests/StaticCaching/InvalidateTest.php
+++ b/tests/StaticCaching/InvalidateTest.php
@@ -6,13 +6,11 @@ use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Events\BlueprintSaved;
-use Statamic\Events\CollectionTreeSaving;
+use Statamic\Events\CollectionTreeEntriesMovedOrRemoved;
 use Statamic\Facades\Entry as EntryFacade;
 use Statamic\Facades\Form;
 use Statamic\StaticCaching\Invalidate;
 use Statamic\StaticCaching\Invalidator;
-use Statamic\Structures\CollectionTree;
-use Statamic\Structures\CollectionTreeDiff;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -45,14 +43,7 @@ class InvalidateTest extends TestCase
         EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($entry1);
         EntryFacade::shouldReceive('find')->with('entry-2')->andReturn($entry2);
 
-        $diff = Mockery::mock(CollectionTreeDiff::class);
-        $diff->shouldReceive('removed')->andReturn(['entry-1', 'entry-2']);
-        $diff->shouldReceive('ancestryChanged')->andReturn([]);
-
-        $tree = Mockery::mock(CollectionTree::class);
-        $tree->shouldReceive('diff')->andReturn($diff);
-
-        $event = new CollectionTreeSaving($tree);
+        $event = new CollectionTreeEntriesMovedOrRemoved(removed: ['entry-1', 'entry-2'], moved: []);
 
         $invalidator = Mockery::mock(Invalidator::class);
         $invalidator->shouldReceive('invalidate')->with($entry1)->once();
@@ -70,14 +61,7 @@ class InvalidateTest extends TestCase
 
         EntryFacade::shouldReceive('find')->with('entry-1')->andReturn($entry);
 
-        $diff = Mockery::mock(CollectionTreeDiff::class);
-        $diff->shouldReceive('removed')->andReturn([]);
-        $diff->shouldReceive('ancestryChanged')->andReturn(['entry-1']);
-
-        $tree = Mockery::mock(CollectionTree::class);
-        $tree->shouldReceive('diff')->andReturn($diff);
-
-        $event = new CollectionTreeSaving($tree);
+        $event = new CollectionTreeEntriesMovedOrRemoved(removed: [], moved: ['entry-1']);
 
         $invalidator = Mockery::mock(Invalidator::class);
         $invalidator->shouldReceive('invalidate')->with($entry)->once();
@@ -90,14 +74,7 @@ class InvalidateTest extends TestCase
     #[Test]
     public function it_does_not_invalidate_entries_only_reordered_within_same_parent_when_collection_tree_is_saving()
     {
-        $diff = Mockery::mock(CollectionTreeDiff::class);
-        $diff->shouldReceive('removed')->andReturn([]);
-        $diff->shouldReceive('ancestryChanged')->andReturn([]);
-
-        $tree = Mockery::mock(CollectionTree::class);
-        $tree->shouldReceive('diff')->andReturn($diff);
-
-        $event = new CollectionTreeSaving($tree);
+        $event = new CollectionTreeEntriesMovedOrRemoved(removed: [], moved: []);
 
         $invalidator = Mockery::mock(Invalidator::class);
         $invalidator->shouldNotReceive('invalidate');
@@ -112,14 +89,7 @@ class InvalidateTest extends TestCase
     {
         EntryFacade::shouldReceive('find')->with('missing-entry')->andReturn(null);
 
-        $diff = Mockery::mock(CollectionTreeDiff::class);
-        $diff->shouldReceive('removed')->andReturn(['missing-entry']);
-        $diff->shouldReceive('ancestryChanged')->andReturn([]);
-
-        $tree = Mockery::mock(CollectionTree::class);
-        $tree->shouldReceive('diff')->andReturn($diff);
-
-        $event = new CollectionTreeSaving($tree);
+        $event = new CollectionTreeEntriesMovedOrRemoved(removed: ['missing-entry'], moved: []);
 
         $invalidator = Mockery::mock(Invalidator::class);
         $invalidator->shouldNotReceive('invalidate');


### PR DESCRIPTION
The Invalidate subscriber only listened to CollectionTreeSaved, which fires after the tree has been persisted. At this point, we no longer have access to the old entry urls.
                                                                                                                                                                                                                                               
So this PR adds a listener to CollectionTreeSaving to invalidate any entry whose position is changing:                                                                                                            
- removed() — entries removed from the tree (their current URL is about to become stale)                                                                                                                                               
- ancestryChanged() — entries moved to a different parent (their URL is about to change, including all descendants via getEntryUrls)                                                                                                   
                                                                                                                                                                                                                                               
Entries that are only reordered within the same parent (moved() but not ancestryChanged()) are correctly left alone since their URL doesn't change.   

Closes #9531