### PR TITLE
[6.x] Show dashed border in assets fieldtype when field is read-only

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -104,7 +104,7 @@
                     >
                         <div
                             class="bg-white relative grid gap-4 2xl:gap-10 p-3 relative rounded-xl border border-gray-300 dark:bg-gray-850 dark:border-gray-700"
-                            :class="{ 'border-t-0 rounded-t-none': !isReadOnly && (showPicker || uploads.length) }"
+                            :class="{ 'border-t-0 rounded-t-none': !isReadOnly && (showPicker || uploads.length), 'border-dashed': isReadOnly }"
                             ref="assets"
                             style="grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));"
                         >
@@ -126,7 +126,7 @@
 
                     <div
                         class="relative overflow-hidden rounded-xl border border-gray-300 dark:border-gray-700"
-                        :class="{ 'not-[.link-fieldtype_&]:border-t-0! not-[.link-fieldtype_&]:rounded-t-none': !isReadOnly && (showPicker || uploads.length) }"
+                        :class="{ 'not-[.link-fieldtype_&]:border-t-0! not-[.link-fieldtype_&]:rounded-t-none': !isReadOnly && (showPicker || uploads.length), 'border-dashed': isReadOnly }"
                         v-if="displayMode === 'list'"
                     >
                         <table class="table-fixed w-full">


### PR DESCRIPTION
Closes #14491

## Before

<img width="649" height="265" alt="CleanShot 2026-04-17 at 09 36 01" src="https://github.com/user-attachments/assets/73cf97bc-5c06-4436-809d-bd407ebc42ad" />


## After

<img width="649" height="265" alt="CleanShot 2026-04-17 at 09 35 50" src="https://github.com/user-attachments/assets/9b993f92-29da-4d5e-8087-07edd401a6b0" />
