### PR TITLE
[6.x] Require 2FA/passkey verification after password reset

### DIFF
--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -12,7 +12,10 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password as PasswordRules;
 use Illuminate\Validation\ValidationException;
+use Statamic\Events\TwoFactorAuthenticationChallenged;
+use Statamic\Facades\TwoFactor;
 use Statamic\Facades\URL;
+use Statamic\Facades\User;
 
 /**
  * A copy of Illuminate\Auth\ResetsPasswords.
@@ -131,6 +134,19 @@ trait ResetsPasswords
 
         event(new PasswordReset($user));
 
+        $statamicUser = User::fromUser($user);
+
+        if ($statamicUser && TwoFactor::enabled() && $statamicUser->hasEnabledTwoFactorAuthentication()) {
+            request()->session()->put([
+                'login.id' => $statamicUser->getKey(),
+                'login.remember' => false,
+            ]);
+
+            TwoFactorAuthenticationChallenged::dispatch($statamicUser);
+
+            return;
+        }
+
         $this->guard()->login($user);
     }
 
@@ -154,12 +170,23 @@ trait ResetsPasswords
      */
     protected function sendResetResponse(Request $request, $response)
     {
+        if ($request->session()->has('login.id')) {
+            return $request->wantsJson()
+                ? new JsonResponse(['two_factor' => true], 200)
+                : redirect($this->twoFactorChallengeRedirect());
+        }
+
         if ($request->wantsJson()) {
             return new JsonResponse(['message' => trans($response)], 200);
         }
 
         return redirect($this->redirectPath())
             ->with('status', trans($response));
+    }
+
+    protected function twoFactorChallengeRedirect(): string
+    {
+        return route('statamic.two-factor-challenge');
     }
 
     /**

--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -147,6 +147,12 @@ trait ResetsPasswords
             return;
         }
 
+        if ($statamicUser
+            && ! config('statamic.webauthn.allow_password_login_with_passkey', true)
+            && $statamicUser->passkeys()->isNotEmpty()) {
+            return;
+        }
+
         $this->guard()->login($user);
     }
 
@@ -180,8 +186,17 @@ trait ResetsPasswords
             return new JsonResponse(['message' => trans($response)], 200);
         }
 
-        return redirect($this->redirectPath())
+        $redirect = $this->guard()->check()
+            ? $this->redirectPath()
+            : $this->loginPath();
+
+        return redirect($redirect)
             ->with('status', trans($response));
+    }
+
+    protected function loginPath(): string
+    {
+        return route('statamic.site');
     }
 
     protected function twoFactorChallengeRedirect(): string

--- a/src/Http/Controllers/CP/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/CP/Auth/ResetPasswordController.php
@@ -29,4 +29,9 @@ class ResetPasswordController extends Controller
     {
         return route('statamic.cp.password.reset.action');
     }
+
+    protected function twoFactorChallengeRedirect(): string
+    {
+        return cp_route('two-factor-challenge');
+    }
 }

--- a/src/Http/Controllers/CP/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/CP/Auth/ResetPasswordController.php
@@ -30,6 +30,11 @@ class ResetPasswordController extends Controller
         return route('statamic.cp.password.reset.action');
     }
 
+    protected function loginPath(): string
+    {
+        return cp_route('login');
+    }
+
     protected function twoFactorChallengeRedirect(): string
     {
         return cp_route('two-factor-challenge');

--- a/tests/Auth/ResetPasswordTest.php
+++ b/tests/Auth/ResetPasswordTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Tests\Auth;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Auth\Passwords\PasswordReset;
+use Statamic\Auth\TwoFactor\RecoveryCode;
+use Statamic\Contracts\Auth\TwoFactor\TwoFactorAuthenticationProvider;
+use Statamic\Events\TwoFactorAuthenticationChallenged;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ResetPasswordTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public static function resetPasswordProvider(): array
+    {
+        return [
+            'cp' => ['cp'],
+            'web' => ['web'],
+        ];
+    }
+
+    private function resetUrl(string $type): string
+    {
+        return match ($type) {
+            'cp' => cp_route('password.reset.action'),
+            'web' => route('statamic.password.reset.action'),
+        };
+    }
+
+    private function twoFactorChallengeUrl(string $type): string
+    {
+        return match ($type) {
+            'cp' => cp_route('two-factor-challenge'),
+            'web' => route('statamic.two-factor-challenge'),
+        };
+    }
+
+    private function broker(string $type)
+    {
+        $broker = config('statamic.users.passwords.'.PasswordReset::BROKER_RESETS);
+
+        if (is_array($broker)) {
+            $broker = $broker[$type];
+        }
+
+        return Password::broker($broker);
+    }
+
+    #[Test]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_resets_password_and_logs_in(string $type)
+    {
+        $user = $this->user();
+        $token = $this->broker($type)->createToken($user);
+
+        $this
+            ->assertGuest()
+            ->post($this->resetUrl($type), [
+                'token' => $token,
+                'email' => $user->email(),
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+            ])
+            ->assertRedirect('/');
+
+        $this->assertAuthenticatedAs($user);
+        $this->assertTrue(Hash::check('newpassword', $user->fresh()->password()));
+    }
+
+    #[Test]
+    #[Group('2fa')]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_redirects_to_two_factor_challenge_when_user_has_two_factor_enabled(string $type)
+    {
+        Event::fake();
+
+        $user = $this->userWithTwoFactorEnabled();
+        $token = $this->broker($type)->createToken($user);
+
+        $this
+            ->assertGuest()
+            ->post($this->resetUrl($type), [
+                'token' => $token,
+                'email' => $user->email(),
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+            ])
+            ->assertRedirect($this->twoFactorChallengeUrl($type))
+            ->assertSessionHas('login.id', $user->id())
+            ->assertSessionHas('login.remember', false);
+
+        $this->assertGuest();
+        $this->assertTrue(Hash::check('newpassword', $user->fresh()->password()));
+
+        Event::assertDispatched(TwoFactorAuthenticationChallenged::class, fn ($event) => $event->user->id === $user->id);
+    }
+
+    #[Test]
+    #[Group('2fa')]
+    #[DefineEnvironment('disableTwoFactor')]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_skips_two_factor_challenge_when_two_factor_is_disabled(string $type)
+    {
+        Event::fake();
+
+        $user = $this->userWithTwoFactorEnabled();
+        $token = $this->broker($type)->createToken($user);
+
+        $this
+            ->assertGuest()
+            ->post($this->resetUrl($type), [
+                'token' => $token,
+                'email' => $user->email(),
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+            ])
+            ->assertRedirect('/');
+
+        $this->assertAuthenticatedAs($user);
+        $this->assertTrue(Hash::check('newpassword', $user->fresh()->password()));
+
+        Event::assertNotDispatched(TwoFactorAuthenticationChallenged::class);
+    }
+
+    protected function disableTwoFactor($app)
+    {
+        $app['config']->set('statamic.users.two_factor_enabled', false);
+    }
+
+    private function user()
+    {
+        return tap(User::make()->makeSuper()->email('david@hasselhoff.com')->password('secret'))->save();
+    }
+
+    private function userWithTwoFactorEnabled()
+    {
+        $user = $this->user();
+
+        $user->merge([
+            'two_factor_confirmed_at' => now()->timestamp,
+            'two_factor_secret' => encrypt(app(TwoFactorAuthenticationProvider::class)->generateSecretKey()),
+            'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, function () {
+                return RecoveryCode::generate();
+            })->all())),
+        ]);
+
+        $user->save();
+
+        return $user;
+    }
+}

--- a/tests/Auth/ResetPasswordTest.php
+++ b/tests/Auth/ResetPasswordTest.php
@@ -10,17 +10,17 @@ use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Auth\File\Passkey;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Auth\TwoFactor\RecoveryCode;
 use Statamic\Contracts\Auth\TwoFactor\TwoFactorAuthenticationProvider;
-use Statamic\Auth\File\Passkey;
 use Statamic\Events\TwoFactorAuthenticationChallenged;
-use Symfony\Component\Uid\Uuid;
-use Webauthn\PublicKeyCredentialSource;
-use Webauthn\TrustPath\EmptyTrustPath;
 use Statamic\Facades\User;
+use Symfony\Component\Uid\Uuid;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\TrustPath\EmptyTrustPath;
 
 class ResetPasswordTest extends TestCase
 {

--- a/tests/Auth/ResetPasswordTest.php
+++ b/tests/Auth/ResetPasswordTest.php
@@ -13,7 +13,11 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Auth\TwoFactor\RecoveryCode;
 use Statamic\Contracts\Auth\TwoFactor\TwoFactorAuthenticationProvider;
+use Statamic\Auth\File\Passkey;
 use Statamic\Events\TwoFactorAuthenticationChallenged;
+use Symfony\Component\Uid\Uuid;
+use Webauthn\PublicKeyCredentialSource;
+use Webauthn\TrustPath\EmptyTrustPath;
 use Statamic\Facades\User;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -133,14 +137,92 @@ class ResetPasswordTest extends TestCase
         Event::assertNotDispatched(TwoFactorAuthenticationChallenged::class);
     }
 
+    #[Test]
+    #[DefineEnvironment('disallowPasswordLoginWithPasskey')]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_does_not_log_in_when_user_has_passkeys_and_password_login_is_disallowed(string $type)
+    {
+        $user = $this->userWithPasskey();
+        $token = $this->broker($type)->createToken($user);
+
+        $this
+            ->assertGuest()
+            ->post($this->resetUrl($type), [
+                'token' => $token,
+                'email' => $user->email(),
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+            ])
+            ->assertRedirect($this->loginUrl($type));
+
+        $this->assertGuest();
+        $this->assertTrue(Hash::check('newpassword', $user->fresh()->password()));
+    }
+
+    #[Test]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_logs_in_when_user_has_passkeys_and_password_login_is_allowed(string $type)
+    {
+        $user = $this->userWithPasskey();
+        $token = $this->broker($type)->createToken($user);
+
+        $this
+            ->assertGuest()
+            ->post($this->resetUrl($type), [
+                'token' => $token,
+                'email' => $user->email(),
+                'password' => 'newpassword',
+                'password_confirmation' => 'newpassword',
+            ])
+            ->assertRedirect('/');
+
+        $this->assertAuthenticatedAs($user);
+        $this->assertTrue(Hash::check('newpassword', $user->fresh()->password()));
+    }
+
     protected function disableTwoFactor($app)
     {
         $app['config']->set('statamic.users.two_factor_enabled', false);
     }
 
+    protected function disallowPasswordLoginWithPasskey($app)
+    {
+        $app['config']->set('statamic.webauthn.allow_password_login_with_passkey', false);
+    }
+
+    private function loginUrl(string $type): string
+    {
+        return match ($type) {
+            'cp' => cp_route('login'),
+            'web' => route('statamic.site'),
+        };
+    }
+
     private function user()
     {
         return tap(User::make()->makeSuper()->email('david@hasselhoff.com')->password('secret'))->save();
+    }
+
+    private function userWithPasskey()
+    {
+        $user = $this->user();
+
+        $credential = PublicKeyCredentialSource::create(
+            publicKeyCredentialId: 'test-credential-id',
+            type: 'public-key',
+            transports: ['usb'],
+            attestationType: 'none',
+            trustPath: new EmptyTrustPath(),
+            aaguid: Uuid::fromString('00000000-0000-0000-0000-000000000000'),
+            credentialPublicKey: 'test-public-key',
+            userHandle: $user->id(),
+            counter: 0
+        );
+
+        $passkey = (new Passkey)->setUser($user)->setName('Test Key')->setCredential($credential);
+        $passkey->save();
+
+        return $user->fresh();
     }
 
     private function userWithTwoFactorEnabled()


### PR DESCRIPTION
## Summary

- Prevent auto-login after password reset when the user has 2FA enabled. Instead, redirect to the 2FA challenge page so the user must complete the second factor before gaining access.
- Prevent auto-login after password reset when `allow_password_login_with_passkey` is `false` and the user has passkeys. Instead, redirect to the login page.
- Both checks apply to CP and front-end password reset flows.
- Add `ResetPasswordTest` covering all scenarios with a data provider for CP/web.

## Test plan

- [x] Existing auth tests pass
- [x] New `ResetPasswordTest` covers:
  - Password reset logs in user (baseline)
  - Password reset redirects to 2FA challenge when user has 2FA enabled
  - Password reset skips 2FA challenge when 2FA is globally disabled
  - Password reset does not auto-login when passkey login is enforced
  - Password reset still auto-logs in when passkey login is allowed
  - All scenarios tested for both CP and web endpoints