### PR TITLE
[6.x] Fix Live Preview iframe becoming unscrollable after resizing in Chromium

### DIFF
--- a/resources/js/components/ui/LivePreview/LivePreview.vue
+++ b/resources/js/components/ui/LivePreview/LivePreview.vue
@@ -271,6 +271,18 @@ function setEditorWidth(width) {
     localStorage.setItem(widthLocalStorageKey, width);
 }
 
+function onResizeEnd() {
+    editorResizing.value = false;
+
+    // Chromium doesn't recalculate iframe scroll state after the parent
+    // container is resized. Toggling a transform forces a reflow. #14540
+    const iframe = iframeContentContainer.value?.querySelector('iframe');
+    if (iframe) {
+        iframe.style.transform = 'translateZ(0)';
+        requestAnimationFrame(() => iframe.style.transform = '');
+    }
+}
+
 function close() {
     if (poppedOut.value) closePopout();
 
@@ -343,7 +355,7 @@ Statamic.$events.$on(`live-preview.${name.value}.refresh`, () => {
                             v-show="!poppedOut"
                             @resized="setEditorWidth"
                             @resize-start="editorResizing = true"
-                            @resize-end="editorResizing = false"
+                            @resize-end="onResizeEnd"
                             @collapsed="collapseEditor"
                         />
                     </div>


### PR DESCRIPTION
This pull request fixes an issue where dragging the Live Preview resize handle would leave the preview iframe unscrollable in Chromium-based browsers (Chrome, Edge, Arc, etc.). Safari was unaffected.

This was happening because Chromium doesn't recalculate an iframe's scroll state when its parent container is resized. Small drags within the same CSS breakpoint were especially bad, as nothing else triggered the necessary reflow.

This PR fixes it by toggling a `translateZ(0)` transform on the iframe for a single animation frame after the resize ends, which forces Chromium to recalculate the iframe's layout and restore scrollability.

Fixes #14540