### PR TITLE
[6.x] Filter invalid UTF-8 locales from dictionary

### DIFF
--- a/src/Dictionaries/Locales.php
+++ b/src/Dictionaries/Locales.php
@@ -20,6 +20,7 @@ class Locales extends BasicDictionary
         $output = Process::run($this->buildLocalesCommand());
 
         return collect(explode(PHP_EOL, $output))
+            ->filter(fn ($locale) => mb_check_encoding($locale, 'UTF-8'))
             ->map(fn ($locale) => Str::before($locale, '.'))
             ->reject(fn ($locale) => in_array($locale, ['C', 'POSIX']))
             ->filter()


### PR DESCRIPTION
This pull request fixes an issue where visiting `/cp/sites` throws a 500 error on Linux servers with the message "Malformed UTF-8 characters, possibly incorrectly encoded".

This was happening because the `Locales` dictionary runs `locale -a` to get system locales. On Linux, this command includes locale alias names from `/etc/locale.alias` that are encoded in ISO-8859-1 rather than UTF-8 (e.g., "bokmål", "français"). When these strings are serialized to JSON for the Inertia response, `json_encode()` fails.

This PR fixes it by filtering out any locale strings that aren't valid UTF-8. This only removes the human-readable alias names - the actual locale codes (like `nb_NO`, `fr_FR`) are all ASCII and remain available.

Fixes #14414