### PR TITLE
[6.x] Fix duplicate slugs allowed with depth-conditional routes

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -486,6 +486,10 @@ class EntriesController extends CpController
 
         $parent = $parent ? $tree->find($parent) : null;
 
+        if ($parent && $parent->isRoot()) {
+            $parent = null;
+        }
+
         return app(\Statamic\Contracts\Routing\UrlBuilder::class)
             ->content($entry)
             ->merge([

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -491,7 +491,7 @@ class EntriesController extends CpController
             ->merge([
                 'parent_uri' => $parent ? $parent->uri() : null,
                 'slug' => $entry->slug(),
-                // 'depth' => '', // todo
+                'depth' => $parent ? $parent->depth() + 1 : 1,
                 'is_root' => false,
             ])
             ->build($entry->route());

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Entries;
 
 use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -11,7 +12,6 @@ use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\User;
-use Facades\Tests\Factories\EntryFactory;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -11,6 +11,7 @@ use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\User;
+use Facades\Tests\Factories\EntryFactory;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -341,6 +342,39 @@ class StoreEntryTest extends TestCase
             ->assertOk();
 
         $this->assertFalse($response->json('values.published'), 'Initial published value should be false when user lacks publish permission, even if collection defaults to published');
+    }
+
+    #[Test]
+    public function it_prevents_duplicate_uris_for_structured_entries_with_depth_conditional_routes()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $collection = tap(
+            Collection::make('test')
+                ->routes('{{ if depth > 1 }}{{ parent_uri }}/{{ slug }}{{ else }}base/{{ slug }}{{ /if }}')
+                ->structureContents(['max_depth' => 10])
+        )->save();
+
+        EntryFactory::id('root-id')->slug('root')->collection('test')->create();
+        EntryFactory::id('child-id')->slug('child')->collection('test')->create();
+
+        $tree = $collection->structure()->in('en');
+        $tree->tree([
+            ['entry' => 'root-id', 'children' => [
+                ['entry' => 'child-id'],
+            ]],
+        ])->save();
+
+        $this
+            ->actingAs($user)
+            ->submit($collection, [
+                'title' => 'Duplicate Child',
+                'slug' => 'child',
+                '_parent' => 'root-id',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['slug']);
     }
 
     private function seedUserAndCollection()

--- a/tests/Feature/Entries/StoreEntryTest.php
+++ b/tests/Feature/Entries/StoreEntryTest.php
@@ -377,6 +377,37 @@ class StoreEntryTest extends TestCase
             ->assertJsonValidationErrors(['slug']);
     }
 
+    #[Test]
+    public function it_prevents_duplicate_uris_when_parent_is_the_explicit_root()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $collection = tap(
+            Collection::make('test')
+                ->routes('{{ if depth > 1 }}{{ parent_uri }}/{{ slug }}{{ else }}base/{{ slug }}{{ /if }}')
+                ->structureContents(['root' => true, 'max_depth' => 10])
+        )->save();
+
+        EntryFactory::id('root-id')->slug('root')->collection('test')->create();
+        EntryFactory::id('sibling-id')->slug('sibling')->collection('test')->create();
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'root-id'],
+            ['entry' => 'sibling-id'],
+        ])->save();
+
+        $this
+            ->actingAs($user)
+            ->submit($collection, [
+                'title' => 'Duplicate Sibling',
+                'slug' => 'sibling',
+                '_parent' => 'root-id',
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['slug']);
+    }
+
     private function seedUserAndCollection()
     {
         $this->setTestRoles(['test' => ['access cp', 'create test entries']]);

--- a/tests/Feature/Entries/UpdateEntryTest.php
+++ b/tests/Feature/Entries/UpdateEntryTest.php
@@ -469,6 +469,41 @@ class UpdateEntryTest extends TestCase
             ->assertOk();
     }
 
+    #[Test]
+    public function it_prevents_duplicate_uris_for_structured_entries_with_depth_conditional_routes()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'edit test entries', 'access en site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $collection = tap(
+            Collection::make('test')
+                ->routes('{{ if depth > 1 }}{{ parent_uri }}/{{ slug }}{{ else }}base/{{ slug }}{{ /if }}')
+                ->structureContents(['max_depth' => 10])
+        )->save();
+
+        EntryFactory::id('root-id')->slug('root')->collection('test')->create();
+        EntryFactory::id('child-id')->slug('child')->collection('test')->create();
+
+        $entry = EntryFactory::id('other-child-id')
+            ->slug('other-child')
+            ->collection('test')
+            ->data(['title' => 'Other Child'])
+            ->create();
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'root-id', 'children' => [
+                ['entry' => 'child-id'],
+                ['entry' => 'other-child-id'],
+            ]],
+        ])->save();
+
+        $this
+            ->actingAs($user)
+            ->update($entry, ['title' => 'Other Child', 'slug' => 'child'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['slug']);
+    }
+
     private function seedUserAndCollection()
     {
         $this->setTestRoles(['test' => [


### PR DESCRIPTION
This pull request fixes an issue where duplicate slugs were allowed for child entries in structured collections when using a route configuration that references `depth` (e.g. `{{ if depth > 1 }}{{ parent_uri }}/{{ slug }}{{ else }}base/{{ slug }}{{ /if }}`).

This was happening because the `depth` variable was not being passed to the URL builder during unique URI validation in `EntriesController::entryUri()`. There was a `// 'depth' => '', // todo` placeholder where it should have been calculated. Without `depth`, the Antlers conditional in the route couldn't evaluate correctly, so the generated URI during validation didn't match the actual URI, and duplicates weren't detected.

This PR fixes it by calculating the depth from the parent page's depth and passing it to the URL builder.

Fixes #14482