### PR TITLE
[6.x] Fix address bar overlapping bottom of content (typically on iOS)

### DIFF
--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -85,7 +85,7 @@ onUnmounted(() => {
             <div id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
                 <div id="content-card" tabindex="-1" class="focus:outline-none relative content-card grid min-h-full mx-auto">
                     <!-- Data attribute used by the CSS style tag below to override max-width when disabled.-->
-                    <div class="w-full min-w-0 mx-auto max-w-page" data-max-width-wrapper>
+                    <div class="w-full min-w-0 mx-auto max-w-page max-[1220px]:mb-18" data-max-width-wrapper>
                         <slot />
                     </div>
                 </div>


### PR DESCRIPTION
## Description of the Problem

Safari's iOS address bar overlaps the bottom of the page as reported in #14395.
<img src="https://github.com/user-attachments/assets/ffbcc317-f8f1-4906-acc3-1aff42daec3c" width="30%">

Usually we could remedy this by accounting for the address bar UI, using an `lvh` unit, but the problem here is `.content-card` is inside a full-height wrapper, so that won't work.

## What this PR Does

To remedy this, we could either make the `.main-content` wrapper artificially taller, or the `.content-card` artificially taller to account for possible extra UI.

I've made the `.content-card` taller at smaller breakpoints because I think this is subtler—before the sidebar is floated.

## How to Reproduce

1. Scroll down to the bottom of a page on iOS, where the container contents do not account for the address bar UI