### PR TITLE
[6.x] Add `.npmrc` file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=3


### PR DESCRIPTION
This PR adds an `.npmrc` file with two rules:

- Prevents post-install scripts from running, which are commonly used to install malware.
- Adds a minimum release age of 3 days to provide sufficient time for insecure releases to be found and pulled if necessary (like what happened with `axios` recently).

Adding as I've noticed Laravel adding these rules to a lot of their repositories recently and thought it'd be a good thing for us to adopt too.