### PR TITLE
[6.x] Persist active tab in URL hash on globals publish form

### DIFF
--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -82,6 +82,7 @@
             :site="site"
             v-model:modified-fields="localizedFields"
             :sync-field-confirmation-text="syncFieldConfirmationText"
+            remember-tab
         />
 
         <confirmation-modal


### PR DESCRIPTION
This PR ensures the active tab is persisted in the URL hash on the globals publish form, so that when you refresh the page you remain on the same tab.

Fixes #14513