### PR TITLE
[6.x] Centralize SVG sanitization and sanitize CSS in style tags

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -8,7 +8,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use League\Flysystem\PathTraversalDetected;
-use Rhukster\DomSanitizer\DOMSanitizer;
 use Statamic\Assets\AssetUploader as Uploader;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
@@ -46,6 +45,7 @@ use Statamic\Search\Searchable;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
+use Statamic\Support\Svg;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Statamic\Support\Traits\Hookable;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -970,9 +970,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
 
             $this->disk()->put(
                 $this->path(),
-                (new DOMSanitizer(DOMSanitizer::SVG))->sanitize($contents, [
-                    'remove-xml-tags' => ! Str::startsWith($contents, '<?xml'),
-                ])
+                Svg::sanitize($contents)
             );
         }
 

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -3,9 +3,9 @@
 namespace Statamic\Assets;
 
 use Facades\Statamic\Imaging\ImageValidator;
-use Rhukster\DomSanitizer\DOMSanitizer;
 use Statamic\Facades\Glide;
 use Statamic\Support\Str;
+use Statamic\Support\Svg;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 abstract class Uploader
@@ -59,10 +59,7 @@ abstract class Uploader
         $stream = fopen($sourcePath, 'r');
 
         if (config('statamic.assets.svg_sanitization_on_upload', true) && Str::endsWith($destinationPath, '.svg')) {
-            $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
-            $stream = $sanitizer->sanitize($svg = stream_get_contents($stream), [
-                'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),
-            ]);
+            $stream = Svg::sanitize(stream_get_contents($stream));
         }
 
         $this->disk()->put($this->uploadPathPrefix().$destinationPath, $stream);

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -3,7 +3,6 @@
 namespace Statamic\CP\Navigation;
 
 use Illuminate\Support\Collection;
-use Rhukster\DomSanitizer\DOMSanitizer;
 use Statamic\CommandPalette\Category;
 use Statamic\CommandPalette\Link;
 use Statamic\Facades\CP\Nav;
@@ -217,11 +216,7 @@ class NavItem
     private function sanitizeSvg(string $svg): string
     {
         try {
-            $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
-
-            return $sanitizer->sanitize($svg, [
-                'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),
-            ]);
+            return Svg::sanitize($svg);
         } catch (\Throwable $e) {
             return '';
         }

--- a/src/Support/Svg.php
+++ b/src/Support/Svg.php
@@ -29,6 +29,18 @@ class Svg
 
     public static function sanitizeCss(string $css): string
     {
+        // Decode all CSS escape sequences in a single pass to prevent bypass.
+        // Hex escapes: \69mport -> import. Non-hex escapes: \i -> i, \@ -> @.
+        $css = preg_replace_callback(
+            '/\\\\(?:([0-9a-fA-F]{1,6})\s?|(.))/s',
+            fn ($m) => ($m[1] !== '') ? mb_chr(hexdec($m[1]), 'UTF-8') : $m[2],
+            $css
+        );
+
+        // Normalize Unicode whitespace and invisible characters to ASCII spaces
+        // so they can't be used to sneak past the regex patterns below
+        $css = preg_replace('/[\p{Z}\x{200B}\x{FEFF}]+/u', ' ', $css);
+
         // Remove @import rules entirely
         $css = preg_replace('/@import\s+[^;]+;?/i', '', $css);
 

--- a/src/Support/Svg.php
+++ b/src/Support/Svg.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Support;
 
+use Rhukster\DomSanitizer\DOMSanitizer;
 use Stringy\StaticStringy;
 
 class Svg
@@ -13,5 +14,36 @@ class Svg
         $svg = StaticStringy::collapseWhitespace($svg);
 
         return str_replace('<svg', sprintf('<svg%s', $attrs), $svg);
+    }
+
+    public static function sanitize(string $svg, ?DOMSanitizer $sanitizer = null): string
+    {
+        $sanitizer = $sanitizer ?? new DOMSanitizer(DOMSanitizer::SVG);
+
+        $svg = $sanitizer->sanitize($svg, [
+            'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),
+        ]);
+
+        return static::sanitizeStyleTags($svg);
+    }
+
+    public static function sanitizeCss(string $css): string
+    {
+        // Remove @import rules entirely
+        $css = preg_replace('/@import\s+[^;]+;?/i', '', $css);
+
+        // Neutralize url() references to external resources (http, https, protocol-relative)
+        $css = preg_replace('/url\s*\(\s*["\']?\s*(?:https?:|\/\/)[^)]*\)/i', 'url()', $css);
+
+        return $css;
+    }
+
+    private static function sanitizeStyleTags(string $svg): string
+    {
+        return preg_replace_callback(
+            '/<style([^>]*)>(.*?)<\/style>/si',
+            fn ($matches) => '<style'.$matches[1].'>'.static::sanitizeCss($matches[2]).'</style>',
+            $svg
+        );
     }
 }

