### PR TITLE
[6.x] Emit event from `bustAndReloadImageCaches` callback

### DIFF
--- a/resources/js/bootstrap/App.vue
+++ b/resources/js/bootstrap/App.vue
@@ -52,6 +52,8 @@ export default {
                     img.src = url;
                 });
             }
+
+            Statamic.$events.emit('bustAndReloadImageCaches', urls);
         });
 
         Statamic.$callbacks.add('removeFromSelections', function (ids) {


### PR DESCRIPTION
This pull request emits an event from the `bustAndReloadImageCaches` callback (used when cropping or re-uploading assets).

The event allows addon developers to hook in and bust any caches they might have (eg. via Glide URLs).