### PR TITLE
[6.x] Disable reportCompressedSize in Storybook build

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -25,6 +25,10 @@ const config: StorybookConfig = {
                 '@api': resolve(process.cwd(), 'resources/js/api.js'),
             };
         }
+        config.build = {
+            ...config.build,
+            reportCompressedSize: false,
+        };
         return config;
     },
 };


### PR DESCRIPTION
## Summary

- Disables `reportCompressedSize` in the Storybook Vite config to reduce memory usage during production builds.

After the Vite 8 upgrade, the Storybook docs build was getting killed by the OOM killer on the deploy server (3.8GB RAM) during the "computing gzip size" phase. This option only controls whether gzip sizes are printed in the build log — it has no effect on the output files.

## Test plan

- [ ] Verify Storybook docs build completes on the deploy server
- [ ] Verify local `npm run build-storybook-docs` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)