### PR TITLE
[6.x] fix(combobox): handle object values in selectedOptions lookup

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -137,7 +137,28 @@ const selectedOptions = computed(() => {
     }
 
     return selections.map((value) => {
-        return props.options.find((option) => getOptionValue(option) === value) ?? { label: value, value };
+        // Extract the actual value when dealing with objects
+        const valueToFind = typeof value === 'object' && value !== null 
+            ? value[props.optionValue] 
+            : value;
+            
+        const foundOption = props.options.find((option) => 
+            getOptionValue(option) === valueToFind
+        );
+        
+        if (foundOption) {
+            return foundOption;
+        }
+        
+        // If value is already a complete option object with optionLabel and optionValue as keys, use it directly
+        if (typeof value === 'object' && value !== null 
+            && props.optionLabel in value 
+            && props.optionValue in value) {
+            return value;
+        }
+        
+        // Fallback for primitive values
+        return { [props.optionLabel]: valueToFind, [props.optionValue]: valueToFind };
     });
 });
 


### PR DESCRIPTION
The selectedOptions computed property failed to find matching options when modelValue contained full option objects (e.g., {label, value}) instead of primitive values. This caused the #selected-option slot to receive fallback objects with incorrect labels.

Now properly extracts the optionValue from object-type values before performing the lookup, ensuring the full option object is returned to slot templates.
