### PR TITLE
[6.x] Disable broadcast provider when broadcasting driver is null

### DIFF
--- a/src/Providers/BroadcastServiceProvider.php
+++ b/src/Providers/BroadcastServiceProvider.php
@@ -50,6 +50,10 @@ class BroadcastServiceProvider extends ServiceProvider
 
     protected function enabled()
     {
+        if (config('broadcasting.default') === 'null') {
+            return false;
+        }
+
         return in_array(
             \Illuminate\Broadcasting\BroadcastServiceProvider::class,
             array_keys($this->app->getLoadedProviders())


### PR DESCRIPTION
Statamic's `BroadcastServiceProvider::enabled()` now returns false when `config('broadcasting.default')` is `null`, so Statamic does not treat broadcasting as active when Laravel is configured with the null driver.

This aligns Statamic's behavior with an explicit "no broadcasting" setup.

Made with [Cursor](https://cursor.com)