### PR TITLE
[6.x] Fix blank page when visiting CP routes with invalid items

### DIFF
--- a/resources/js/pages/errors/404.vue
+++ b/resources/js/pages/errors/404.vue
@@ -1,5 +1,10 @@
 <script setup>
-import { Card, Heading, Description } from '@ui';
+import { Card, Heading, Description, Button } from '@ui';
+import Blank from '@/pages/layout/Blank.vue';
+import useBodyClasses from '@/pages/layout/body-classes.js';
+
+defineOptions({ layout: Blank });
+useBodyClasses('bg-gray-50 dark:bg-gray-900');
 </script>
 
 <template>
@@ -7,6 +12,7 @@ import { Card, Heading, Description } from '@ui';
         <Card class="text-center flex flex-col items-center space-y-2">
             <Heading size="2xl" :text="__('404')" />
             <Description :text="__('The page you are looking for could not be found.')" />
+            <Button as="a" :href="cp_url('/')" size="xs" variant="filled" class="mt-4" :text="__('Return to Control Panel')" />
         </Card>
     </div>
 </template>

--- a/resources/js/pages/errors/Error.vue
+++ b/resources/js/pages/errors/Error.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Card, Heading, Description } from '@ui';
+import { Card, Heading, Description, Button } from '@ui';
 import Blank from '@/pages/layout/Blank.vue';
 import useBodyClasses from '@/pages/layout/body-classes.js';
 
@@ -13,6 +13,7 @@ useBodyClasses('bg-gray-50 dark:bg-gray-900');
         <Card class="text-center flex flex-col items-center space-y-2">
             <Heading size="2xl" :text="__('Whoops!')" />
             <Description :text="`${__('Something went wrong')} (${status})`" />
+            <Button as="a" :href="cp_url('/')" size="xs" variant="filled" class="mt-4" :text="__('Return to Control Panel')" />
         </Card>
     </div>
 </template>

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -6,7 +6,9 @@ use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Inertia\Inertia;
+use Statamic\Exceptions\AuthenticationException;
 use Statamic\Facades\Cascade;
+use Statamic\Facades\User;
 use Statamic\Statamic;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\Cachers\ApplicationCacher;
@@ -23,6 +25,10 @@ trait RendersHttpExceptions
         }
 
         if (Statamic::isCpRoute()) {
+            if (! User::current()) {
+                return (new AuthenticationException)->toResponse($request);
+            }
+
             return Inertia::render('errors/'.$this->getStatusCode())
                 ->toResponse(request())
                 ->setStatusCode($this->getStatusCode());

--- a/tests/Routing/RouteBindingTest.php
+++ b/tests/Routing/RouteBindingTest.php
@@ -129,6 +129,8 @@ class RouteBindingTest extends TestCase
     ) {
         $this->setupContent();
 
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
+
         $response = $this->get($uri);
 
         if ($expectationCallback) {
@@ -147,6 +149,8 @@ class RouteBindingTest extends TestCase
         $expectationCallback = null
     ) {
         $this->setupContent();
+
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
 
         $response = $this->get($uri);
 


### PR DESCRIPTION
## Summary

Visiting a CP URL with an invalid item (e.g. `/cp/collections/invalid`, `/cp/collections/blog/entries/missing-id`, invalid terms, etc.) rendered a blank page with a JS error instead of a 404. Logged-out users hitting the same URLs also got the blank page instead of being redirected to login.

## Why

Route binders throw `NotFoundHttpException` inside `SubstituteBindings`, which is in the outer `statamic.cp` middleware group. That fires **before** the inner `statamic.cp.authenticated` group, so `HandleAuthenticatedInertiaRequests` never runs and the Inertia response is missing `_statamic.sessionExpiry`/`nav`. The default layout mounts `SessionExpiry.vue`, which destructures the missing prop → `TypeError` → blank page.

For the same reason, `Authorize` (which normally redirects unauthenticated users to login) never gets a chance to run when the binder throws first.

## Changes

- `resources/js/pages/errors/404.vue` — use the `Blank` layout, matching `errors/Error.vue`. Error pages shouldn't depend on auth-only CP chrome props.
- `src/Exceptions/Concerns/RendersHttpExceptions.php` — when an HTTP exception fires on a CP route without a current user, return `AuthenticationException::toResponse()` (login redirect) instead of rendering the error Inertia page. Matches what `Authorize` would have produced.
- Added a "Return to Control Panel" button on both error pages.

Note: the catch-all `/cp/{segments}` 404 route previously rendered inside the full CP chrome (it's declared inside `statamic.cp.authenticated`, so auth middleware runs for it). With this change it renders on the blank layout too, making the two 404 paths consistent.

## Test plan

- [ ] Logged in, visit `/cp/collections/invalid` → shows 404 page (no crash)
- [ ] Logged in, visit `/cp/collections/<valid>/entries/invalid` → shows 404 page (no crash)
- [ ] Logged in, visit `/cp/not-a-route` → shows 404 page
- [ ] Logged out, visit `/cp/collections/invalid` → redirects to login
- [ ] Logged out, visit `/cp/not-a-route` → redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)