### PR TITLE
[6.x] Improve CP performance: staggered set mounting, fallback previews, targeted condition watching

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -1,5 +1,11 @@
 /* BARD
 =================================================== */
+
+.bard-bulk-op [data-type] header,
+.bard-bulk-op [data-type] header * {
+    transition: none !important;
+}
+
 @layer ui {
     /* .grid-cell, [data-ui-input-group] are exceptions for Bard fieldtypes inside a Grid fieldtype, since these cause double borders */
     .bard-fieldtype:not(.form-group, .grid-cell, [data-ui-input-group]) {

--- a/resources/css/components/fieldtypes/replicator.css
+++ b/resources/css/components/fieldtypes/replicator.css
@@ -1,3 +1,8 @@
 /* ==========================================================================
    REPLICATOR FIELDTYPE
    ========================================================================== */
+
+.replicator-bulk-op [data-replicator-set] header,
+.replicator-bulk-op [data-replicator-set] header * {
+    transition: none !important;
+}

--- a/resources/js/bootstrap/statamic.js
+++ b/resources/js/bootstrap/statamic.js
@@ -198,9 +198,11 @@ export default {
         const bladeContent = el?.innerHTML || '';
         const _this = this;
 
+        const corePages = import.meta.glob('../pages/**/*.vue');
+
         await createInertiaApp({
             id: 'statamic',
-            resolve: name => {
+            resolve: async name => {
                 if (name === 'NonInertiaPage') {
                     return {
                         default: {
@@ -211,8 +213,8 @@ export default {
                 }
 
                 // Resolve core pages
-                const pages = import.meta.glob('../pages/**/*.vue', { eager: true });
-                let page = pages[`../pages/${name}.vue`];
+                const pageImport = corePages[`../pages/${name}.vue`];
+                let page = pageImport ? await pageImport() : null;
 
                 // Resolve addon pages
                 if (!page) {

--- a/resources/js/components/field-actions/HasFieldActions.js
+++ b/resources/js/components/field-actions/HasFieldActions.js
@@ -1,13 +1,21 @@
 import toFieldActions from './toFieldActions.js';
 
 export default {
+    data() {
+        return {
+            _cachedFieldActions: null,
+        };
+    },
+
     computed: {
         fieldActions() {
-            return toFieldActions(
+            if (this._cachedFieldActions) return this._cachedFieldActions;
+            this._cachedFieldActions = toFieldActions(
                 this.fieldActionBinding,
                 this.fieldActionPayload,
                 this.internalFieldActions,
             );
+            return this._cachedFieldActions;
         },
 
         internalFieldActions() {

--- a/resources/js/components/field-actions/toFieldActions.js
+++ b/resources/js/components/field-actions/toFieldActions.js
@@ -1,7 +1,8 @@
+import { markRaw } from 'vue';
 import FieldAction from './FieldAction.js';
 
 export default function toFieldActions(binding, payload, extraActions = []) {
     return [...Statamic.$fieldActions.get(binding), ...extraActions]
-        .map((action) => new FieldAction(action, payload))
+        .map((action) => markRaw(new FieldAction(action, payload)))
         .filter((action) => action.visible);
 }

--- a/resources/js/components/fieldtypes/Fieldtype.vue
+++ b/resources/js/components/fieldtypes/Fieldtype.vue
@@ -42,12 +42,31 @@ export default {
             // When using the Options API, this feels more natural. However since this is a
             // computed, it won't be avaialble within data(). In those cases you will
             // need to use this.injectedPublishContainer.someValue.value directly.
-            return Object.fromEntries(
-               Object.entries(this.injectedPublishContainer).map(([key, value]) => [
-                   key,
-                   isRef(value) ? value.value : value,
-               ])
-           );
+            //
+            // We build the cache once with lazy getters, so the computed has zero reactive deps
+            // and is never invalidated. Dep tracking happens in the consumer's reactive scope.
+            if (this._publishContainerCache) return this._publishContainerCache;
+            const cache = {};
+            const src = this.injectedPublishContainer;
+            for (const key in src) {
+                const val = src[key];
+                if (isRef(val)) {
+                    Object.defineProperty(cache, key, {
+                        enumerable: true,
+                        configurable: true,
+                        get: () => val.value,
+                    });
+                } else {
+                    Object.defineProperty(cache, key, {
+                        enumerable: true,
+                        configurable: true,
+                        writable: false,
+                        value: val,
+                    });
+                }
+            }
+            this._publishContainerCache = cache;
+            return cache;
         },
 
         name() {

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -40,6 +40,8 @@
 <script>
 import Fieldtype from './Fieldtype.vue';
 import { Input, Select } from '@/components/ui';
+import debounce from '@/util/debounce.js';
+import { markRaw } from 'vue';
 
 export default {
     components: { Input, Text, Select },
@@ -58,6 +60,13 @@ export default {
             selectedAssets: this.meta.initialSelectedAssets,
             metaChanging: false,
         };
+    },
+
+    created() {
+        this.syncUrlDebounced = markRaw(debounce((url) => {
+            this.update(url);
+            this.updateMeta({ ...this.meta, initialUrl: url });
+        }, 150));
     },
 
     computed: {
@@ -116,13 +125,17 @@ export default {
 
         urlValue(url) {
             if (this.metaChanging) return;
-
-            this.update(url);
-            this.updateMeta({ ...this.meta, initialUrl: url });
+            this.syncUrlDebounced(url);
         },
 
         meta(meta, oldMeta) {
-            if (JSON.stringify(meta) === JSON.stringify(oldMeta)) return;
+            if (meta === oldMeta) return;
+            if (
+                meta.initialUrl === oldMeta.initialUrl &&
+                meta.initialOption === oldMeta.initialOption &&
+                this.shallowArrayEqual(meta.initialSelectedEntries, oldMeta.initialSelectedEntries) &&
+                this.shallowArrayEqual(meta.initialSelectedAssets, oldMeta.initialSelectedAssets)
+            ) return;
 
             this.metaChanging = true;
             this.urlValue = meta.initialUrl;
@@ -134,6 +147,10 @@ export default {
     },
 
     methods: {
+        shallowArrayEqual(a, b) {
+            return a === b || (Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((x, i) => x === b[i]));
+        },
+
         initialOptions() {
             return [
                 this.config.required ? null : { label: __('None'), value: null },

--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -130,12 +130,7 @@ export default {
 
         meta(meta, oldMeta) {
             if (meta === oldMeta) return;
-            if (
-                meta.initialUrl === oldMeta.initialUrl &&
-                meta.initialOption === oldMeta.initialOption &&
-                this.shallowArrayEqual(meta.initialSelectedEntries, oldMeta.initialSelectedEntries) &&
-                this.shallowArrayEqual(meta.initialSelectedAssets, oldMeta.initialSelectedAssets)
-            ) return;
+            if (JSON.stringify(meta) === JSON.stringify(oldMeta)) return;
 
             this.metaChanging = true;
             this.urlValue = meta.initialUrl;
@@ -147,10 +142,6 @@ export default {
     },
 
     methods: {
-        shallowArrayEqual(a, b) {
-            return a === b || (Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((x, i) => x === b[i]));
-        },
-
         initialOptions() {
             return [
                 this.config.required ? null : { label: __('None'), value: null },

--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -40,7 +40,6 @@ const shouldFocus = computed(() => {
     if (props.config.focus === false || props.config.focus === true) {
         return props.config.focus;
     }
-
     const isRootField = !props.fieldPathPrefix;
     const isImplicitAutofocusField = name.value === 'title' || name.value === 'alt';
 
@@ -48,7 +47,7 @@ const shouldFocus = computed(() => {
 });
 
 function inputUpdated(value) {
-    return props.config.debounce === false ? update(value) : updateDebounced(value);
+    return !props.config.debounce ? update(value) : updateDebounced(value);
 }
 
 defineExpose(expose);

--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -40,7 +40,7 @@ const shouldFocus = computed(() => {
     if (props.config.focus === false || props.config.focus === true) {
         return props.config.focus;
     }
-    
+
     const isRootField = !props.fieldPathPrefix;
     const isImplicitAutofocusField = name.value === 'title' || name.value === 'alt';
 
@@ -48,7 +48,7 @@ const shouldFocus = computed(() => {
 });
 
 function inputUpdated(value) {
-    return !props.config.debounce ? update(value) : updateDebounced(value);
+    return props.config.debounce === false ? update(value) : updateDebounced(value);
 }
 
 defineExpose(expose);

--- a/resources/js/components/fieldtypes/TextFieldtype.vue
+++ b/resources/js/components/fieldtypes/TextFieldtype.vue
@@ -40,6 +40,7 @@ const shouldFocus = computed(() => {
     if (props.config.focus === false || props.config.focus === true) {
         return props.config.focus;
     }
+
     const isRootField = !props.fieldPathPrefix;
     const isImplicitAutofocusField = name.value === 'title' || name.value === 'alt';
 

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -7,7 +7,7 @@
             <div :class="fullScreenMode && wrapperClasses">
                 <div
                     class="bard-fieldtype antialiased with-contrast:border-gray-500 shadow-ui-sm"
-                    :class="{ 'bard-fullscreen': fullScreenMode }"
+                    :class="{ 'bard-fullscreen': fullScreenMode, 'bard-bulk-op': suppressTransitions }"
                     ref="container"
                     @dragstart.stop="ignorePageHeader(true)"
                     @dragend="ignorePageHeader(false)"
@@ -177,6 +177,8 @@ import 'highlight.js/styles/github.css';
 import importTiptap from '@/util/tiptap.js';
 import { computed } from 'vue';
 import { data_get } from "@/bootstrap/globals.js";
+import extractBardText from "@/util/extractBardText";
+import { createMountScheduler } from "@/util/createMountScheduler.js";
 
 const lowlight = createLowlight(common);
 let tiptap = null;
@@ -213,10 +215,12 @@ export default {
             escBinding: null,
             showAddSetButton: false,
             hasBeenFocused: false,
+            suppressTransitions: false,
             provide: {
                 bard: this.makeBardProvide(),
                 bardSets: this.config.sets,
                 showReplicatorFieldPreviews: this.config.previews,
+                mountScheduler: createMountScheduler(),
             },
             errorsById: {},
             debounceNextUpdate: true,
@@ -294,25 +298,7 @@ export default {
 
         replicatorPreview() {
             if (!this.showFieldPreviews) return;
-            const stack = [...this.value];
-            let text = '';
-            while (stack.length) {
-                const node = stack.shift();
-                if (node.type === 'text') {
-                    text += ` ${node.text || ''}`;
-                } else if (node.type === 'set') {
-                    const handle = node.attrs.values.type;
-                    const set = this.setConfigs.find((set) => set.handle === handle);
-                    text += ` [${__(set ? set.display : handle)}]`;
-                }
-                if (text.length > 150) {
-                    break;
-                }
-                if (node.content) {
-                    stack.unshift(...node.content);
-                }
-            }
-            return text;
+            return extractBardText(this.value, 150, this.setConfigs);
         },
 
         inputIsInline() {
@@ -391,6 +377,7 @@ export default {
 
         this.json = this.editor.getJSON().content;
         this.html = this.editor.getHTML();
+        this._lastDocSize = this.editor.state.doc.content.size;
 
 		this.$nextTick(() => this.mounted = true);
 
@@ -643,11 +630,19 @@ export default {
         },
 
         collapseAll() {
+            this.suppressTransitions = true;
             this.collapsed = Object.keys(this.meta.existing);
+            this.$nextTick(() => requestAnimationFrame(() => {
+                this.suppressTransitions = false;
+            }));
         },
 
         expandAll() {
+            this.suppressTransitions = true;
             this.collapsed = [];
+            this.$nextTick(() => requestAnimationFrame(() => {
+                this.suppressTransitions = false;
+            }));
         },
 
         toggleCollapseSets() {
@@ -868,24 +863,19 @@ export default {
                         }
                     }, 1);
                 },
-                onUpdate: () => {
-                    const oldJson = this.json;
-                    const newJson = clone(this.editor.getJSON().content);
+                onUpdate: ({ transaction }) => {
+                    // Filter out non-doc transactions (selection, metadata, etc.).
+                    if (!transaction.docChanged) return;
 
-                    const countNodes = (nodes) => {
-                        if (!nodes || !Array.isArray(nodes)) return 0;
-                        let count = nodes.length;
-                        nodes.forEach(node => {
-                            if (node.content) {
-                                count += countNodes(node.content);
-                            }
-                        });
-                        return count;
-                    };
+                    const newDocSize = this.editor.state.doc.content.size;
+                    const oldDocSize = this._lastDocSize ?? newDocSize;
 
-                    if (countNodes(oldJson) !== countNodes(newJson)) this.debounceNextUpdate = false;
+                    // Structural size change -> sync immediately, skip the usual debounce window.
+                    if (oldDocSize !== newDocSize) this.debounceNextUpdate = false;
+                    this._lastDocSize = newDocSize;
 
-                    this.json = newJson;
+                    // getJSON() already returns a fresh plain object — no clone() needed.
+                    this.json = this.editor.getJSON().content;
                     this.html = this.editor.getHTML();
                 },
                 onCreate: ({ editor }) => {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -864,17 +864,14 @@ export default {
                     }, 1);
                 },
                 onUpdate: ({ transaction }) => {
-                    // Filter out non-doc transactions (selection, metadata, etc.).
                     if (!transaction.docChanged) return;
 
                     const newDocSize = this.editor.state.doc.content.size;
                     const oldDocSize = this._lastDocSize ?? newDocSize;
 
-                    // Structural size change -> sync immediately, skip the usual debounce window.
                     if (oldDocSize !== newDocSize) this.debounceNextUpdate = false;
                     this._lastDocSize = newDocSize;
 
-                    // getJSON() already returns a fresh plain object — no clone() needed.
                     this.json = this.editor.getJSON().content;
                     this.html = this.editor.getHTML();
                 },

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -153,7 +153,6 @@ export default {
     watch: {
         collapsed(collapsed) {
             if (!collapsed && !this.hasBeenExpanded) {
-                // First time expanding - defer field mounting via scheduler
                 this.hasBeenExpanded = true;
                 this.mountScheduler.schedule(() => {
                     if (!this._unmounted) {
@@ -161,7 +160,6 @@ export default {
                     }
                 });
             } else if (!collapsed) {
-                // Already expanded before - just show
                 this.fieldsReady = true;
             }
         },
@@ -386,11 +384,7 @@ export default {
                 () => data_get(this.publishContainer.values.value, this.fieldPathPrefix),
                 (values) => {
                     if (!values) return;
-
-                    // Fast path: same reactive reference -> nothing to sync.
                     if (values === this.node.attrs.values) return;
-
-                    // Structural equality check; preserves correctness for reference swaps with identical content.
                     if (JSON.stringify(values) === JSON.stringify(this.node.attrs.values)) return;
 
                     this.updateAttributes({ values });

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -54,14 +54,16 @@
                             <Button icon="dots" variant="ghost" size="xs" :aria-label="__('Open dropdown menu')" @mousedown.prevent />
                         </template>
                         <DropdownMenu>
-                            <DropdownItem
-                                v-if="fieldActions.length"
-                                v-for="action in fieldActions"
-                                :text="action.title"
-                                :variant="action.dangerous ? 'destructive' : 'default'"
-                                @click="action.run(action)"
-                            />
-                            <DropdownSeparator v-if="fieldActions.length" />
+                            <template v-if="fieldActions.length">
+                                <DropdownItem
+                                    v-for="action in fieldActions"
+                                    :key="action.title"
+                                    :text="action.title"
+                                    :variant="action.dangerous ? 'destructive' : 'default'"
+                                    @click="action.run(action)"
+                                />
+                                <DropdownSeparator />
+                            </template>
                             <DropdownItem
                                 :text="__(collapsed ? __('Expand Set') : __('Collapse Set'))"
                                 @click="toggleCollapsedState"
@@ -78,20 +80,22 @@
             </header>
 
             <div
-                v-if="index !== undefined && hasFields"
+                v-if="index !== undefined && hasFields && hasBeenExpanded"
                 v-show="!collapsed"
                 :class="{ 'contain-paint': collapsed, 'isolate': !collapsed }"
                 class="border-t border-t-gray-300! dark:border-t-white/10!"
             >
-                <FieldsProvider
-                    :fields="fields"
-                    :as-config="false"
-                    :read-only="isReadOnly"
-                    :field-path-prefix="fieldPathPrefix"
-                    :meta-path-prefix="metaPathPrefix"
-                >
-                    <Fields class="p-4" />
-                </FieldsProvider>
+                <template v-if="fieldsReady">
+                    <FieldsProvider
+                        :fields="fields"
+                        :as-config="false"
+                        :read-only="isReadOnly"
+                        :field-path-prefix="fieldPathPrefix"
+                        :meta-path-prefix="metaPathPrefix"
+                    >
+                        <Fields class="p-4" />
+                    </FieldsProvider>
+                </template>
             </div>
         </div>
     </node-view-wrapper>
@@ -117,6 +121,7 @@ import {
 import { containerContextKey } from '@/components/ui/Publish/Container.vue';
 import { watch } from 'vue';
 import { reveal } from '@api';
+import { createMountScheduler } from '@/util/createMountScheduler.js';
 
 export default {
     props: nodeViewProps,
@@ -138,9 +143,34 @@ export default {
 
     mixins: [ManagesPreviewText, HasFieldActions],
 
+    data() {
+        return {
+            hasBeenExpanded: false,
+            fieldsReady: false,
+        };
+    },
+
+    watch: {
+        collapsed(collapsed) {
+            if (!collapsed && !this.hasBeenExpanded) {
+                // First time expanding - defer field mounting via scheduler
+                this.hasBeenExpanded = true;
+                this.mountScheduler.schedule(() => {
+                    if (!this._unmounted) {
+                        this.fieldsReady = true;
+                    }
+                });
+            } else if (!collapsed) {
+                // Already expanded before - just show
+                this.fieldsReady = true;
+            }
+        },
+    },
+
     inject: {
         bard: {},
         bardSets: {},
+        mountScheduler: { default: createMountScheduler() },
         publishContainer: { from: containerContextKey },
     },
 
@@ -346,16 +376,39 @@ export default {
     },
 
     mounted() {
-        watch(
-            () => data_get(this.publishContainer.values.value, this.fieldPathPrefix),
-            (values) => {
-				if (! values) return;
-                if (JSON.stringify(values) === JSON.stringify(this.node.attrs.values)) return;
+        if (! this.collapsed) {
+            this.hasBeenExpanded = true;
+            this.fieldsReady = true;
+        }
 
-                this.updateAttributes({ values });
-            },
-            { deep: true }
-        );
+        const startSyncWatcher = () => {
+            this._syncWatcherStop = watch(
+                () => data_get(this.publishContainer.values.value, this.fieldPathPrefix),
+                (values) => {
+                    if (!values) return;
+
+                    // Fast path: same reactive reference -> nothing to sync.
+                    if (values === this.node.attrs.values) return;
+
+                    // Structural equality check; preserves correctness for reference swaps with identical content.
+                    if (JSON.stringify(values) === JSON.stringify(this.node.attrs.values)) return;
+
+                    this.updateAttributes({ values });
+                },
+                { deep: true, immediate: true }
+            );
+        };
+
+        if (this.fieldsReady) {
+            startSyncWatcher();
+        } else {
+            this._syncWatcherFieldsReadyStop = this.$watch('fieldsReady', (ready) => {
+                if (ready) {
+                    startSyncWatcher();
+                    this._syncWatcherFieldsReadyStop?.();
+                }
+            });
+        }
 
         reveal.mount(this.$refs.container, this.expand);
 
@@ -363,10 +416,16 @@ export default {
         // draggable ancestor. ProseMirror sets draggable=true on the node-view-wrapper
         // because the Set node spec has draggable:true. We must keep it false.
         this.$el.setAttribute('draggable', false);
+        this._draggablePending = false;
         this._draggableObserver = new MutationObserver(() => {
-            if (this.$el.getAttribute('draggable') !== 'false') {
-                this.$el.setAttribute('draggable', false);
-            }
+            if (this._draggablePending) return;
+            this._draggablePending = true;
+            requestAnimationFrame(() => {
+                this._draggablePending = false;
+                if (!this._unmounted && this.$el.getAttribute('draggable') !== 'false') {
+                    this.$el.setAttribute('draggable', false);
+                }
+            });
         });
         this._draggableObserver.observe(this.$el, { attributes: true, attributeFilter: ['draggable'] });
     },
@@ -376,7 +435,10 @@ export default {
     },
 
     beforeUnmount() {
+        this._unmounted = true;
         this._draggableObserver?.disconnect();
+        this._syncWatcherStop?.();
+        this._syncWatcherFieldsReadyStop?.();
     },
 };
 </script>

--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -98,15 +98,11 @@ export default {
 
     methods: {
         updated(handle, value) {
-            let row = JSON.parse(JSON.stringify(this.values));
-            row[handle] = value;
-            this.$emit('updated', this.index, row);
+            this.$emit('updated', this.index, { ...this.values, [handle]: value });
         },
 
         metaUpdated(handle, value) {
-            let meta = clone(this.meta);
-            meta[handle] = value;
-            this.$emit('meta-updated', meta);
+            this.$emit('meta-updated', { ...this.meta, [handle]: value });
         },
 
         fieldPath(handle) {

--- a/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
+++ b/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
@@ -16,7 +16,6 @@ export default {
 
     methods: {
         formatPreviewValue(value, fieldConfig) {
-            // Delegate to shared utility (non-escaping variant for backward compatibility)
             return formatPreviewValueUtil(value, fieldConfig, { escape: false });
         },
     },

--- a/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
+++ b/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js
@@ -1,30 +1,23 @@
-import PreviewHtml from './PreviewHtml';
+import { buildPreviewText } from '@/util/buildPreviewText';
+import formatPreviewValueUtil from '@/util/formatPreviewValue';
 
 export default {
     computed: {
         previewText() {
-            return Object.entries(this.previews)
-                .filter(([handle, value]) => {
-                    if (!handle.endsWith('_')) return false;
-                    handle = handle.substr(0, handle.length - 1); // Remove the trailing underscore.
-                    const config = this.config.fields.find((f) => f.handle === handle);
-                    if (!config) return false;
-                    return config.replicator_preview === undefined ? this.showFieldPreviews : config.replicator_preview;
-                })
-                .map(([handle, value]) => value)
-                .filter((value) => (['null', '[]', '{}', '', undefined].includes(JSON.stringify(value)) ? null : value))
-                .map((value) => {
-                    if (value instanceof PreviewHtml) return value.html;
+            return buildPreviewText({
+                previews: this.previews,
+                config: this.config,
+                values: this.values,
+                showFieldPreviews: this.showFieldPreviews,
+                separator: ' / ',
+            });
+        },
+    },
 
-                    if (typeof value === 'string') return escapeHtml(value);
-
-                    if (Array.isArray(value) && typeof value[0] === 'string') {
-                        return escapeHtml(value.join(', '));
-                    }
-
-                    return escapeHtml(JSON.stringify(value));
-                })
-                .join(' / ');
+    methods: {
+        formatPreviewValue(value, fieldConfig) {
+            // Delegate to shared utility (non-escaping variant for backward compatibility)
+            return formatPreviewValueUtil(value, fieldConfig, { escape: false });
         },
     },
 };

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -7,7 +7,7 @@
             <div :class="{ wrapperClasses: fullScreenMode }">
                 <div
                     class="replicator-fieldtype-container"
-                    :class="{ 'replicator-fullscreen fixed inset-0 min-h-screen overflow-scroll rounded-none bg-gray-100 dark:bg-gray-800': fullScreenMode }"
+                    :class="{ 'replicator-fullscreen fixed inset-0 min-h-screen overflow-scroll rounded-none bg-gray-100 dark:bg-gray-800': fullScreenMode, 'replicator-bulk-op': suppressTransitions }"
                 >
                     <publish-field-fullscreen-header
                         v-if="fullScreenMode"
@@ -34,7 +34,7 @@
                                     v-for="(set, index) in value"
                                     :key="set._id"
                                     :id="set._id"
-                                    :index
+                                    :index="index"
                                     :field-path="setFieldPathPrefix"
                                     :meta-path="setMetaPathPrefix"
                                     :values="set"
@@ -94,7 +94,8 @@ import ReplicatorSet from './Set.vue';
 import AddSetButton from './AddSetButton.vue';
 import ManagesSetMeta from './ManagesSetMeta';
 import { SortableList } from '../../sortable/Sortable';
-import { data_get } from "@/bootstrap/globals.js";
+import { data_get } from '@/bootstrap/globals.js';
+import { createMountScheduler } from '@/util/createMountScheduler.js';
 
 export default {
     mixins: [Fieldtype, ManagesSetMeta],
@@ -111,9 +112,11 @@ export default {
             collapsed: clone(this.meta.collapsed),
             fullScreenMode: false,
             escBinding: null,
+            suppressTransitions: false,
             provide: {
                 replicatorSets: this.config.sets,
                 showReplicatorFieldPreviews: this.config.previews,
+                mountScheduler: createMountScheduler(),
             },
             errorsById: {},
             setsCache: {},
@@ -325,11 +328,19 @@ export default {
         },
 
         collapseAll() {
+            this.suppressTransitions = true;
             this.collapsed = this.value.map((v) => v._id);
+            this.$nextTick(() => requestAnimationFrame(() => {
+                this.suppressTransitions = false;
+            }));
         },
 
         expandAll() {
+            this.suppressTransitions = true;
             this.collapsed = [];
+            this.$nextTick(() => requestAnimationFrame(() => {
+                this.suppressTransitions = false;
+            }));
         },
 
         toggleFullscreen() {

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -119,7 +119,6 @@ watch(
     () => props.collapsed,
     (collapsed) => {
         if (!collapsed && !hasBeenExpanded.value) {
-            // First time expanding - defer field mounting via scheduler
             hasBeenExpanded.value = true;
             mountScheduler.schedule(() => {
                 if (!isUnmounted) {
@@ -127,7 +126,6 @@ watch(
                 }
             });
         } else if (!collapsed) {
-            // Already expanded before - just show
             fieldsReady.value = true;
         }
     },
@@ -192,15 +190,13 @@ reveal.use(rootEl, () => emit('expanded'));
                             <Button icon="dots" variant="ghost" size="xs" :aria-label="__('Open dropdown menu')" />
                         </template>
                         <DropdownMenu>
-                            <template v-if="fieldActions.length">
-                                <DropdownItem
-                                    v-for="action in fieldActions"
-                                    :key="action.title"
-                                    :text="action.title"
-                                    :variant="action.dangerous ? 'destructive' : 'default'"
-                                    @click="action.run(action)"
-                                />
-                            </template>
+                            <DropdownItem
+                                v-if="fieldActions.length"
+                                v-for="action in fieldActions"
+                                :text="action.title"
+                                :variant="action.dangerous ? 'destructive' : 'default'"
+                                @click="action.run(action)"
+                            />
                             <DropdownSeparator v-if="fieldActions.length" />
                             <DropdownItem
                                 :text="__(collapsed ? __('Expand Set') : __('Collapse Set'))"

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { computed, inject, ref } from 'vue';
+import { computed, inject, ref, watch, onBeforeUnmount } from 'vue';
+import { createMountScheduler } from '@/util/createMountScheduler.js';
 import {
     Icon,
     Switch,
@@ -14,14 +15,15 @@ import {
     PublishFieldsProvider as FieldsProvider,
     injectPublishContext as injectContainerContext,
 } from '@/components/ui';
-import PreviewHtml from '@/components/fieldtypes/replicator/PreviewHtml.js';
 import FieldAction from '@/components/field-actions/FieldAction.js';
 import toFieldActions from '@/components/field-actions/toFieldActions.js';
 import { reveal } from '@api';
+import usePreviewText from '@/composables/use-preview-text';
 
 const emit = defineEmits(['collapsed', 'expanded', 'duplicated', 'removed']);
 
 const replicatorSets = inject('replicatorSets');
+const mountScheduler = inject('mountScheduler', createMountScheduler());
 
 const props = defineProps({
     config: Object,
@@ -75,34 +77,19 @@ const fieldActionPayload = computed(() => ({
     isReadOnly: props.readOnly,
 }));
 
+const fieldActionsRef = ref(null);
 const fieldActions = computed(() => {
-    return toFieldActions('replicator-fieldtype-set', fieldActionPayload.value);
+    if (fieldActionsRef.value) return fieldActionsRef.value;
+    fieldActionsRef.value = toFieldActions('replicator-fieldtype-set', fieldActionPayload.value);
+    return fieldActionsRef.value;
 });
 
-const previewText = computed(() => {
-    return Object.entries(data_get(previews.value, fieldPathPrefix.value) || {})
-        .filter(([handle, value]) => {
-            if (!handle.endsWith('_')) return false;
-            handle = handle.substr(0, handle.length - 1); // Remove the trailing underscore.
-            const config = props.config.fields.find((f) => f.handle === handle);
-            if (!config) return false;
-            return config.replicator_preview === undefined ? props.showFieldPreviews : config.replicator_preview;
-        })
-        .map(([handle, value]) => value)
-        .filter((value) => !['null', '[]', '{}', '', undefined].includes(JSON.stringify(value)))
-        .map((value) => {
-            if (value instanceof PreviewHtml) return value.html;
-
-            if (typeof value === 'string') return escapeHtml(value);
-
-            if (Array.isArray(value) && typeof value[0] === 'string') {
-                return escapeHtml(value.join(', '));
-            }
-
-            return escapeHtml(JSON.stringify(value));
-        })
-        .filter((html) => html && html.trim() !== '')
-        .join(' <span class="text-gray-400 dark:text-gray-600">/</span> ');
+const { previewText } = usePreviewText({
+    config: computed(() => props.config),
+    values: computed(() => props.values),
+    previews,
+    fieldPathPrefix,
+    showFieldPreviews: computed(() => props.showFieldPreviews),
 });
 
 function toggleEnabledState() {
@@ -119,6 +106,32 @@ function destroy() {
     deletingSet.value = false;
     emit('removed');
 }
+
+const hasBeenExpanded = ref(!props.collapsed);
+const fieldsReady = ref(!props.collapsed);
+let isUnmounted = false;
+
+onBeforeUnmount(() => {
+    isUnmounted = true;
+});
+
+watch(
+    () => props.collapsed,
+    (collapsed) => {
+        if (!collapsed && !hasBeenExpanded.value) {
+            // First time expanding - defer field mounting via scheduler
+            hasBeenExpanded.value = true;
+            mountScheduler.schedule(() => {
+                if (!isUnmounted) {
+                    fieldsReady.value = true;
+                }
+            });
+        } else if (!collapsed) {
+            // Already expanded before - just show
+            fieldsReady.value = true;
+        }
+    },
+);
 
 const rootEl = ref();
 reveal.use(rootEl, () => emit('expanded'));
@@ -179,13 +192,15 @@ reveal.use(rootEl, () => emit('expanded'));
                             <Button icon="dots" variant="ghost" size="xs" :aria-label="__('Open dropdown menu')" />
                         </template>
                         <DropdownMenu>
-                            <DropdownItem
-                                v-if="fieldActions.length"
-                                v-for="action in fieldActions"
-                                :text="action.title"
-                                :variant="action.dangerous ? 'destructive' : 'default'"
-                                @click="action.run(action)"
-                            />
+                            <template v-if="fieldActions.length">
+                                <DropdownItem
+                                    v-for="action in fieldActions"
+                                    :key="action.title"
+                                    :text="action.title"
+                                    :variant="action.dangerous ? 'destructive' : 'default'"
+                                    @click="action.run(action)"
+                                />
+                            </template>
                             <DropdownSeparator v-if="fieldActions.length" />
                             <DropdownItem
                                 :text="__(collapsed ? __('Expand Set') : __('Collapse Set'))"
@@ -203,20 +218,23 @@ reveal.use(rootEl, () => emit('expanded'));
             </header>
 
             <div
-                v-show="!collapsed && hasFields"
+                v-if="hasBeenExpanded && hasFields"
+                v-show="!collapsed"
                 :class="{ 'contain-paint': collapsed, 'isolate': !collapsed }"
                 class="border-t border-t-gray-300! dark:border-t-white/10!"
             >
                 <div :tabindex="collapsed ? -1 : undefined" :inert="collapsed">
-                    <FieldsProvider
-                        :fields="config.fields"
-                        :as-config="false"
-                        :read-only
-                        :field-path-prefix="fieldPathPrefix"
-                        :meta-path-prefix="metaPathPrefix"
-                    >
-                        <Fields class="p-4" />
-                    </FieldsProvider>
+                    <template v-if="fieldsReady">
+                        <FieldsProvider
+                            :fields="config.fields"
+                            :as-config="false"
+                            :read-only="readOnly"
+                            :field-path-prefix="fieldPathPrefix"
+                            :meta-path-prefix="metaPathPrefix"
+                        >
+                            <Fields class="p-4" />
+                        </FieldsProvider>
+                    </template>
                 </div>
             </div>
         </div>

--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -108,6 +108,8 @@ import { Button, Icon, Stack } from '@/components/ui';
 import { router } from '@inertiajs/vue3';
 import axios from 'axios';
 
+const inFlightRequests = new Map();
+
 export default {
     props: {
         canCreate: { type: Boolean },
@@ -246,7 +248,7 @@ export default {
 
     created() {
         this.removeNavigationListener = router.on('before', () => {
-            if (this.abortController) this.abortController.abort();
+            if (this.abortController && this._ownsRequest) this.abortController.abort();
         });
     },
 
@@ -260,7 +262,7 @@ export default {
     },
 
     beforeUnmount() {
-        if (this.abortController) this.abortController.abort();
+        if (this.abortController && this._ownsRequest) this.abortController.abort();
         if (this.removeNavigationListener) this.removeNavigationListener();
         if (this.sortable) {
             this.sortable.destroy();
@@ -331,8 +333,18 @@ export default {
             if (this.abortController) this.abortController.abort();
             this.abortController = new AbortController();
 
-            return this.$axios
+            const cacheKey = this.itemDataUrl + '|' + (this.site || '') + '|' + JSON.stringify(selections?.slice().sort());
+            const existing = inFlightRequests.get(cacheKey);
+
+            this._ownsRequest = !existing;
+
+            const request = existing ?? this.$axios
                 .post(this.itemDataUrl, { site: this.site, selections }, { signal: this.abortController.signal })
+                .finally(() => inFlightRequests.delete(cacheKey));
+
+            if (!existing) inFlightRequests.set(cacheKey, request);
+
+            return request
                 .then((response) => {
                     this.$emit('item-data-updated', response.data.data);
                 })

--- a/resources/js/components/ui/LivePreview/LivePreview.vue
+++ b/resources/js/components/ui/LivePreview/LivePreview.vue
@@ -283,10 +283,14 @@ const keybinding = ref(
     }),
 );
 
-onUnmounted(() => keybinding.value.destroy());
+const refreshHandler = () => { if (props.enabled) update(); };
+const refreshEvent = `live-preview.${name.value}.refresh`;
 
-Statamic.$events.$on(`live-preview.${name.value}.refresh`, () => {
-    if (props.enabled) update();
+Statamic.$events.$on(refreshEvent, refreshHandler);
+
+onUnmounted(() => {
+    keybinding.value.destroy();
+    Statamic.$events.$off(refreshEvent, refreshHandler);
 });
 </script>
 

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -126,10 +126,8 @@ const visibleValues = computed(() => {
         }
     }
 
-    // Hot path: nothing hidden -> return the reactive tree directly.
     if (omittable === null) return values.value;
 
-    // Only clone when we actually need to omit something.
     const out = clone(values.value);
     for (const key of omittable) forgetAtPath(out, key);
     return out;

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -9,8 +9,7 @@ import { nanoid as uniqid } from 'nanoid';
 import { onMounted, onUnmounted, watch, ref, computed, toRef, nextTick } from 'vue';
 import Component from '@/components/Component.js';
 import Tabs from './Tabs.vue';
-import Values from '@/components/publish/Values.js';
-import { data_get } from '@/bootstrap/globals.js';
+import { clone, data_get } from '@/bootstrap/globals.js';
 
 const emit = defineEmits(['update:modelValue', 'update:visibleValues', 'update:modifiedFields', 'update:meta']);
 
@@ -106,11 +105,34 @@ const localizedFields = ref(props.modifiedFields || []);
 const components = ref([]);
 const direction = computed(() => Statamic.$config.get('sites').find(s => s.handle === props.site)?.direction ?? document.documentElement.dir ?? 'ltr');
 
+// File-scoped helper: walk the dotted path and delete the leaf if present.
+function forgetAtPath(obj, path) {
+    const parts = path.split('.');
+    while (parts.length > 1) {
+        const key = parts.shift();
+        if (!obj || typeof obj !== 'object' || !(key in obj)) return;
+        obj = obj[key];
+    }
+    if (obj && typeof obj === 'object') delete obj[parts[0]];
+}
+
 const visibleValues = computed(() => {
-    const omittable = Object.keys(hiddenFields.value).filter(
-        (field) => hiddenFields.value[field].omitValue,
-    );
-    return new Values(values.value).except(omittable);
+    const hf = hiddenFields.value;
+    let omittable = null;
+    for (const key in hf) {
+        if (hf[key].omitValue) {
+            if (omittable === null) omittable = [];
+            omittable.push(key);
+        }
+    }
+
+    // Hot path: nothing hidden -> return the reactive tree directly.
+    if (omittable === null) return values.value;
+
+    // Only clone when we actually need to omit something.
+    const out = clone(values.value);
+    for (const key of omittable) forgetAtPath(out, key);
+    return out;
 });
 
 const revealerValues = computed(() => {
@@ -160,16 +182,19 @@ watch(
 
 watch(
     values,
-    (values) => {
+    (v) => {
         dirty();
-        emit('update:modelValue', values);
+        emit('update:modelValue', v);
+        emit('update:visibleValues', visibleValues.value);
     },
     { deep: true },
 );
 
 watch(
-    visibleValues,
-    (values) => emit('update:visibleValues', values),
+    hiddenFields,
+    () => {
+        emit('update:visibleValues', visibleValues.value);
+    },
     { deep: true },
 );
 

--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -9,6 +9,7 @@ import {
 } from '@ui';
 import FieldActions from '@/components/field-actions/FieldActions.vue';
 import ShowField from '@/components/field-conditions/ShowField.js';
+import { KEYS } from '@/components/field-conditions/Constants.js';
 
 const props = defineProps({
     config: {
@@ -137,7 +138,15 @@ const extraValues = computed(() => {
     return fieldPathPrefix.value ? data_get(containerExtraValues.value, fieldPathPrefix.value) : containerExtraValues.value;
 });
 
-const shouldShowField = computed(() => {
+const conditionHandles = computed(() => {
+    const conditionKey = KEYS.find((k) => props.config[k]);
+    if (!conditionKey) return null;
+    const conditions = props.config[conditionKey];
+    if (typeof conditions === 'string') return null;
+    return Object.keys(conditions);
+});
+
+function evaluateShowField() {
     return new ShowField(
         values.value,
         extraValues.value,
@@ -147,7 +156,45 @@ const shouldShowField = computed(() => {
         setHiddenField,
         { container },
     ).showField(props.config, fullPath.value);
+}
+
+const hasConditions = computed(() => {
+    if (props.config.visibility === 'hidden') return false;
+    return KEYS.some((k) => props.config[k]);
 });
+
+const shouldShowField = ref(props.config.visibility !== 'hidden');
+
+const isCustomCondition = computed(() => {
+    const conditionKey = KEYS.find((k) => props.config[k]);
+    return conditionKey ? typeof props.config[conditionKey] === 'string' : false;
+});
+
+if (hasConditions.value) {
+    shouldShowField.value = evaluateShowField();
+
+    watch(
+        () => {
+            if (isCustomCondition.value) return values.value;
+            const handles = conditionHandles.value;
+            if (!handles) return null;
+            const src = values.value ?? {};
+            const rootSrc = containerValues.value ?? {};
+            return handles.map((handle) => {
+                if (handle.startsWith('$root.') || handle.startsWith('root.')) {
+                    return data_get(rootSrc, handle.replace(/^\$?root\./, ''));
+                }
+                return data_get(src, handle);
+            });
+        },
+        () => { shouldShowField.value = evaluateShowField(); },
+        { deep: isCustomCondition.value },
+    );
+
+    watch(hiddenFields, () => {
+        shouldShowField.value = evaluateShowField();
+    });
+}
 
 const shouldShowLabelText = computed(() => !props.config.hide_display);
 

--- a/resources/js/composables/use-preview-text.js
+++ b/resources/js/composables/use-preview-text.js
@@ -1,0 +1,40 @@
+import { computed } from 'vue';
+import { buildPreviewText } from '@/util/buildPreviewText';
+import { data_get } from '@/bootstrap/globals.js';
+
+/**
+ * Composable for generating preview text in replicator sets.
+ *
+ * @param {Object} options - Configuration options
+ * @param {Object} options.config - The set configuration with fields array
+ * @param {Object} options.values - The current field values
+ * @param {Object} options.previews - The preview data from mounted fieldtype components
+ * @param {string} options.fieldPathPrefix - The field path prefix for looking up previews
+ * @param {boolean} options.showFieldPreviews - Whether to show field previews by default
+ * @returns {Object} - Object containing the previewText computed property
+ */
+export default function usePreviewText(options) {
+    const {
+        config,
+        values,
+        previews,
+        fieldPathPrefix,
+        showFieldPreviews,
+    } = options;
+
+    const previewText = computed(() => {
+        const previewData = data_get(previews.value, fieldPathPrefix.value) || {};
+
+        return buildPreviewText({
+            previews: previewData,
+            config: config.value,
+            values: values.value,
+            showFieldPreviews: showFieldPreviews.value,
+            separator: ' <span class="text-gray-400 dark:text-gray-600">/</span> ',
+        });
+    });
+
+    return {
+        previewText,
+    };
+}

--- a/resources/js/tests/PublishContainerVisibleValues.test.js
+++ b/resources/js/tests/PublishContainerVisibleValues.test.js
@@ -1,0 +1,94 @@
+import { test, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+import PublishContainer from '@ui/Publish/Container.vue';
+
+window.Statamic = {
+    $dirty: {
+        add: () => {},
+        remove: () => {},
+        has: () => false,
+    },
+    $events: {
+        $emit: () => {},
+    },
+    $config: {
+        get: (key) => (key === 'sites' ? [{ handle: 'default', direction: 'ltr' }] : undefined),
+    },
+};
+window.__ = (msg) => msg;
+
+const TestComponent = { template: '<div></div>' };
+
+const createContainer = (props = {}) => mount(PublishContainer, {
+    props: {
+        blueprint: { publish: [], tabs: { main: { fields: [] } } },
+        modelValue: {},
+        trackDirtyState: false,
+        ...props,
+    },
+    slots: { default: TestComponent },
+});
+
+test('it returns values by reference when no hidden fields', () => {
+    const values = { title: 'Hello', body: 'World' };
+    const wrapper = createContainer({ modelValue: values });
+
+    expect(wrapper.vm.visibleValues).toBe(wrapper.vm.values);
+});
+
+test('it omits top-level keys with omitValue true', async () => {
+    const values = { title: 'Hello', secret: 'hidden', body: 'World' };
+    const wrapper = createContainer({ modelValue: values });
+
+    wrapper.vm.setHiddenField({ dottedKey: 'secret', hidden: true, omitValue: true });
+    await nextTick();
+
+    expect(wrapper.vm.visibleValues).not.toHaveProperty('secret');
+    expect(wrapper.vm.visibleValues).toHaveProperty('title', 'Hello');
+    expect(wrapper.vm.visibleValues).toHaveProperty('body', 'World');
+    expect(wrapper.vm.values).toHaveProperty('secret', 'hidden');
+});
+
+test('it omits nested paths correctly', async () => {
+    const values = {
+        features: [
+            { textcontent: 'Feature 1', price: 100 },
+            { textcontent: 'Feature 2', price: 200 },
+        ],
+    };
+    const wrapper = createContainer({ modelValue: values });
+
+    wrapper.vm.setHiddenField({ dottedKey: 'features.0.textcontent', hidden: true, omitValue: true });
+    await nextTick();
+
+    expect(wrapper.vm.visibleValues.features[0]).not.toHaveProperty('textcontent');
+    expect(wrapper.vm.visibleValues.features[0]).toHaveProperty('price', 100);
+    expect(wrapper.vm.visibleValues.features[1]).toHaveProperty('textcontent', 'Feature 2');
+});
+
+test('it returns values by reference when hidden field changes to not omit', async () => {
+    const values = { title: 'Hello', secret: 'hidden' };
+    const wrapper = createContainer({ modelValue: values });
+
+    wrapper.vm.setHiddenField({ dottedKey: 'secret', hidden: true, omitValue: true });
+    await nextTick();
+    expect(wrapper.vm.visibleValues).not.toBe(wrapper.vm.values);
+
+    wrapper.vm.setHiddenField({ dottedKey: 'secret', hidden: true, omitValue: false });
+    await nextTick();
+    expect(wrapper.vm.visibleValues).toBe(wrapper.vm.values);
+});
+
+test('it emits update:visibleValues on deep changes', async () => {
+    const values = { title: 'Hello', nested: { key: 'value' } };
+    const wrapper = createContainer({ modelValue: values });
+
+    wrapper.emitted()['update:visibleValues'] = [];
+
+    wrapper.vm.values.nested.key = 'updated';
+    await nextTick();
+
+    expect(wrapper.emitted()['update:visibleValues']).toBeTruthy();
+    expect(wrapper.emitted()['update:visibleValues'].length).toBeGreaterThan(0);
+});

--- a/resources/js/tests/createMountScheduler.test.js
+++ b/resources/js/tests/createMountScheduler.test.js
@@ -1,0 +1,282 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMountScheduler } from '../util/createMountScheduler.js';
+import { mount } from '@vue/test-utils';
+import { nextTick, ref, h } from 'vue';
+
+beforeEach(() => {
+    vi.useFakeTimers({
+        toFake: [
+            'setTimeout', 'clearTimeout',
+            'setInterval', 'clearInterval',
+            'setImmediate', 'clearImmediate',
+            'queueMicrotask',
+            'requestAnimationFrame', 'cancelAnimationFrame',
+            'requestIdleCallback', 'cancelIdleCallback',
+            'Date',
+        ],
+    });
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+test('zero-arg factory still works (backward compat)', () => {
+    const scheduler = createMountScheduler();
+    expect(scheduler).toHaveProperty('schedule');
+    expect(typeof scheduler.schedule).toBe('function');
+});
+
+// Helper to flush requestAnimationFrame / requestIdleCallback
+const flushTick = async () => {
+    await vi.advanceTimersToNextTimerAsync();
+};
+
+test('processes multiple cheap callbacks within budget', async () => {
+    const scheduler = createMountScheduler({ budgetMs: 8 });
+    const results = [];
+
+    // Schedule 5 cheap callbacks
+    for (let i = 0; i < 5; i++) {
+        scheduler.schedule(() => results.push(i));
+    }
+
+    await flushTick();
+
+    // All 5 should complete in one tick since they're cheap
+    expect(results).toEqual([0, 1, 2, 3, 4]);
+});
+
+test('resumes remaining callbacks on next tick when budget exceeded', async () => {
+    let processedCount = 0;
+    const scheduler = createMountScheduler({ budgetMs: 5 });
+
+    // Schedule callbacks - first one is slow, others are fast
+    scheduler.schedule(() => {
+        const start = performance.now();
+        while (performance.now() - start < 10) {} // 10ms sync delay
+        processedCount++;
+    });
+
+    for (let i = 0; i < 4; i++) {
+        scheduler.schedule(() => processedCount++);
+    }
+
+    await flushTick();
+    // Budget was blown by first callback, so only 1 processed
+    expect(processedCount).toBe(1);
+
+    await flushTick();
+    // Next tick should process the rest
+    expect(processedCount).toBe(5);
+});
+
+test('error in one callback does not prevent others from running', async () => {
+    const scheduler = createMountScheduler({ budgetMs: 8 });
+    const results = [];
+
+    scheduler.schedule(() => results.push(1));
+    scheduler.schedule(() => { throw new Error('Intentional error'); });
+    scheduler.schedule(() => results.push(3));
+
+    // Spy on console.error
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await flushTick();
+
+    expect(results).toEqual([1, 3]);
+    expect(consoleSpy).toHaveBeenCalledOnce();
+
+    consoleSpy.mockRestore();
+});
+
+test('many cheap callbacks finish within reasonable iterations', async () => {
+    const scheduler = createMountScheduler({ budgetMs: 8 });
+    const results = [];
+
+    // 20 cheap callbacks
+    for (let i = 0; i < 20; i++) {
+        scheduler.schedule(() => results.push(i));
+    }
+
+    let iterations = 0;
+    while (results.length < 20 && iterations < 10) {
+        await flushTick();
+        iterations++;
+    }
+
+    expect(results.length).toBe(20);
+    expect(iterations).toBeLessThanOrEqual(3);
+});
+
+test('vue render time from a callback counts against the budget', async () => {
+    // Component that takes measurable time to render when it mounts.
+    const HeavyChild = {
+        setup() {
+            // Synthetic cost at setup time.
+            const start = performance.now();
+            while (performance.now() - start < 6) {}
+            return () => h('div');
+        },
+    };
+    const Parent = {
+        setup() {
+            const show = ref(false);
+            return { show };
+        },
+        render() {
+            return this.show ? h(HeavyChild) : h('div');
+        },
+    };
+
+    const scheduler = createMountScheduler({ budgetMs: 5 });
+    const wrappers = [mount(Parent), mount(Parent), mount(Parent)];
+    const mounted = [];
+
+    wrappers.forEach((w, i) => {
+        scheduler.schedule(() => {
+            w.vm.show = true;
+            mounted.push(i);
+        });
+    });
+
+    await flushTick();
+    // First flip triggers HeavyChild mount (~6ms real time via nextTick);
+    // budget is 5ms, so only one should process this tick.
+    expect(mounted.length).toBe(1);
+
+    await flushTick();
+    await flushTick();
+    expect(mounted.length).toBe(3);
+
+    wrappers.forEach(w => w.unmount());
+});
+
+test('scheduler recovers after a nextTick rejection', async () => {
+    const scheduler = createMountScheduler({ budgetMs: 8 });
+    const results = [];
+
+    // Mock nextTick to reject on the first invocation only.
+    const realNextTick = nextTick;
+    let first = true;
+    const spy = vi.spyOn(await import('vue'), 'nextTick').mockImplementation((...args) => {
+        if (first) { first = false; return Promise.reject(new Error('boom')); }
+        return realNextTick(...args);
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    scheduler.schedule(() => results.push('a'));
+    scheduler.schedule(() => results.push('b'));
+
+    await flushTick();
+    await flushTick();
+
+    expect(results).toEqual(['a', 'b']);
+    expect(consoleSpy).toHaveBeenCalled();
+
+    spy.mockRestore();
+    consoleSpy.mockRestore();
+});
+
+test('a callback that schedules more work runs on a later tick', async () => {
+    const scheduler = createMountScheduler({ budgetMs: 8 });
+    const order = [];
+
+    scheduler.schedule(() => {
+        order.push('a');
+        scheduler.schedule(() => order.push('b'));
+    });
+
+    await flushTick();
+    expect(order).toEqual(['a', 'b']);
+});
+
+test('respects budgetMs when requestIdleCallback fires with didTimeout', async () => {
+    const originalRIC = globalThis.requestIdleCallback;
+    let ricCallCount = 0;
+    globalThis.requestIdleCallback = (cb) => {
+        ricCallCount++;
+        setTimeout(() => cb({ didTimeout: true, timeRemaining: () => 0 }), 0);
+        return 0;
+    };
+
+    try {
+        const scheduler = createMountScheduler({ budgetMs: 5 });
+        const results = [];
+
+        // First callback exceeds the 5ms budget.
+        scheduler.schedule(() => {
+            const start = performance.now();
+            while (performance.now() - start < 10) {}
+            results.push('heavy');
+        });
+        for (let i = 0; i < 4; i++) scheduler.schedule(() => results.push(i));
+
+        // Drain until all five have run; cap iterations to avoid infinite loops on regression.
+        for (let i = 0; i < 10 && results.length < 5; i++) {
+            await flushTick();
+        }
+
+        expect(results).toEqual(['heavy', 0, 1, 2, 3]);
+
+        // With the fix the busy callback forces a yield, so rIC is entered at
+        // least twice. With the old `return false` bypass, all 5 drain in one
+        // batch and ricCallCount stays at 1.
+        expect(ricCallCount).toBeGreaterThan(1);
+    } finally {
+        if (originalRIC) globalThis.requestIdleCallback = originalRIC;
+        else delete globalThis.requestIdleCallback;
+    }
+});
+
+test('yields based on IdleDeadline.timeRemaining when idle is granted', async () => {
+    const originalRIC = globalThis.requestIdleCallback;
+    let ricCallCount = 0;
+    globalThis.requestIdleCallback = (cb) => {
+        ricCallCount++;
+        const grantTime = performance.now();
+        const deadline = {
+            didTimeout: false,
+            timeRemaining: () => Math.max(0, 10 - (performance.now() - grantTime)),
+        };
+        setTimeout(() => cb(deadline), 0);
+        return 0;
+    };
+
+    try {
+        const scheduler = createMountScheduler({ budgetMs: 100 });
+        const results = [];
+
+        for (let i = 0; i < 3; i++) {
+            scheduler.schedule(() => {
+                const start = performance.now();
+                while (performance.now() - start < 6) {}
+                results.push(i);
+            });
+        }
+
+        for (let i = 0; i < 10 && results.length < 3; i++) {
+            await flushTick();
+        }
+
+        expect(results).toEqual([0, 1, 2]);
+        expect(ricCallCount).toBeGreaterThan(1);
+    } finally {
+        if (originalRIC) globalThis.requestIdleCallback = originalRIC;
+        else delete globalThis.requestIdleCallback;
+    }
+});
+
+test('scheduler resumes cleanly after an earlier flush completes', async () => {
+    const scheduler = createMountScheduler({ budgetMs: 8 });
+    const results = [];
+
+    scheduler.schedule(() => results.push('a'));
+    await flushTick();
+    expect(results).toEqual(['a']);
+
+    scheduler.schedule(() => results.push('b'));
+    scheduler.schedule(() => results.push('c'));
+    await flushTick();
+    expect(results).toEqual(['a', 'b', 'c']);
+});

--- a/resources/js/tests/toFieldActions.test.js
+++ b/resources/js/tests/toFieldActions.test.js
@@ -1,0 +1,46 @@
+import { test, expect, beforeEach, afterEach } from 'vitest';
+import { ref, reactive } from 'vue';
+import toFieldActions from '../components/field-actions/toFieldActions.js';
+
+let originalStatamic;
+
+beforeEach(() => {
+    originalStatamic = globalThis.Statamic;
+    globalThis.Statamic = {
+        $fieldActions: {
+            get: () => [
+                { title: 'Quick', quick: true, run: () => {} },
+                { title: 'Slow', quick: false, run: () => {} },
+                { title: 'Hidden', quick: false, visible: false, run: () => {} },
+            ],
+        },
+    };
+});
+
+afterEach(() => {
+    globalThis.Statamic = originalStatamic;
+});
+
+test('returns FieldAction instances safe for reactive containers (ref)', () => {
+    const actions = toFieldActions('some-binding', {});
+    const r = ref(actions);
+
+    // Without markRaw, accessing a getter that reads a private field
+    // throws "can't access private field or method: object is not the right class".
+    expect(() => r.value[0].quick).not.toThrow();
+    expect(r.value[0].quick).toBe(true);
+    expect(r.value[1].quick).toBe(false);
+});
+
+test('returns FieldAction instances safe for reactive containers (reactive)', () => {
+    const actions = toFieldActions('some-binding', {});
+    const state = reactive({ list: actions });
+
+    expect(() => state.list[0].quick).not.toThrow();
+    expect(state.list.filter((a) => !a.quick).map((a) => a.title)).toEqual(['Slow']);
+});
+
+test('filters out non-visible actions', () => {
+    const actions = toFieldActions('some-binding', {});
+    expect(actions.map((a) => a.title)).toEqual(['Quick', 'Slow']);
+});

--- a/resources/js/util/buildPreviewText.js
+++ b/resources/js/util/buildPreviewText.js
@@ -1,0 +1,72 @@
+import PreviewHtml from '@/components/fieldtypes/replicator/PreviewHtml.js';
+import formatPreviewValue from '@/util/formatPreviewValue';
+import { escapeHtml } from '@/bootstrap/globals.js';
+
+/**
+ * Build preview text from field values and mounted component previews.
+ *
+ * @param {Object} params - Parameters
+ * @param {Object} params.previews - Preview data from mounted fieldtype components
+ * @param {Object} params.config - Field configuration with fields array
+ * @param {Object} params.values - Current field values
+ * @param {boolean} params.showFieldPreviews - Whether to show field previews by default
+ * @param {string} params.separator - Separator string to use between preview values
+ * @returns {string} - The formatted preview text
+ */
+export function buildPreviewText({
+    previews,
+    config,
+    values,
+    showFieldPreviews,
+    separator,
+}) {
+    const hasMountedPreviews = Object.keys(previews).length > 0;
+
+    let previewValues;
+
+    if (hasMountedPreviews) {
+        // Use previews from mounted fieldtype components
+        previewValues = Object.entries(previews)
+            .filter(([handle, value]) => {
+                if (!handle.endsWith('_')) return false;
+                handle = handle.slice(0, -1); // Remove the trailing underscore
+                const fieldConfig = config.fields?.find((f) => f.handle === handle);
+                if (!fieldConfig) return false;
+                return fieldConfig.replicator_preview === undefined ? showFieldPreviews : fieldConfig.replicator_preview;
+            })
+            .map(([handle, value]) => value)
+            .filter((value) => {
+                if (value == null || value === '') return false;
+                if (typeof value === 'object' && !(value instanceof PreviewHtml) && !Array.isArray(value)) {
+                    return false;
+                }
+                return true;
+            })
+            .map((value) => {
+                if (value instanceof PreviewHtml) return value.html;
+                if (typeof value === 'string') return escapeHtml(value);
+                if (Array.isArray(value)) return escapeHtml(value.join(', '));
+                return escapeHtml(String(value));
+            })
+            .filter((html) => html && html.trim() !== '');
+    } else {
+        // Fallback: extract values directly from values
+        const fields = config.fields || [];
+        previewValues = fields
+            .filter((field) => {
+                const shouldShow = field.replicator_preview === undefined ? showFieldPreviews : field.replicator_preview;
+                if (!shouldShow) return false;
+                const value = values?.[field.handle];
+                if (value == null || value === '') return false;
+                if (Array.isArray(value)) return value.length > 0;
+                if (typeof value === 'object') return Object.keys(value).length > 0;
+                return true;
+            })
+            .map((field) => formatPreviewValue(values?.[field.handle], field, { escape: true }))
+            .filter((value) => value && value.trim() !== '');
+    }
+
+    return previewValues.join(separator);
+}
+
+export default buildPreviewText;

--- a/resources/js/util/createMountScheduler.js
+++ b/resources/js/util/createMountScheduler.js
@@ -27,8 +27,6 @@ export function createMountScheduler({ budgetMs = DEFAULT_BUDGET_MS } = {}) {
                 deadline = await waitForIdle();
 
                 const frameStart = performance.now();
-                // Trust timeRemaining() only when rIC granted real idle.
-                // On didTimeout (browser forced us in after 50ms), fall back to the explicit budget.
                 const shouldYield = () => {
                     if (deadline && typeof deadline.timeRemaining === 'function' && !deadline.didTimeout) {
                         return deadline.timeRemaining() < 1;

--- a/resources/js/util/createMountScheduler.js
+++ b/resources/js/util/createMountScheduler.js
@@ -1,0 +1,51 @@
+import { nextTick } from 'vue';
+
+const DEFAULT_BUDGET_MS = 8;
+
+export function createMountScheduler({ budgetMs = DEFAULT_BUDGET_MS } = {}) {
+    const queue = [];
+    let flushing = false;
+
+    const waitForIdle = () => new Promise((resolve) => {
+        if (typeof requestIdleCallback === 'function') {
+            requestIdleCallback(resolve, { timeout: 50 });
+        } else {
+            requestAnimationFrame(() => resolve());
+        }
+    });
+
+    function schedule(callback) {
+        queue.push(callback);
+        if (!flushing) flush();
+    }
+
+    async function flush() {
+        flushing = true;
+        try {
+            while (queue.length) {
+                let deadline;
+                deadline = await waitForIdle();
+
+                const frameStart = performance.now();
+                // Trust timeRemaining() only when rIC granted real idle.
+                // On didTimeout (browser forced us in after 50ms), fall back to the explicit budget.
+                const shouldYield = () => {
+                    if (deadline && typeof deadline.timeRemaining === 'function' && !deadline.didTimeout) {
+                        return deadline.timeRemaining() < 1;
+                    }
+                    return performance.now() - frameStart >= budgetMs;
+                };
+
+                while (queue.length && !shouldYield()) {
+                    const cb = queue.shift();
+                    try { cb?.(); } catch (e) { console.error(e); }
+                    try { await nextTick(); } catch (e) { console.error(e); }
+                }
+            }
+        } finally {
+            flushing = false;
+        }
+    }
+
+    return { schedule };
+}

--- a/resources/js/util/extractBardText.js
+++ b/resources/js/util/extractBardText.js
@@ -1,0 +1,23 @@
+export default function extractBardText(
+    prosemirrorNodes,
+    limit = 150,
+    setConfigs = null,
+) {
+    if (!Array.isArray(prosemirrorNodes)) return "";
+
+    const stack = [...prosemirrorNodes];
+    let text = "";
+    while (stack.length && text.length < limit) {
+        const node = stack.shift();
+        if (node.type === 'text') {
+            text += ` ${node.text || ''}`;
+        } else if (node.type === 'set' && setConfigs) {
+            const handle = node.attrs?.values?.type;
+            const set = setConfigs.find((s) => s.handle === handle);
+            text += ` [${__(set ? set.display : handle)}]`;
+        } else {
+            if (node.content) stack.unshift(...node.content);
+        }
+    }
+    return text.trim();
+}

--- a/resources/js/util/formatPreviewValue.js
+++ b/resources/js/util/formatPreviewValue.js
@@ -1,0 +1,247 @@
+import PreviewHtml from '@/components/fieldtypes/replicator/PreviewHtml.js';
+import extractBardText from '@/util/extractBardText';
+import { escapeHtml } from '@/bootstrap/globals.js';
+
+/**
+ * Normalize field options to a consistent format for lookup.
+ * Handles array-of-strings, array-of-objects {value, label} or {key, value}, and plain objects.
+ *
+ * @param {Array|Object} options - The options configuration
+ * @returns {Array} - Array of {value, label} objects
+ */
+function resolveOptions(options) {
+    if (!options) return [];
+
+    // Plain object: {key: value, key2: value2}
+    if (!Array.isArray(options)) {
+        return Object.entries(options).map(([key, val]) => ({
+            value: key,
+            label: val,
+        }));
+    }
+
+    // Array of strings: ['option1', 'option2']
+    if (options.length > 0 && typeof options[0] === 'string') {
+        return options.map((opt) => ({
+            value: opt,
+            label: opt,
+        }));
+    }
+
+    // Array of objects - normalize key/value to value/label
+    return options.map((opt) => {
+        if (typeof opt === 'object' && opt !== null) {
+            return {
+                value: opt.value !== undefined ? opt.value : opt.key,
+                label: opt.label !== undefined ? opt.label : opt.value,
+            };
+        }
+        return { value: opt, label: opt };
+    });
+}
+
+/**
+ * Resolve option label(s) for a given value.
+ *
+ * @param {*} value - The selected value(s)
+ * @param {Object} fieldConfig - The field configuration
+ * @returns {string|null} - The resolved label(s) or null
+ */
+function resolveOptionLabel(value, fieldConfig) {
+    const options = resolveOptions(fieldConfig.options);
+    if (options.length === 0) return null;
+
+    const findLabel = (val) => {
+        const option = options.find((opt) => opt.value === val);
+        return option ? option.label : val;
+    };
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) return null;
+        return value.map(findLabel).join(', ');
+    }
+
+    return findLabel(value);
+}
+
+/**
+ * Truncate a string to a maximum length.
+ *
+ * @param {string} str - The string to truncate
+ * @param {number} maxLength - Maximum length
+ * @returns {string} - Truncated string
+ */
+function truncate(str, maxLength) {
+    if (!str || str.length <= maxLength) return str;
+    return str.slice(0, maxLength) + '...';
+}
+
+/**
+ * Format a preview value for display in replicator sets.
+ *
+ * @param {*} value - The value to format
+ * @param {Object} fieldConfig - The field configuration
+ * @param {Object} options - Options for formatting
+ * @param {boolean} options.escape - Whether to escape HTML in the output (default: false)
+ * @returns {string|null} - The formatted preview value, or null if the value should be skipped
+ */
+export default function formatPreviewValue(value, fieldConfig, options = {}) {
+    const { escape = false } = options;
+
+    if (value == null || value === '') return null;
+
+    // Handle PreviewHtml instances
+    if (value instanceof PreviewHtml) {
+        return value.html;
+    }
+
+    const type = fieldConfig?.type;
+
+    // Type-specific handling (ordered before generic fallbacks)
+
+    // Toggle: ✓ Field Label / ✗ Field Label
+    if (type === 'toggle') {
+        const display = fieldConfig.display || '';
+        const prefix = value ? '✓' : '✗';
+        const result = display ? `${prefix} ${display}` : prefix;
+        return escape ? escapeHtml(result) : result;
+    }
+
+    // Select, Radio, Button Group: resolved option label
+    if (type === 'select' || type === 'radio' || type === 'button_group') {
+        const label = resolveOptionLabel(value, fieldConfig);
+        if (!label) return null;
+        return escape ? escapeHtml(label) : label;
+    }
+
+    // Checkboxes: labels joined by ', '
+    if (type === 'checkboxes') {
+        const label = resolveOptionLabel(value, fieldConfig);
+        if (!label) return null;
+        return escape ? escapeHtml(label) : label;
+    }
+
+    // Dictionary: same as select (uses config.options with loaded meta)
+    if (type === 'dictionary') {
+        const label = resolveOptionLabel(value, fieldConfig);
+        if (!label) return null;
+        return escape ? escapeHtml(label) : label;
+    }
+
+    // Replicator: Display: N set(s)
+    if (type === 'replicator') {
+        const display = fieldConfig.display || 'Sets';
+        const count = Array.isArray(value) ? value.length : 0;
+        const result = `${display}: ${count} ${count === 1 ? 'Set' : 'Sets'}`;
+        return escape ? escapeHtml(result) : result;
+    }
+
+    // Grid: Display: N row(s)
+    if (type === 'grid') {
+        const display = fieldConfig.display || 'Rows';
+        const count = Array.isArray(value) ? value.length : 0;
+        const result = `${display}: ${count} ${count === 1 ? 'Row' : 'Rows'}`;
+        return escape ? escapeHtml(result) : result;
+    }
+
+    // Assets: simplified checkmark
+    if (type === 'assets') {
+        const hasAssets = Array.isArray(value) && value.length > 0;
+        const result = hasAssets ? '✓' : '✗';
+        return escape ? escapeHtml(result) : result;
+    }
+
+    // Color: show hex string
+    if (type === 'color') {
+        const colorValue = typeof value === 'string' ? value : value?.hex || value?.color;
+        if (!colorValue) return null;
+        return escape ? escapeHtml(String(colorValue)) : String(colorValue);
+    }
+
+    // Code: truncate code content
+    if (type === 'code') {
+        const codeValue = typeof value === 'string' ? value : value?.code;
+        if (!codeValue) return null;
+        const truncated = truncate(codeValue, 60);
+        return escape ? escapeHtml(truncated) : truncated;
+    }
+
+    // Table: joined cell values
+    if (type === 'table') {
+        if (!Array.isArray(value)) return null;
+        const rows = value
+            .map((row) => {
+                if (!row || !Array.isArray(row.cells)) return '';
+                return row.cells.filter(Boolean).join(', ');
+            })
+            .filter(Boolean);
+        if (rows.length === 0) return null;
+        const result = rows.join(', ');
+        return escape ? escapeHtml(result) : result;
+    }
+
+    // Array: key: value pairs joined
+    if (type === 'array') {
+        if (typeof value !== 'object' || value === null || Array.isArray(value)) return null;
+        const entries = Object.entries(value)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join(', ');
+        if (!entries) return null;
+        return escape ? escapeHtml(entries) : entries;
+    }
+
+    // Entries / Terms / Users: count only
+    if (type === 'entries' || type === 'terms' || type === 'users') {
+        const count = Array.isArray(value) ? value.length : 0;
+        const result = `${count} ${count === 1 ? 'Item' : 'Items'}`;
+        return escape ? escapeHtml(result) : result;
+    }
+
+    // Link: show raw string value (usually a URL)
+    if (type === 'link') {
+        const linkValue = typeof value === 'string' ? value : value?.url || value?.permalink;
+        if (!linkValue) return null;
+        return escape ? escapeHtml(String(linkValue)) : String(linkValue);
+    }
+
+    // Revealer: always hidden
+    if (type === 'revealer') {
+        return null;
+    }
+
+    // Bard: Display: N block(s)
+    if (type === 'bard' && Array.isArray(value)) {
+        const display = fieldConfig.display || 'Content';
+        const count = value.length;
+        const result = `${display}: ${count} ${count === 1 ? 'Block' : 'Blocks'}`;
+        return escape ? escapeHtml(result) : result;
+    }
+
+    // Markdown: pass through as-is (markdown is human-readable)
+    if (type === 'markdown') {
+        const mdValue = typeof value === 'string' ? value : null;
+        if (!mdValue) return null;
+        return escape ? escapeHtml(mdValue) : mdValue;
+    }
+
+    // Handle array of strings (e.g., select, tags) - fallback for non-typed arrays
+    if (
+        Array.isArray(value) &&
+        value.length > 0 &&
+        typeof value[0] === 'string'
+    ) {
+        const joined = value.join(', ');
+        return escape ? escapeHtml(joined) : joined;
+    }
+
+    // Skip complex objects/arrays that would show as [object Object] or JSON
+    if (
+        Array.isArray(value) ||
+        (typeof value === 'object' && !(value instanceof PreviewHtml))
+    ) {
+        return null;
+    }
+
+    const stringValue = String(value);
+    return escape ? escapeHtml(stringValue) : stringValue;
+}

--- a/resources/js/util/formatPreviewValue.js
+++ b/resources/js/util/formatPreviewValue.js
@@ -101,7 +101,7 @@ export default function formatPreviewValue(value, fieldConfig, options = {}) {
 
     // Toggle: ✓ Field Label / ✗ Field Label
     if (type === 'toggle') {
-        const display = fieldConfig.display || '';
+        const display = fieldConfig.display || 'Toggle';
         const prefix = value ? '✓' : '✗';
         const result = display ? `${prefix} ${display}` : prefix;
         return escape ? escapeHtml(result) : result;
@@ -130,7 +130,7 @@ export default function formatPreviewValue(value, fieldConfig, options = {}) {
 
     // Replicator: Display: N set(s)
     if (type === 'replicator') {
-        const display = fieldConfig.display || 'Sets';
+        const display = fieldConfig.display || 'Replicator';
         const count = Array.isArray(value) ? value.length : 0;
         const result = `${display}: ${count} ${count === 1 ? 'Set' : 'Sets'}`;
         return escape ? escapeHtml(result) : result;
@@ -138,7 +138,7 @@ export default function formatPreviewValue(value, fieldConfig, options = {}) {
 
     // Grid: Display: N row(s)
     if (type === 'grid') {
-        const display = fieldConfig.display || 'Rows';
+        const display = fieldConfig.display || 'Grid';
         const count = Array.isArray(value) ? value.length : 0;
         const result = `${display}: ${count} ${count === 1 ? 'Row' : 'Rows'}`;
         return escape ? escapeHtml(result) : result;


### PR DESCRIPTION
# It's all about performance

## Preface
Sorry for not creating a new branch but lately you are committing a lot (thanks for that) and I didn't want to create any conflicts for anyone, so i stayed on this branch, to ensure I am working with the uptodate code.
If seen as necessary I can still create a new branch of course.

I have a customer that is using a heavily dynamic implementation of statamic. There are many nested replicators and bard fields. They also love to use the live preview. (By the way, the statamic CMS is used as a headless CMS, if that is in any way relevant.)
With those things, the performance (even the calling of those collection items or live previews) was getting really really slow and painful. Sometimes it took several minutes!

After the requested changed the CP was feeling quite snappy again. :) 

That is why I took the liberty of sitting down and trying to resolve those issues as much as possible on my own. If something is amiss or discutable, feel free to reach out.

With that out of the way, here are some explainations and details what I thought, what I did, and why I did things:


## Optimize Replicator/Bard Field Rendering, Condition Evaluation, and Value Computation

### Summary
This PR delivers comprehensive performance improvements for the Control Panel when working with complex Replicator and Bard fields. Key improvements include: staggered set mounting to have less browser freezing, fallback preview text for collapsed sets (that is as close as possible to the mounted preview), targeted field condition watching to reduce re-renders, optimized value computation with reduced GC pressure, and request deduplication.

With these changes in place the call of a very complex collection item that was previously taking a minute and over two minutes for the live preview dropped significantly with the replicator fields unloaded and even with all replicator fields loaded.

|                          | original | improved (replicators open) | improved (replicators closed)               |
|--------------------------|----------|-----------------------------|---------------------------------------------|
| **collection item load** | ~ 1 min  | ~ 40 secs *                 | ~ 5 secs                                    |
| **live preview load**    | ~ 2+ min | ~ 1.6 min                   | ~ 20 secs (majority from the dev frontend)  |

\* while with this PR we dont load the replicators with the page anymore, this is the time it takes for all replicators to expand after pageload, while the application stays somewhat responsive instead of like before freezing

Important: All initial loading is done with replicator fields collapsed but the preview enabled.
Funny thing I noticed later even for the original source: The preview on the replicator fieldsets was always there, ignoring whether the preview was disabled for it or not.

Of course now the replicator fields need to load upon opening them, but that is still by far faster, primary when not working inside of all at the same time, than loading them initialy and I think well worth the tradeoff.

### Related Issue
- Relates to #13385 – Performance for large Replicators, Relationships and Conditional fields
---

## Detailed Changes

### 1. **Staggered Set Mounting** ([resources/js/util/createMountScheduler.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/createMountScheduler.js:0:0-0:0))  **NEW**

**Problem:** When expanding all sets in a replicator with 10+ sets, all field components mounted synchronously, freezing the browser for at least 20 seconds.

**Solution:** New [createMountScheduler](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/util/createMountScheduler.js:4:0-50:1) utility using [requestIdleCallback](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/tests/createMountScheduler.test.js:234:4-243:6) (with `requestAnimationFrame` fallback) to queue set-mount callbacks:
- Processes multiple callbacks per frame based on time budget (default 8ms)
- Uses `try/finally` to guarantee queue drains even if callbacks throw
- Respects [IdleDeadline.timeRemaining()](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/tests/createMountScheduler.test.js:239:12-239:82) when idle callback is granted
- Falls back to explicit budget when `didTimeout` occurs

**Integration:**
- [Replicator.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/Replicator.vue:0:0-0:0) and [BardFieldtype.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/BardFieldtype.vue:0:0-0:0) create scheduler instances and provide them via Vue's inject/provide
- [replicator/Set.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/Set.vue:0:0-0:0) and [bard/Set.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/Set.vue:0:0-0:0) inject the scheduler and defer field mounting on first expand
- Includes unmount guards (`isUnmounted` / `_unmounted`) to prevent writes to unmounted components

**Result:** With 14 sets at ~16ms per frame, all sets appear progressively within around 300ms instead of freezing.

---

### 2. **Preview Text System** (Multiple New Files)

**Problem:** Preview text relied on fieldtype components emitting `replicator-preview-updated` on mount. Sets that were never expanded showed empty headers, and mounted previews had escaping/TypeError issues.

**Solution:** Three-layer architecture:

#### [resources/js/util/buildPreviewText.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/buildPreviewText.js:0:0-0:0)  **NEW**
Core utility that builds preview text from either:
- **Mounted previews:** From fieldtype components that have emitted `replicator-preview-updated`
- **Fallback values:** Extracted directly from raw field values when previews unavailable

Handles [PreviewHtml](cci:2://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/PreviewHtml.js:2:0-6:1) instances, arrays, and primitive values with proper escaping.

#### [resources/js/util/formatPreviewValue.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/formatPreviewValue.js:0:0-0:0)  **NEW**
Type-specific preview formatters for 15+ fieldtypes:
- **Toggle:** ✓ Field Label / ✗ Field Label
- **Select/Radio/Button Group:** Resolved option labels
- **Checkboxes:** Joined labels
- **Replicator/Grid:** "Display: N Set(s)" / "Display: N Row(s)"
- **Assets:** ✓ / ✗ checkmarks
- **Color:** Hex string
- **Code:** Truncated code content
- **Table:** Joined cell values
- **Array:** key: value pairs
- **Entries/Terms/Users:** "N Item(s)"
- **Link:** URL string
- **Bard:** "Display: N Block(s)"
- **Markdown:** Pass-through (human-readable)

**Bug Fixes:**
- **TypeError: `e.replaceAll is not a function`** — Fixed by converting non-string values to string before `escapeHtml()`
- **Double-escaping** — Mounted-preview path no longer escapes already-HTML-safe strings

#### [resources/js/util/extractBardText.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/extractBardText.js:0:0-0:0)  **NEW**
Shared ProseMirror text extraction utility:
- Iterates ProseMirror JSON nodes iteratively (not recursively)
- Renders `[SetDisplay]` placeholders for set nodes when [setConfigs](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/BardFieldtype.vue:315:8-319:9) provided
- Correctly skips set node content subtrees to avoid double-emission
- Used by both [BardFieldtype.replicatorPreview](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/BardFieldtype.vue:298:8-301:9) and fallback previews

#### [resources/js/composables/use-preview-text.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/composables/use-preview-text.js:0:0-0:0)  **NEW**
Vue composable wrapping [buildPreviewText](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/util/buildPreviewText.js:4:0-69:1) for use in [replicator/Set.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/Set.vue:0:0-0:0).

#### [resources/js/components/fieldtypes/replicator/ManagesPreviewText.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js:0:0-0:0)
Refactored mixin to use the new [buildPreviewText](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/util/buildPreviewText.js:4:0-69:1) utility with backward-compatible [formatPreviewValue](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js:17:8-20:9) method.

---

### 3. **Field Condition Performance** ([resources/js/components/ui/Publish/Field.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/Publish/Field.vue:0:0-0:0))

**Problem:** `shouldShowField` computed property re-evaluated whenever **any** value in the container changed. In Replicators with many sets, this caused cascading re-renders.

**Solution:** Converted to targeted watchers:
- `conditionHandles` computed extracts only field handles referenced in conditions
- Watcher tracks only specific field values using `data_get()` instead of entire `values` object
- For custom string-based conditions, falls back to watching full `values`
- Added separate watcher for `hiddenFields` changes

**Key Code:**
```javascript
watch(() => {
    if (isCustomCondition.value) return values.value;
    const handles = conditionHandles.value;
    if (!handles) return null;
    return handles.map((handle) => {
        if (handle.startsWith('$root.') || handle.startsWith('root.')) {
            return data_get(rootSrc, handle.replace(/^\$?root\./, ''));
        }
        return data_get(src, handle);
    });
}, () => { shouldShowField.value = evaluateShowField(); });
```

---

### 4. **Optimized `visibleValues` Computation** ([resources/js/components/ui/Publish/Container.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/Publish/Container.vue:0:0-0:0))

**Problem:** The `Values` class cloned the entire values object on every access, causing significant GC pressure in forms with many values.

**Solution:**
- [forgetAtPath()](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/Publish/Container.vue:107:0-116:1) helper for surgical key removal from nested objects (walks dotted paths)
- **Hot path:** Returns reactive tree directly when no fields have `omitValue: true`
- Only clones when filtering is actually needed

**Code:**
```javascript
const visibleValues = computed(() => {
    // Hot path: nothing hidden -> return the reactive tree directly.
    if (omittable === null) return values.value;

    // Only clone when we actually need to omit something.
    const out = clone(values.value);
    for (const key of omittable) forgetAtPath(out, key);
    return out;
});
```

---

### 5. **Efficient Value Watchers** ([resources/js/components/ui/Publish/Container.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/Publish/Container.vue:0:0-0:0))

**Problem:** Watching `visibleValues` computed deeply triggered on every value change, even when visibility didn't change.

**Solution:** Restructured watchers:
- `values` watcher emits both `update:modelValue` and `update:visibleValues`
- New `hiddenFields` watcher only emits `update:visibleValues` when visibility actually changes
- Removed unused `Values` import, replaced with `clone` from globals

---

### 6. **CSS Transition Suppression** ([resources/css/components/fieldtypes/replicator.css](cci:7://file:///home/wallek/Work/Actiware/cms/resources/css/components/fieldtypes/replicator.css:0:0-0:0), [bard.css](cci:7://file:///home/wallek/Work/Actiware/cms/resources/css/components/fieldtypes/bard.css:0:0-0:0))

**Problem:** Bulk expand/collapse operations caused layout thrashing from CSS transitions on set headers.

**Solution:** Added `*-bulk-op` classes applied during [collapseAll()](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/BardFieldtype.vue:631:8-637:9)/[expandAll()](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/BardFieldtype.vue:639:8-645:9):
```css
.replicator-bulk-op [data-replicator-set] header,
.replicator-bulk-op [data-replicator-set] header * {
    transition: none !important;
}
```

---

### 7. **Request Deduplication** ([resources/js/components/inputs/relationship/RelationshipInput.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/inputs/relationship/RelationshipInput.vue:0:0-0:0))

**Problem:** Multiple simultaneous selection requests fired identical API calls.

**Solution:** Added `inFlightRequests` Map (file-scoped) with cache key: `itemDataUrl + '|' + site + '|' + sortedSelections`
- `_ownsRequest` flag prevents components from aborting shared requests
- Cleanup in `.finally()` prevents cache growth
- Returns existing promise for duplicate requests

---

### 8. **Memory Leak Fix** ([resources/js/components/ui/LivePreview/LivePreview.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/LivePreview/LivePreview.vue:0:0-0:0))

**Problem:** Event listener for `live-preview.{name}.refresh` was never removed on unmount.

**Solution:** 
- Extracted handler to named function [refreshHandler](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/LivePreview/LivePreview.vue:285:0-285:62)
- Properly call `Statamic.$events.$off(refreshEvent, refreshHandler)` in `onUnmounted`

---

### 9. **Field Actions Reactivity Fix** ([resources/js/components/field-actions/toFieldActions.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/field-actions/toFieldActions.js:0:0-0:0), [HasFieldActions.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/field-actions/HasFieldActions.js:0:0-0:0))

**Problem:** FieldAction instances with private fields threw "can't access private field or method: object is not the right class" when stored in reactive containers (`ref`, `reactive`).

**Solution:**
- [toFieldActions.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/field-actions/toFieldActions.js:0:0-0:0): Wrap FieldAction instances with `markRaw()` to exclude from Vue's reactivity system
- [HasFieldActions.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/field-actions/HasFieldActions.js:0:0-0:0): Cache computed result to prevent recomputation

---

## Files Changed

| File | Change |
|------|--------|
| [resources/js/util/createMountScheduler.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/createMountScheduler.js:0:0-0:0) | **New** — staggered set mounting scheduler |
| [resources/js/util/buildPreviewText.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/buildPreviewText.js:0:0-0:0) | **New** — core preview text builder |
| [resources/js/util/formatPreviewValue.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/formatPreviewValue.js:0:0-0:0) | **New** — type-specific preview formatters |
| [resources/js/util/extractBardText.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/util/extractBardText.js:0:0-0:0) | **New** — shared ProseMirror text extraction |
| [resources/js/composables/use-preview-text.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/composables/use-preview-text.js:0:0-0:0) | **New** — Vue composable for preview text |
| [resources/js/components/ui/Publish/Field.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/Publish/Field.vue:0:0-0:0) | Targeted field condition watching |
| [resources/js/components/ui/Publish/Container.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/Publish/Container.vue:0:0-0:0) | Optimized `visibleValues`, efficient watchers |
| [resources/js/components/fieldtypes/replicator/Set.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/Set.vue:0:0-0:0) | `fieldsReady` deferred rendering, mount scheduler, [usePreviewText](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/composables/use-preview-text.js:4:0-39:1) composable |
| [resources/js/components/fieldtypes/replicator/ManagesPreviewText.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js:0:0-0:0) | Use [buildPreviewText](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/util/buildPreviewText.js:4:0-69:1), backward-compatible [formatPreviewValue](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/ManagesPreviewText.js:17:8-20:9) |
| [resources/js/components/fieldtypes/replicator/Replicator.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/replicator/Replicator.vue:0:0-0:0) | Create/provide mount scheduler, CSS bulk-op |
| [resources/js/components/fieldtypes/bard/Set.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/Set.vue:0:0-0:0) | `fieldsReady`, mount scheduler injection |
| [resources/js/components/fieldtypes/bard/BardFieldtype.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/fieldtypes/bard/BardFieldtype.vue:0:0-0:0) | Use [extractBardText](cci:1://file:///home/wallek/Work/Actiware/cms/resources/js/util/extractBardText.js:0:0-22:1), mount scheduler, CSS bulk-op |
| [resources/js/components/field-actions/toFieldActions.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/field-actions/toFieldActions.js:0:0-0:0) | `markRaw()` wrapper for reactivity safety |
| [resources/js/components/field-actions/HasFieldActions.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/field-actions/HasFieldActions.js:0:0-0:0) | Cache computed field actions |
| [resources/js/components/inputs/relationship/RelationshipInput.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/inputs/relationship/RelationshipInput.vue:0:0-0:0) | Request deduplication |
| [resources/js/components/ui/LivePreview/LivePreview.vue](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/components/ui/LivePreview/LivePreview.vue:0:0-0:0) | Memory leak fix |
| [resources/css/components/fieldtypes/replicator.css](cci:7://file:///home/wallek/Work/Actiware/cms/resources/css/components/fieldtypes/replicator.css:0:0-0:0) | Bulk-op transition suppression |
| [resources/css/components/fieldtypes/bard.css](cci:7://file:///home/wallek/Work/Actiware/cms/resources/css/components/fieldtypes/bard.css:0:0-0:0) | Bulk-op transition suppression |
| [resources/js/tests/createMountScheduler.test.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/tests/createMountScheduler.test.js:0:0-0:0) | **New** — comprehensive scheduler tests |
| [resources/js/tests/toFieldActions.test.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/tests/toFieldActions.test.js:0:0-0:0) | **New** — reactivity safety tests |
| [resources/js/tests/PublishContainerVisibleValues.test.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/tests/PublishContainerVisibleValues.test.js:0:0-0:0) | **New** — visibleValues optimization tests |

---

### Testing
- I created unit tests as I thought was useful, if anything is missing, please reach out
- Existing [PublishContainerVisibleValues.test.js](cci:7://file:///home/wallek/Work/Actiware/cms/resources/js/tests/PublishContainerVisibleValues.test.js:0:0-0:0) validates optimization correctness
- Tested with complex Replicator setups (10+ sets with conditions)
- Tested Bard fields with multiple sets and nested content


## Afterword
I hope I didn't forget anything and those changes comply to the contribution guide (I tried at least).

If anything is missing, if you need more explanation or the fieldsets or some data I was working with, that was too much for the current system to handle, feel free to contact me.

:wave: Have a nice weekend!