### PR TITLE
[6.x] Make the collapsible section icon smaller to fit in with the rest of UI

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -66,7 +66,7 @@ function toggleSection(section) {
                 <Button
                     @click="toggleSection(section)"
                     v-if="section.collapsible"
-                    class="static! [&_svg]:size-4.5 rounded-xl after:content-[''] after:absolute after:inset-0"
+                    class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
                     :icon="section.collapsed ? 'expand' : 'collapse'"
                     size="sm"
                     variant="ghost"


### PR DESCRIPTION
## Description of the Problem

I noticed the collapsible section icon felt a bit off/big compared with the rest of our icons, such as "full screen"

## What this PR Does

Makes it smaller so that it fits better with the rest of the UI, while still being noticeable

### Before

![2026-04-10 at 14 23 12@2x](https://github.com/user-attachments/assets/878efeba-5e8c-4495-9997-dae644f135f3)

### After

![2026-04-10 at 14 22 50@2x](https://github.com/user-attachments/assets/18da10fd-092e-4724-9dd4-eb307d8a5a99)

## How to Reproduce

1. Edit a blueprint > click the little pencil to edit a section > turn on "Collapsible"