### PR TITLE
[6.x] Improve Link fieldtype in listings

### DIFF
--- a/resources/js/bootstrap/fieldtypes.js
+++ b/resources/js/bootstrap/fieldtypes.js
@@ -35,6 +35,7 @@ import HtmlFieldtype from '../components/fieldtypes/HtmlFieldtype.vue';
 import IconFieldtype from '../components/fieldtypes/IconFieldtype.vue';
 import IntegerFieldtype from '../components/fieldtypes/IntegerFieldtype.vue';
 import LinkFieldtype from '../components/fieldtypes/LinkFieldtype.vue';
+import LinkIndexFieldtype from '../components/fieldtypes/LinkIndexFieldtype.vue';
 import ListFieldtype from '../components/fieldtypes/ListFieldtype.vue';
 import ListIndexFieldtype from '../components/fieldtypes/ListIndexFieldtype.vue';
 import MarkdownButtonsSettingFieldtype from '../components/fieldtypes/markdown/MarkdownButtonsSettingFieldtype.vue';
@@ -107,6 +108,7 @@ export default function registerFieldtypes(app) {
     app.component('icon-fieldtype', IconFieldtype);
     app.component('integer-fieldtype', IntegerFieldtype);
     app.component('link-fieldtype', LinkFieldtype);
+    app.component('link-fieldtype-index', LinkIndexFieldtype);
     app.component('list-fieldtype', ListFieldtype);
     app.component('list-fieldtype-index', ListIndexFieldtype);
     app.component(

--- a/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
@@ -6,7 +6,7 @@ const props = defineProps(IndexFieldtype.props);
 </script>
 
 <template>
-    <a v-if="value" :key="value.url" :href="value.url" target="_blank" class="flex items-center space-x-2 text-ellipsis">
+    <a v-if="value" :key="value.url" :href="value.url" target="_blank" rel="noopener noreferrer" class="flex items-center space-x-2 text-ellipsis">
         <Icon v-if="value.type === 'asset'" name="assets" class="size-3 flex-shrink-0" />
         <Icon v-else-if="value.type === 'entry'" name="collections" class="size-3 flex-shrink-0" />
         <Icon v-else-if="value.type === 'child'" name="page" class="size-3 flex-shrink-0" />

--- a/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
@@ -6,7 +6,7 @@ const props = defineProps(IndexFieldtype.props);
 </script>
 
 <template>
-    <a :key="value.url" :href="value.url" target="_blank" class="flex items-center space-x-2 text-ellipsis">
+    <a v-if="value" :key="value.url" :href="value.url" target="_blank" class="flex items-center space-x-2 text-ellipsis">
         <Icon v-if="value.type === 'asset'" name="assets" class="size-3 flex-shrink-0" />
         <Icon v-else-if="value.type === 'entry'" name="collections" class="size-3 flex-shrink-0" />
         <Icon v-else-if="value.type === 'child'" name="page" class="size-3 flex-shrink-0" />

--- a/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
@@ -7,10 +7,10 @@ const props = defineProps(IndexFieldtype.props);
 
 <template>
     <a :key="value.url" :href="value.url" target="_blank" class="flex items-center space-x-2 text-ellipsis">
-        <Icon v-if="value.type === 'asset'" name="assets" class="size-3" />
-        <Icon v-else-if="value.type === 'entry'" name="collections" class="size-3" />
-        <Icon v-else-if="value.type === 'child'" name="page" class="size-3" />
-        <Icon v-else name="external-link" class="size-3" />
+        <Icon v-if="value.type === 'asset'" name="assets" class="size-3 flex-shrink-0" />
+        <Icon v-else-if="value.type === 'entry'" name="collections" class="size-3 flex-shrink-0" />
+        <Icon v-else-if="value.type === 'child'" name="page" class="size-3 flex-shrink-0" />
+        <Icon v-else name="external-link" class="size-3 flex-shrink-0" />
         <span v-text="value.url ?? value" />
     </a>
 </template>

--- a/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
@@ -1,0 +1,16 @@
+<script setup>
+import IndexFieldtype from '@/components/fieldtypes/index-fieldtype.js';
+import { Icon } from '@ui';
+
+const props = defineProps(IndexFieldtype.props);
+</script>
+
+<template>
+    <a :key="value.url" :href="value.url" target="_blank" class="flex items-center space-x-2 text-ellipsis">
+        <Icon v-if="value.type === 'asset'" name="assets" class="size-3" />
+        <Icon v-else-if="value.type === 'entry'" name="collections" class="size-3" />
+        <Icon v-else-if="value.type === 'child'" name="page" class="size-3" />
+        <Icon v-else name="external-link" class="size-3" />
+        <span v-text="value.url ?? value" />
+    </a>
+</template>

--- a/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkIndexFieldtype.vue
@@ -11,6 +11,6 @@ const props = defineProps(IndexFieldtype.props);
         <Icon v-else-if="value.type === 'entry'" name="collections" class="size-3 flex-shrink-0" />
         <Icon v-else-if="value.type === 'child'" name="page" class="size-3 flex-shrink-0" />
         <Icon v-else name="external-link" class="size-3 flex-shrink-0" />
-        <span v-text="value.url ?? value" />
+        <span v-text="value.url" />
     </a>
 </template>

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -70,6 +70,10 @@ class Link extends Fieldtype
             return null;
         }
 
+        if ($data === '@child' && ! $this->field->parent() instanceof Entry) {
+            return null;
+        }
+
         if (! $item = ResolveRedirect::item($data, $this->field->parent())) {
             return null;
         }

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -74,6 +74,10 @@ class Link extends Fieldtype
             return null;
         }
 
