### PR TITLE
[6.x] Allow extending asset preset generation command

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -78,7 +78,7 @@ class AssetsGeneratePresets extends Command
      * @param  \Statamic\Contracts\Assets\AssetContainer  $container
      * @return void
      */
-    private function generatePresets($container)
+    protected function generatePresets($container)
     {
         $assets = $container->assets()->filter->isImage();
         $counts = [];


### PR DESCRIPTION
- Make the `statamic:assets:generate-presets` command extendable
- Mark the method handling core logic `protected` instead of `private`
- Use case: extend the core command and switch a config flag before executing the logic