### PR TITLE
[6.x] Fix durationForHumans deprecation warning and rounding

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -151,6 +151,7 @@ class Str
 
     public static function durationForHumans($s)
     {
+        $s = (int) $s;
         $hours = floor($s / 3600);
         $mins = floor(($s % 3600) / 60);
         $secs = $s % 60;

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -151,7 +151,7 @@ class Str
 
     public static function durationForHumans($s)
     {
-        $s = (int) $s;
+        $s = (int) round($s);
         $hours = floor($s / 3600);
         $mins = floor(($s % 3600) / 60);
         $secs = $s % 60;

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -162,6 +162,7 @@ class StrTest extends TestCase
         $this->assertEquals('1:01:01', Str::durationForHumans(3661));
         $this->assertEquals('2:10:00', Str::durationForHumans(7800));
         $this->assertEquals('10:05:30', Str::durationForHumans(36330));
+        $this->assertEquals('0:36', Str::durationForHumans(36.92));
     }
 
     #[Test]

--- a/tests/Support/StrTest.php
+++ b/tests/Support/StrTest.php
@@ -162,7 +162,7 @@ class StrTest extends TestCase
         $this->assertEquals('1:01:01', Str::durationForHumans(3661));
         $this->assertEquals('2:10:00', Str::durationForHumans(7800));
         $this->assertEquals('10:05:30', Str::durationForHumans(36330));
-        $this->assertEquals('0:36', Str::durationForHumans(36.92));
+        $this->assertEquals('0:37', Str::durationForHumans(36.92));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where `Str::durationForHumans()` emits "Implicit conversion from float to int loses precision" warnings on PHP 8.4 when called with a non-integer duration (e.g. `36.92` seconds from video/audio asset metadata).

This was happening because the `%` modulo operator was being used directly on the float input, which PHP 8.4 flags as a deprecation warning.

This PR fixes it by casting the input to an integer at the top of the method.

Fixes #14538