### PR TITLE
[6.x] Implement whereStatus() on search query builder

### DIFF
--- a/src/Search/QueryBuilder.php
+++ b/src/Search/QueryBuilder.php
@@ -87,6 +87,11 @@ abstract class QueryBuilder extends BaseQueryBuilder
         return new DataCollection($items);
     }
 
+    public function whereStatus(string $status)
+    {
+        return $this->where('status', $status);
+    }
+
     public function getTableNameForFakeQuery()
     {
         return 'search_'.$this->index->name();

--- a/tests/Search/QueryBuilderTest.php
+++ b/tests/Search/QueryBuilderTest.php
@@ -659,6 +659,27 @@ class QueryBuilderTest extends TestCase
             'Smeagol\'s Precious',
         ], $query->where('type', 'b')->pluck('title')->all());
     }
+
+    #[Test]
+    public function results_are_found_using_where_status()
+    {
+        $items = collect([
+            ['reference' => 'a', 'status' => 'published'],
+            ['reference' => 'b', 'status' => 'draft'],
+            ['reference' => 'c', 'status' => 'published'],
+            ['reference' => 'd', 'status' => 'scheduled'],
+        ]);
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->whereStatus('published')->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals(['a', 'c'], $results->map->reference->all());
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->whereStatus('draft')->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals(['b'], $results->map->reference->all());
+    }
 }
 
 class FakeQueryBuilder extends QueryBuilder


### PR DESCRIPTION
This PR adds whereStatus(string $status) to src/Search/QueryBuilder.php, which calls $this->where('status', $status). This works because:  
                                                                                                  
1. The IteratorBuilder's filterWhereBasic() calls ResolveValue on each result                                                                                                                                                                
2. ResolveValue detects that Result implements ContainsQueryableValues and calls getQueryableValue('status')                                                                                                                                 
3. Result::getQueryableValue('status') (already implemented at Result.php:90) calls $this->searchable->status()       
 
Closes https://github.com/statamic/cms/issues/11751