--- a/src/Tags/Svg.php
+++ b/src/Tags/Svg.php
@@ -6,6 +6,7 @@ use Rhukster\DomSanitizer\DOMSanitizer;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Support\Str;
+use Statamic\Support\Svg as SvgSupport;
 use Stringy\StaticStringy;
 
 class Svg extends Tags
@@ -105,9 +106,7 @@ class Svg extends Tags
         $this->setAllowedAttrs($sanitizer);
         $this->setAllowedTags($sanitizer);
 
-        return $sanitizer->sanitize($svg, [
-            'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),
-        ]);
+        return SvgSupport::sanitize($svg, $sanitizer);
     }
 
     private function setAllowedAttrs(DOMSanitizer $sanitizer)

--- a/tests/Support/SvgTest.php
+++ b/tests/Support/SvgTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Support;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Support\Svg;
+use Tests\TestCase;
+
+class SvgTest extends TestCase
+{
+    #[Test]
+    public function it_strips_import_with_url()
+    {
+        $this->assertSame('', trim(Svg::sanitizeCss('@import url("https://evil.com/x.css");')));
+    }
+
+    #[Test]
+    public function it_strips_import_with_bare_string()
+    {
+        $this->assertSame('', trim(Svg::sanitizeCss('@import "https://evil.com/x.css";')));
+    }
+
+    #[Test]
+    public function it_strips_import_with_protocol_relative_url()
+    {
+        $this->assertSame('', trim(Svg::sanitizeCss('@import url(//evil.com/x.css);')));
+    }
+
+    #[Test]
+    public function it_strips_import_without_semicolon()
+    {
+        $this->assertSame('', trim(Svg::sanitizeCss("@import url('https://evil.com/x.css')")));
+    }
+
+    #[Test]
+    public function it_neutralizes_external_url_in_property()
+    {
+        $this->assertSame(
+            '.cls { background: url(); }',
+            Svg::sanitizeCss('.cls { background: url(https://evil.com/beacon.gif); }')
+        );
+    }
+
+    #[Test]
+    public function it_neutralizes_protocol_relative_url_in_property()
+    {
+        $this->assertSame(
+            '.cls { background: url(); }',
+            Svg::sanitizeCss('.cls { background: url(//evil.com/x); }')
+        );
+    }
+
+    #[Test]
+    public function it_neutralizes_quoted_external_url()
+    {
+        $this->assertSame(
+            '.cls { background: url(); }',
+            Svg::sanitizeCss('.cls { background: url("http://evil.com/x"); }')
+        );
+    }
+
+    #[Test]
+    public function it_preserves_normal_css()
+    {
+        $css = '.cls-1 { fill: #333; stroke: red; }';
+
+        $this->assertSame($css, Svg::sanitizeCss($css));
+    }
+
+    #[Test]
+    public function it_preserves_internal_url_references()
+    {
+        $css = '.cls { fill: url(#myGradient); }';
+
+        $this->assertSame($css, Svg::sanitizeCss($css));
+    }
+
+    #[Test]
+    public function it_preserves_data_uris()
+    {
+        $css = '.cls { background: url(data:image/png;base64,abc123); }';
+
+        $this->assertSame($css, Svg::sanitizeCss($css));
+    }
+
+    #[Test]
+    public function it_handles_mixed_legitimate_and_malicious_css()
+    {
+        $css = ".cls-1 { fill: #333; }\n@import url(\"https://evil.com/track.css\");\n.cls-2 { stroke: url(#grad); background: url(https://evil.com/bg.gif); }";
+        $expected = ".cls-1 { fill: #333; }\n\n.cls-2 { stroke: url(#grad); background: url(); }";
+
+        $this->assertSame($expected, Svg::sanitizeCss($css));
+    }
+
+    #[Test]
+    public function it_strips_font_face_with_external_src()
+    {
+        $css = '@font-face { font-family: "x"; src: url("https://evil.com/font.woff"); }';
+        $expected = '@font-face { font-family: "x"; src: url(); }';
+
+        $this->assertSame($expected, Svg::sanitizeCss($css));
+    }
+
+    #[Test]
+    public function it_sanitizes_style_tags_in_full_svg()
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><style>@import url("https://evil.com/track.css"); .cls-1 { fill: #333; }</style><rect class="cls-1"/></svg>';
+
+        $result = Svg::sanitize($svg);
+
+        $this->assertStringNotContainsString('@import', $result);
+        $this->assertStringNotContainsString('evil.com', $result);
+        $this->assertStringContainsString('.cls-1', $result);
+        $this->assertStringContainsString('fill:', $result);
+    }
+
+    #[Test]
+    public function it_passes_through_svg_without_style_tags()
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="1" height="1" fill="white"/></svg>';
+
+        $result = Svg::sanitize($svg);
+
+        $this->assertStringContainsString('<rect', $result);
+        $this->assertStringContainsString('<svg', $result);
+    }
+
+    #[Test]
+    public function it_preserves_xml_declaration()
+    {
+        $svg = '<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>';
+
+        $result = Svg::sanitize($svg);
+
+        $this->assertStringStartsWith('<?xml', $result);
+    }
+
+    #[Test]
+    public function it_does_not_add_xml_declaration()
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>';
+
+        $result = Svg::sanitize($svg);
+
+        $this->assertStringStartsWith('<svg', $result);
+    }
+}

