### PR TITLE
[6.x] Fix TypeError when asset last_modified meta is null

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -601,7 +601,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
      */
     public function lastModified()
     {
-        return Carbon::createFromTimestamp($this->meta('last_modified'), config('app.timezone'));
+        return Carbon::createFromTimestamp($this->meta('last_modified') ?? 0, config('app.timezone'));
     }
 
     /**

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -664,6 +664,22 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_epoch_when_last_modified_meta_is_null()
+    {
+        Storage::fake('test');
+        Storage::disk('test')->put('foo/test.txt', '');
+        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump([
+            'data' => [],
+        ]));
+
+        $asset = (new Asset)->container($this->container)->path('foo/test.txt');
+
+        $lastModified = $asset->lastModified();
+        $this->assertInstanceOf(Carbon::class, $lastModified);
+        $this->assertEquals(0, $lastModified->timestamp);
+    }
+
+    #[Test]
     public function it_generates_and_clears_meta_caches()
     {
         Storage::fake('test');

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -664,19 +664,15 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_epoch_when_last_modified_meta_is_null()
+    public function it_does_not_throw_when_last_modified_meta_is_missing()
     {
         Storage::fake('test');
         Storage::disk('test')->put('foo/test.txt', '');
-        Storage::disk('test')->put('foo/.meta/test.txt.yaml', YAML::dump([
-            'data' => [],
-        ]));
 
         $asset = (new Asset)->container($this->container)->path('foo/test.txt');
 
         $lastModified = $asset->lastModified();
         $this->assertInstanceOf(Carbon::class, $lastModified);
-        $this->assertEquals(0, $lastModified->timestamp);
     }
 
     #[Test]

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -664,10 +664,14 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    public function it_does_not_throw_when_last_modified_meta_is_missing()
+    public function it_does_not_throw_when_getting_last_modified_and_file_doesnt_exist()
     {
+        // This is really a workaround for an underlying bug.
+        // It's odd for an asset to not have a corresponding file.
+        // Once resolved, this test could be removed, although it doesn't hurt by being here.
+
         Storage::fake('test');
-        Storage::disk('test')->put('foo/test.txt', '');
+        // Intentionally do no not create the actual file.
 
         $asset = (new Asset)->container($this->container)->path('foo/test.txt');
 


### PR DESCRIPTION
## Summary

- Fixes a `TypeError` in `Asset::lastModified()` when the `last_modified` meta value is `null`
- Falls back to epoch `0` instead of passing `null` to `Carbon::createFromTimestamp()`
- Adds a test covering the null meta scenario

Fixes #14529
