### PR TITLE
[6.x] Use `cursor: pointer` when selecting from asset grid

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -416,6 +416,7 @@ export default {
                 folder: this.folder,
                 folderActionUrl: this.folderActionUrl,
                 folders: this.folders,
+                maxFiles: this.maxFiles,
                 restrictFolderNavigation: this.restrictFolderNavigation,
                 path: this.path,
                 creatingFolder: this.creatingFolder,

--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -117,7 +117,7 @@
                                     @click.stop="selectionClicked(index, $event)"
                                     @dblclick.stop="$emit('edit-asset', asset)"
                                 >
-                                    <div class="relative flex aspect-square size-full items-center justify-center cursor-pointer">
+                                    <div class="relative flex aspect-square size-full items-center justify-center" :class="{ 'cursor-pointer': maxFiles === 1 }">
                                         <div class="asset-thumb">
                                             <img
                                                 v-if="asset.thumbnail"
@@ -228,6 +228,7 @@ export default {
         assets: { type: Array },
         selectedAssets: { type: Array },
         thumbnailSize: { type: Number },
+        maxFiles: { type: Number },
         showCheckerboard: { type: Boolean, default: false },
         checkerboardMode: { type: String, default: 'transparent' },
     },

--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -117,7 +117,7 @@
                                     @click.stop="selectionClicked(index, $event)"
                                     @dblclick.stop="$emit('edit-asset', asset)"
                                 >
-                                    <div class="relative flex aspect-square size-full items-center justify-center">
+                                    <div class="relative flex aspect-square size-full items-center justify-center cursor-pointer">
                                         <div class="asset-thumb">
                                             <img
                                                 v-if="asset.thumbnail"


### PR DESCRIPTION
Uses `cursor: pointer` on the asset grid when max files is set to 1. Otherwise keeps the default one to select >1 file.

Closes https://github.com/statamic/cms/issues/14456.