### PR TITLE
[6.x] Hide default Statamic logo on frontend auth pages

### DIFF
--- a/resources/js/pages/layout/Outside.vue
+++ b/resources/js/pages/layout/Outside.vue
@@ -7,10 +7,11 @@ import { colorMode } from '@api';
 import PortalTargets from "@/components/portals/PortalTargets.vue";
 
 useBodyClasses('bg-gray-50 dark:bg-gray-900 font-sans leading-normal scheme-light p-2 outside');
-const { logos, cmsName } = useStatamicPageProps();
+const { logos, cmsName, isCpRoute } = useStatamicPageProps();
 const customLogo = logos?.light?.outside ?? logos?.dark?.outside ?? null;
 const lightCustomLogo = logos?.light?.outside ?? null;
 const darkCustomLogo = logos?.dark?.outside ?? logos?.light?.outside ?? null;
+const showLogo = customLogo || logos?.text || isCpRoute;
 
 onMounted(() => {
     let userMode = localStorage.getItem('statamic.color_mode');
@@ -21,7 +22,7 @@ onMounted(() => {
 
 <template>
     <div class="relative mx-auto max-w-[400px] items-center justify-center">
-        <div class="flex items-center justify-center py-6">
+        <div v-if="showLogo" class="flex items-center justify-center py-6">
             <div class="logo max-w-3/4 md:pt-18">
                 <template v-if="customLogo">
                     <img
@@ -39,7 +40,7 @@ onMounted(() => {
                     v-else-if="logos.text"
                     class="mx-auto mb-8 max-w-xs text-center text-lg font-medium opacity-50"
                     v-text="logos.text" />
-                <StatamicLogo v-else class="h-6" />
+                <StatamicLogo v-else-if="isCpRoute" class="h-6" />
             </div>
         </div>
         <slot />

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -29,6 +29,7 @@ class HandleInertiaRequests extends Middleware
                 'version' => Statamic::version(),
                 'cmsName' => __(Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic'),
                 'logos' => $this->logos(),
+                'isCpRoute' => Statamic::isCpRoute(),
             ],
             '_toasts' => $this->toasts($request),
         ]);


### PR DESCRIPTION
## Summary
- The `Outside` layout is used for auth-style pages rendered both inside the Control Panel (`/cp/auth/*`) and on the frontend (`/!/auth/*`, e.g. the default password reset screen).
- On frontend routes we no longer render the default Statamic logo fallback — developers shouldn't see Statamic branding on their own site's auth pages when they haven't customized anything.
- Custom logos (image or text) set via `statamic.cp.custom_logo_url` / `custom_logo_text` continue to render on both CP and frontend routes.
- Exposes `isCpRoute` through the shared Inertia `_statamic` props so the Vue layout can distinguish the two contexts; hides the entire logo wrapper on frontend routes when nothing would render, to avoid leaving an empty padded block.

## Test plan
- [ ] Visit `/cp/auth/login` with no custom logo configured — default Statamic logo still appears.
- [ ] Visit `/!/auth/password/reset/{token}` with no custom logo — no logo is rendered and there's no empty space where it used to be.
- [ ] Configure `statamic.cp.custom_logo_url` — custom logo appears on both `/cp/auth/*` and `/!/auth/*`.
- [ ] Configure `statamic.cp.custom_logo_text` — custom text appears on both `/cp/auth/*` and `/!/auth/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)