### PR TITLE
[6.x] Fix addon settings always showing as migratable

### DIFF
--- a/src/Console/Commands/InstallEloquentDriver.php
+++ b/src/Console/Commands/InstallEloquentDriver.php
@@ -153,7 +153,7 @@ class InstallEloquentDriver extends Command
     {
         switch ($repository) {
             case 'addon_settings':
-                return config('statamic.system.addon_settings_driver') === 'database';
+                return config('statamic.eloquent-driver.addon_settings.driver') === 'eloquent';
 
             case 'asset_containers':
                 return config('statamic.eloquent-driver.asset_containers.driver') === 'eloquent';


### PR DESCRIPTION
This pull request fixes an issue I spotted where the "Addon Settings" repository was always showing as migratable in the `install:eloquent-driver` command.

This was caused by it checking the wrong config option to determine if the repo had already been migrated.