### PR TITLE
[6.x] Add ability to filter submission exports

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -135,6 +135,7 @@ return [
     'form_configure_mailer_instructions' => 'Choose the mailer for sending this email. Leave blank to fall back to the default mailer.',
     'form_configure_store_instructions' => 'Disable to stop storing submissions. Events and email notifications will still be sent.',
     'form_configure_title_instructions' => 'Use a call to action, such as \'Contact Us\'.',
+    'form_export_filtered_description' => 'Exports submissions with current filters and visible columns.',
     'form_create_description' => 'Get started by creating your first form.',
     'getting_started_widget_collections' => 'Collections hold the different content types that make up your site, helping you stay organized.',
     'getting_started_widget_docs' => 'Discover everything Statamic can do, and learn how to use its powerful features the right way.',

--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -1,5 +1,6 @@
 <template>
     <Listing
+        ref="listing"
         :url="requestUrl"
         :columns="columns"
         :action-url="actionUrl"
@@ -42,5 +43,13 @@ export default {
             requestUrl: cp_url(`forms/${this.form}/submissions`),
         };
     },
+
+    methods: {
+        getParameters() {
+            return this.$refs.listing?.getParameters();
+        },
+    },
+
+    expose: ['getParameters'],
 };
 </script>

--- a/resources/js/components/forms/SubmissionListing.vue
+++ b/resources/js/components/forms/SubmissionListing.vue
@@ -44,12 +44,12 @@ export default {
         };
     },
 
