### PR TITLE
[6.x] Fix Eloquent user merge setting roles and groups as model attributes

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -303,7 +303,11 @@ class User extends BaseUser
 
     public function merge($data)
     {
-        $this->data($this->data()->merge(collect($data)->filter(fn ($v) => $v !== null)->all()));
+        $merged = $this->data()
+            ->except(['roles', 'groups'])
+            ->merge(collect($data)->filter(fn ($v) => $v !== null)->all());
+
+        $this->data($merged->all());
 
         return $this;
     }

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -336,6 +336,20 @@ class EloquentUserTest extends TestCase
     }
 
     #[Test]
+    public function merge_does_not_set_roles_and_groups_as_model_attributes()
+    {
+        $user = $this->user();
+
+        $user->merge(['name' => 'Updated Name']);
+
+        $attributes = $user->model()->getAttributes();
+
+        $this->assertArrayNotHasKey('roles', $attributes);
+        $this->assertArrayNotHasKey('groups', $attributes);
+        $this->assertEquals('Updated Name', $attributes['name']);
+    }
+
+    #[Test]
     #[Group('passkeys')]
     public function it_gets_passkeys()
     {


### PR DESCRIPTION
This pull request fixes an issue where calling `merge()` on an Eloquent user would cause a `Column not found` SQL error for `roles` and `groups`.

This was happening because `merge()` round-trips through `data()` — the getter injects `roles` and `groups` from their relationship tables, but the setter passes every key through `set()`, which assigns directly to the Eloquent model. When the model saves, it tries to write `roles` and `groups` columns that don't exist.

This PR fixes it by stripping `roles` and `groups` from the data before passing it back through the setter, since they're managed via their own relationship tables and should never be set as model attributes.

Fixes duncanmcclean/statamic-cargo#176