+        if (! ($url = is_object($item) ? $item->url() : $item)) {
+            return null;
+        }
+
         $type = match (true) {
             $data === '@child' => 'child',
             Str::startsWith($data, 'asset::') => 'asset',
@@ -81,10 +85,7 @@ class Link extends Fieldtype
             default => 'url',
         };
 
-        return [
-            'type' => $type,
-            'url' => is_object($item) ? $item->url() : $item,
-        ];
+        return ['type' => $type, 'url' => $url];
     }
 
     public function preload()

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -83,7 +83,7 @@ class Link extends Fieldtype
 
         return [
             'type' => $type,
-            'url' => is_string($item) ? $item : $item->url(),
+            'url' => is_object($item) ? $item->url() : $item,
         ];
     }
 

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -64,6 +64,49 @@ class Link extends Fieldtype
         );
     }
 
+    public function preProcessIndex($data)
+    {
+        if (! $data) {
+            return null;
+        }
+
+        if ($data === '@child') {
+            $parent = $this->field->parent()->page();
+
+            $children = $parent->isRoot()
+                ? $parent->structure()->in($parent->locale())->pages()->all()->slice(1, 1)
+                : $parent->pages()->all();
+
+            if ($children->isEmpty()) {
+                return null;
+            }
+
+            return ['type' => 'child', 'url' => $children->first()->url()];
+        }
+
+        if (Str::startsWith($data, 'entry::')) {
+            $entry = Facades\Entry::find(Str::after($data, 'entry::'));
+
+            if (! $entry) {
+                return $data;
+            }
+
+            return ['type' => 'entry', 'url' => $entry->url()];
+        }
+
+        if (Str::startsWith($data, 'asset::')) {
+            $asset = Facades\Asset::find(Str::after($data, 'asset::'));
+
+            if (! $asset) {
+                return $data;
+            }
+
+            return ['type' => 'asset', 'url' => $asset->url()];
+        }
+
+        return $data;
+    }
+
     public function preload()
     {
         $value = $this->field->value();

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -70,41 +70,21 @@ class Link extends Fieldtype
             return null;
         }
 
-        if ($data === '@child') {
-            $parent = $this->field->parent()->page();
-
-            $children = $parent->isRoot()
-                ? $parent->structure()->in($parent->locale())->pages()->all()->slice(1, 1)
-                : $parent->pages()->all();
-
-            if ($children->isEmpty()) {
-                return null;
-            }
-
-            return ['type' => 'child', 'url' => $children->first()->url()];
+        if (! $item = ResolveRedirect::item($data, $this->field->parent())) {
+            return null;
         }
 
-        if (Str::startsWith($data, 'entry::')) {
-            $entry = Facades\Entry::find(Str::after($data, 'entry::'));
+        $type = match (true) {
+            $data === '@child' => 'child',
+            Str::startsWith($data, 'asset::') => 'asset',
+            Str::startsWith($data, 'entry::') => 'entry',
+            default => 'url',
+        };
 
-            if (! $entry) {
-                return $data;
-            }
-
-            return ['type' => 'entry', 'url' => $entry->url()];
-        }
-
-        if (Str::startsWith($data, 'asset::')) {
-            $asset = Facades\Asset::find(Str::after($data, 'asset::'));
-
-            if (! $asset) {
-                return $data;
-            }
-
-            return ['type' => 'asset', 'url' => $asset->url()];
-        }
-
-        return $data;
+        return [
+            'type' => $type,
+            'url' => is_string($item) ? $item : $item->url(),
+        ];
     }
 
     public function preload()

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -233,6 +233,16 @@ class LinkTest extends TestCase
     }
 
     #[Test]
