### PR TITLE
[6.x] Fix creating passkeys with JSON session serialization

### DIFF
--- a/src/Auth/WebAuthn/WebAuthn.php
+++ b/src/Auth/WebAuthn/WebAuthn.php
@@ -31,7 +31,7 @@ class WebAuthn
     {
         $challenge = random_bytes(32);
 
-        session()->put('webauthn.challenge', $challenge);
+        session()->put('webauthn.challenge', base64_encode($challenge));
 
         return $this->getRequestOptions($challenge);
     }
@@ -42,7 +42,7 @@ class WebAuthn
 
         $passkey = $this->getPasskey($user, $publicKeyCredential);
 
-        $options = $this->getRequestOptions(session()->pull('webauthn.challenge'));
+        $options = $this->getRequestOptions(base64_decode(session()->pull('webauthn.challenge')));
 
         $publicKeyCredentialSource = $this->assertionResponseValidator->check(
             $passkey->credential(),
@@ -79,7 +79,7 @@ class WebAuthn
     {
         $challenge = random_bytes(16);
 
-        session()->put('webauthn.challenge', $challenge);
+        session()->put('webauthn.challenge', base64_encode($challenge));
 
         return $this->getCreationOptions($user, $challenge);
     }
@@ -92,7 +92,7 @@ class WebAuthn
             throw new Exception(__('Invalid credentials.'));
         }
 
-        $options = $this->getCreationOptions($user, session()->pull('webauthn.challenge'));
+        $options = $this->getCreationOptions($user, base64_decode(session()->pull('webauthn.challenge')));
 
         $publicKeyCredentialSource = $this->attestationResponseValidator->check(
             $publicKeyCredential->response,

--- a/tests/Auth/WebAuthn/WebAuthnTest.php
+++ b/tests/Auth/WebAuthn/WebAuthnTest.php
@@ -180,7 +180,7 @@ class WebAuthnTest extends TestCase
 
         $credentials = ['id' => 'credential-id', 'rawId' => 'raw-id', 'response' => [], 'type' => 'public-key'];
         $challenge = random_bytes(32);
-        session()->put('webauthn.challenge', $challenge);
+        session()->put('webauthn.challenge', base64_encode($challenge));
 
         // Create real objects
         $publicKeyCredential = new PublicKeyCredential(
@@ -219,6 +219,7 @@ class WebAuthnTest extends TestCase
         $this->mockAssertionValidator
             ->shouldReceive('check')
             ->once()
+            ->withArgs(fn ($credential, $response, $options) => $options->challenge === $challenge)
             ->andReturn($updatedCredentialSource);
 
         $result = $this->webauthn->validateAssertion($mockUser, $credentials);
@@ -234,7 +235,6 @@ class WebAuthnTest extends TestCase
         $user->save();
 
         $credentials = ['id' => 'credential-id', 'rawId' => 'raw-id', 'response' => [], 'type' => 'public-key'];
-        session()->put('webauthn.challenge', random_bytes(32));
 
         $publicKeyCredential = new PublicKeyCredential(
             'public-key',

--- a/tests/Auth/WebAuthn/WebAuthnTest.php
+++ b/tests/Auth/WebAuthn/WebAuthnTest.php
@@ -56,7 +56,7 @@ class WebAuthnTest extends TestCase
 
         $this->assertInstanceOf(PublicKeyCredentialRequestOptions::class, $options);
         $this->assertNotNull(session('webauthn.challenge'));
-        $this->assertEquals(32, strlen(session('webauthn.challenge')));
+        $this->assertEquals(32, strlen(base64_decode(session('webauthn.challenge'))));
         $this->assertEquals(PublicKeyCredentialRequestOptions::USER_VERIFICATION_REQUIREMENT_REQUIRED, $options->userVerification);
     }
 
@@ -84,11 +84,11 @@ class WebAuthnTest extends TestCase
         // Challenge should be stored in session for later verification
         $storedChallenge = session('webauthn.challenge');
         $this->assertNotNull($storedChallenge);
-        $this->assertEquals(32, strlen($storedChallenge));
+        $this->assertEquals(32, strlen(base64_decode($storedChallenge)));
 
         // The challenge in the options should be the same binary value
         // (base64url encoding happens during serialization, not in the object)
-        $this->assertEquals($storedChallenge, $options->challenge);
+        $this->assertEquals(base64_decode($storedChallenge), $options->challenge);
     }
 
     #[Test]

--- a/tests/Feature/Auth/PasskeyLoginTest.php
+++ b/tests/Feature/Auth/PasskeyLoginTest.php
@@ -65,9 +65,10 @@ class PasskeyLoginTest extends TestCase
         // Verify the session has been populated
         $this->assertNotNull(session('webauthn.challenge'));
 
-        // The session challenge is the binary form (32 bytes)
+        // The session challenge is base64 encoded (32 bytes -> 44 chars)
         // The response challenge is the base64url encoded form
-        $this->assertEquals(32, strlen(session('webauthn.challenge')));
+        $this->assertEquals(44, strlen(session('webauthn.challenge')));
+        $this->assertEquals(32, strlen(base64_decode(session('webauthn.challenge'))));
         $this->assertIsString($responseChallenge);
     }
 

--- a/tests/Feature/Auth/StorePasskeyTest.php
+++ b/tests/Feature/Auth/StorePasskeyTest.php
@@ -69,7 +69,7 @@ class StorePasskeyTest extends TestCase
         $responseChallenge = $response->json('challenge');
 
         $this->assertNotNull(session('webauthn.challenge'));
-        $this->assertEquals(16, strlen(session('webauthn.challenge')));
+        $this->assertEquals(16, strlen(base64_decode(session('webauthn.challenge'))));
         $this->assertIsString($responseChallenge);
     }
 


### PR DESCRIPTION
This pull request fixes an issue when creating passkeys alongside the `json` serializer for sessions, which was made [the default in Laravel 13](https://github.com/laravel/laravel/commit/75cef503c6edc3447dd79053a648ea981857e15b).

The WebAuthn challenge is generated using `random_bytes()`, which produces binary data. Since `json_encode()` cannot encode binary data (it returns `false` for invalid UTF-8), the session write fails silently, resulting in an empty session file and the user being logged out.

This PR fixes it by base64 encoding the challenge before storing it in the session, ensuring compatibility with both PHP and JSON session serialization methods.