### PR TITLE
[6.x] Remove deprecated function calls

### DIFF
--- a/src/View/Antlers/Language/Runtime/RuntimeParser.php
+++ b/src/View/Antlers/Language/Runtime/RuntimeParser.php
@@ -510,7 +510,6 @@ class RuntimeParser implements Parser
         $rebuiltTrace = array_merge($rebuiltTrace, $exception->getTrace());
 
         $traceProperty = new ReflectionProperty('Exception', 'trace');
-        $traceProperty->setAccessible(true);
         $traceProperty->setValue($newException, $rebuiltTrace);
 
         $this->cleanUpTempFiles();
@@ -606,7 +605,6 @@ INFO;
 
         $ignitionException = new $exceptionClass($newMessage, 0, 1, $exceptionView, $exceptionLine, $antlersException);
         $traceProperty = new ReflectionProperty('Exception', 'trace');
-        $traceProperty->setAccessible(true);
         $traceProperty->setValue($ignitionException, $rebuiltTrace);
 
         $ignitionException->setViewData($data);

--- a/src/Yaml/Yaml.php
+++ b/src/Yaml/Yaml.php
@@ -136,7 +136,6 @@ class Yaml
             'args' => $args,
         ]);
         $traceProperty = new ReflectionProperty('Exception', 'trace');
-        $traceProperty->setAccessible(true);
         $traceProperty->setValue($exception, $trace);
 
         return $exception;

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -953,7 +953,6 @@ class AssetTest extends TestCase
 
         $reflection = new ReflectionClass($asset);
         $property = $reflection->getProperty('withEvents');
-        $property->setAccessible(true);
         $withEvents = $property->getValue($asset);
         $this->assertTrue($withEvents);
     }

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -437,7 +437,6 @@ class ElevatedSessionTest extends TestCase
         // Use reflection to set the passkeys property
         $reflection = new \ReflectionClass($user);
         $property = $reflection->getProperty('passkeys');
-        $property->setAccessible(true);
         $property->setValue($user, $mockCollection);
 
         $this->assertEquals('passkey', $user->getElevatedSessionMethod());
@@ -456,7 +455,6 @@ class ElevatedSessionTest extends TestCase
         // Use reflection to set the passkeys property
         $reflection = new \ReflectionClass($user);
         $property = $reflection->getProperty('passkeys');
-        $property->setAccessible(true);
         $property->setValue($user, $mockCollection);
 
         $this->assertEquals('password_confirmation', $user->getElevatedSessionMethod());
@@ -493,7 +491,6 @@ class ElevatedSessionTest extends TestCase
         // Use reflection to set the passkeys property
         $reflection = new \ReflectionClass($user);
         $property = $reflection->getProperty('passkeys');
-        $property->setAccessible(true);
         $property->setValue($user, $mockCollection);
 
         $response = $this
@@ -520,7 +517,6 @@ class ElevatedSessionTest extends TestCase
         // Use reflection to set the passkeys property
         $reflection = new \ReflectionClass($user);
         $property = $reflection->getProperty('passkeys');
-        $property->setAccessible(true);
         $property->setValue($user, $mockCollection);
 
         $credentials = [
@@ -556,7 +552,6 @@ class ElevatedSessionTest extends TestCase
         // Use reflection to set the passkeys property
         $reflection = new \ReflectionClass($user);
         $property = $reflection->getProperty('passkeys');
-        $property->setAccessible(true);
         $property->setValue($user, $mockCollection);
 
         $this

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1430,7 +1430,6 @@ class EntryTest extends TestCase
         $cached = Cache::get('stache::items::entries::blog::1');
         $reflection = new ReflectionClass($cached);
         $property = $reflection->getProperty('withEvents');
-        $property->setAccessible(true);
         $withEvents = $property->getValue($cached);
         $this->assertTrue($withEvents);
     }

--- a/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
+++ b/tests/Feature/GraphQL/Fieldtypes/DateFieldtypeTest.php
@@ -19,7 +19,6 @@ class DateFieldtypeTest extends FieldtypeTestCase
             $reflection = new ReflectionClass(self::this());
 
             $factory = $reflection->getMethod('getFactory');