--- a/tests/Support/SvgTest.php
+++ b/tests/Support/SvgTest.php
@@ -144,4 +144,17 @@ class SvgTest extends TestCase
 
         $this->assertStringStartsWith('<svg', $result);
     }
+
+    #[Test]
+    public function it_sanitizes_css_inside_cdata_sections()
+    {
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg"><style><![CDATA[@import url("https://evil.com/track.css"); .cls-1 { fill: url(https://evil.com/bg.gif); }]]></style><rect class="cls-1"/></svg>';
+
+        $result = Svg::sanitize($svg);
+
+        $this->assertStringNotContainsString('@import', $result);
+        $this->assertStringNotContainsString('evil.com', $result);
+        $this->assertStringContainsString('.cls-1', $result);
+        $this->assertStringContainsString('fill:', $result);
+    }
 }

--- a/tests/Support/SvgTest.php
+++ b/tests/Support/SvgTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Support;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Support\Svg;
 use Tests\TestCase;
@@ -9,96 +10,96 @@ use Tests\TestCase;
 class SvgTest extends TestCase
 {
     #[Test]
-    public function it_strips_import_with_url()
+    #[DataProvider('sanitizeCssProvider')]
+    public function it_sanitizes_css(string $input, string $expected)
     {
-        $this->assertSame('', trim(Svg::sanitizeCss('@import url("https://evil.com/x.css");')));
+        $this->assertSame($expected, trim(Svg::sanitizeCss($input)));
     }
 
-    #[Test]
-    public function it_strips_import_with_bare_string()
+    public static function sanitizeCssProvider()
     {
-        $this->assertSame('', trim(Svg::sanitizeCss('@import "https://evil.com/x.css";')));
-    }
-
-    #[Test]
-    public function it_strips_import_with_protocol_relative_url()
-    {
-        $this->assertSame('', trim(Svg::sanitizeCss('@import url(//evil.com/x.css);')));
-    }
-
-    #[Test]
-    public function it_strips_import_without_semicolon()
-    {
-        $this->assertSame('', trim(Svg::sanitizeCss("@import url('https://evil.com/x.css')")));
-    }
-
-    #[Test]
-    public function it_neutralizes_external_url_in_property()
-    {
-        $this->assertSame(
-            '.cls { background: url(); }',
-            Svg::sanitizeCss('.cls { background: url(https://evil.com/beacon.gif); }')
-        );
-    }
-
-    #[Test]
-    public function it_neutralizes_protocol_relative_url_in_property()
-    {
-        $this->assertSame(
-            '.cls { background: url(); }',
-            Svg::sanitizeCss('.cls { background: url(//evil.com/x); }')
-        );
-    }
-
-    #[Test]
-    public function it_neutralizes_quoted_external_url()
-    {
-        $this->assertSame(
-            '.cls { background: url(); }',
-            Svg::sanitizeCss('.cls { background: url("http://evil.com/x"); }')
-        );
-    }
-
-    #[Test]
-    public function it_preserves_normal_css()
-    {
-        $css = '.cls-1 { fill: #333; stroke: red; }';
-
-        $this->assertSame($css, Svg::sanitizeCss($css));
-    }
-
-    #[Test]
-    public function it_preserves_internal_url_references()
-    {
-        $css = '.cls { fill: url(#myGradient); }';
-
-        $this->assertSame($css, Svg::sanitizeCss($css));
-    }
-
-    #[Test]
-    public function it_preserves_data_uris()
-    {
-        $css = '.cls { background: url(data:image/png;base64,abc123); }';
-
-        $this->assertSame($css, Svg::sanitizeCss($css));
-    }
-
-    #[Test]
-    public function it_handles_mixed_legitimate_and_malicious_css()
-    {
-        $css = ".cls-1 { fill: #333; }\n@import url(\"https://evil.com/track.css\");\n.cls-2 { stroke: url(#grad); background: url(https://evil.com/bg.gif); }";
-        $expected = ".cls-1 { fill: #333; }\n\n.cls-2 { stroke: url(#grad); background: url(); }";
-
-        $this->assertSame($expected, Svg::sanitizeCss($css));
-    }
-
-    #[Test]
-    public function it_strips_font_face_with_external_src()
-    {
-        $css = '@font-face { font-family: "x"; src: url("https://evil.com/font.woff"); }';
-        $expected = '@font-face { font-family: "x"; src: url(); }';
-
-        $this->assertSame($expected, Svg::sanitizeCss($css));
+        return [
+            'strips @import with url()' => [
+                '@import url("https://evil.com/x.css");',
+                '',
+            ],
+            'strips @import with bare string' => [
+                '@import "https://evil.com/x.css";',
+                '',
+            ],
+            'strips @import with protocol-relative url' => [
+                '@import url(//evil.com/x.css);',
+                '',
+            ],
+            'strips @import without semicolon' => [
+                "@import url('https://evil.com/x.css')",
+                '',
+            ],
+            'strips @import using hex escapes' => [
+                '@\\69mport url("https://evil.com/x.css");',
+                '',
+            ],
+            'strips @import using non-hex backslash escapes' => [
+                '@\import url("https://evil.com/x.css");',
+                '',
+            ],
+            'strips @import using mixed hex and non-hex escapes' => [
+                '@\\69\mport url("https://evil.com/x.css");',
+                '',
+            ],
+            'neutralizes external url' => [
+                '.cls { background: url(https://evil.com/beacon.gif); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes protocol-relative url' => [
+                '.cls { background: url(//evil.com/x); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes quoted external url' => [
+                '.cls { background: url("http://evil.com/x"); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes external url using hex escapes' => [
+                '.cls { background: url(\\68\\74\\74\\70\\73://evil.com/beacon.gif); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes external url using non-hex backslash escapes' => [
+                '.cls { background: url(\https://evil.com/x); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes external url using non-breaking space escape' => [
+                '.cls { background: url(\\a0 https://evil.com/x); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes external url using zero-width space escape' => [
+                '.cls { background: url(\\200B https://evil.com/x); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes external url using BOM escape' => [
+                '.cls { background: url(\\FEFF https://evil.com/x); }',
+                '.cls { background: url(); }',
+            ],
+            'neutralizes external url in @font-face src' => [
+                '@font-face { font-family: "x"; src: url("https://evil.com/font.woff"); }',
+                '@font-face { font-family: "x"; src: url(); }',
+            ],
+            'preserves normal css' => [
+                '.cls-1 { fill: #333; stroke: red; }',
+                '.cls-1 { fill: #333; stroke: red; }',
+            ],
+            'preserves internal url references' => [
+                '.cls { fill: url(#myGradient); }',
+                '.cls { fill: url(#myGradient); }',
+            ],
+            'preserves data uris' => [
+                '.cls { background: url(data:image/png;base64,abc123); }',
+                '.cls { background: url(data:image/png;base64,abc123); }',
+            ],
+            'handles mixed legitimate and malicious css' => [
+                ".cls-1 { fill: #333; }\n@import url(\"https://evil.com/track.css\");\n.cls-2 { stroke: url(#grad); background: url(https://evil.com/bg.gif); }",
+                ".cls-1 { fill: #333; }\n\n.cls-2 { stroke: url(#grad); background: url(); }",
+            ],
+        ];
     }
 
     #[Test]

--- a/tests/Tags/SvgTagTest.php
+++ b/tests/Tags/SvgTagTest.php
@@ -115,6 +115,19 @@ SVG);
     }
 
     #[Test]
+    public function it_sanitizes_css_in_style_tags()
+    {
+        File::put(resource_path('css-inject.svg'), '<svg xmlns="http://www.w3.org/2000/svg"><style>@import url("https://evil.com/track.css"); .cls-1 { fill: #333; }</style><rect class="cls-1"/></svg>');
+
+        $result = $this->tag('{{ svg src="css-inject" }}');
+
+        $this->assertStringNotContainsString('@import', $result);
+        $this->assertStringNotContainsString('evil.com', $result);
+        $this->assertStringContainsString('.cls-1', $result);
+        $this->assertStringContainsString('fill:', $result);
+    }
+
+    #[Test]
     public function fails_gracefully_when_src_is_empty()
     {
         $output = $this->tag('{{ svg :src="icon" }}', [


### PR DESCRIPTION
## Summary

- Centralized SVG sanitization into `Statamic\Support\Svg::sanitize()`, replacing duplicated `DOMSanitizer` usage across four call sites
- Added CSS content sanitization for `<style>` tags within SVGs — strips `@import` rules and external `url()` references while preserving internal CSS, fragment references (`url(#gradient)`), and data URIs
- Updated `Assets\Uploader`, `Assets\Asset`, `CP\Navigation\NavItem`, and `Tags\Svg` to use the centralized method
- The `{{ svg }}` tag's `allow_tags`/`allow_attrs` customization continues to work via an optional `$sanitizer` parameter

## Test plan

- [x] 16 new tests in `tests/Support/SvgTest.php` covering `sanitizeCss()` and full SVG pipeline
- [x] 1 new test in `tests/Tags/SvgTagTest.php` for CSS injection via `{{ svg }}` tag
- [x] Existing asset sanitization tests pass