### PR TITLE
[6.x] Fix NavBuilder crash when nav item has an unresolved children Closure

### DIFF
--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -998,7 +998,7 @@ class NavBuilder
         $updated = collect($this->items)
             ->filter(fn ($item) => collect($this->itemsWithChildrenClosures)->contains($item->id()))
             ->filter(fn ($item) => $item->isActive() || $this->withHidden)
-            ->mapWithKeys(fn ($item) => [$item->id() => $item->children()?->map->url()->all() ?? []])
+            ->mapWithKeys(fn ($item) => [$item->id() => $item->resolveChildren()->children()?->map->url()->all() ?? []])
             ->filter(fn ($urls, $id) => $this->urlsUnresolvedChildren->get($id) != $urls)
             ->each(fn ($urls, $id) => $this->trackChangedChildren($id, $urls))
             ->isNotEmpty();


### PR DESCRIPTION
## Description

`NavBuilder::ensureUrlCachesAreUpToDate()` crashes with `Undefined property: Closure::$map` when a nav item has a children closure that hasn't been resolved yet.

## Root Cause

`resolveChildrenClosures()` only resolves children for active items (`$item->isActive()`). However, `ensureUrlCachesAreUpToDate()` processes all items in `$itemsWithChildrenClosures` (filtered by `isActive()`) and calls `$item->children()?->map->url()` on them.

If an item's children closure wasn't resolved during `resolveChildrenClosures()` (e.g. it wasn't active at that point but is now active), `$item->children()` returns the raw `Closure`. The null-safe operator `?->` doesn't help since a `Closure` is not `null`, so accessing `->map` on it throws `Undefined property: Closure::$map`.

## Fix

Call `resolveChildren()` on each item before accessing `children()` in `ensureUrlCachesAreUpToDate()`. `resolveChildren()` is idempotent — if children are already resolved it returns early.

```php
// Before
->mapWithKeys(fn ($item) => [$item->id() => $item->children()?->map->url()->all() ?? []])

// After
->mapWithKeys(fn ($item) => [$item->id() => $item->resolveChildren()->children()?->map->url()->all() ?? []])
```

## Stack Trace

```
ErrorException: Undefined property: Closure::$map
  at vendor/statamic/cms/src/CP/Navigation/NavBuilder.php:1001
```
