### PR TITLE
[5.x] Add `create_blueprints` config to entries fieldtype

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -330,6 +330,12 @@ class Entries extends Relationship
 
             $blueprints = $collection->entryBlueprints();
 
+            if ($createBlueprints = $this->config('create_blueprints')) {
+                $blueprints = $blueprints->filter(
+                    fn ($blueprint) => in_array($blueprint->handle(), $createBlueprints)
+                );
+            }
+
             return $blueprints
                 ->reject->hidden()
                 ->map(function ($blueprint) use ($collection, $collections, $blueprints) {

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -2,12 +2,16 @@
 
 namespace Tests\Feature\Fieldtypes;
 
+use Facades\Statamic\Fields\BlueprintRepository;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Entries;
 use Statamic\Query\Scopes\Scope;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -186,6 +190,41 @@ class RelationshipFieldtypeTest extends TestCase
             ->actingAs($user)
             ->getJson("/cp/fieldtypes/relationship?config={$config}")
             ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_filters_creatable_blueprints_using_create_blueprints_config()
+    {
+        $article = Blueprint::makeFromFields([])->setHandle('article')->setNamespace('collections.test');
+        $page = Blueprint::makeFromFields([])->setHandle('page')->setNamespace('collections.test');
+
+        BlueprintRepository::partialMock();
+        BlueprintRepository::shouldReceive('in')->with('collections/test')->andReturn(collect([
+            'article' => $article,
+            'page' => $page,
+        ]));
+
+        $this->setTestRoles(['test' => ['access cp', 'view test entries', 'create test entries']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this->actingAs($user);
+
+        $fieldtype = $this->entriesFieldtype([
+            'collections' => ['test'],
+            'create_blueprints' => ['article'],
+        ]);
+
+        $creatables = $fieldtype->preload()['creatables'];
+
+        $this->assertCount(1, $creatables);
+        $this->assertStringContainsString('blueprint=article', $creatables[0]['url']);
+    }
+
+    private function entriesFieldtype($config = [])
+    {
+        $field = new Field('test', array_merge(['type' => 'entries'], $config));
+
+        return (new Entries)->setField($field);
     }
 }
 


### PR DESCRIPTION
This adds a `create_blueprints` config option to the entries fieldtype, allowing you to restrict which blueprints appear in the "Create & Link" dropdown.

This is the creation-side counterpart to the `blueprints` config added in #7047, which filters the selection list. It follows the same approach: a YAML-only config, not exposed in the CP field configurator, consistent with how `blueprints` was introduced.

### Usage

```yaml
related_entries:
  type: entries
  collections:
    - pages
  blueprints:          # filters selection list (existing, #7047)
    - article
    - page
  create_blueprints:   # filters creation dropdown (new)
    - article
```
