### PR TITLE
Add config for disabling Elevated Sessions feature

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -176,10 +176,23 @@ return [
     | Users may be required to reauthorize before performing certain
     | sensitive actions. This is called an elevated session. Here
     | you may configure the duration of the session in minutes.
+    | You may also disable the elevated session entirely.
     |
     */
 
     'elevated_session_duration' => 15,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Elevated Session Disabled
+    |--------------------------------------------------------------------------
+    |
+    | Here you may disable elevated sessions entirely. This can be
+    | useful when using OAuth.
+    |
+    */
+
+    'elevated_session_disabled' => false,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Http/Controllers/CP/CpController.php
+++ b/src/Http/Controllers/CP/CpController.php
@@ -72,7 +72,7 @@ class CpController extends Controller
 
     public function requireElevatedSession(): void
     {
-        if (! request()->hasElevatedSession()) {
+        if (! config('statamic.users.elevated_session_disabled') && ! request()->hasElevatedSession()) {
             throw new ElevatedSessionAuthorizationException;
         }
     }

--- a/src/Http/Middleware/CP/RequireElevatedSession.php
+++ b/src/Http/Middleware/CP/RequireElevatedSession.php
@@ -9,7 +9,7 @@ class RequireElevatedSession
 {
     public function handle($request, Closure $next)
     {
-        if (! $request->hasElevatedSession()) {
+        if (! config('statamic.users.elevated_session_disabled') && ! $request->hasElevatedSession()) {
             throw new ElevatedSessionAuthorizationException;
         }
 

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -301,6 +301,47 @@ class ElevatedSessionTest extends TestCase
     }
 
     #[Test]
+    public function middleware_does_not_require_elevated_session_when_elevated_session_is_disabled()
+    {
+        config(['statamic.users.elevated_session_disabled' => true]);
+
+        $this->actingAs($this->user);
+
+        $this
+            ->get('/requires-elevated-session')
+            ->assertOk()
+            ->assertSee('ok');
+    }
+
+    #[Test]
+    public function middleware_does_not_require_elevated_session_when_elevated_session_is_disabled_even_if_session_expired()
+    {
+        config(['statamic.users.elevated_session_disabled' => true]);
+
+        $this->actingAs($this->user);
+
+        $this
+            ->withElevatedSession(now()->subMinutes(16))
+            ->get('/requires-elevated-session')
+            ->assertOk()
+            ->assertSee('ok');
+    }
+
+    #[Test]
+    public function middleware_does_not_require_elevated_session_when_elevated_session_is_disabled_via_json()
+    {
+        config(['statamic.users.elevated_session_disabled' => true]);
+
+        $this->actingAs($this->user);
+
+        $this
+            ->withElevatedSession(now()->subMinutes(16))
+            ->getJson('/requires-elevated-session')
+            ->assertOk()
+            ->assertSee('ok');
+    }
+
+    #[Test]
     public function the_session_is_elevated_upon_login()
     {
         $this

--- a/tests/Feature/Roles/StoreRoleTest.php
+++ b/tests/Feature/Roles/StoreRoleTest.php
@@ -69,6 +69,26 @@ class StoreRoleTest extends TestCase
     }
 
     #[Test]
+    public function it_allows_storing_a_role_without_elevated_session_when_elevated_sessions_are_disabled()
+    {
+        config(['statamic.users.elevated_session_disabled' => true]);
+
+        $this
+            ->actingAsUserWithPermissions(['edit roles'])
+            ->store([
+                'title' => 'No Elevated Session',
+                'handle' => 'no_elevated_session',
+                'permissions' => ['one', 'two'],
+            ])
+            ->assertOk()
+            ->assertJson(['redirect' => cp_route('roles.index')]);
+
+        $role = Role::find('no_elevated_session');
+        $this->assertEquals('No Elevated Session', $role->title());
+        $this->assertEquals(['one', 'two'], $role->permissions()->all());
+    }
+
+    #[Test]
     public function it_stores_a_role()
     {
         $this


### PR DESCRIPTION
This PR is an attempt to provide a configuration option for disabling Elevated Sessions described [in this idea](https://github.com/statamic/ideas/issues/1415).

By setting `elevated_session_disabled` to `true` users will never be prompted to validate their session.