+    public function it_pre_processes_first_child_for_index_when_parent_is_not_an_entry()
+    {
+        $field = new Field('test', ['type' => 'link']);
+        $field->setParent(Mockery::mock());
+        $fieldtype = (new Link)->setField($field);
+
+        $this->assertNull($fieldtype->preProcessIndex('@child'));
+    }
+
+    #[Test]
     public function it_pre_processes_first_child_for_index_when_no_children()
     {
         $pages = Mockery::mock();

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -6,6 +6,7 @@ use Facades\Statamic\Routing\ResolveRedirect;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Entries\Entry;
+use Statamic\Facades;
 use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Link;
@@ -87,5 +88,130 @@ class LinkTest extends TestCase
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertNull($augmented->value());
         $this->assertEquals(['url' => null], $augmented->toArray());
+    }
+
+    #[Test]
+    public function it_pre_processes_url_for_index()
+    {
+        $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
+
+        $this->assertEquals('https://example.com', $fieldtype->preProcessIndex('https://example.com'));
+    }
+
+    #[Test]
+    public function it_pre_processes_entry_reference_for_index()
+    {
+        $entry = Mockery::mock(\Statamic\Contracts\Entries\Entry::class);
+        $entry->shouldReceive('url')->once()->andReturn('/the-entry-url');
+
+        Facades\Entry::shouldReceive('find')->with('entry-id')->once()->andReturn($entry);
+
+        $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
+
+        $this->assertEquals(
+            ['type' => 'entry', 'url' => '/the-entry-url'],
+            $fieldtype->preProcessIndex('entry::entry-id')
+        );
+    }
+
+    #[Test]
+    public function it_pre_processes_asset_reference_for_index()
+    {
+        $asset = Mockery::mock(\Statamic\Contracts\Assets\Asset::class);
+        $asset->shouldReceive('url')->once()->andReturn('/assets/image.jpg');
+
+        Facades\Asset::shouldReceive('find')->with('main::image.jpg')->once()->andReturn($asset);
+
+        $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
+
+        $this->assertEquals(
+            ['type' => 'asset', 'url' => '/assets/image.jpg'],
+            $fieldtype->preProcessIndex('asset::main::image.jpg')
+        );
+    }
+
+    #[Test]
+    public function it_pre_processes_missing_asset_reference_for_index()
+    {
+        Facades\Asset::shouldReceive('find')->with('main::missing.jpg')->once()->andReturnNull();
+
+        $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
+
+        $this->assertEquals('asset::main::missing.jpg', $fieldtype->preProcessIndex('asset::main::missing.jpg'));
+    }
+
+    #[Test]
+    public function it_pre_processes_first_child_for_index()
+    {
+        $child = Mockery::mock();
+        $child->shouldReceive('url')->once()->andReturn('/parent/child');
+
+        $pages = Mockery::mock();
+        $pages->shouldReceive('all')->once()->andReturn(collect([$child]));
+
+        $parent = Mockery::mock();
+        $parent->shouldReceive('isRoot')->once()->andReturn(false);
+        $parent->shouldReceive('pages')->once()->andReturn($pages);
+
+        $entry = Mockery::mock(\Statamic\Contracts\Entries\Entry::class);
+        $entry->shouldReceive('page')->once()->andReturn($parent);
+
+        $field = new Field('test', ['type' => 'link']);
+        $field->setParent($entry);
+        $fieldtype = (new Link)->setField($field);
+
+        $this->assertEquals(
+            ['type' => 'child', 'url' => '/parent/child'],
+            $fieldtype->preProcessIndex('@child')
+        );
+    }
+
+    #[Test]
+    public function it_pre_processes_first_child_for_index_when_parent_is_root()
+    {
+        $child = Mockery::mock();
+        $child->shouldReceive('url')->once()->andReturn('/first-child');
+
+        $tree = Mockery::mock();
+        $tree->shouldReceive('pages')->once()->andReturn($tree);
+        $tree->shouldReceive('all')->once()->andReturn(collect(['root-page', $child])->slice(0));
+
+        $parent = Mockery::mock();
+        $parent->shouldReceive('isRoot')->once()->andReturn(true);
+        $parent->shouldReceive('locale')->once()->andReturn('en');
+        $parent->shouldReceive('structure')->once()->andReturn($structure = Mockery::mock());
+        $structure->shouldReceive('in')->with('en')->once()->andReturn($tree);
+
+        $entry = Mockery::mock(\Statamic\Contracts\Entries\Entry::class);
+        $entry->shouldReceive('page')->once()->andReturn($parent);
+
+        $field = new Field('test', ['type' => 'link']);
+        $field->setParent($entry);
+        $fieldtype = (new Link)->setField($field);
+
+        $this->assertEquals(
+            ['type' => 'child', 'url' => '/first-child'],
+            $fieldtype->preProcessIndex('@child')
+        );
+    }
+
+    #[Test]
+    public function it_pre_processes_first_child_for_index_when_no_children()
+    {
+        $pages = Mockery::mock();
+        $pages->shouldReceive('all')->once()->andReturn(collect());
+
+        $parent = Mockery::mock();
+        $parent->shouldReceive('isRoot')->once()->andReturn(false);
+        $parent->shouldReceive('pages')->once()->andReturn($pages);
+
+        $entry = Mockery::mock(\Statamic\Contracts\Entries\Entry::class);
+        $entry->shouldReceive('page')->once()->andReturn($parent);
+
+        $field = new Field('test', ['type' => 'link']);
+        $field->setParent($entry);
+        $fieldtype = (new Link)->setField($field);
+
+        $this->assertNull($fieldtype->preProcessIndex('@child'));
     }
 }

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -102,6 +102,17 @@ class LinkTest extends TestCase
     }
 
     #[Test]
