### PR TITLE
[6.x] Fix serializable_classes issues

### DIFF
--- a/src/API/Cachers/DefaultCacher.php
+++ b/src/API/Cachers/DefaultCacher.php
@@ -4,6 +4,7 @@ namespace Statamic\API\Cachers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Statamic\API\AbstractCacher;
 use Statamic\Events\Event;
@@ -15,7 +16,13 @@ class DefaultCacher extends AbstractCacher
      */
     public function get(Request $request)
     {
-        return Cache::get($this->getCacheKey($request));
+        $cached = Cache::get($this->getCacheKey($request));
+
+        if (! is_array($cached)) {
+            return null;
+        }
+
+        return new Response($cached['content'], $cached['status'], $cached['headers']);
     }
 
     /**
@@ -25,7 +32,11 @@ class DefaultCacher extends AbstractCacher
     {
         $key = $this->trackEndpoint($request);
 
-        Cache::put($key, $response, $this->cacheExpiry());
+        Cache::put($key, [
+            'content' => $response->getContent(),
+            'status' => $response->getStatusCode(),
+            'headers' => $response->headers->all(),
+        ], $this->cacheExpiry());
     }
 
     /**

--- a/src/API/Cachers/DefaultCacher.php
+++ b/src/API/Cachers/DefaultCacher.php
@@ -4,7 +4,6 @@ namespace Statamic\API\Cachers;
 
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Cache;
 use Statamic\API\AbstractCacher;
 use Statamic\Events\Event;
@@ -22,7 +21,7 @@ class DefaultCacher extends AbstractCacher
             return null;
         }
 
-        return new Response($cached['content'], $cached['status'], $cached['headers']);
+        return new JsonResponse($cached['content'], $cached['status'], $cached['headers'], true);
     }
 
     /**

--- a/src/API/Cachers/DefaultCacher.php
+++ b/src/API/Cachers/DefaultCacher.php
@@ -21,7 +21,7 @@ class DefaultCacher extends AbstractCacher
             return null;
         }
 
-        return new JsonResponse($cached['content'], $cached['status'], $cached['headers'], true);
+        return new JsonResponse($cached['content'], $cached['status'], $cached['headers'], json: true);
     }
 
     /**

--- a/src/GraphQL/ResponseCache/DefaultCache.php
+++ b/src/GraphQL/ResponseCache/DefaultCache.php
@@ -2,8 +2,8 @@
 
 namespace Statamic\GraphQL\ResponseCache;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Contracts\GraphQL\ResponseCache;
@@ -19,7 +19,7 @@ class DefaultCache implements ResponseCache
             return null;
         }
 
-        return new Response($cached['content'], $cached['status'], $cached['headers']);
+        return new JsonResponse($cached['content'], $cached['status'], $cached['headers'], true);
     }
 
     public function put(Request $request, $response)

--- a/src/GraphQL/ResponseCache/DefaultCache.php
+++ b/src/GraphQL/ResponseCache/DefaultCache.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL\ResponseCache;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Contracts\GraphQL\ResponseCache;
@@ -12,7 +13,13 @@ class DefaultCache implements ResponseCache
 {
     public function get(Request $request)
     {
-        return Cache::get($this->getCacheKey($request));
+        $cached = Cache::get($this->getCacheKey($request));
+
+        if (! is_array($cached)) {
+            return null;
+        }
+
+        return new Response($cached['content'], $cached['status'], $cached['headers']);
     }
 
     public function put(Request $request, $response)
@@ -21,7 +28,11 @@ class DefaultCache implements ResponseCache
 
         $ttl = Carbon::now()->addMinutes((int) config('statamic.graphql.cache.expiry', 60));
 
-        Cache::put($key, $response, $ttl);
+        Cache::put($key, [
+            'content' => $response->getContent(),
+            'status' => $response->getStatusCode(),
+            'headers' => $response->headers->all(),
+        ], $ttl);
     }
 
     protected function track($request)

--- a/src/GraphQL/ResponseCache/DefaultCache.php
+++ b/src/GraphQL/ResponseCache/DefaultCache.php
@@ -19,7 +19,7 @@ class DefaultCache implements ResponseCache
             return null;
         }
 
-        return new JsonResponse($cached['content'], $cached['status'], $cached['headers'], true);
+        return new JsonResponse($cached['content'], $cached['status'], $cached['headers'], json: true);
     }
 
     public function put(Request $request, $response)

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -721,11 +721,11 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         $existing = $this->app['config']->get('cache.serializable_classes');
 
-        if (! is_array($existing)) {
+        if ($existing === null || $existing === true) {
             return;
         }
 
-        $this->app['config']->set('cache.serializable_classes', array_merge($existing, $classes));
+        $this->app['config']->set('cache.serializable_classes', array_merge(is_array($existing) ? $existing : [], $classes));
     }
 
     protected function schedule(Schedule $schedule)

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -721,14 +721,11 @@ abstract class AddonServiceProvider extends ServiceProvider
     {
         $existing = $this->app['config']->get('cache.serializable_classes');
 
-        if ($existing === true) {
+        if (! is_array($existing)) {
             return;
         }
 
-        $this->app['config']->set('cache.serializable_classes', array_merge(
-            is_array($existing) ? $existing : [],
-            $classes
-        ));
+        $this->app['config']->set('cache.serializable_classes', array_merge($existing, $classes));
     }
 
     protected function schedule(Schedule $schedule)

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -245,6 +245,8 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app['config']->set('cache.serializable_classes', array_merge(is_array($existing) ? $existing : [], [
             \Statamic\Auth\File\User::class,
+            \Statamic\Auth\File\Passkey::class,
+            \Statamic\Auth\Eloquent\Passkey::class,
             \Statamic\Assets\Asset::class,
             \Statamic\Assets\AssetContainer::class,
             \Statamic\Entries\Collection::class,

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -239,11 +239,11 @@ class AppServiceProvider extends ServiceProvider
     {
         $existing = $this->app['config']->get('cache.serializable_classes');
 
-        if ($existing === true) {
+        if (! is_array($existing)) {
             return;
         }
 
-        $classes = [
+        $this->app['config']->set('cache.serializable_classes', array_merge($existing, [
             \Statamic\Auth\File\User::class,
             \Statamic\Assets\Asset::class,
             \Statamic\Assets\AssetContainer::class,
@@ -264,12 +264,7 @@ class AppServiceProvider extends ServiceProvider
             \Carbon\Carbon::class,
             \Illuminate\Support\Carbon::class,
             \Illuminate\Support\Collection::class,
-        ];
-
-        $this->app['config']->set('cache.serializable_classes', array_merge(
-            is_array($existing) ? $existing : [],
-            $classes
-        ));
+        ]));
     }
 
     protected function registerMiddlewareGroup()

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -239,11 +239,11 @@ class AppServiceProvider extends ServiceProvider
     {
         $existing = $this->app['config']->get('cache.serializable_classes');
 
-        if (! is_array($existing)) {
+        if ($existing === null || $existing === true) {
             return;
         }
 
-        $this->app['config']->set('cache.serializable_classes', array_merge($existing, [
+        $this->app['config']->set('cache.serializable_classes', array_merge(is_array($existing) ? $existing : [], [
             \Statamic\Auth\File\User::class,
             \Statamic\Assets\Asset::class,
             \Statamic\Assets\AssetContainer::class,

--- a/tests/API/CacherTest.php
+++ b/tests/API/CacherTest.php
@@ -57,7 +57,11 @@ class CacherTest extends TestCase
         $this->assertEquals([$cacheKey], Cache::get('api-cache:tracked-responses'));
 
         // manually manipulate whats in the cache so we can be sure it uses it.
-        Cache::put($cacheKey, response()->json(['foo' => 'bar']), 10);
+        Cache::put($cacheKey, [
+            'content' => json_encode(['foo' => 'bar']),
+            'status' => 200,
+            'headers' => ['content-type' => ['application/json']],
+        ], 10);
 
         $this->get($endpoint)
             ->assertOk()

--- a/tests/Feature/GraphQL/RequestCacheTest.php
+++ b/tests/Feature/GraphQL/RequestCacheTest.php
@@ -211,6 +211,23 @@ class RequestCacheTest extends TestCase
     }
 
     #[Test]
+    public function it_caches_response_data_as_primitives()
+    {
+        app()->instance('request-tracking', $requests = Collection::make());
+
+        $this->post('/graphql', ['query' => '{one}']);
+
+        $key = 'gql-cache:'.md5('{one}').'_'.md5(json_encode(null));
+        $cached = Cache::get($key);
+
+        $this->assertIsArray($cached);
+        $this->assertArrayHasKey('content', $cached);
+        $this->assertArrayHasKey('status', $cached);
+        $this->assertArrayHasKey('headers', $cached);
+        $this->assertEquals(200, $cached['status']);
+    }
+
+    #[Test]
     public function it_can_disable_caching()
     {
         config(['statamic.graphql.cache' => false]);


### PR DESCRIPTION
## Summary

- **Make `registerSerializableClasses()` opt-in** in both `AppServiceProvider` and `AddonServiceProvider`. Previously it eagerly converted an unconfigured (`null`) `cache.serializable_classes` into a restrictive allowlist on every boot, which caused cached Response objects to deserialize as `__PHP_Incomplete_Class`.
- **Store response data as primitives** in both `API\Cachers\DefaultCacher` and `GraphQL\ResponseCache\DefaultCache`. Instead of caching full Response objects (which require class allowlisting), store `content`, `status`, and `headers` as an array and reconstruct on cache hit. Old cached Response objects are treated as cache misses and re-cached in the new format.
- **Fix `serializable_classes` handling when config is `false`** (the Laravel 13 default). The guard was treating `false` the same as `null`/`true` and skipping registration, but `false` means "restrict to no classes", breaking all Stache deserialization. Now only `null` and `true` (both unrestricted) are skipped.
- **Fix `JsonResponse` constructor** to use a named `json:` argument, since Laravel's `JsonResponse` has an extra `$options` parameter before `$json` compared to Symfony's.
- **Add Passkey classes to the `serializable_classes` allowlist.** Users with passkeys would get incomplete class errors when their cached User object was unserialized, since `Statamic\Auth\File\Passkey` and `Statamic\Auth\Eloquent\Passkey` weren't in the allowlist.

Fixes the 500 error on GraphQL POST requests after upgrading to 6.10.0:
```
TypeError: Symfony\Component\HttpFoundation\Response::setContent():
Argument #1 ($content) must be of type ?string, __PHP_Incomplete_Class given
```

## Test plan

- [x] Existing `RequestCacheTest` and `CacherTest` suites pass
- [x] New test verifies cached GraphQL response is stored as primitive data
- [x] Manual: confirm GraphQL POST requests work with file cache driver and `serializable_classes` configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)