### PR TITLE
[6.x] Add serializable classes to allowlist

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -717,6 +717,20 @@ abstract class AddonServiceProvider extends ServiceProvider
         Statamic::externalStyle($url);
     }
 
+    protected function registerSerializableClasses(array $classes)
+    {
+        $existing = $this->app['config']->get('cache.serializable_classes');
+
+        if ($existing === true) {
+            return;
+        }
+
+        $this->app['config']->set('cache.serializable_classes', array_merge(
+            is_array($existing) ? $existing : [],
+            $classes
+        ));
+    }
+
     protected function schedule(Schedule $schedule)
     {
         //

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -259,6 +259,7 @@ class AppServiceProvider extends ServiceProvider
             \Statamic\Taxonomies\Taxonomy::class,
             \Statamic\Taxonomies\LocalizedTerm::class,
             \Statamic\Taxonomies\Term::class,
+            \Illuminate\Support\Carbon::class,
             \Illuminate\Support\Collection::class,
         ];
 

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -229,6 +229,40 @@ class AppServiceProvider extends ServiceProvider
                 ->finalNewline(config('statamic.templates.style.final_newline', false))
                 ->preferComponentSyntax(config('statamic.templates.antlers.use_components', false));
         });
+
+        $this->registerSerializableClasses();
+    }
+
+    private function registerSerializableClasses()
+    {
+        $existing = $this->app['config']->get('cache.serializable_classes');
+
+        if ($existing === true) {
+            return;
+        }
+
+        $classes = [
+            \Statamic\Assets\AssetContainer::class,
+            \Statamic\Entries\Collection::class,
+            \Statamic\Entries\Entry::class,
+            \Statamic\Forms\Form::class,
+            \Statamic\Forms\Submission::class,
+            \Statamic\Globals\GlobalSet::class,
+            \Statamic\Globals\Variables::class,
+            \Statamic\Structures\Nav::class,
+            \Statamic\Structures\NavTree::class,
+            \Statamic\Structures\CollectionTree::class,
+            \Statamic\Structures\CollectionStructure::class,
+            \Statamic\Taxonomies\Taxonomy::class,
+            \Statamic\Taxonomies\LocalizedTerm::class,
+            \Statamic\Taxonomies\Term::class,
+            \Illuminate\Support\Collection::class,
+        ];
+
+        $this->app['config']->set('cache.serializable_classes', array_merge(
+            is_array($existing) ? $existing : [],
+            $classes
+        ));
     }
 
     protected function registerMiddlewareGroup()

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -259,6 +259,7 @@ class AppServiceProvider extends ServiceProvider
             \Statamic\Taxonomies\Taxonomy::class,
             \Statamic\Taxonomies\LocalizedTerm::class,
             \Statamic\Taxonomies\Term::class,
+            \Carbon\Carbon::class,
             \Illuminate\Support\Carbon::class,
             \Illuminate\Support\Collection::class,
         ];

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -242,6 +242,8 @@ class AppServiceProvider extends ServiceProvider
         }
 
         $classes = [
+            \Statamic\Auth\File\User::class,
+            \Statamic\Assets\Asset::class,
             \Statamic\Assets\AssetContainer::class,
             \Statamic\Entries\Collection::class,
             \Statamic\Entries\Entry::class,
@@ -249,6 +251,7 @@ class AppServiceProvider extends ServiceProvider
             \Statamic\Forms\Submission::class,
             \Statamic\Globals\GlobalSet::class,
             \Statamic\Globals\Variables::class,
+            \Statamic\Revisions\Revision::class,
             \Statamic\Structures\Nav::class,
             \Statamic\Structures\NavTree::class,
             \Statamic\Structures\CollectionTree::class,

--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -45,7 +45,12 @@ class CacheServiceProvider extends ServiceProvider
 
             Cache::extend('file', function ($app, $config) {
                 return Cache::repository(
-                    (new FileStore($app['files'], $config['path'], $config['permission'] ?? null))
+                    (new FileStore(
+                        $app['files'],
+                        $config['path'],
+                        $config['permission'] ?? null,
+                        $app['config']['cache.serializable_classes'] ?? null
+                    ))
                         ->setLockDirectory($config['lock_path'] ?? null),
                     $config
                 );

--- a/tests/Stache/BasicStoreTest.php
+++ b/tests/Stache/BasicStoreTest.php
@@ -44,6 +44,7 @@ class BasicStoreTest extends TestCase
     public function items_are_different_instances_every_time()
     {
         config(['cache.default' => 'file']); // Doesn't work when they're arrays since the object is stored in memory.
+        config()->set('cache.serializable_classes', [TestBasicStoreItem::class]);
         \Illuminate\Support\Facades\Cache::clear();
 
         file_put_contents($this->tempDir.'/foo.yaml', '');


### PR DESCRIPTION
Laravel recently introduced the `serializable_classes` config to limit which classes with `__destruct`, `__wakeup` methods can be deserialised.

This option is `false` in new Laravel 13 applications, meaning you'll see an error when Statamic attempts to retrieve objects from the cache:

```
The script tried to call a method on an incomplete object. Please ensure that the class definition "Illuminate\Support\Collection" of the object you are trying to operate on was loaded _before_ unserialize() gets called or provide an autoloader to load the class definition
```

This PR fixes it by adding specific classes from Statamic to the allowlist, preventing the error.

Related: https://github.com/laravel/framework/pull/58911