### PR TITLE
[6.x] Add ability to filter Submission exports

### DIFF
--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -48,6 +48,10 @@ export default {
         refresh() {
             this.$refs.listing?.refresh();
         },
+
+        getParameters() {
+            return this.$refs.listing?.getParameters?.() ?? {};
+        },
     },
 };
 </script>

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -670,6 +670,7 @@ provideListingContext({
 defineExpose({
     refresh,
     setFilter,
+    getParameters: () => ({ ...parameters.value }),
 });
 
 watch(parameters, (newParams, oldParams) => {

--- a/resources/js/pages/forms/Layout.vue
+++ b/resources/js/pages/forms/Layout.vue
@@ -1,9 +1,8 @@
 <script setup>
-import { computed } from 'vue';
 import { Link, usePage } from '@inertiajs/vue3';
 
 const page = usePage();
-const form = computed(() => page.props.form);
+const form = page.props.form;
 
 const navItems = [
     { label: __('Edit'), href: cp_url(`forms/${form.value.handle}/fields`) },
@@ -13,7 +12,7 @@ const navItems = [
     { label: __('Configure'), href: cp_url(`forms/${form.value.handle}/edit`) },
 ];
 
-const isActive = (href) => page.url === new URL(href, window.location.origin).pathname;
+const isActive = (href) => page.url.split('?')[0] === href;
 </script>
 
 <template>

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -24,6 +24,7 @@ const deleter = ref(null);
 const generatingFakeSubmission = ref(false);
 const deletingFakeSubmissions = ref(false);
 const submissionListing = ref(null);
+const submissionListingParameters = ref({});
 const exportModalOpen = ref(false);
 const exportingSubmissions = ref(false);
 const exportFormat = ref('');
@@ -64,7 +65,7 @@ const exportScopeOptions = [
 
 const selectedExporter = computed(() => findExporterByFormat(exportFormat.value));
 const hasFilteredScope = computed(() => {
-    const parameters = getSubmissionListingParameters();
+    const parameters = submissionListingParameters.value;
 
     return Boolean(parameters.search || parameters.filters);
 });
@@ -120,6 +121,8 @@ async function deleteFakeSubmissions() {
 }
 
 function openExportModal() {
+    updateSubmissionListingParameters();
+
     const firstAvailableFormat = exportFormats.value[0];
 
     exportFormat.value = firstAvailableFormat?.value ?? '';
@@ -141,13 +144,19 @@ function findExporterByFormat(format) {
 }
 
 function getSubmissionListingParameters() {
-    const parameters = submissionListing.value?.getParameters?.() ?? {};
-
     return {
-        sort: parameters.sort,
-        order: parameters.order,
-        search: parameters.search,
-        filters: parameters.filters,
+        ...submissionListingParameters.value,
+    };
+}
+
+function updateSubmissionListingParameters(parameters = null) {
+    const latestParameters = parameters ?? submissionListing.value?.getParameters?.() ?? {};
+
+    submissionListingParameters.value = {
+        sort: latestParameters.sort,
+        order: latestParameters.order,
+        search: latestParameters.search,
+        filters: latestParameters.filters,
     };
 }
 
@@ -171,6 +180,7 @@ function exportSubmissions() {
     }
 
     exportingSubmissions.value = true;
+    updateSubmissionListingParameters();
 
     const params = exportScope.value === 'filtered' ? getSubmissionListingParameters() : {};
     const exportUrl = appendParamsToUrl(selectedExporter.value.downloadUrl, params);
@@ -307,6 +317,7 @@ function exportSubmissions() {
             sort-direction="desc"
             :columns="columns"
             :filters="filters"
+            @request-completed="({ parameters }) => updateSubmissionListingParameters(parameters)"
         />
 
         <Modal v-model:open="exportModalOpen" :title="__('Export Submissions')" blur class="max-w-xl!">

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -1,8 +1,8 @@
 <script setup>
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import axios from 'axios';
 import Head from '@/pages/layout/Head.vue';
-import { Header, Dropdown, DropdownMenu, DropdownItem, Button, CommandPaletteItem } from '@ui';
+import { Header, Dropdown, DropdownMenu, DropdownItem, Button, CommandPaletteItem, Modal, ModalClose, Radio, RadioGroup } from '@ui';
 import ResourceDeleter from '@/components/ResourceDeleter.vue';
 import FormSubmissionListing from '@/components/forms/SubmissionListing.vue';
 import Layout from '@/pages/layout/Layout.vue';
@@ -24,6 +24,33 @@ const deleter = ref(null);
 const generatingFakeSubmission = ref(false);
 const deletingFakeSubmissions = ref(false);
 const submissionListing = ref(null);
+const exportModalOpen = ref(false);
+const exportingSubmissions = ref(false);
+const exportFormat = ref('csv');
+const exportScope = ref('all');
+
+const exportFormats = [
+    { value: 'csv', label: __('CSV') },
+    { value: 'json', label: __('JSON') },
+];
+
+const exportScopeOptions = [
+    {
+        value: 'all',
+        label: __('All Submissions'),
+    },
+    {
+        value: 'filtered',
+        label: __('Filtered Submissions'),
+    },
+];
+
+const selectedExporter = computed(() => findExporterByFormat(exportFormat.value));
+const hasFilteredScope = computed(() => {
+    const parameters = getSubmissionListingParameters();
+
+    return Boolean(parameters.search || parameters.filters);
+});
 
 async function generateFakeSubmission(mode) {
     if (generatingFakeSubmission.value) {
@@ -73,6 +100,68 @@ async function deleteFakeSubmissions() {
     } finally {
         deletingFakeSubmissions.value = false;
     }
+}
+
+function openExportModal() {
+    const firstAvailableFormat = exportFormats.find(({ value }) => Boolean(findExporterByFormat(value)));
+
+    exportFormat.value = firstAvailableFormat?.value ?? 'csv';
+    exportScope.value = 'all';
+    exportModalOpen.value = true;
+}
+
+function normalizedValue(value) {
+    return String(value ?? '').toLowerCase();
+}
+
+function findExporterByFormat(format) {
+    const normalizedFormat = normalizedValue(format);
+
+    return props.exporters.find((exporter) => {
+        const handle = normalizedValue(exporter.handle);
+        const title = normalizedValue(exporter.title);
+        const downloadUrl = normalizedValue(exporter.downloadUrl);
+        const exporterValue = `${handle} ${title} ${downloadUrl}`;
+
+        return exporterValue.includes(normalizedFormat);
+    }) || null;
+}
+
+function getSubmissionListingParameters() {
+    const parameters = submissionListing.value?.getParameters?.() ?? {};
+
+    return {
+        sort: parameters.sort,
+        order: parameters.order,
+        search: parameters.search,
+        filters: parameters.filters,
+    };
+}
+
+function appendParamsToUrl(url, params) {
+    const result = new URL(url, window.location.origin);
+
+    Object.entries(params).forEach(([key, value]) => {
+        if (value === null || value === undefined || value === '') {
+            return;
+        }
+
+        result.searchParams.set(key, value);
+    });
+
+    return result.toString();
+}
+
+function exportSubmissions() {
+    exportingSubmissions.value = true;
+
+    const params = exportScope.value === 'filtered' ? getSubmissionListingParameters() : {};
+    const exportUrl = appendParamsToUrl(selectedExporter.value.downloadUrl, params);
+
+    window.open(exportUrl, '_blank', 'noopener,noreferrer');
+
+    exportModalOpen.value = false;
+    exportingSubmissions.value = false;
 }
 </script>
 
@@ -129,20 +218,7 @@ async function deleteFakeSubmissions() {
                 :redirect="redirectUrl"
             />
 
-            <Dropdown v-if="exporters.length">
-                <template #trigger>
-                    <Button :text="__('Export Submissions')" />
-                </template>
-                <DropdownMenu>
-                    <DropdownItem
-                        v-for="exporter in exporters"
-                        :key="exporter.downloadUrl"
-                        :text="exporter.title"
-                        :href="exporter.downloadUrl"
-                        target="_blank"
-                    />
-                </DropdownMenu>
-            </Dropdown>
+            <Button v-if="exporters.length" :text="__('Export Submissions')" @click="openExportModal" />
 
             <Dropdown v-if="form.canGenerateFakeSubmissions">
                 <template #trigger>
@@ -197,12 +273,11 @@ async function deleteFakeSubmissions() {
             />
 
             <CommandPaletteItem
-                v-for="exporter in exporters"
-                :key="exporter.downloadUrl"
+                v-if="exporters.length"
                 category="Actions"
-                :text="[__('Export Submissions'), exporter.title]"
+                :text="__('Export Submissions')"
                 icon="save"
-                :url="exporter.downloadUrl"
+                :action="openExportModal"
                 prioritize
             />
         </Header>
@@ -216,5 +291,53 @@ async function deleteFakeSubmissions() {
             :columns="columns"
             :filters="filters"
         />
+
+        <Modal v-model:open="exportModalOpen" :title="__('Export Submissions')" blur class="max-w-xl!">
+            <div class="space-y-6">
+                <div class="space-y-2">
+                    <p class="text-sm font-medium">{{ __('Format') }}</p>
+                    <RadioGroup v-model="exportFormat" :name="`form-export-format-${form.handle}`">
+                        <Radio
+                            v-for="option in exportFormats"
+                            :key="option.value"
+                            :value="option.value"
+                            :label="option.label"
+                            :description="findExporterByFormat(option.value) ? null : __('No exporter configured for this format.')"
+                            :disabled="!findExporterByFormat(option.value)"
+                        />
+                    </RadioGroup>
+                </div>
+
+                <div class="space-y-2">
+                    <p class="text-sm font-medium">{{ __('Scope') }}</p>
+                    <RadioGroup v-model="exportScope" :name="`form-export-scope-${form.handle}`">
+                        <Radio
+                            v-for="option in exportScopeOptions"
+                            :key="option.value"
+                            :value="option.value"
+                            :label="option.label"
+                            :description="option.value === 'filtered' && !hasFilteredScope
+                                ? __('No active filters are set right now. This will export all submissions.')
+                                : option.description"
+                        />
+                    </RadioGroup>
+                </div>
+
+            </div>
+                <template #footer>
+                    <div class="flex items-center justify-end gap-2 pt-3 pb-1">
+                        <ModalClose asChild>
+                            <Button variant="ghost" :text="__('Cancel')" />
+                        </ModalClose>
+                        <Button
+                            variant="primary"
+                            :text="__('Export')"
+                            :loading="exportingSubmissions"
+                            :disabled="!selectedExporter"
+                            @click="exportSubmissions"
+                        />
+                    </div>
+                </template>
+        </Modal>
     </div>
 </template>

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -26,13 +26,30 @@ const deletingFakeSubmissions = ref(false);
 const submissionListing = ref(null);
 const exportModalOpen = ref(false);
 const exportingSubmissions = ref(false);
-const exportFormat = ref('csv');
+const exportFormat = ref('');
 const exportScope = ref('all');
 
-const exportFormats = [
-    { value: 'csv', label: __('CSV') },
-    { value: 'json', label: __('JSON') },
-];
+const exportFormats = computed(() => {
+    const seen = new Set();
+
+    return props.exporters.reduce((formats, exporter) => {
+        const handle = String(exporter?.handle ?? '').trim();
+        const normalizedHandle = normalizedValue(handle);
+
+        if (!normalizedHandle || seen.has(normalizedHandle)) {
+            return formats;
+        }
+
+        seen.add(normalizedHandle);
+
+        formats.push({
+            value: handle,
+            label: exporter.title || handle.toUpperCase(),
+        });
+
+        return formats;
+    }, []);
+});
 
 const exportScopeOptions = [
     {
@@ -103,9 +120,9 @@ async function deleteFakeSubmissions() {
 }
 
 function openExportModal() {
-    const firstAvailableFormat = exportFormats.find(({ value }) => Boolean(findExporterByFormat(value)));
+    const firstAvailableFormat = exportFormats.value[0];
 
-    exportFormat.value = firstAvailableFormat?.value ?? 'csv';
+    exportFormat.value = firstAvailableFormat?.value ?? '';
     exportScope.value = 'all';
     exportModalOpen.value = true;
 }
@@ -149,6 +166,10 @@ function appendParamsToUrl(url, params) {
 }
 
 function exportSubmissions() {
+    if (!selectedExporter.value) {
+        return;
+    }
+
     exportingSubmissions.value = true;
 
     const params = exportScope.value === 'filtered' ? getSubmissionListingParameters() : {};
@@ -298,8 +319,6 @@ function exportSubmissions() {
                             :key="option.value"
                             :value="option.value"
                             :label="option.label"
-                            :description="findExporterByFormat(option.value) ? null : __('No exporter configured for this format.')"
-                            :disabled="!findExporterByFormat(option.value)"
                         />
                     </RadioGroup>
                 </div>

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -119,11 +119,7 @@ function findExporterByFormat(format) {
 
     return props.exporters.find((exporter) => {
         const handle = normalizedValue(exporter.handle);
-        const title = normalizedValue(exporter.title);
-        const downloadUrl = normalizedValue(exporter.downloadUrl);
-        const exporterValue = `${handle} ${title} ${downloadUrl}`;
-
-        return exporterValue.includes(normalizedFormat);
+        return handle === normalizedFormat;
     }) || null;
 }
 

--- a/src/Forms/Exporters/CsvExporter.php
+++ b/src/Forms/Exporters/CsvExporter.php
@@ -29,15 +29,20 @@ class CsvExporter extends Exporter
 
         $headers = $this->form->fields()
             ->map(fn ($field) => $key === 'display' ? $field->display() : $field->handle())
-            ->push($key === 'display' ? __('Date') : 'date')
             ->values()->all();
+
+        $dateHeader = $key === 'display' ? __('Date') : 'date';
+
+        if (! in_array($dateHeader, $headers, true)) {
+            $headers[] = $dateHeader;
+        }
 
         $this->writer->insertOne($headers);
     }
 
     private function insertData()
     {
-        $data = $this->form->submissions()->map(function ($submission) {
+        $data = $this->submissions()->map(function ($submission) {
             $submission = $submission->toArray();
 
             $submission['date'] = (string) $submission['date'];

--- a/src/Forms/Exporters/Exporter.php
+++ b/src/Forms/Exporters/Exporter.php
@@ -3,6 +3,7 @@
 namespace Statamic\Forms\Exporters;
 
 use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
 use Statamic\Contracts\Forms\Form;
 use Statamic\Facades\File;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -15,6 +16,7 @@ abstract class Exporter
     protected array $config;
     protected string $handle;
     protected Form $form;
+    protected ?Collection $submissions = null;
 
     abstract public function export(): string;
 
@@ -39,6 +41,13 @@ abstract class Exporter
         return $this;
     }
 
+    public function setSubmissions(Collection $submissions)
+    {
+        $this->submissions = $submissions;
+
+        return $this;
+    }
+
     public function contentType(): string
     {
         return 'text/plain';
@@ -52,6 +61,11 @@ abstract class Exporter
     public function title(): string
     {
         return __($this->config['title'] ?? static::$title);
+    }
+
+    public function handle(): string
+    {
+        return $this->handle;
     }
 
     public function allowedOnForm(Form $form)
@@ -82,5 +96,10 @@ abstract class Exporter
         File::put($path, $content);
 
         return response()->download($path)->deleteFileAfterSend();
+    }
+
+    protected function submissions(): Collection
+    {
+        return $this->submissions ?? $this->form->submissions();
     }
 }

--- a/src/Forms/Exporters/JsonExporter.php
+++ b/src/Forms/Exporters/JsonExporter.php
@@ -8,7 +8,7 @@ class JsonExporter extends Exporter
 
     public function export(): string
     {
-        $submissions = $this->form->submissions()->toArray();
+        $submissions = $this->submissions()->toArray();
 
         return json_encode($submissions);
     }

--- a/src/Http/Controllers/CP/Forms/Concerns/QueriesFormSubmissionSearch.php
+++ b/src/Http/Controllers/CP/Forms/Concerns/QueriesFormSubmissionSearch.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Forms\Concerns;
+
+use Statamic\Fields\Field;
+
+trait QueriesFormSubmissionSearch
+{
+    protected function applySubmissionSearch($query, $form, ?string $search): void
+    {
+        if (! $search) {
+            return;
+        }
+
+        $query->where(function ($query) use ($form, $search) {
+            $query->where('date', 'like', '%'.$search.'%');
+
+            $form->blueprint()->fields()->all()
+                ->filter(function (Field $field): bool {
+                    return in_array($field->type(), ['text', 'textarea', 'integer']);
+                })
+                ->each(function (Field $field) use ($query, $search): void {
+                    $query->orWhere($field->handle(), 'like', '%'.$search.'%');
+                });
+        });
+    }
+}

--- a/src/Http/Controllers/CP/Forms/FormExportController.php
+++ b/src/Http/Controllers/CP/Forms/FormExportController.php
@@ -3,11 +3,16 @@
 namespace Statamic\Http\Controllers\CP\Forms;
 
 use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 
 class FormExportController extends CpController
 {
-    public function export($form, $type)
+    use QueriesFilters;
+
+    public function export(FilteredRequest $request, $form, $type)
     {
         $this->authorize('view', $form);
 
@@ -15,6 +20,47 @@ class FormExportController extends CpController
             throw new NotFoundHttpException;
         }
 
+        if ($this->shouldApplyFilteredScope($request)) {
+            $exporter->setSubmissions($this->getScopedSubmissions($request, $form));
+        }
+
         return $this->request->has('download') ? $exporter->download() : $exporter->response();
+    }
+
+    private function shouldApplyFilteredScope(FilteredRequest $request): bool
+    {
+        return collect(['filters', 'search', 'sort', 'order'])->contains(function ($parameter) use ($request) {
+            return filled($request->input($parameter));
+        });
+    }
+
+    private function getScopedSubmissions(FilteredRequest $request, $form)
+    {
+        $query = $form->querySubmissions();
+
+        $this->queryFilters($query, $request->filters, [
+            'form' => $form->handle(),
+        ]);
+
+        if ($search = $request->search) {
+            $query->where(function ($query) use ($form, $search) {
+                $query->where('date', 'like', '%'.$search.'%');
+
+                $form->blueprint()->fields()->all()
+                    ->filter(function (Field $field): bool {
+                        return in_array($field->type(), ['text', 'textarea', 'integer']);
+                    })
+                    ->each(function (Field $field) use ($query, $search): void {
+                        $query->orWhere($field->handle(), 'like', '%'.$search.'%');
+                    });
+            });
+        }
+
+        if ($sortField = $request->input('sort')) {
+            $sortDirection = $request->input('order', $sortField === 'date' ? 'desc' : 'asc');
+            $query->orderBy($sortField, $sortDirection);
+        }
+
+        return $query->get();
     }
 }

--- a/src/Http/Controllers/CP/Forms/FormExportController.php
+++ b/src/Http/Controllers/CP/Forms/FormExportController.php
@@ -3,14 +3,15 @@
 namespace Statamic\Http\Controllers\CP\Forms;
 
 use Statamic\Exceptions\NotFoundHttpException;
-use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Controllers\CP\Forms\Concerns\QueriesFormSubmissionSearch;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 
 class FormExportController extends CpController
 {
     use QueriesFilters;
+    use QueriesFormSubmissionSearch;
 
     public function export(FilteredRequest $request, $form, $type)
     {
@@ -42,19 +43,7 @@ class FormExportController extends CpController
             'form' => $form->handle(),
         ]);
 
-        if ($search = $request->search) {
-            $query->where(function ($query) use ($form, $search) {
-                $query->where('date', 'like', '%'.$search.'%');
-
-                $form->blueprint()->fields()->all()
-                    ->filter(function (Field $field): bool {
-                        return in_array($field->type(), ['text', 'textarea', 'integer']);
-                    })
-                    ->each(function (Field $field) use ($query, $search): void {
-                        $query->orWhere($field->handle(), 'like', '%'.$search.'%');
-                    });
-            });
-        }
+        $this->applySubmissionSearch($query, $form, $request->search);
 
         if ($sortField = $request->input('sort')) {
             $sortDirection = $request->input('order', $sortField === 'date' ? 'desc' : 'asc');

--- a/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
+++ b/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
@@ -6,10 +6,10 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Statamic\Events\FormSubmitted;
 use Statamic\Facades\Site;
-use Statamic\Fields\Field;
 use Statamic\Forms\FakeSubmissionGenerator;
 use Statamic\Forms\SendEmails;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Controllers\CP\Forms\Concerns\QueriesFormSubmissionSearch;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Http\Resources\CP\Submissions\Submissions;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
@@ -17,6 +17,7 @@ use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 class FormSubmissionsController extends CpController
 {
     use QueriesFilters;
+    use QueriesFormSubmissionSearch;
 
     public function index(FilteredRequest $request, $form)
     {
@@ -53,19 +54,7 @@ class FormSubmissionsController extends CpController
     {
         $query = $form->querySubmissions();
 
-        if ($search = request('search')) {
-            $query->where(function ($query) use ($form, $search) {
-                $query->where('date', 'like', '%'.$search.'%');
-
-                $form->blueprint()->fields()->all()
-                    ->filter(function (Field $field): bool {
-                        return in_array($field->type(), ['text', 'textarea', 'integer']);
-                    })
-                    ->each(function (Field $field) use ($query, $search): void {
-                        $query->orWhere($field->handle(), 'like', '%'.$search.'%');
-                    });
-            });
-        }
+        $this->applySubmissionSearch($query, $form, request('search'));
 
         return $query;
     }

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -86,6 +86,7 @@ class FormsController extends CpController
             'actionUrl' => cp_route('forms.submissions.actions.run', $form->handle()),
             'generateFakeSubmissionUrl' => cp_route('forms.submissions.generate-fake', $form->handle()),
             'exporters' => $form->exporters()->map(fn ($exporter) => [
+                'handle' => $exporter->handle(),
                 'title' => $exporter->title(),
                 'downloadUrl' => $exporter->downloadUrl(),
             ])->values(),


### PR DESCRIPTION
<img width="1264" height="732" alt="CleanShot 2026-04-01 at 15 37 30@2x" src="https://github.com/user-attachments/assets/d5e1b974-83a5-42d2-84c8-9017b9044238" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches form submission export and action flows, adding new query-scoping behavior and destructive fake-submission deletion; regressions could impact exported data correctness or submission management in the CP.
> 
> **Overview**
> Adds **filtered form submission exports**: the export modal now lets users export *all* vs *currently filtered/sorted* submissions, and `FormExportController` scopes exporter data using the same filters/search/sort parameters as the listing.
> 
> Introduces **fake submission tooling** in the CP: a per-form toggle (`generate_fake_submissions`), an endpoint to generate fake submissions in `cp_only` or `full_pipeline` mode (optionally dispatching `FormSubmitted` + email jobs), and a new dangerous action `DeleteFakeSubmissions` to purge `_fake` submissions.
> 
> Also begins a **new multi-panel forms UI layout** (new Forms top-nav pages, global header slot/actions, resizable left/right layout panels, and supporting CSS/utilities/icons), and updates listings to expose current request parameters for reuse (export scoping).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cebf37372e29662e62f6d5e35213a77d78bf4b1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->