### PR TITLE
[6.x] Catch axios errors in blueprint builder

### DIFF
--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -232,7 +232,7 @@ export default {
         this.$axios.get(url)
             .then((response) => (loadedFieldtypes.value = response.data))
             .catch((e) => {
-                this.$toast.error(e.response.data.message);
+                this.$toast.error(e.response?.data?.message || __('Something went wrong'));
                 this.close();
             });
     },

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -229,7 +229,12 @@ export default {
 
         if (this.$config.get('isFormBlueprint')) url += '&forms=true';
 
-        this.$axios.get(url).then((response) => (loadedFieldtypes.value = response.data));
+        this.$axios.get(url)
+            .then((response) => (loadedFieldtypes.value = response.data))
+            .catch((e) => {
+                this.$toast.error(e.response.data.message);
+                this.close();
+            });
     },
 
     methods: {

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -366,7 +366,7 @@ export default {
                 this.errors = errors;
                 this.$toast.error(message);
             } else {
-                this.$toast.error(__('Something went wrong'));
+                this.$toast.error(e.response?.data?.message || __('Something went wrong'));
             }
         },
 
@@ -397,7 +397,10 @@ export default {
                     this.originValues = response.data.originValues;
                     this.originMeta = response.data.originMeta;
                 })
-                .catch((e) => this.handleAxiosError(e));
+                .catch((e) => {
+                    this.loading = false;
+                    this.handleAxiosError(e);
+                });
         },
     },
 };

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -396,7 +396,8 @@ export default {
                     this.meta = { ...response.data.meta };
                     this.originValues = response.data.originValues;
                     this.originMeta = response.data.originMeta;
-                });
+                })
+                .catch((e) => this.handleAxiosError(e));
         },
     },
 };

--- a/resources/js/components/publish/FieldMeta.vue
+++ b/resources/js/components/publish/FieldMeta.vue
@@ -68,9 +68,9 @@ export default {
                     this.loading = false;
                     this.$emit('loaded');
                 })
-                .catch(() => {
+                .catch((e) => {
                     this.loading = false;
-                    this.$toast.error(__('Something went wrong'));
+                    this.$toast.error(e.response?.data?.message || __('Something went wrong'));
                 });
         },
 

--- a/resources/js/components/publish/FieldMeta.vue
+++ b/resources/js/components/publish/FieldMeta.vue
@@ -60,12 +60,18 @@ export default {
                 value: this.value,
             };
 
-            this.$axios.post(cp_url('fields/field-meta'), params).then((response) => {
-                this.meta = response.data.meta;
-                this.value = response.data.value;
-                this.loading = false;
-                this.$emit('loaded');
-            });
+            this.$axios
+                .post(cp_url('fields/field-meta'), params)
+                .then((response) => {
+                    this.meta = response.data.meta;
+                    this.value = response.data.value;
+                    this.loading = false;
+                    this.$emit('loaded');
+                })
+                .catch(() => {
+                    this.loading = false;
+                    this.$toast.error(__('Something went wrong'));
+                });
         },
 
         updateMeta(value) {


### PR DESCRIPTION
This pull request fixes an issue where axios errors in various blueprint builder components weren't being caught, resulting in endless loading spinners with no user feedback.

This was happening because the axios requests had `.then()` handlers but no `.catch()` handlers. When a request failed (eg. invalid fieldtype config), the promise rejection was unhandled and a console error was logged.

This PR fixes it by adding `.catch()` handlers that display a "Something went wrong" toast message, consistent with error handling elsewhere in the Control Panel.

Fixes #14397
