### PR TITLE
[6.x] Rename elevated_session_url config to elevated_sessions_url

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -181,7 +181,7 @@ return [
 
     'elevated_session_duration' => 15,
 
-    'elevated_session_url' => null,
+    'elevated_sessions_url' => null,
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Http/Controllers/Auth/ElevatedSessionController.php
+++ b/src/Http/Controllers/Auth/ElevatedSessionController.php
@@ -17,7 +17,7 @@ class ElevatedSessionController extends Controller
 {
     public function showForm(Request $request)
     {
-        if ($customUrl = config('statamic.users.elevated_session_url')) {
+        if ($customUrl = config('statamic.users.elevated_sessions_url')) {
             return redirect()->to($customUrl);
         }
 

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -647,7 +647,7 @@ class ElevatedSessionTest extends TestCase
     #[Test]
     public function frontend_elevated_session_redirects_to_custom_url_when_configured()
     {
-        config(['statamic.users.elevated_session_url' => '/custom-elevated-session']);
+        config(['statamic.users.elevated_sessions_url' => '/custom-elevated-session']);
 
         $this
             ->actingAs($this->user)
@@ -658,7 +658,7 @@ class ElevatedSessionTest extends TestCase
     #[Test]
     public function frontend_elevated_session_shows_inertia_page_when_no_custom_url()
     {
-        config(['statamic.users.elevated_session_url' => null]);
+        config(['statamic.users.elevated_sessions_url' => null]);
 
         $this
             ->actingAs($this->user)
@@ -735,7 +735,7 @@ class ElevatedSessionTest extends TestCase
     {
         Notification::fake();
         Str::createRandomStringsUsing(fn () => 'abc');
-        config(['statamic.users.elevated_session_url' => null]);
+        config(['statamic.users.elevated_sessions_url' => null]);
 
         $this
             ->actingAs($user = tap(User::make()->email('foo@bar.com')->makeSuper())->save())


### PR DESCRIPTION
Renames the `elevated_session_url` config option in `config/users.php` to `elevated_sessions_url` for consistency, and updates all references in the controller and tests.

This is a follow-up to #14424 