### PR TITLE
[6.x] Fix collection listing dates from wrapping

### DIFF
--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -90,7 +90,7 @@
                                         </div>
                                     </template>
                                     <template #cell-date="{ row: entry }" v-if="collection.dated">
-                                        <div class="text-end font-mono text-xs text-gray-500 ps-6">
+                                        <div class="text-end font-mono text-xs text-gray-500 ps-6 whitespace-nowrap">
                                             <date-time :of="entry.date.date" date-only />
                                         </div>
                                     </template>

--- a/resources/js/components/collections/Listing.vue
+++ b/resources/js/components/collections/Listing.vue
@@ -105,7 +105,7 @@
                     </div>
                 </ui-card>
 
-                <ui-panel-footer v-if="collection.available_in_selected_site" class="flex items-center gap-6 text-sm text-gray-600 dark:text-gray-400">
+                <ui-panel-footer v-if="collection.available_in_selected_site" class="flex items-center gap-6 gap-y-1.5 text-sm text-gray-600 dark:text-gray-400">
                     <div class="flex items-center gap-1.5">
                         <ui-badge :text="String(collection.published_entries_count)" pill class="bg-white! dark:bg-gray-700! [&_span]:st-text-trim-cap" />
                         <span>{{ __('Published') }}</span>

--- a/resources/js/components/ui/Panel/Footer.vue
+++ b/resources/js/components/ui/Panel/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-    <footer class="px-4.5 pt-2.5 md:pt-3 pb-1.5 antialiased" data-ui-panel-footer>
+    <footer class="flex-wrap px-4.5 pt-2.5 md:pt-3 pb-1.5 antialiased" data-ui-panel-footer>
         <slot />
     </footer>
 </template>


### PR DESCRIPTION
## Description of the Problem

When dates are in a format such as `dd–mm–yyyy` we need to prevent wrapping `–` otherwise the collection index looks funky, as per #14398

## What this PR Does

- Prevent wrapping for the collection index
- Closes #14398 

### Date Before

(Articles collection)

![2026-04-01 at 14 29 52@2x](https://github.com/user-attachments/assets/4dc1d38f-9381-4abf-b643-fd7f9f6e9416)

### Date After

![2026-04-01 at 14 30 20@2x](https://github.com/user-attachments/assets/63c8a8a8-0cb1-4a55-918e-8a02095db9e8)

- Fix a badge overflow problem

### Badge Overflow Before

![2026-04-01 at 14 30 59@2x](https://github.com/user-attachments/assets/190c9693-4425-4209-91a2-469f3caa2c26)

### Badge Overflow After

![2026-04-01 at 14 35 37@2x](https://github.com/user-attachments/assets/aa686573-0dc9-410c-a72b-75bf14f8b492)

## How to Reproduce

1. Go to `/cp/collections` and switch to the grid view
2. Change your language preferences to include en dashes in the date format (in macOS it's System Preferences > General > Language and Region > Date format)
3. You might need to restart your browser