### PR TITLE
[6.x] Improve error handling when requiring starter kits

### DIFF
--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -244,8 +244,10 @@ final class Installer
      */
     protected function requireStarterKit(): self
     {
+        $error = null;
+
         spin(
-            function () {
+            function () use (&$error) {
                 $version = $this->branch;
 
                 // Allow dev stability when installing from VCS repo without tagged releases
@@ -265,11 +267,15 @@ final class Installer
                 try {
                     Composer::withoutQueue()->throwOnFailure()->require($package);
                 } catch (ProcessException $exception) {
-                    $this->rollbackWithError("Error installing starter kit [{$this->package}].", $exception->getMessage());
+                    $error = $exception;
                 }
             },
             "Preparing starter kit [{$this->package}]..."
         );
+
+        if ($error) {
+            $this->rollbackWithError("Error installing starter kit [{$this->package}].", $error->getMessage());
+        }
 
         return $this;
     }


### PR DESCRIPTION
This pull request fixes an issue where installing a starter kit would continue after encountering a Composer error (eg. a GitHub authentication failure).

<img width="622" height="489" alt="CleanShot 2026-04-01 at 10 50 26" src="https://github.com/user-attachments/assets/9bf1da5d-58f2-4729-bc17-5957e239c0b5" />

<p></p>

This was happening because `rollbackWithError()` was being called inside a `spin()` callback. When `rollbackWithError()` executes cleanup, it calls `removeStarterKit()` which contains its own nested `spin()` call. This nested spinner situation was interfering with exception propagation, causing the `StarterKitException` to not properly bubble up.

This PR fixes it by capturing the `ProcessException` in a variable inside the `spin()` callback, then calling `rollbackWithError()` after the spinner completes. This ensures the exception is thrown in a clean context without nested spinners, allowing it to properly propagate and stop the installation.
