### PR TITLE
[6.x] Fix /!/nocache and /!/csrf CSRF exemption on Laravel 13

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -98,11 +98,11 @@ Route::name('statamic.')->group(function () {
 
         Route::post('nocache', NoCacheController::class)
             ->middleware(NoCacheLocalize::class)
-            ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken'])
+            ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\PreventRequestForgery'])
             ->name('nocache');
 
         Route::post('csrf', CsrfTokenController::class)
-            ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken']);
+            ->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\PreventRequestForgery']);
 
         Statamic::additionalActionRoutes();
     });


### PR DESCRIPTION
Laravel 13 renamed the CSRF middleware to `Illuminate\Foundation\Http\Middleware\PreventRequestForgery`. `VerifyCsrfToken` and `ValidateCsrfToken` are now `@deprecated` aliases that **extend** `PreventRequestForgery`.

`routes/web.php` exempts the legacy classes on `/!/nocache` and `/!/csrf`:

```php
->withoutMiddleware(['App\Http\Middleware\VerifyCsrfToken', 'Illuminate\Foundation\Http\Middleware\VerifyCsrfToken'])
```

Laravel's `Router::resolveMiddleware` filters excluded middleware via `ReflectionClass::isSubclassOf` — asking "is the registered middleware a subclass of anything in the excluded list?" On Laravel 13, the registered middleware is `PreventRequestForgery` and the excluded classes are its subclasses, not its parents, so the check returns false and the exemption is a no-op. `PreventRequestForgery::handle` runs against an unauthenticated POST, throws `TokenMismatchException`, and Laravel returns 419.

### Symptoms

- With `STATAMIC_STATIC_CACHING_STRATEGY=full`, the client-side nocache bootstrap POSTs to `/!/nocache` and gets 419. Regions never hydrate.
- `/!/csrf` (the token-refresh endpoint) has the same stale exempt list and the same failure mode.

Likely related to #10801 (full-cache CSRF mismatch), reported on Laravel 11 / Statamic 5; that symptom surface differs, but the underlying drift — `withoutMiddleware` no longer matching the active CSRF class — is the same root cause and is tripped again by the Laravel 13 rename.

### Repro

Laravel 13 + Statamic 6:

```bash
curl -X POST 'http://<app>.test/!/nocache' \
  -H 'Content-Type: application/json' \
  -d '{"url":"http://<app>.test/","sections":["x"]}'
# → HTTP/1.1 419 unknown status
```

Reproduces with `STATAMIC_STATIC_CACHING_STRATEGY=null`, so no caching needed.

`app('router')->gatherRouteMiddleware($route)` on the `statamic.nocache` route returns `[EncryptCookies, AddQueuedCookiesToResponse, StartSession, ShareErrorsFromSession, PreventRequestForgery, SubstituteBindings, NoCacheLocalize]` — `PreventRequestForgery` is still in the list.

### Fix

Add `Illuminate\Foundation\Http\Middleware\PreventRequestForgery` to both `withoutMiddleware` lists. The legacy entries stay for Laravel 10–12 compatibility through the deprecated aliases.

### Notes

- If the CI matrix doesn't already include Laravel 13, this is a good moment to add a cell — the legacy aliases are marked `@deprecated` and will likely be removed in a future Laravel major, which would turn the existing list into dead entries.
- Fully backwards compatible: adding a class to the array has no effect on Laravel 10–12 where `PreventRequestForgery` does not exist in the active stack.