### PR TITLE
[6.x] Fix Parameters make method

### DIFF
--- a/src/Tags/Parameters.php
+++ b/src/Tags/Parameters.php
@@ -8,8 +8,10 @@ use Statamic\Support\Str;
 
 class Parameters extends ArrayAccessor
 {
-    public static function make($items = [], $context = null)
+    public static function make($items = [], ...$args)
     {
+        $context = $args[0] ?? null;
+
         if (! $context) {
             throw new \InvalidArgumentException('A Context object is expected.');
         }


### PR DESCRIPTION
https://github.com/laravel/framework/pull/59455 technically introduced a breaking change but it's not a big deal for us to fix it on our end.

This fixes the following error:

```
Declaration of Statamic\Tags\Parameters::make($items = [], $context = null) must be compatible with Illuminate\Support\Collection::make($items = [], ...$args)
```
