### PR TITLE
[6.x] Fallback to option key in listings when label is missing

### DIFF
--- a/src/Fieldtypes/HasSelectOptions.php
+++ b/src/Fieldtypes/HasSelectOptions.php
@@ -138,7 +138,7 @@ trait HasSelectOptions
 
         $option = collect($this->getOptions())->filter(fn ($option) => $option['value'] === $value)->first();
 
-        return $option ? $option['label'] : $actualValue;
+        return $option ? ($option['label'] ?? $option['value']) : $actualValue;
     }
 
     private function castToBoolean($value)

--- a/tests/Fieldtypes/HasSelectOptionsTests.php
+++ b/tests/Fieldtypes/HasSelectOptionsTests.php
@@ -58,4 +58,52 @@ trait HasSelectOptionsTests
             ],
         ];
     }
+
+    #[Test]
+    #[DataProvider('preProcessIndexProvider')]
+    public function it_preprocesses_index_values($options, $value, $expected)
+    {
+        $field = $this->field(['options' => $options]);
+
+        $this->assertSame($expected, $field->preProcessIndex($value));
+    }
+
+    public static function preProcessIndexProvider()
+    {
+        return [
+            'list' => [
+                ['one', 'two', 'three'],
+                'two',
+                ['two'],
+            ],
+            'associative with labels' => [
+                ['one' => 'One', 'two' => 'Two', 'three' => 'Three'],
+                'two',
+                ['Two'],
+            ],
+            'associative without labels' => [
+                ['one' => null, 'two' => null, 'three' => null],
+                'two',
+                ['two'],
+            ],
+            'multidimensional with labels' => [
+                [
+                    ['key' => 'one', 'value' => 'One'],
+                    ['key' => 'two', 'value' => 'Two'],
+                    ['key' => 'three', 'value' => 'Three'],
+                ],
+                'two',
+                ['Two'],
+            ],
+            'multidimensional without labels' => [
+                [
+                    ['key' => 'one', 'value' => null],
+                    ['key' => 'two', 'value' => null],
+                    ['key' => 'three', 'value' => null],
+                ],
+                'two',
+                ['two'],
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue where the Select fieldtype returns `[null]` in CP collection listings when option labels are omitted.

This was happening because the `getLabel()` method in the `HasSelectOptions` trait would return the option's label even when it was `null`, instead of falling back to the key.

This PR fixes it by using null coalescing to fall back to the option's key when the label is null:

```php
// Before
return $option ? $option['label'] : $actualValue;

// After
return $option ? ($option['label'] ?? $option['value']) : $actualValue;
```

Fixes #14377