### PR TITLE
[6.x] Emit `asset.saved` event from asset editor

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -459,6 +459,7 @@ export default {
                     this.saving = false;
                     this.clearErrors();
                     this.$nextTick(() => this.$refs.container.clearDirtyState());
+                    Statamic.$events.$emit('asset.saved', this.asset);
                 })
                 .catch((e) => {
                     this.saving = false;


### PR DESCRIPTION
This pull request makes the asset editor emit an `asset.saved` event after saving.

Planning to use this SEO Pro to ensure preview images are hard-reloaded when an asset's focal point is updated.