+    public function it_pre_processes_numeric_value_for_index()
+    {
+        $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
+
+        $this->assertEquals(
+            ['type' => 'url', 'url' => 404],
+            $fieldtype->preProcessIndex('404')
+        );
+    }
+
+    #[Test]
     public function it_pre_processes_entry_reference_for_index()
     {
         $entry = Mockery::mock(\Statamic\Contracts\Entries\Entry::class);

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -145,6 +145,19 @@ class LinkTest extends TestCase
     }
 
     #[Test]
+    public function it_pre_processes_entry_with_null_url_for_index()
+    {
+        $entry = Mockery::mock(\Statamic\Contracts\Entries\Entry::class);
+        $entry->shouldReceive('url')->once()->andReturnNull();
+
+        Facades\Entry::shouldReceive('find')->with('entry-id')->once()->andReturn($entry);
+
+        $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
+
+        $this->assertNull($fieldtype->preProcessIndex('entry::entry-id'));
+    }
+
+    #[Test]
     public function it_pre_processes_missing_entry_reference_for_index()
     {
         Facades\Entry::shouldReceive('find')->with('missing-id')->once()->andReturnNull();

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -95,7 +95,10 @@ class LinkTest extends TestCase
     {
         $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
 
-        $this->assertEquals('https://example.com', $fieldtype->preProcessIndex('https://example.com'));
+        $this->assertEquals(
+            ['type' => 'url', 'url' => 'https://example.com'],
+            $fieldtype->preProcessIndex('https://example.com')
+        );
     }
 
     #[Test]
@@ -131,13 +134,23 @@ class LinkTest extends TestCase
     }
 
     #[Test]
+    public function it_pre_processes_missing_entry_reference_for_index()
+    {
+        Facades\Entry::shouldReceive('find')->with('missing-id')->once()->andReturnNull();
+
+        $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
+
+        $this->assertNull($fieldtype->preProcessIndex('entry::missing-id'));
+    }
+
+    #[Test]
     public function it_pre_processes_missing_asset_reference_for_index()
     {
         Facades\Asset::shouldReceive('find')->with('main::missing.jpg')->once()->andReturnNull();
 
         $fieldtype = (new Link)->setField(new Field('test', ['type' => 'link']));
 
-        $this->assertEquals('asset::main::missing.jpg', $fieldtype->preProcessIndex('asset::main::missing.jpg'));
+        $this->assertNull($fieldtype->preProcessIndex('asset::main::missing.jpg'));
     }
 
     #[Test]


### PR DESCRIPTION
This PR aims to improve how the Link fieldtype is rendered in listings. Instead of displaying raw values, the URL for entries/terms/first-child is displayed with an icon to indicate the type of link.

## Before
<img width="351" height="184" alt="CleanShot 2026-04-22 at 15 26 31" src="https://github.com/user-attachments/assets/30f8c54e-e43e-4338-aeef-42728b859187" />



## After


<img width="351" height="184" alt="CleanShot 2026-04-22 at 15 26 14" src="https://github.com/user-attachments/assets/b9aeb948-4d9a-4906-bbb1-22e9a94a9dc9" />