-            $factory->setAccessible(true);
 
             return Arr::get($factory->invoke(self::this())->getSettings(), 'toStringFormat');
         });

--- a/tests/Fieldtypes/UsersTest.php
+++ b/tests/Fieldtypes/UsersTest.php
@@ -164,7 +164,6 @@ class UsersTest extends TestCase
     private function getColumns(Users $fieldtype): array
     {
         $method = new \ReflectionMethod($fieldtype, 'getColumns');
-        $method->setAccessible(true);
 
         return $method->invoke($fieldtype);
     }

--- a/tests/Imaging/GlideTest.php
+++ b/tests/Imaging/GlideTest.php
@@ -174,12 +174,10 @@ class GlideTest extends TestCase
 
         $reflection = new \ReflectionClass($adapter);
         $visibilityConverter = $reflection->getProperty('visibility');
-        $visibilityConverter->setAccessible(true);
         $visibilityConverter = $visibilityConverter->getValue($adapter);
 
         $reflection = new \ReflectionClass($visibilityConverter);
         $visibility = $reflection->getProperty('defaultForDirectories');
-        $visibility->setAccessible(true);
 
         return $visibility->getValue($visibilityConverter);
     }
@@ -188,7 +186,6 @@ class GlideTest extends TestCase
     {
         $reflection = new \ReflectionClass($filesystem);
         $property = $reflection->getProperty('adapter');
-        $property->setAccessible(true);
 
         return $property->getValue($filesystem);
     }
@@ -197,7 +194,6 @@ class GlideTest extends TestCase
     {
         $reflection = new \ReflectionClass($adapter);
         $property = $reflection->getProperty('prefixer');
-        $property->setAccessible(true);
         $prefixer = $property->getValue($adapter);
 
         return $prefixer->prefixPath('');

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -445,7 +445,6 @@ class ImageGeneratorTest extends TestCase
     {
         $reflection = new \ReflectionClass($adapter);
         $property = $reflection->getProperty('prefixer');
-        $property->setAccessible(true);
         $prefixer = $property->getValue($adapter);
 
         return $prefixer->prefixPath('');
@@ -455,7 +454,6 @@ class ImageGeneratorTest extends TestCase
     {
         $reflection = new \ReflectionClass($filesystem);
         $property = $reflection->getProperty('adapter');
-        $property->setAccessible(true);
 
         return $property->getValue($filesystem);
     }

--- a/tests/Stache/StoreTest.php
+++ b/tests/Stache/StoreTest.php
@@ -38,7 +38,6 @@ class StoreTest extends TestCase
         // Check the value of the property to make sure the property was set with
         // the slash, and that ->directory() isn't just appending it.
         $property = (new \ReflectionClass($this->store))->getProperty('directory');
-        $property->setAccessible(true);
         $this->assertEquals('/path/to/directory/', $property->getValue($this->store));
     }
 

--- a/tests/Stache/Stores/CollectionTreeStoreTest.php
+++ b/tests/Stache/Stores/CollectionTreeStoreTest.php
@@ -176,7 +176,6 @@ EOT;
         // the structure. That'll happen later within the repository.
         $reflect = new \ReflectionObject($item);
         $property = $reflect->getProperty('tree');
-        $property->setAccessible(true);
         $this->assertEquals($array, $property->getValue($item));
     }
 }

--- a/tests/Stache/Stores/NavTreeStoreTest.php
+++ b/tests/Stache/Stores/NavTreeStoreTest.php
@@ -140,7 +140,6 @@ EOT;
         // the structure. That'll happen later within the repository.
         $reflect = new \ReflectionObject($item);
         $property = $reflect->getProperty('tree');
-        $property->setAccessible(true);
         $this->assertEquals($array, $property->getValue($item));
     }
 }


### PR DESCRIPTION
When upgrading to PHP 8.5, deprecation warnings appeared for the `ReflectionProperty::setAccessible()` method. Given the deprecation in 8.5, and having no effect since 8.1, these references should be removed.

It appears [other `setAccessible` calls](https://github.com/statamic/cms/pull/13971) have already been removed. I believe these are the last references left in the `6.x` branch.