### PR TITLE
[6.x] Fix visible he-tree accessibility text in tree view

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -256,6 +256,7 @@ return [
     'theme_share_instructions' => 'Publish this theme through your statamic.com account to make it available to others.',
     'try_again_in_seconds' => '{0,1}Try again now.|Try again in :count seconds.',
     'try_again_in_minutes' => 'Try again in a minute.|Try again in :count minutes.',
+    'tree_aria_instructions' => 'Use arrow keys to navigate. Alt plus arrow keys to reorder.',
     'two_factor_account_requirement' => 'Your account requires two-factor authentication. Please enable it before proceeding.',
     'two_factor_challenge_code_instructions' => 'Enter the 6-digit code from your authenticator app to confirm access to your account.',
     'two_factor_enable_introduction' => 'When enabled, you will be prompted for a secure, random token from your phone\'s authenticator app every time you log in.',

--- a/resources/css/components/page-tree.css
+++ b/resources/css/components/page-tree.css
@@ -93,3 +93,7 @@
         @apply pt-1 rounded-t-2xl;
     }
 }
+
+.he-tree-sr-only {
+    @apply sr-only;
+}

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -150,6 +150,16 @@ export default {
             this.getPages();
         },
 
+        loading(loading) {
+            if (!loading) {
+                this.$nextTick(() => {
+                    if (this.$refs.tree) {
+                        this.$refs.tree.ariaInstructions = __('Use arrow keys to navigate. Alt plus arrow keys to reorder.');
+                    }
+                });
+            }
+        },
+
         collapsedState: {
             deep: true,
             handler(state) {

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -154,7 +154,7 @@ export default {
             if (!loading) {
                 this.$nextTick(() => {
                     if (this.$refs.tree) {
-                        this.$refs.tree.ariaInstructions = __('Use arrow keys to navigate. Alt plus arrow keys to reorder.');
+                        this.$refs.tree.ariaInstructions = __('messages.tree_aria_instructions');
                     }
                 });
             }

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -31,6 +31,7 @@
                     :each-droppable="eachDroppable"
                     :max-level="maxDepth"
                     :stat-handler="statHandler"
+                    :aria-label="__('Tree Structure')"
                     @after-drop="afterDrop"
                     @open:node="nodeOpened"
                     @close:node="nodeClosed"

--- a/resources/js/pages/preferences/nav/Edit.vue
+++ b/resources/js/pages/preferences/nav/Edit.vue
@@ -86,6 +86,7 @@
                     :indent="24"
                     :dir="direction"
                     :stat-handler="statHandler"
+                    :aria-label="__('Tree Structure')"
                     keep-placeholder
                     trigger-class="page-move"
                     :each-droppable="eachDroppable"
@@ -289,6 +290,12 @@ export default {
     mounted() {
         this.setInitialNav(this.nav);
         this.addToCommandPalette();
+
+        this.$nextTick(() => {
+            if (this.$refs.tree) {
+                this.$refs.tree.ariaInstructions = __('messages.tree_aria_instructions');
+            }
+        });
     },
 
     computed: {


### PR DESCRIPTION
This pull request fixes an issue where the `@he-tree/vue` tree component displays a visible "Use arrow keys to navigate..." message at the bottom of the tree view.

This was happening because `@he-tree/vue` v2.10.2 added accessibility features (screen-reader-only elements) that rely on a `.he-tree-sr-only` CSS class defined in the library's own stylesheet. Since Statamic doesn't import that stylesheet, the elements were rendered visibly.

This PR fixes it by adding the `.he-tree-sr-only` styles to Statamic's page tree CSS. It also overrides the library's hardcoded `ariaInstructions` text with a translatable string.

---

Fixes #14463
Caused by #14459