### PR TITLE
[6.x] Fix conditional field borders

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -2,8 +2,8 @@
 =================================================== */
 /* Here we extend Tailwind's classes to add additional functionality where we're sure it won't break anything. */
 
-/* If the next sibling is hidden (by a Vue conditional), remove the bottom border. For example, /cp/asset-containers/assets/edit, the Image Manipulation toggle. */
-.divide-y > *:has(+[style*="display: none"]:last-child) {
+/* If all the next siblings are hidden (by a Vue conditional), remove the bottom border. For example, /cp/asset-containers/assets/edit, the Image Manipulation toggle. */
+.divide-y > *:not(:has(~ :not([style*="display: none"]))) {
     border-block-end: none;
 }
 


### PR DESCRIPTION
This PR improves (and aims to finally resolve) the conditional field border issue partially addressed in #13098.

The current implementation fails when multiple hidden sibling elements are present. In such cases, the border is not correctly removed.

This change ensures that the border is removed whenever a field has no visible (non-hidden) siblings, effectively treating it as the last visible child. The proposed selector accounts for this scenario and corrects the edge case.