### PR TITLE
[6.x] Add padding around 2FA QR code for dark mode scanning

### DIFF
--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -67,7 +67,7 @@ watch(setupModalOpen, (open) => {
                     <ui-description class="mb-6">{{ __('statamic::messages.two_factor_setup_instructions') }}</ui-description>
 
                     <div class="flex space-x-6">
-                        <div class="bg-white p-2 border border-gray-200 rounded-md" v-html="qrCode"></div>
+                        <div class="shrink-0 rounded-md border border-gray-200 dark:border-none overflow-hidden" v-html="qrCode"></div>
                         <div class="space-y-6 w-full">
                             <ui-field :label="__('Setup Key')">
                                 <ui-input copyable readonly :model-value="secretKey" />

--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -67,7 +67,7 @@ watch(setupModalOpen, (open) => {
                     <ui-description class="mb-6">{{ __('statamic::messages.two_factor_setup_instructions') }}</ui-description>
 
                     <div class="flex space-x-6">
-                        <div class="bg-white" v-html="qrCode"></div>
+                        <div class="bg-white p-2" v-html="qrCode"></div>
                         <div class="space-y-6 w-full">
                             <ui-field :label="__('Setup Key')">
                                 <ui-input copyable readonly :model-value="secretKey" />

--- a/resources/js/components/two-factor/Setup.vue
+++ b/resources/js/components/two-factor/Setup.vue
@@ -67,7 +67,7 @@ watch(setupModalOpen, (open) => {
                     <ui-description class="mb-6">{{ __('statamic::messages.two_factor_setup_instructions') }}</ui-description>
 
                     <div class="flex space-x-6">
-                        <div class="bg-white p-2" v-html="qrCode"></div>
+                        <div class="bg-white p-2 border border-gray-200 rounded-md" v-html="qrCode"></div>
                         <div class="space-y-6 w-full">
                             <ui-field :label="__('Setup Key')">
                                 <ui-input copyable readonly :model-value="secretKey" />

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -430,7 +430,7 @@ abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticata
     {
         $svg = (new Writer(
             new ImageRenderer(
-                new RendererStyle(192, 4, null, null, Fill::uniformColor(new Rgb(255, 255, 255), new Rgb(45, 55, 72))),
+                new RendererStyle(size: 192, fill: Fill::uniformColor(new Rgb(255, 255, 255), new Rgb(45, 55, 72))),
                 new SvgImageBackEnd
             )
         ))->writeString($this->twoFactorQrCodeUrl());

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -430,7 +430,7 @@ abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticata
     {
         $svg = (new Writer(
             new ImageRenderer(
-                new RendererStyle(192, 0, null, null, Fill::uniformColor(new Rgb(255, 255, 255), new Rgb(45, 55, 72))),
+                new RendererStyle(192, 4, null, null, Fill::uniformColor(new Rgb(255, 255, 255), new Rgb(45, 55, 72))),
                 new SvgImageBackEnd
             )
         ))->writeString($this->twoFactorQrCodeUrl());


### PR DESCRIPTION
This pull request fixes an issue where the 2FA setup QR code was difficult to scan on Android devices when using dark mode.

This was happening because the QR code SVG had no "quiet zone" (white border) around it, making it hard for scanners to detect the code boundaries against a dark background.

This PR fixes it by adding padding to the QR code container.

## Before

<img width="1360" height="906" alt="CleanShot 2026-04-08 at 16 44 58@2x" src="https://github.com/user-attachments/assets/2b6ff5c7-4bab-4e42-b5f7-e756bce5097e" />


## After

<img width="1360" height="906" alt="CleanShot 2026-04-08 at 16 44 33@2x" src="https://github.com/user-attachments/assets/20479a6f-48e8-4143-a5cd-0a88cb3bfbc8" />

---

Fixes #14445