### PR TITLE
[6.x] Fix CP auth error when using multiple user providers

### DIFF
--- a/src/Preferences/Preferences.php
+++ b/src/Preferences/Preferences.php
@@ -45,7 +45,7 @@ class Preferences
     {
         $this->resetState();
 
-        if (auth()->check()) {
+        if (User::current()) {
             $this
                 ->mergeDottedUserPreferences()
                 ->mergeDottedRolePreferences();

--- a/tests/CP/AuthRedirectTest.php
+++ b/tests/CP/AuthRedirectTest.php
@@ -97,7 +97,7 @@ class AuthRedirectTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_non_logged_in_statamic_users()
+    public function it_redirects_to_login_when_authenticated_user_is_not_a_statamic_user()
     {
         $nonStatamicUser = EloquentUser::make();
 

--- a/tests/CP/AuthRedirectTest.php
+++ b/tests/CP/AuthRedirectTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Exceptions\AuthorizationException;
 use Statamic\Facades\User;
 use Statamic\Statamic;
+use Tests\Auth\Eloquent\User as EloquentUser;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -93,5 +94,16 @@ class AuthRedirectTest extends TestCase
             ->get('/cp')
             ->assertRedirect(cp_route('unauthorized'))
             ->assertSessionHas(['error' => 'Unauthorized.']);
+    }
+
+    #[Test]
+    public function it_redirects_non_logged_in_statamic_users()
+    {
+        $nonStatamicUser = EloquentUser::make();
+
+        $this
+            ->actingAs($nonStatamicUser)
+            ->get('/cp')
+            ->assertRedirect(cp_route('login'));
     }
 }


### PR DESCRIPTION
When a package or an install relies on a different user provider, the redirect to the CP login fails if one attempts to access a CP page. ``Call to a member function preferences() on null``

This is because `` auth()->check()`` doesn't explicitly check if the authenticated user is a statamic user.

```php
 if (User::current()) {
      $this
          ->mergeDottedUserPreferences()
          ->mergeDottedRolePreferences();
  }
```