-    methods: {
-        getParameters() {
-            return this.$refs.listing?.getParameters();
+    computed: {
+        parameters() {
+            return this.$refs.listing?.parameters;
         },
     },
 
-    expose: ['getParameters'],
+    expose: ['parameters'],
 };
 </script>

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -670,7 +670,7 @@ provideListingContext({
 defineExpose({
     refresh,
     setFilter,
-    getParameters: () => ({ ...parameters.value }),
+    parameters,
 });
 
 watch(parameters, (newParams, oldParams) => {

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -670,6 +670,7 @@ provideListingContext({
 defineExpose({
     refresh,
     setFilter,
+    getParameters: () => ({ ...parameters.value }),
 });
 
 watch(parameters, (newParams, oldParams) => {

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -1,7 +1,7 @@
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import Head from '@/pages/layout/Head.vue';
-import { Header, Dropdown, DropdownMenu, DropdownItem, Button, CommandPaletteItem } from '@ui';
+import { Header, Dropdown, DropdownMenu, DropdownItem, Button, Modal, RadioGroup, Radio, CommandPaletteItem } from '@ui';
 import ResourceDeleter from '@/components/ResourceDeleter.vue';
 import FormSubmissionListing from '@/components/forms/SubmissionListing.vue';
 
@@ -15,6 +15,55 @@ const props = defineProps([
 ]);
 
 const deleter = ref(null);
+const submissionListing = ref(null);
+const exportModalOpen = ref(false);
+const exportFormat = ref(null);
+const exportScope = ref('all');
+const listingParameters = ref({});
+
+const exportFormats = computed(() => {
+    const seen = new Set();
+    return props.exporters.filter((e) => {
+        const handle = e.handle.toLowerCase();
+        if (seen.has(handle)) return false;
+        seen.add(handle);
+        return true;
+    });
+});
+
+const hasFilteredScope = computed(() => {
+    const params = listingParameters.value;
+    return !!(params.search || params.filters);
+});
+
+function openExportModal() {
+    listingParameters.value = submissionListing.value?.getParameters() ?? {};
+    exportFormat.value = exportFormats.value[0]?.handle ?? null;
+    exportScope.value = 'all';
+    exportModalOpen.value = true;
+}
+
+function exportSubmissions() {
+    const exporter = props.exporters.find((e) => e.handle === exportFormat.value);
+    if (!exporter) return;
+
+    let url = exporter.downloadUrl;
+
+    if (exportScope.value === 'filtered') {
+        const params = listingParameters.value;
+        const query = new URLSearchParams();
+        if (params.search) query.set('search', params.search);
+        if (params.sort) query.set('sort', params.sort);
+        if (params.order) query.set('order', params.order);
+        if (params.filters) query.set('filters', params.filters);
+
+        const separator = url.includes('?') ? '&' : '?';
+        url += separator + query.toString();
+    }
+
+    window.open(url, '_blank');
+    exportModalOpen.value = false;
+}
 </script>
 
 <template>
@@ -70,39 +119,51 @@ const deleter = ref(null);
                 :redirect="redirectUrl"
             />
 
-            <Dropdown v-if="exporters.length">
-                <template #trigger>
-                    <Button :text="__('Export Submissions')" />
-                </template>
-                <DropdownMenu>
-                    <DropdownItem
-                        v-for="exporter in exporters"
-                        :key="exporter.downloadUrl"
-                        :text="exporter.title"
-                        :href="exporter.downloadUrl"
-                        target="_blank"
-                    />
-                </DropdownMenu>
-            </Dropdown>
+            <Button v-if="exporters.length" :text="__('Export Submissions')" @click="openExportModal" />
 
             <CommandPaletteItem
-                v-for="exporter in exporters"
-                :key="exporter.downloadUrl"
+                v-if="exporters.length"
                 category="Actions"
-                :text="[__('Export Submissions'), exporter.title]"
+                :text="__('Export Submissions')"
                 icon="save"
-                :url="exporter.downloadUrl"
+                :action="openExportModal"
                 prioritize
             />
         </Header>
 
         <FormSubmissionListing
+            ref="submissionListing"
             :form="form.handle"
             :action-url="actionUrl"
             sort-column="datestamp"
             sort-direction="desc"
             :columns="columns"
-                :filters="filters"
+            :filters="filters"
         />
+
+        <Modal :open="exportModalOpen" @update:open="exportModalOpen = $event" :title="__('Export Submissions')">
+            <div class="space-y-4">
+                <div>
+                    <label class="text-sm font-medium mb-1.5 block">{{ __('Format') }}</label>
+                    <RadioGroup v-model="exportFormat" inline>
+                        <Radio v-for="format in exportFormats" :key="format.handle" :value="format.handle" :label="format.title" />
+                    </RadioGroup>
+                </div>
+
+                <div>
+                    <label class="text-sm font-medium mb-1.5 block">{{ __('Submissions') }}</label>
+                    <RadioGroup v-model="exportScope">
+                        <Radio value="all" :label="__('All Submissions')" />
+                        <Radio value="filtered" :label="__('Filtered Submissions')" :disabled="!hasFilteredScope" />
+                    </RadioGroup>
+                </div>
+            </div>
+
+            <template #footer>
+                <div class="flex justify-end p-2">
+                    <Button variant="primary" :text="__('Export')" @click="exportSubmissions" />
+                </div>
+            </template>
+        </Modal>
     </div>
 </template>

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -28,7 +28,7 @@ const hasFilteredScope = computed(() => {
 });
 
 function openExportModal() {
-    listingParameters.value = submissionListing.value?.getParameters() ?? {};
+    listingParameters.value = submissionListing.value?.parameters ?? {};
     exportFormat.value = props.exporters[0]?.handle ?? null;
     exportScope.value = 'all';
     exportModalOpen.value = true;

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -21,16 +21,6 @@ const exportFormat = ref(null);
 const exportScope = ref('all');
 const listingParameters = ref({});
 
-const exportFormats = computed(() => {
-    const seen = new Set();
-    return props.exporters.filter((e) => {
-        const handle = e.handle.toLowerCase();
-        if (seen.has(handle)) return false;
-        seen.add(handle);
-        return true;
-    });
-});
-
 const hasFilteredScope = computed(() => {
     const params = listingParameters.value;
     return !!(params.search || params.filters);
@@ -38,7 +28,7 @@ const hasFilteredScope = computed(() => {
 
 function openExportModal() {
     listingParameters.value = submissionListing.value?.getParameters() ?? {};
-    exportFormat.value = exportFormats.value[0]?.handle ?? null;
+    exportFormat.value = props.exporters[0]?.handle ?? null;
     exportScope.value = 'all';
     exportModalOpen.value = true;
 }
@@ -146,7 +136,7 @@ function exportSubmissions() {
                 <div>
                     <label class="text-sm font-medium mb-1.5 block">{{ __('Format') }}</label>
                     <RadioGroup v-model="exportFormat" inline>
-                        <Radio v-for="format in exportFormats" :key="format.handle" :value="format.handle" :label="format.title" />
+                        <Radio v-for="format in exporters" :key="format.handle" :value="format.handle" :label="format.title" />
                     </RadioGroup>
                 </div>
 

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -23,7 +23,8 @@ const listingParameters = ref({});
 
 const hasFilteredScope = computed(() => {
     const params = listingParameters.value;
-    return !!(params.search || params.filters);
+    const hasSortOverride = (params.sort && params.sort !== 'datestamp') || (params.order && params.order !== 'desc');
+    return !!(params.search || params.filters || hasSortOverride);
 });
 
 function openExportModal() {

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -145,7 +145,7 @@ function exportSubmissions() {
                     <label class="text-sm font-medium mb-1.5 block">{{ __('Submissions') }}</label>
                     <RadioGroup v-model="exportScope">
                         <Radio value="all" :label="__('All Submissions')" />
-                        <Radio value="filtered" :label="__('Filtered Submissions')" :disabled="!hasFilteredScope" />
+                        <Radio value="filtered" :label="__('Filtered Submissions')" :description="__('statamic::messages.form_export_filtered_description')" :disabled="!hasFilteredScope" />
                     </RadioGroup>
                 </div>
             </div>

--- a/src/Forms/Exporters/CsvExporter.php
+++ b/src/Forms/Exporters/CsvExporter.php
@@ -29,15 +29,20 @@ class CsvExporter extends Exporter
 
         $headers = $this->form->fields()
             ->map(fn ($field) => $key === 'display' ? $field->display() : $field->handle())
-            ->push($key === 'display' ? __('Date') : 'date')
             ->values()->all();
+
+        $dateHeader = $key === 'display' ? __('Date') : 'date';
+
+        if (! in_array($dateHeader, $headers)) {
+            $headers[] = $dateHeader;
+        }
 
         $this->writer->insertOne($headers);
     }
 
     private function insertData()
     {
-        $data = $this->form->submissions()->map(function ($submission) {
+        $data = $this->submissions()->map(function ($submission) {
             $submission = $submission->toArray();
 
             $submission['date'] = (string) $submission['date'];

--- a/src/Forms/Exporters/CsvExporter.php
+++ b/src/Forms/Exporters/CsvExporter.php
@@ -29,13 +29,8 @@ class CsvExporter extends Exporter
 
         $headers = $this->form->fields()
             ->map(fn ($field) => $key === 'display' ? $field->display() : $field->handle())
+            ->push($key === 'display' ? __('Date') : 'date')
             ->values()->all();
-
-        $dateHeader = $key === 'display' ? __('Date') : 'date';
-
-        if (! in_array($dateHeader, $headers)) {
-            $headers[] = $dateHeader;
-        }
 
         $this->writer->insertOne($headers);
     }

--- a/src/Forms/Exporters/Exporter.php
+++ b/src/Forms/Exporters/Exporter.php
@@ -3,6 +3,7 @@
 namespace Statamic\Forms\Exporters;
 
 use Illuminate\Http\Response;
+use Illuminate\Support\Collection;
 use Statamic\Contracts\Forms\Form;
 use Statamic\Facades\File;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
@@ -15,6 +16,7 @@ abstract class Exporter
     protected array $config;
     protected string $handle;
     protected Form $form;
+    protected ?Collection $submissions = null;
 
     abstract public function export(): string;
 
@@ -37,6 +39,23 @@ abstract class Exporter
         $this->form = $form;
 
         return $this;
+    }
+
+    public function setSubmissions(Collection $submissions)
+    {
+        $this->submissions = $submissions;
+
+        return $this;
+    }
+
+    public function handle(): string
+    {
+        return $this->handle;
+    }
+
+    protected function submissions(): Collection
+    {
+        return $this->submissions ?? $this->form->submissions();
     }
 
     public function contentType(): string

--- a/src/Forms/Exporters/Exporter.php
+++ b/src/Forms/Exporters/Exporter.php
@@ -27,6 +27,11 @@ abstract class Exporter
         return $this;
     }
 
+    public function handle(): string
+    {
+        return $this->handle;
+    }
+
     public function setConfig(array $config)
     {
         $this->config = $config;
@@ -46,11 +51,6 @@ abstract class Exporter
         $this->submissions = $submissions;
 
         return $this;
-    }
-
-    public function handle(): string
-    {
-        return $this->handle;
     }
 
     protected function submissions(): Collection

--- a/src/Forms/Exporters/JsonExporter.php
+++ b/src/Forms/Exporters/JsonExporter.php
@@ -8,7 +8,7 @@ class JsonExporter extends Exporter
 
     public function export(): string
     {
-        $submissions = $this->form->submissions()->toArray();
+        $submissions = $this->submissions()->toArray();
 
         return json_encode($submissions);
     }

--- a/src/Http/Controllers/CP/Forms/Concerns/QueriesFormSubmissionSearch.php
+++ b/src/Http/Controllers/CP/Forms/Concerns/QueriesFormSubmissionSearch.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Statamic\Http\Controllers\CP\Forms\Concerns;
+
+use Statamic\Contracts\Forms\Form;
+use Statamic\Fields\Field;
+
+trait QueriesFormSubmissionSearch
+{
+    protected function applySubmissionSearch($query, Form $form, ?string $search)
+    {
+        if (! $search) {
+            return $query;
+        }
+
+        $query->where(function ($query) use ($form, $search) {
+            $query->where('date', 'like', '%'.$search.'%');
+
+            $form->blueprint()->fields()->all()
+                ->filter(function (Field $field): bool {
+                    return in_array($field->type(), ['text', 'textarea', 'integer']);
+                })
+                ->each(function (Field $field) use ($query, $search): void {
+                    $query->orWhere($field->handle(), 'like', '%'.$search.'%');
+                });
+        });
+
+        return $query;
+    }
+}

--- a/src/Http/Controllers/CP/Forms/FormExportController.php
+++ b/src/Http/Controllers/CP/Forms/FormExportController.php
@@ -6,6 +6,7 @@ use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Controllers\CP\Forms\Concerns\QueriesFormSubmissionSearch;
 use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Query\OrderBy;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 
 class FormExportController extends CpController
@@ -42,7 +43,7 @@ class FormExportController extends CpController
 
         $this->applySubmissionSearch($query, $form, $request->input('search'));
 
-        if ($sort = $request->input('sort')) {
+        if ($sort = OrderBy::column($request->input('sort'))) {
             $query->orderBy($sort, $request->input('order', 'asc'));
         }
 

--- a/src/Http/Controllers/CP/Forms/FormExportController.php
+++ b/src/Http/Controllers/CP/Forms/FormExportController.php
@@ -4,10 +4,15 @@ namespace Statamic\Http\Controllers\CP\Forms;
 
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Controllers\CP\Forms\Concerns\QueriesFormSubmissionSearch;
+use Statamic\Http\Requests\FilteredRequest;
+use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 
 class FormExportController extends CpController
 {
-    public function export($form, $type)
+    use QueriesFilters, QueriesFormSubmissionSearch;
+
+    public function export(FilteredRequest $request, $form, $type)
     {
         $this->authorize('view', $form);
 
@@ -15,6 +20,32 @@ class FormExportController extends CpController
             throw new NotFoundHttpException;
         }
 
-        return $this->request->has('download') ? $exporter->download() : $exporter->response();
+        if ($this->shouldApplyFilteredScope($request)) {
+            $exporter->setSubmissions($this->getScopedSubmissions($request, $form));
+        }
+
+        return $request->has('download') ? $exporter->download() : $exporter->response();
+    }
+
+    protected function shouldApplyFilteredScope(FilteredRequest $request)
+    {
+        return $request->has('filters') || $request->has('search') || $request->has('sort') || $request->has('order');
+    }
+
+    protected function getScopedSubmissions(FilteredRequest $request, $form)
+    {
+        $query = $form->querySubmissions();
+
+        $this->queryFilters($query, $request->filters, [
+            'form' => $form->handle(),
+        ]);
+
+        $this->applySubmissionSearch($query, $form, $request->input('search'));
+
+        if ($sort = $request->input('sort')) {
+            $query->orderBy($sort, $request->input('order', 'asc'));
+        }
+
+        return $query->get();
     }
 }

--- a/src/Http/Controllers/CP/Forms/FormExportController.php
+++ b/src/Http/Controllers/CP/Forms/FormExportController.php
@@ -44,7 +44,7 @@ class FormExportController extends CpController
         $this->applySubmissionSearch($query, $form, $request->input('search'));
 
         if ($sort = OrderBy::column($request->input('sort'))) {
-            $query->orderBy($sort, $request->input('order', 'asc'));
+            $query->orderBy($sort, $request->input('order', $sort === 'date' ? 'desc' : 'asc'));
         }
 
         return $query->get();

--- a/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
+++ b/src/Http/Controllers/CP/Forms/FormSubmissionsController.php
@@ -3,8 +3,8 @@
 namespace Statamic\Http\Controllers\CP\Forms;
 
 use Inertia\Inertia;
-use Statamic\Fields\Field;
 use Statamic\Http\Controllers\CP\CpController;
+use Statamic\Http\Controllers\CP\Forms\Concerns\QueriesFormSubmissionSearch;
 use Statamic\Http\Requests\FilteredRequest;
 use Statamic\Http\Resources\CP\Submissions\Submissions;
 use Statamic\Query\OrderBy;
@@ -12,7 +12,7 @@ use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 
 class FormSubmissionsController extends CpController
 {
-    use QueriesFilters;
+    use QueriesFilters, QueriesFormSubmissionSearch;
 
     public function index(FilteredRequest $request, $form)
     {
@@ -49,19 +49,7 @@ class FormSubmissionsController extends CpController
     {
         $query = $form->querySubmissions();
 
-        if ($search = request('search')) {
-            $query->where(function ($query) use ($form, $search) {
-                $query->where('date', 'like', '%'.$search.'%');
-
-                $form->blueprint()->fields()->all()
-                    ->filter(function (Field $field): bool {
-                        return in_array($field->type(), ['text', 'textarea', 'integer']);
-                    })
-                    ->each(function (Field $field) use ($query, $search): void {
-                        $query->orWhere($field->handle(), 'like', '%'.$search.'%');
-                    });
-            });
-        }
+        $this->applySubmissionSearch($query, $form, request('search'));
 
         return $query;
     }

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -85,6 +85,7 @@ class FormsController extends CpController
             ]),
             'actionUrl' => cp_route('forms.submissions.actions.run', $form->handle()),
             'exporters' => $form->exporters()->map(fn ($exporter) => [
+                'handle' => $exporter->handle(),
                 'title' => $exporter->title(),
                 'downloadUrl' => $exporter->downloadUrl(),
             ])->values(),


### PR DESCRIPTION
## Summary

- Replaces the "Export Submissions" dropdown with a modal where users choose the export format (CSV/JSON) and scope (all submissions vs currently filtered submissions)
- Extracts submission search logic into a reusable `QueriesFormSubmissionSearch` trait shared by `FormSubmissionsController` and `FormExportController`
- Adds `setSubmissions()` / `submissions()` to the `Exporter` base class so exporters can operate on a scoped collection instead of always fetching all submissions
- When "Filtered Submissions" is selected, the current listing parameters (search, filters, sort, order) are passed to the export endpoint and applied server-side

## Changes

**Backend:**
- `Exporter` base class: new `$submissions` property, `setSubmissions()`, `handle()`, and `submissions()` methods
- `CsvExporter` / `JsonExporter`: use `$this->submissions()` instead of `$this->form->submissions()`
- `FormExportController`: accepts `FilteredRequest`, detects filter params, builds scoped query
- `QueriesFormSubmissionSearch` trait: extracted from `FormSubmissionsController`
- `FormsController`: passes exporter `handle` to the frontend

**Frontend:**
- `Listing.vue`: exposes `getParameters()` via `defineExpose`
- `SubmissionListing.vue`: forwards `getParameters()` from inner Listing
- `Show.vue`: new export modal with format and scope radio groups

## Test plan

- [x] Export all submissions as CSV — should work as before
- [x] Export all submissions as JSON — should work as before
- [x] Apply a search/filter on the submissions listing, then export as "Filtered Submissions" — only matching submissions should be in the export
- [x] Verify the "Filtered Submissions" radio option is disabled when no filters/search are active
- [x] Verify the command palette export action opens the modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)