### PR TITLE
[6.x] Allow control over who can be impersonated in UserPolicy

### DIFF
--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -38,7 +38,7 @@ class Impersonate extends Action
 
     public function authorize($authed, $user)
     {
-        return $authed->can('impersonate users') && $authed->can('impersonate', $user);
+        return $authed->can('impersonate', $user);
     }
 
     public function run($users, $values)

--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -24,7 +24,11 @@ class Impersonate extends Action
             return false;
         }
 
-        return $item instanceof UserContract && $item->id() != User::current()->id();
+        if (! ($item instanceof UserContract && $item->id() != User::current()->id())) {
+            return false;
+        }
+
+        return User::current()->can('impersonate', $item);
     }
 
     public function visibleToBulk($items)
@@ -34,7 +38,7 @@ class Impersonate extends Action
 
     public function authorize($authed, $user)
     {
-        return $authed->can('impersonate users');
+        return $authed->can('impersonate users') && $authed->can('impersonate', $user);
     }
 
     public function run($users, $values)

--- a/src/Policies/UserPolicy.php
+++ b/src/Policies/UserPolicy.php
@@ -70,6 +70,6 @@ class UserPolicy
 
     public function impersonate($authed, $user)
     {
-        return true;
+        return $authed->hasPermission('impersonate users');
     }
 }

--- a/src/Policies/UserPolicy.php
+++ b/src/Policies/UserPolicy.php
@@ -70,6 +70,8 @@ class UserPolicy
 
     public function impersonate($authed, $user)
     {
+        $authed = User::fromUser($authed);
+
         return $authed->hasPermission('impersonate users');
     }
 }

--- a/src/Policies/UserPolicy.php
+++ b/src/Policies/UserPolicy.php
@@ -67,4 +67,9 @@ class UserPolicy
     {
         return $this->edit($authed, $user);
     }
+
+    public function impersonate($authed, $user)
+    {
+        return true;
+    }
 }

--- a/tests/Actions/ImpersonateTest.php
+++ b/tests/Actions/ImpersonateTest.php
@@ -2,10 +2,14 @@
 
 namespace Tests\Actions;
 
+use Illuminate\Support\Facades\Gate;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Actions\Impersonate as Action;
 use Statamic\Facades\User;
+use Statamic\Policies\UserPolicy;
 use Tests\ElevatesSessions;
+use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -13,6 +17,7 @@ use Tests\TestCase;
 class ImpersonateTest extends TestCase
 {
     use ElevatesSessions;
+    use FakesRoles;
     use PreventSavingStacheItemsToDisk;
 
     private function impersonate($user)
@@ -40,5 +45,77 @@ class ImpersonateTest extends TestCase
 
         $this->assertEquals($impersonated->id(), auth()->id());
         $this->assertFalse(request()->hasElevatedSession());
+    }
+
+    #[Test]
+    public function it_is_visible_to_a_valid_target_user()
+    {
+        $impersonator = tap(User::make()->email('admin@example.com')->makeSuper())->save();
+        $impersonated = tap(User::make()->email('user@example.com'))->save();
+
+        $this->actingAs($impersonator);
+
+        $this->assertTrue((new Action)->visibleTo($impersonated));
+    }
+
+    #[Test]
+    public function it_is_not_visible_when_policy_denies_impersonation()
+    {
+        $this->setTestRoles(['impersonator' => ['impersonate users']]);
+
+        $impersonator = tap(User::make()->email('admin@example.com')->assignRole('impersonator'))->save();
+        $impersonated = tap(User::make()->email('user@example.com'))->save();
+
+        Gate::policy(get_class($impersonated), DenyImpersonationPolicy::class);
+
+        $this->actingAs($impersonator);
+
+        $this->assertFalse((new Action)->visibleTo($impersonated));
+    }
+
+    #[Test]
+    public function it_is_authorized_with_the_default_policy()
+    {
+        $this->setTestRoles(['impersonator' => ['impersonate users']]);
+
+        $impersonator = tap(User::make()->email('admin@example.com')->assignRole('impersonator'))->save();
+        $impersonated = tap(User::make()->email('user@example.com'))->save();
+
+        $this->assertTrue((new Action)->authorize($impersonator, $impersonated));
+    }
+
+    #[Test]
+    public function it_is_not_authorized_when_policy_denies_impersonation()
+    {
+        $this->setTestRoles(['impersonator' => ['impersonate users']]);
+
+        $impersonator = tap(User::make()->email('admin@example.com')->assignRole('impersonator'))->save();
+        $impersonated = tap(User::make()->email('user@example.com'))->save();
+
+        Gate::policy(get_class($impersonated), DenyImpersonationPolicy::class);
+
+        $this->assertFalse((new Action)->authorize($impersonator, $impersonated));
+    }
+
+    #[Test]
+    public function super_users_bypass_the_policy_check()
+    {
+        $impersonator = tap(User::make()->email('admin@example.com')->makeSuper())->save();
+        $impersonated = tap(User::make()->email('user@example.com'))->save();
+
+        Gate::policy(get_class($impersonated), DenyImpersonationPolicy::class);
+
+        $this->actingAs($impersonator);
+
+        $this->assertTrue((new Action)->visibleTo($impersonated));
+        $this->assertTrue((new Action)->authorize($impersonator, $impersonated));
+    }
+}
+
+class DenyImpersonationPolicy extends UserPolicy
+{
+    public function impersonate($authed, $user)
+    {
+        return false;
     }
 }

--- a/tests/Actions/ImpersonateTest.php
+++ b/tests/Actions/ImpersonateTest.php
@@ -98,6 +98,17 @@ class ImpersonateTest extends TestCase
     }
 
     #[Test]
+    public function it_is_not_authorized_without_permission()
+    {
+        $this->setTestRoles(['editor' => ['edit users']]);
+
+        $impersonator = tap(User::make()->email('admin@example.com')->assignRole('editor'))->save();
+        $impersonated = tap(User::make()->email('user@example.com'))->save();
+
+        $this->assertFalse((new Action)->authorize($impersonator, $impersonated));
+    }
+
+    #[Test]
     public function super_users_bypass_the_policy_check()
     {
         $impersonator = tap(User::make()->email('admin@example.com')->makeSuper())->save();


### PR DESCRIPTION
This PR adds an `impersonate($authed, $user)` method to the Statamic UserPolicy which is checked by the Impersonate action. This allows a developer to add custom logic in their own UserPolicy to determine if the authed user can impersonate the user in question... e.g. if you want admins not to be able to impersonate super admins.

Usage example:

```php
// app/Policies/UserPolicy.php
namespace App\Policies;

use Statamic\Policies\UserPolicy as StatamicUserPolicy;

class UserPolicy extends StatamicUserPolicy
{
    public function impersonate($authed, $user)
    {
        // don't allow impersonating super users
        return ! $user->super;
    }
}

// app/Providers/AppServiceProvider.php
use Illuminate\Support\Facades\Gate;
use Statamic\Auth\File\User;

public function boot(): void
{
    Gate::policy(User::class, \App\Policies\UserPolicy::class);
}
```