### PR TITLE
[6.x] Add elevated session guards to AssignGroups and AssignRoles actions

### DIFF
--- a/src/Actions/AssignGroups.php
+++ b/src/Actions/AssignGroups.php
@@ -24,6 +24,11 @@ class AssignGroups extends Action
         return $authed->can('assign user groups');
     }
 
+    public function requiresElevatedSession(): bool
+    {
+        return true;
+    }
+
     public function confirmationText()
     {
         /** @translation */

--- a/src/Actions/AssignRoles.php
+++ b/src/Actions/AssignRoles.php
@@ -24,6 +24,11 @@ class AssignRoles extends Action
         return $authed->can('assign roles');
     }
 
+    public function requiresElevatedSession(): bool
+    {
+        return true;
+    }
+
     public function confirmationText()
     {
         /** @translation */


### PR DESCRIPTION
## Summary

- Add `requiresElevatedSession()` returning `true` to `AssignGroups` and `AssignRoles` actions
- This requires users to re-confirm their password before assigning roles or groups, matching the pattern already used in `CopyPasswordResetLink`

🤖 Generated with [Claude Code](https://claude.com/claude-code)