### PR TITLE
[6.x] Fix blank term edit screen and JS error for restricted users

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -131,7 +131,7 @@ class TermsController extends CpController
                     'url' => $localized->editUrl(),
                     'livePreviewUrl' => $localized->livePreviewUrl(),
                 ];
-            })->all(),
+            })->values()->all(),
             'previewTargets' => $taxonomy->previewTargets()->all(),
             'itemActions' => Action::for($term, ['taxonomy' => $taxonomy->handle(), 'view' => 'form']),
             'hasTemplate' => view()->exists($term->template()),


### PR DESCRIPTION
Right now when you use the Control Panel as a restricted user (e.g. multi-site with permission to access only one site) and you try to edit a taxonomy term, you see a blank publish form and the console shows the following error:
```
(TypeError: this.localizations.find is not a function. (In 'this.localizations.find(e=>e.active)', 'this.localizations.find' is undefined))
```

The reason is that `getAuthorizedSitesForTaxonomy()` returns a filtered collection with non-sequential keys. Without `->values()`, JSON can encode that as an object instead of an array, so the CP JS fails on `this.localizations.find(...)`.
Adding `->values()` reindexes the collection so it's an array in JSON.

Thanks to Theo for pointing out that bug through support!