### PR TITLE
[6.x] Fix bard undos

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -350,6 +350,7 @@ export default {
             () => data_get(this.publishContainer.values.value, this.fieldPathPrefix),
             (values) => {
 				if (! values) return;
+                if (JSON.stringify(values) === JSON.stringify(this.node.attrs.values)) return;
 
                 this.updateAttributes({ values });
             },


### PR DESCRIPTION
Prevent no-op ProseMirror transactions from being added to history which are essentially no-change undo states that make it appear like the undo didn't work.

References: https://github.com/statamic/cms/pull/14467#issuecomment-4262366817