### PR TITLE
[6.x] Always display time zone in DatePicker

### DIFF
--- a/resources/js/components/fieldtypes/DateIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateIndexFieldtype.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-text="formatted"></div>
+    <div v-text="formatted" v-tooltip="tooltip"></div>
 </template>
 
 <script setup>
@@ -17,6 +17,23 @@ const formatted = computed(() => {
     }
 
     const formatter = new DateFormatter().options(props.value.time_enabled ? 'datetime' : 'date');
+
+    if (props.value.mode === 'range') {
+        let start = new Date(props.value.start);
+        let end = new Date(props.value.end);
+
+        return formatter.date(start) + ' – ' + formatter.date(end);
+    }
+
+    return formatter.date(props.value.date).toString();
+});
+
+const tooltip = computed(() => {
+    if (!props.value) {
+        return null;
+    }
+
+    const formatter = new DateFormatter().options({ dateStyle: 'long', timeStyle: 'long' });
 
     if (props.value.mode === 'range') {
         let start = new Date(props.value.start);

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -24,6 +24,7 @@ import Card from '../Card/Card.vue';
 import Button from '../Button/Button.vue';
 import Calendar from '../Calendar/Calendar.vue';
 import Icon from '../Icon/Icon.vue';
+import Text from '../Text.vue';
 
 const emit = defineEmits(['update:modelValue']);
 
@@ -94,6 +95,16 @@ const calendarEvents = computed(() => ({
         emit('update:modelValue', event);
     },
 }));
+
+const timeZoneName = computed(() => props.modelValue?.timeZone ?? null);
+
+const timeZoneLabel = computed(() => {
+    const tz = timeZoneName.value;
+    if (!tz) return null;
+
+    const parts = new Intl.DateTimeFormat(undefined, { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.toDate());
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
+});
 
 const isInvalid = computed(() => {
     // Check if the component has invalid state from form validation
@@ -187,6 +198,12 @@ const getInputLabel = (part) => {
                                 </div>
                             </template>
                         </div>
+                        <Text
+                            class="text-gray-600 dark:text-gray-400 me-1"
+                            size="xs"
+                            v-tooltip="timeZoneName"
+                            :text="timeZoneLabel"
+                        />
                         <Button
                             v-if="clearable && !readOnly"
                             @click="emit('update:modelValue', null)"


### PR DESCRIPTION
Always render the time zone next to the date segments in the DatePicker, regardless of granularity. Reka only shows it when the granularity includes a time. But we had it disabled anyway as it was weird to only show it sometimes.

We keep the `hide-time-zone` prop set on `DatePickerRoot` (so reka-ui never renders its own segment) and instead render the zone ourselves using `Intl.DateTimeFormat` with `timeZoneName: 'short'` (e.g. "EDT"). A tooltip exposes the full IANA name (e.g. "America/Toronto").

There can and will be more improvements to the date field regarding timezones, but this is the lowest hanging fruit. At least now you'll be able to see what timezone you're dealing with - alleviating some confusion.

Closes https://github.com/statamic/ideas/issues/1452

<p><img width="300" height="102" alt="CleanShot 2026-04-20 at 11 16 03" src="https://github.com/user-attachments/assets/a280f2da-a6e2-48f6-8de4-67f2af15c0b9" /></p>

It also adds the full date and timezone to the listings.

<p><img width="256" height="79" alt="CleanShot 2026-04-20 at 12 08 01" src="https://github.com/user-attachments/assets/c48f5e54-54d7-46fb-a027-16e8a5a478ad" /></p>
