### PR TITLE
[6.x] Fix addon settings blueprint cache collision with field settings blueprint

### DIFF
--- a/src/Addons/Addon.php
+++ b/src/Addons/Addon.php
@@ -361,7 +361,7 @@ final class Addon
             return null;
         }
 
-        return Blueprint::make()->setContents(app($binding));
+        return Blueprint::make("addons.{$this->slug()}")->setContents(app($binding));
     }
 
     public function setting($key, $default = null): mixed


### PR DESCRIPTION
This pull request fixes an issue where using addon settings inside a fieldtype's `configFieldItems` method would cause the addon settings blueprint fields to be returned rather than the field's own settings.

This was happening because `Addon::settingsBlueprint()` created a `Blueprint::make()` with no handle. When a fieldtype's `configFieldItems` accessed addon settings, the `applyBlueprintDefaults` method (added in #14384) would resolve the addon's settings blueprint, caching its contents and fields under a Blink key based on an empty handle. Later, when the field settings blueprint (also created with `Blueprint::make()` and no handle) tried to resolve its own fields, it would get the cached addon settings blueprint fields instead.

This PR fixes it by giving addon settings blueprints a unique handle (`addons.{slug}`), preventing the Blink cache collision.

Fixes #14472
Caused by #14384