### PR TITLE
[5.x] Add ability to exclude queries from graphql cache

### DIFF
--- a/config/graphql.php
+++ b/config/graphql.php
@@ -86,6 +86,7 @@ return [
 
     'cache' => [
         'expiry' => 60,
+        'exclude' => [],
     ],
 
 ];

--- a/src/GraphQL/ResponseCache/DefaultCache.php
+++ b/src/GraphQL/ResponseCache/DefaultCache.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\GraphQL\ResponseCache;
 
+use GraphQL\Language\AST\FieldNode;
+use GraphQL\Language\Parser;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
@@ -12,6 +14,10 @@ class DefaultCache implements ResponseCache
 {
     public function get(Request $request)
     {
+        if ($this->shouldBypassCache($request->input('query'))) {
+            return null;
+        }
+
         return Cache::get($this->getCacheKey($request));
     }
 
@@ -65,5 +71,50 @@ class DefaultCache implements ResponseCache
         });
 
         Cache::forget($this->getTrackingKey());
+    }
+
+    public function shouldBypassCache(string $query): bool
+    {
+        $excludedQueries = config('statamic.graphql.cache.exclude', []);
+        if (!$excludedQueries) {
+            return false;
+        }
+
+        $ast = Parser::parse($query);
+
+        foreach ($ast->definitions as $definition) {
+            if (!isset($definition->selectionSet)) {
+                continue;
+            }
+
+            foreach (array_keys($excludedQueries) as $excludedQuery) {
+                foreach ($definition->selectionSet->selections as $selection) {
+                    if ($this->containsFieldRecursive($selection, $excludedQuery)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private function containsFieldRecursive($node, string $fieldName): bool
+    {
+        if ($node instanceof FieldNode) {
+            if ($node->name->value === $fieldName) {
+                return true;
+            }
+
+            if ($node->selectionSet) {
+                foreach ($node->selectionSet->selections as $selection) {
+                    if ($this->containsFieldRecursive($selection, $fieldName)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
This PR provides introduces a new option to exclude certain queries from the GraphQL cache. This can be handy if you need to ensure certain data needs to be retrieved in real-time, while keeping the other responses cached.

Note: I'll try to add a test soon too!