### PR TITLE
[6.x] Fix form submissions with non-UTF-8 data crashing the CP listing

### DIFF
--- a/src/Stache/Stores/FormSubmissionsStore.php
+++ b/src/Stache/Stores/FormSubmissionsStore.php
@@ -44,6 +44,8 @@ class FormSubmissionsStore extends ChildStore
             Log::warning('Could not parse form submission file: '.$path);
         }
 
+        $data = $this->sanitizeData($data);
+
         $form = pathinfo($path, PATHINFO_DIRNAME);
         $form = Str::after($form, $this->parent->directory());
 
@@ -55,5 +57,20 @@ class FormSubmissionsStore extends ChildStore
             ->data($data);
 
         return $submission;
+    }
+
+    private function sanitizeData(array $data): array
+    {
+        return collect($data)->map(function ($value) {
+            if (is_array($value)) {
+                return $this->sanitizeData($value);
+            }
+
+            if (is_string($value) && ! mb_check_encoding($value, 'UTF-8')) {
+                return mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+            }
+
+            return $value;
+        })->all();
     }
 }

--- a/tests/Stache/Stores/FormSubmissionStoreTest.php
+++ b/tests/Stache/Stores/FormSubmissionStoreTest.php
@@ -53,6 +53,8 @@ class FormSubmissionStoreTest extends TestCase
         );
 
         $this->assertInstanceOf(Submission::class, $item);
+        $this->assertEquals('Test User', $item->get('name'));
+        $this->assertStringContainsString('test message with bad bytes:', $item->get('message'));
         $this->assertTrue(mb_check_encoding($item->get('message'), 'UTF-8'));
         $this->assertNotNull(json_encode($item->data()->all()));
     }

--- a/tests/Stache/Stores/FormSubmissionStoreTest.php
+++ b/tests/Stache/Stores/FormSubmissionStoreTest.php
@@ -45,6 +45,19 @@ class FormSubmissionStoreTest extends TestCase
     }
 
     #[Test]
+    public function it_sanitizes_non_utf8_data()
+    {
+        $item = $this->parent->store('contact_form')->makeItemFromFile(
+            Path::tidy($this->directory).'/contact_form/1631083591.2832.yaml',
+            "name: 'Test User'\nmessage: !!binary dGVzdCBtZXNzYWdlIHdpdGggYmFkIGJ5dGVzOiDtoL3tsYk="
+        );
+
+        $this->assertInstanceOf(Submission::class, $item);
+        $this->assertTrue(mb_check_encoding($item->get('message'), 'UTF-8'));
+        $this->assertNotNull(json_encode($item->data()->all()));
+    }
+
+    #[Test]
     public function it_saves_to_disk()
     {
         $form = tap(Facades\Form::make('test_form'))->save();


### PR DESCRIPTION
This pull request fixes an issue where form submissions containing non-UTF-8 bytes (e.g. from spam bots injecting binary data, or copy-pasted text from Word/Google Docs containing control characters) would crash the entire CP forms listing.

This was happening because Symfony's YAML dumper stores non-UTF-8 values using the `!!binary` tag with base64 encoding. This is valid YAML, so the existing `ParseException` catch in `FormSubmissionsStore::makeItemFromFile()` doesn't trigger. The decoded binary data then passes through to the CP's JSON response, where `json_encode()` throws an `InvalidArgumentException: Malformed UTF-8 characters`.

This PR fixes it by sanitizing parsed submission data after YAML parsing, stripping any invalid UTF-8 bytes before the data reaches JSON serialization.

Fixes #14447