### PR TITLE
[6.x] Fix nocache database driver failing on MySQL with invalid UTF-8

### DIFF
--- a/src/StaticCaching/NoCache/DatabaseSession.php
+++ b/src/StaticCaching/NoCache/DatabaseSession.php
@@ -30,7 +30,17 @@ class DatabaseSession extends Session
             throw new RegionNotFound($key);
         }
 
-        return unserialize(base64_decode($region->region), ['allowed_classes' => true]);
+        // Fall back to treating the value as a raw serialized string for rows
+        // written before base64 encoding was introduced. Strict base64_decode
+        // returns false on legacy rows because serialized PHP output contains
+        // characters outside the base64 alphabet.
+        $decoded = base64_decode($region->region, true);
+
+        if ($decoded === false) {
+            $decoded = $region->region;
+        }
+
+        return unserialize($decoded, ['allowed_classes' => true]);
     }
 
     protected function cacheRegion(Region $region)

--- a/src/StaticCaching/NoCache/DatabaseSession.php
+++ b/src/StaticCaching/NoCache/DatabaseSession.php
@@ -30,7 +30,7 @@ class DatabaseSession extends Session
             throw new RegionNotFound($key);
         }
 
-        return unserialize($region->region, ['allowed_classes' => true]);
+        return unserialize(base64_decode($region->region), ['allowed_classes' => true]);
     }
 
     protected function cacheRegion(Region $region)
@@ -39,7 +39,7 @@ class DatabaseSession extends Session
             'key' => $region->key(),
         ], [
             'url' => md5($this->url),
-            'region' => serialize($region),
+            'region' => base64_encode(serialize($region)),
         ]);
     }
 }

--- a/src/StaticCaching/NoCache/DatabaseSession.php
+++ b/src/StaticCaching/NoCache/DatabaseSession.php
@@ -32,8 +32,8 @@ class DatabaseSession extends Session
 
         // Fall back to treating the value as a raw serialized string for rows
         // written before base64 encoding was introduced. Strict base64_decode
-        // returns false on legacy rows because serialized PHP output contains
-        // characters outside the base64 alphabet.
+        // reliably detects legacy rows because any serialized PHP value always
+        // contains ":" or ";", neither of which are in the base64 alphabet.
         $decoded = base64_decode($region->region, true);
 
         if ($decoded === false) {

--- a/tests/StaticCaching/NoCacheDatabaseSessionTest.php
+++ b/tests/StaticCaching/NoCacheDatabaseSessionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\StaticCaching;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\StaticCaching\NoCache\DatabaseRegion;
+use Statamic\StaticCaching\NoCache\DatabaseSession;
+use Statamic\StaticCaching\NoCache\StringRegion;
+use Tests\TestCase;
+
+class NoCacheDatabaseSessionTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::create('nocache_regions', function (Blueprint $table) {
+            $table->string('key')->index()->primary();
+            $table->string('url')->index();
+            $table->longText('region');
+            $table->timestamps();
+        });
+    }
+
+    public function tearDown(): void
+    {
+        Schema::dropIfExists('nocache_regions');
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_stores_regions_base64_encoded()
+    {
+        $session = new DatabaseSession('http://localhost/test');
+
+        $region = $session->pushRegion('the contents', ['foo' => 'bar'], '.html');
+
+        $stored = DatabaseRegion::where('key', $region->key())->first()->region;
+
+        $this->assertEquals(base64_encode(serialize($region)), $stored);
+    }
+
+    #[Test]
+    public function it_reads_base64_encoded_regions()
+    {
+        $session = new DatabaseSession('http://localhost/test');
+
+        $region = $session->pushRegion('the contents', ['foo' => 'bar'], '.html');
+
+        $retrieved = $session->region($region->key());
+
+        $this->assertInstanceOf(StringRegion::class, $retrieved);
+        $this->assertEquals($region->key(), $retrieved->key());
+        $this->assertEquals(['foo' => 'bar'], $retrieved->context());
+    }
+
+    #[Test]
+    public function it_reads_legacy_non_base64_encoded_regions()
+    {
+        // Simulate a row written before base64 encoding was introduced
+        // (e.g. an existing PostgreSQL or SQLite install that ran the
+        // nocache migration prior to this fix).
+        $session = new DatabaseSession('http://localhost/test');
+        $region = new StringRegion($session, 'the contents', ['foo' => 'bar'], '.html');
+
+        DatabaseRegion::create([
+            'key' => $region->key(),
+            'url' => md5('http://localhost/test'),
+            'region' => serialize($region),
+        ]);
+
+        $retrieved = $session->region($region->key());
+
+        $this->assertInstanceOf(StringRegion::class, $retrieved);
+        $this->assertEquals($region->key(), $retrieved->key());
+        $this->assertEquals(['foo' => 'bar'], $retrieved->context());
+    }
+}


### PR DESCRIPTION
Fixes #14504.

## Problem

Since 6.10.0, `DatabaseSession::cacheRegion()` stores `serialize($region)` directly into the `region` LONGTEXT column of `nocache_regions`. PHP's `serialize()` emits binary content around protected/private property markers (`\x00*\x00`, `\x00ClassName\x00`) that is not valid UTF-8. MySQL's `utf8mb4` charset rejects these sequences:

```
SQLSTATE[HY000]: General error: 1366 Incorrect string value: '\xDB\xE2\x88\xB2...' for column 'region'
```

PostgreSQL and SQLite don't enforce UTF-8 on text columns, so they're unaffected.

## Fix

Wrap the serialized string with `base64_encode`/`base64_decode` in `DatabaseSession` so the value written to MySQL is always pure ASCII. This matches the workaround documented in the issue.

This was chosen over changing the column type to `binary`/`blob` because a schema change would require a new migration for every existing install that has already run `statamic:nocache:migration`. The ~33% base64 size overhead is negligible against a `LONGTEXT` column (4 GB ceiling) and typical region payload sizes.

The cache-backed `Session` path is unchanged — Redis/memcached/file stores don't enforce UTF-8.