### PR TITLE
[6.x] Use he-tree i18n prop for tree aria instructions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@davidenke/marked-text-renderer": "^3.0.0",
         "@floating-ui/dom": "^1.6.0",
-        "@he-tree/vue": "^2.10.0-beta.2",
+        "@he-tree/vue": "^2.10.5",
         "@hoppscotch/vue-toasted": "^0.1.0",
         "@inertiajs/vue3": "^2.1.11",
         "@internationalized/date": "^3.7.0",
@@ -893,9 +893,9 @@
       }
     },
     "node_modules/@he-tree/vue": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@he-tree/vue/-/vue-2.10.2.tgz",
-      "integrity": "sha512-SYDafYWNzVpkliyHgSy0OyUxV/XjpDmXbASJNAFZqT6LHEbcAN54Sc5CNeCOcVO10fL890ziSqJuhuQtAOTYkw==",
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@he-tree/vue/-/vue-2.10.5.tgz",
+      "integrity": "sha512-+/C3FxoGb1WpkElQA0kASSe0W9EUXTQSzg/1c7+1ucheiX4uFc8m1mSuD74lO7FXr6PWWbVRX2lzo/hxoUOTzA==",
       "license": "MIT",
       "dependencies": {
         "@he-tree/dnd-utils": "^0.1.0-alpha.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@davidenke/marked-text-renderer": "^3.0.0",
     "@floating-ui/dom": "^1.6.0",
-    "@he-tree/vue": "^2.10.0-beta.2",
+    "@he-tree/vue": "^2.10.5",
     "@hoppscotch/vue-toasted": "^0.1.0",
     "@inertiajs/vue3": "^2.1.11",
     "@internationalized/date": "^3.7.0",

--- a/resources/css/components/page-tree.css
+++ b/resources/css/components/page-tree.css
@@ -93,7 +93,3 @@
         @apply pt-1 rounded-t-2xl;
     }
 }
-
-.he-tree-sr-only {
-    @apply sr-only;
-}

--- a/resources/js/components/structures/PageTree.vue
+++ b/resources/js/components/structures/PageTree.vue
@@ -31,6 +31,7 @@
                     :each-droppable="eachDroppable"
                     :max-level="maxDepth"
                     :stat-handler="statHandler"
+                    :i18n="treeDraggableI18n"
                     :aria-label="__('Tree Structure')"
                     @after-drop="afterDrop"
                     @open:node="nodeOpened"
@@ -143,21 +144,17 @@ export default {
         direction() {
             return this.$config.get('direction', 'ltr');
         },
+
+        treeDraggableI18n() {
+            return {
+                instructions: __('messages.tree_aria_instructions'),
+            };
+        },
     },
 
     watch: {
         site(site) {
             this.getPages();
-        },
-
-        loading(loading) {
-            if (!loading) {
-                this.$nextTick(() => {
-                    if (this.$refs.tree) {
-                        this.$refs.tree.ariaInstructions = __('messages.tree_aria_instructions');
-                    }
-                });
-            }
         },
 
         collapsedState: {

--- a/resources/js/pages/preferences/nav/Edit.vue
+++ b/resources/js/pages/preferences/nav/Edit.vue
@@ -86,6 +86,7 @@
                     :indent="24"
                     :dir="direction"
                     :stat-handler="statHandler"
+                    :i18n="treeDraggableI18n"
                     :aria-label="__('Tree Structure')"
                     keep-placeholder
                     trigger-class="page-move"
@@ -290,15 +291,15 @@ export default {
     mounted() {
         this.setInitialNav(this.nav);
         this.addToCommandPalette();
-
-        this.$nextTick(() => {
-            if (this.$refs.tree) {
-                this.$refs.tree.ariaInstructions = __('messages.tree_aria_instructions');
-            }
-        });
     },
 
     computed: {
+        treeDraggableI18n() {
+            return {
+                instructions: __('messages.tree_aria_instructions'),
+            };
+        },
+
         isDirty() {
             return this.changed;
         },


### PR DESCRIPTION
Updates `@he-tree/vue` to 2.10.5, which supports an `i18n.instructions` prop for the screen-reader instructions string instead of assigning `ariaInstructions` on the component instance after mount.

Replaces the workaround added in #14465 in `PageTree.vue` and `preferences/nav/Edit.vue` with `:i18n="treeDraggableI18n"` (computed from `__('messages.tree_aria_instructions')`).

Removes the `.he-tree-sr-only` Tailwind bridge in `page-tree.css`; newer he-tree renders that node with the `sr-only` class directly.

Made with [Cursor](https://cursor.com)