### PR TITLE
[6.x] Prevent npm packages from executing malicious code via `postinstall`

### DIFF
--- a/src/Console/Commands/Concerns/MakesVueComponents.php
+++ b/src/Console/Commands/Concerns/MakesVueComponents.php
@@ -81,7 +81,7 @@ trait MakesVueComponents
 
         $this->files->makeDirectory($addonPath.'/resources/dist', 0777, true, true);
 
-        Process::path(base_path())->run('npm install', function (string $type, string $buffer) {
+        Process::path(base_path())->run('npm install --ignore-scripts', function (string $type, string $buffer) {
             echo $buffer;
         });
 

--- a/src/Console/Commands/SetupCpVite.php
+++ b/src/Console/Commands/SetupCpVite.php
@@ -63,7 +63,7 @@ class SetupCpVite extends Command
 
                 File::put($packageJsonPath, json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
-                return Process::path(base_path())->run('npm install');
+                return Process::path(base_path())->run('npm install --ignore-scripts');
             },
             message: 'Installing dependencies...'
         );

--- a/src/Console/Commands/SetupCpVite.php
+++ b/src/Console/Commands/SetupCpVite.php
@@ -70,7 +70,7 @@ class SetupCpVite extends Command
 
         if ($result->failed()) {
             $this->line($result->errorOutput() ?: $result->output());
-            $this->components->error('Failed to install dependencies. You need to run "npm install" manually.');
+            $this->components->error('Failed to install dependencies. You need to run "npm install --ignore-scripts" manually.');
 
             return $this;
         }

--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -45,7 +45,12 @@ class CacheServiceProvider extends ServiceProvider
 
             Cache::extend('file', function ($app, $config) {
                 return Cache::repository(
-                    (new FileStore($app['files'], $config['path'], $config['permission'] ?? null))
+                    (new FileStore(
+                        $app['files'],
+                        $config['path'],
+                        $config['permission'] ?? null,
+                        $app['config']['cache.serializable_classes'] ?? null
+                    ))
                         ->setLockDirectory($config['lock_path'] ?? null),
                     $config
                 );

--- a/src/Providers/CacheServiceProvider.php
+++ b/src/Providers/CacheServiceProvider.php
@@ -45,12 +45,7 @@ class CacheServiceProvider extends ServiceProvider
 
             Cache::extend('file', function ($app, $config) {
                 return Cache::repository(
-                    (new FileStore(
-                        $app['files'],
-                        $config['path'],
-                        $config['permission'] ?? null,
-                        $app['config']['cache.serializable_classes'] ?? null
-                    ))
+                    (new FileStore($app['files'], $config['path'], $config['permission'] ?? null))
                         ->setLockDirectory($config['lock_path'] ?? null),
                     $config
                 );

--- a/tests/Console/Commands/MakeFieldtypeTest.php
+++ b/tests/Console/Commands/MakeFieldtypeTest.php
@@ -102,7 +102,7 @@ PHP
             ->artisan('statamic:make:fieldtype', ['name' => 'KnightRider'])
             ->expectsQuestion("It doesn't look like Vite is setup for the Control Panel. Would you like to run `php please setup-cp-vite`?", true);
 
-        Process::assertRan('npm install');
+        Process::assertRan('npm install --ignore-scripts');
 
         $this->assertFileExists($fieldtype = base_path('app/Fieldtypes/KnightRider.php'));
         $this->assertStringContainsString('namespace App\Fieldtypes;', $this->files->get($fieldtype));
@@ -167,7 +167,7 @@ PHP
 
         $this->artisan('statamic:make:fieldtype', ['name' => 'Yoda', 'addon' => 'yoda/bag-odah']);
 
-        Process::assertRan('npm install');
+        Process::assertRan('npm install --ignore-scripts');
 
         $this->assertFileExists($fieldtype);
         $this->assertStringContainsString('namespace Yoda\BagOdah\Fieldtypes;', $this->files->get($fieldtype));

--- a/tests/Console/Commands/MakeWidgetTest.php
+++ b/tests/Console/Commands/MakeWidgetTest.php
@@ -111,7 +111,7 @@ PHP
             ->artisan('statamic:make:widget', ['name' => 'Sloth'])
             ->expectsQuestion("It doesn't look like Vite is setup for the Control Panel. Would you like to run `php please setup-cp-vite`?", true);
 
-        Process::assertRan('npm install');
+        Process::assertRan('npm install --ignore-scripts');
 
         $this->assertFileExists($widget);
         $this->assertStringContainsString('namespace App\Widgets;', $this->files->get($widget));

--- a/tests/Console/Commands/SetupCpViteTest.php
+++ b/tests/Console/Commands/SetupCpViteTest.php
@@ -50,7 +50,7 @@ JSON);
             ->artisan('statamic:setup-cp-vite')
             ->expectsOutputToContain('Installed dependencies');
 
-        Process::assertRan('npm install');
+        Process::assertRan('npm install --ignore-scripts');
 
         $this->assertStringContainsString(<<<'JSON'
     "dependencies": {


### PR DESCRIPTION
I noticed that the Laravel team [added this](https://github.com/laravel/installer/pull/489) to `npm install` commands in their installer and thought it'd be a good security measure for us to have too.

`--ignore-scripts` prevents the execution of any lifecycle scripts defined in `package.json` files during package installation. It is a security measure to avoid running potentially malicious code from third-party packages.
