### PR TITLE
[6.x] Serialize nocache regions before storing in cache

### DIFF
--- a/src/StaticCaching/NoCache/DatabaseSession.php
+++ b/src/StaticCaching/NoCache/DatabaseSession.php
@@ -30,7 +30,7 @@ class DatabaseSession extends Session
             throw new RegionNotFound($key);
         }
 
-        return unserialize($region->region);
+        return unserialize($region->region, ['allowed_classes' => true]);
     }
 
     protected function cacheRegion(Region $region)

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -51,7 +51,13 @@ class Session
     public function region(string $key): Region
     {
         if ($this->regions->contains($key) && ($region = StaticCache::cacheStore()->get('nocache::region.'.$key))) {
-            return $region instanceof Region ? $region : unserialize($region, ['allowed_classes' => true]);
+            if ($region instanceof Region) {
+                return $region;
+            }
+
+            if (is_string($region)) {
+                return unserialize($region, ['allowed_classes' => true]);
+            }
         }
 
         throw new RegionNotFound($key);

--- a/src/StaticCaching/NoCache/Session.php
+++ b/src/StaticCaching/NoCache/Session.php
@@ -51,7 +51,7 @@ class Session
     public function region(string $key): Region
     {
         if ($this->regions->contains($key) && ($region = StaticCache::cacheStore()->get('nocache::region.'.$key))) {
-            return $region;
+            return $region instanceof Region ? $region : unserialize($region, ['allowed_classes' => true]);
         }
 
         throw new RegionNotFound($key);
@@ -150,6 +150,6 @@ class Session
 
     protected function cacheRegion(Region $region)
     {
-        StaticCache::cacheStore()->forever('nocache::region.'.$region->key(), $region);
+        StaticCache::cacheStore()->forever('nocache::region.'.$region->key(), serialize($region));
     }
 }

--- a/tests/StaticCaching/NoCacheSessionTest.php
+++ b/tests/StaticCaching/NoCacheSessionTest.php
@@ -8,6 +8,7 @@ use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\StaticCache;
 use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\NoCache\RegionNotFound;
 use Statamic\StaticCaching\NoCache\Session;
 use Statamic\StaticCaching\NoCache\StringRegion;
 use Tests\FakesContent;
@@ -164,6 +165,22 @@ class NoCacheSessionTest extends TestCase
         $this->assertInstanceOf(StringRegion::class, $retrieved);
         $this->assertEquals($region->key(), $retrieved->key());
         $this->assertEquals(['foo' => 'bar'], $retrieved->context());
+    }
+
+    #[Test]
+    public function it_throws_region_not_found_when_cached_region_is_an_incomplete_class()
+    {
+        $session = new Session('http://localhost/test');
+
+        $region = $session->pushRegion('the contents', ['foo' => 'bar'], '.html');
+
+        // Simulate what happens when serializable_classes enforcement
+        // turns a cached Region object into __PHP_Incomplete_Class.
+        StaticCache::cacheStore()->forever('nocache::region.'.$region->key(), new \__PHP_Incomplete_Class);
+
+        $this->expectException(RegionNotFound::class);
+
+        $session->region($region->key());
     }
 
     #[Test]

--- a/tests/StaticCaching/NoCacheSessionTest.php
+++ b/tests/StaticCaching/NoCacheSessionTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\StaticCache;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\NoCache\Session;
 use Statamic\StaticCaching\NoCache\StringRegion;
@@ -146,6 +147,23 @@ class NoCacheSessionTest extends TestCase
         $this->assertEquals('/test', $cascade['url']);
         $this->assertEquals('Test page', $cascade['title']);
         $this->assertEquals('http://localhost/cp', $cascade['cp_url']);
+    }
+
+    #[Test]
+    public function it_serializes_and_unserializes_regions_through_cache()
+    {
+        $session = new Session('http://localhost/test');
+
+        $region = $session->pushRegion('the contents', ['foo' => 'bar'], '.html');
+
+        $cached = StaticCache::cacheStore()->get('nocache::region.'.$region->key());
+        $this->assertIsString($cached, 'Region should be stored as a serialized string, not an object.');
+
+        $retrieved = $session->region($region->key());
+
+        $this->assertInstanceOf(StringRegion::class, $retrieved);
+        $this->assertEquals($region->key(), $retrieved->key());
+        $this->assertEquals(['foo' => 'bar'], $retrieved->context());
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Wraps `Region` objects in `serialize()` before storing them in the cache store, so the cache layer only ever sees a plain string — avoiding issues with Laravel 13's `serializable_classes` allowlist.
- Region `$context` can contain arbitrary objects (entries, addon classes, etc.), making it impractical to add every possible class to the allowlist. By controlling the `unserialize()` call ourselves with `allowed_classes => true`, we scope the permissive deserialization to just nocache region entries.
- Adds backwards compatibility in `Session::region()` for any existing cached `Region` objects that were stored before this change.
- Handles `__PHP_Incomplete_Class` objects that can occur when `serializable_classes` enforcement is active and old cached `Region` objects exist — gracefully falls through to `RegionNotFound`, which triggers an uncached response that re-caches the region in the new format.
- Adds `['allowed_classes' => true]` to `DatabaseSession::region()` for consistency.

## Test plan

- [x] `tests/StaticCaching/NoCacheSessionTest.php` — 13 tests pass
- [x] `tests/StaticCaching/NocacheRouteTest.php` — integration tests pass
- [x] Full `tests/StaticCaching/` suite — 156 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)