### PR TITLE
[5.x] Remove negative assertions from `TestCase`

### DIFF
--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -32,12 +32,10 @@ abstract class AddonTestCase extends OrchestraTestCase
             $this->preventSavingStacheItemsToDisk();
         }
 
-        Version::shouldReceive('get')->zeroOrMoreTimes()->andReturn(Composer::create(__DIR__.'/../')->installedVersion(Statamic::PACKAGE));
-        $this->addToAssertionCount(-1);
+        Version::shouldReceive('get')->andReturn(Composer::create(__DIR__.'/../')->installedVersion(Statamic::PACKAGE));
 
-        \Statamic\Facades\CP\Nav::shouldReceive('build')->zeroOrMoreTimes()->andReturn(collect());
-        \Statamic\Facades\CP\Nav::shouldReceive('clearCachedUrls')->zeroOrMoreTimes();
-        $this->addToAssertionCount(-2); // Dont want to assert this
+        \Statamic\Facades\CP\Nav::shouldReceive('build')->andReturn(collect());
+        \Statamic\Facades\CP\Nav::shouldReceive('clearCachedUrls');
     }
 
     protected function tearDown(): void

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -17,7 +17,6 @@ use Statamic\Events\ResponseCreated;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Collection;
-use Statamic\Facades\Entry;
 use Statamic\Facades\User;
 use Statamic\Tags\Tags;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
@@ -38,8 +37,7 @@ class FrontendTest extends TestCase
 
     private function withStandardBlueprints()
     {
-        $this->addToAssertionCount(-1);
-        Blueprint::shouldReceive('in')->withAnyArgs()->zeroOrMoreTimes()->andReturn(collect([new \Statamic\Fields\Blueprint]));
+        Blueprint::shouldReceive('in')->withAnyArgs()->andReturn(collect([new \Statamic\Fields\Blueprint]));
     }
 
     #[Test]

--- a/tests/Licensing/AddonLicenseTest.php
+++ b/tests/Licensing/AddonLicenseTest.php
@@ -14,9 +14,7 @@ class AddonLicenseTest extends TestCase
     protected function license($response = [])
     {
         Addon::shouldReceive('get')->with('test/addon')
-            ->zeroOrMoreTimes()
             ->andReturn(new FakeAddonLicenseAddon('Test Addon', '1.2.3', 'rad'));
-        $this->addToAssertionCount(-1); // dont need to assert this.
 
         return new AddonLicense('test/addon', $response);
     }

--- a/tests/Licensing/LicenseManagerTest.php
+++ b/tests/Licensing/LicenseManagerTest.php
@@ -191,8 +191,7 @@ class LicenseManagerTest extends TestCase
     {
         $outpost = $this->mock(Outpost::class);
 
-        $this->addToAssertionCount(-1); // Dont want to assert this
-        $outpost->shouldReceive('response')->zeroOrMoreTimes()->andReturn($response);
+        $outpost->shouldReceive('response')->andReturn($response);
 
         return new LicenseManager($outpost);
     }

--- a/tests/Markdown/ManagerTest.php
+++ b/tests/Markdown/ManagerTest.php
@@ -105,7 +105,6 @@ class ManagerTest extends TestCase
     #[Test]
     public function it_throws_an_exception_if_extending_without_returning_a_parser()
     {
-        $this->expectNotToPerformAssertions();
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage('A ['.Markdown\Parser::class.'] instance is expected.');
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,14 +32,12 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         if ($this->shouldFakeVersion) {
-            \Facades\Statamic\Version::shouldReceive('get')->zeroOrMoreTimes()->andReturn('3.0.0-testing');
-            $this->addToAssertionCount(-1); // Dont want to assert this
+            \Facades\Statamic\Version::shouldReceive('get')->andReturn('3.0.0-testing');
         }
 
         if ($this->shouldPreventNavBeingBuilt) {
-            \Statamic\Facades\CP\Nav::shouldReceive('build')->zeroOrMoreTimes()->andReturn(collect());
-            \Statamic\Facades\CP\Nav::shouldReceive('clearCachedUrls')->zeroOrMoreTimes();
-            $this->addToAssertionCount(-2); // Dont want to assert this
+            \Statamic\Facades\CP\Nav::shouldReceive('build')->andReturn(collect());
+            \Statamic\Facades\CP\Nav::shouldReceive('clearCachedUrls');
         }
 
         $this->addGqlMacros();


### PR DESCRIPTION
Backports #13674 to `5.x`.

Fixes https://github.com/statamic/cms/issues/14446

Related: https://github.com/el-schneider/statamic-calendar/commit/2a0e57c0036f02fb7a1fd843dc2e5964ce8c3600