### PR TITLE
[6.x] Fix SVG sanitization tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "pixelfear/composer-dist-plugin": "^0.1.4",
         "pragmarx/google2fa": "^8.0 || ^9.0",
         "rebing/graphql-laravel": "^9.15",
-        "rhukster/dom-sanitizer": "^1.0.7",
+        "rhukster/dom-sanitizer": "^1.0.10",
         "spatie/blink": "^1.3",
         "spatie/error-solutions": "^1.0 || ^2.0",
         "statamic/stringy": "^3.1.2",

--- a/src/Support/Svg.php
+++ b/src/Support/Svg.php
@@ -20,11 +20,11 @@ class Svg
     {
         $sanitizer = $sanitizer ?? new DOMSanitizer(DOMSanitizer::SVG);
 
-        $svg = $sanitizer->sanitize($svg, [
+        $svg = static::sanitizeStyleTags($svg);
+
+        return $sanitizer->sanitize($svg, [
             'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),
         ]);
-
-        return static::sanitizeStyleTags($svg);
     }
 
     public static function sanitizeCss(string $css): string


### PR DESCRIPTION
This pull request fixes [failing SVG sanitization tests](https://github.com/statamic/cms/actions/runs/24320010736/job/71004305973) caused by an upstream security fix in `rhukster/dom-sanitizer` (GHSA-93vf-569f-22cq).

This PR fixes it by running Statamic's CSS sanitization before the DOM sanitizer, and bumping the minimum `rhukster/dom-sanitizer` version to `^1.0.10`.