### PR TITLE
[6.x] Fix Bard arrow keys/undo

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -349,7 +349,6 @@ export default {
             () => data_get(this.publishContainer.values.value, this.fieldPathPrefix),
             (values) => {
 				if (! values) return;
-                if (JSON.stringify(values) === JSON.stringify(this.node.attrs.values)) return;
 
                 this.updateAttributes({ values });
             },

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -349,6 +349,7 @@ export default {
             () => data_get(this.publishContainer.values.value, this.fieldPathPrefix),
             (values) => {
 				if (! values) return;
+                if (JSON.stringify(values) === JSON.stringify(this.node.attrs.values)) return;
 
                 this.updateAttributes({ values });
             },

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -495,5 +495,9 @@ export default {
                 .map((result) => result.obj);
         }
     },
+
+    beforeUnmount() {
+        this.unbindKeys();
+    },
 };
 </script>


### PR DESCRIPTION
SetPicker was binding global arrow/enter handlers but never cleaned them up if the component was unmounted while open (which happens in Bard after inserting a set).

Closes #13806.