### PR TITLE
[6.x] Fix invalid HTML `lang` attribute

### DIFF
--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html
-    lang="{{ Statamic::cpLocale() }}"
+    lang="{{ str_replace('_', '-', Statamic::cpLocale()) }}"
     dir="{{ Statamic::cpDirection() }}"
 >
     <head>


### PR DESCRIPTION
This pull request fixes an issue where the Preferences page would fail to load when the CP locale uses an underscore format (eg. `de_CH`).

This was happening because the `lang` attribute on the `<html>` element was being set directly from `Statamic::cpLocale()`, which returns locales in PHP/Laravel's underscore format (`de_CH`). However, the `Intl.DisplayNames` JavaScript API in `FormattingLocalesFieldtype.vue` requires BCP 47 format, which uses hyphens (`de-CH`).

This PR fixes it by converting underscores to hyphens when outputting the locale to the `lang` attribute in the layout template. This is also more standards-compliant, as the HTML `lang` attribute should use BCP 47 format.

Fixes #14410