### PR TITLE
[6.x] Fix nav section border radius

### DIFF
--- a/resources/css/components/page-tree.css
+++ b/resources/css/components/page-tree.css
@@ -40,6 +40,11 @@
     .tree-node:has(.page-tree-branch--has-children):has(.is-open) + .tree-node .page-tree-branch {
         border-top-left-radius: 0;
     }
+
+    /* A section node followed by another section node should always have a rounded border. E.g. Tools + Settings */
+    .tree-node:has(.is-section) + .tree-node:has(.is-section) .page-tree-branch {
+        @apply rounded-xl;
+    }
 }
 
 /* GROUP PAGE TREE / NAV BUILDER

--- a/resources/css/components/page-tree.css
+++ b/resources/css/components/page-tree.css
@@ -38,7 +38,7 @@
     .tree-node:has(.is-section) + .tree-node .page-tree-branch,
     /* 3rd level down */
     .tree-node:has(.page-tree-branch--has-children):has(.is-open) + .tree-node .page-tree-branch {
-        border-top-left-radius: 0;
+        border-start-start-radius: 0;
     }
 
     /* A section node followed by another section node should always have a rounded border. E.g. Tools + Settings */


### PR DESCRIPTION
## Description of the Problem

Adjacent section nodes would erroneously have their top border-radius chopped off.
This happened because we didn't account for single-parent sections.

## What this PR Does

- Enforces a border radius for section nodes followed by section nodes
- Fixed a logical property while I was here
- Closes #14406

## How to Reproduce

1. Add a few isolated sections like this

### Before

![2026-04-01 at 10 24 08@2x](https://github.com/user-attachments/assets/d1fdf794-cf69-415d-8b4d-d948ee405a6a)

### After

![2026-04-01 at 10 23 50@2x](https://github.com/user-attachments/assets/fcf0aacb-03d9-4e8e-8032-00ce7639c437)
