### PR TITLE
[6.x] Fix nested Bard toolbar focus issues

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardButtonsSettingFieldtype.vue
@@ -6,6 +6,7 @@
                 :key="button.name"
                 v-tooltip="button.text"
                 :class="{ active: enabled(button.name) }"
+                @mousedown.prevent
                 @click="toggleButton(button.name)"
             >
                 <ui-icon :name="button.svg" v-if="button.svg" />

--- a/resources/js/components/fieldtypes/bard/Image.vue
+++ b/resources/js/components/fieldtypes/bard/Image.vue
@@ -14,12 +14,12 @@
             <div
                 class="flex flex-wrap items-center justify-center gap-2 border-t px-2 py-2 text-center text-2xs text-white @container/toolbar dark:border-gray-900 dark:text-gray-300"
             >
-                <Button v-if="!src" size="sm" icon="folder-photos" :text="__('Choose Image')" @click="openSelector" />
+                <Button v-if="!src" size="sm" icon="folder-photos" :text="__('Choose Image')" @mousedown.prevent @click="openSelector" />
 
-                <Button v-if="src" size="sm" icon="edit" :text="__('Edit Image')" @click="edit" />
-                <Button v-if="src" size="sm" icon="rename" :text="__('Override Alt')" :class="{ active: showingAltEdit }" @click="toggleAltEditor" />
-                <Button v-if="src" size="sm" icon="replace" :text="__('Replace')" @click="openSelector" />
-                <Button v-if="src" size="sm" icon="trash" :text="__('Remove')" @click="deleteNode" />
+                <Button v-if="src" size="sm" icon="edit" :text="__('Edit Image')" @mousedown.prevent @click="edit" />
+                <Button v-if="src" size="sm" icon="rename" :text="__('Override Alt')" :class="{ active: showingAltEdit }" @mousedown.prevent @click="toggleAltEditor" />
+                <Button v-if="src" size="sm" icon="replace" :text="__('Replace')" @mousedown.prevent @click="openSelector" />
+                <Button v-if="src" size="sm" icon="trash" :text="__('Remove')" @mousedown.prevent @click="deleteNode" />
             </div>
 
             <div

--- a/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbarButton.vue
@@ -14,6 +14,7 @@
                 size="sm"
                 :aria-label="button.text"
                 v-tooltip="button.text"
+                @mousedown.prevent
             >
                 <ui-icon :name="button.svg" v-if="button.svg" class="size-4" />
                 <div class="flex items-center" v-html="button.html" v-if="button.html" />

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -51,7 +51,7 @@
 
                     <Dropdown>
                         <template #trigger>
-                            <Button icon="dots" variant="ghost" size="xs" :aria-label="__('Open dropdown menu')" />
+                            <Button icon="dots" variant="ghost" size="xs" :aria-label="__('Open dropdown menu')" @mousedown.prevent />
                         </template>
                         <DropdownMenu>
                             <DropdownItem

--- a/resources/js/components/fieldtypes/bard/ToolbarButton.vue
+++ b/resources/js/components/fieldtypes/bard/ToolbarButton.vue
@@ -6,6 +6,7 @@
         size="sm"
         :aria-label="button.text"
         v-tooltip="button.text"
+        @mousedown.prevent
         @click="button.command(editor, button.args)"
     >
         <ui-icon :name="button.svg" v-if="button.svg" class="size-3.5! " :class="{ 'group-hover:text-white text-yellow-300!': active && variant === 'floating' }" />


### PR DESCRIPTION
## Description of the Problem

- If you interact with the toolbar with a nested Bard field once the toolbar is "stuck", the field focus is very briefly lost
- In Safari, clicking a toolbar button can move focus away from the active nested Bard editor before the command runs.
  - Chrome correctly re-focuses back on the Bard field but in Safari it doesn't
  - This is documented in #14374 

Here's an example:

https://github.com/user-attachments/assets/86765881-44ee-4cb4-ac41-f86019bda0ae

## What this PR Does

- Prevents default on mousedown, which preserves the current selection/focus target, so commands apply to the correct sub-Bard instance.
- An upside of this is that you don't see the current behaviour of the focus outline flickering when interacting with the Bard toolbar.
- Closes #14374 

After fix:

https://github.com/user-attachments/assets/a85c099b-186f-4053-9efa-f16189750be2

## How to Reproduce

Add a Bard field within a Bard field

Here's a blueprint demo:

```
title: 'Test Blueprint'
tabs:
  main:
    display: Hauptbereich
    sections:
      -
        fields:
          -
            handle: title
            field:
              type: text
              required: true
              localizable: false
              validate:
                - required
          -
            handle: content
            field:
              container: assets
              remove_empty_nodes: false
              type: bard
              display: Content
              localizable: false
              sets:
                bardmodule:
                  display: Bard-Module
                  sets:
                    neues_set:
                      display: 'New Set'
                      fields:
                        -
                          handle: bardsubfield
                          field:
                            container: assets
                            remove_empty_nodes: false
                            type: bard
                            display: bardsubfield
                            localizable: false
  sidebar:
    display: Sidebar
    sections:
      -
        fields:
          -
            handle: slug
            field:
              type: slug
              localizable: true
              validate: 'max:200'
          -
            handle: date
            field:
              type: date
              required: true
              default: now
              localizable: false
              validate:
                - required
```