### PR TITLE
[6.x] Fix elevated session redirect for POST endpoints

### DIFF
--- a/src/Exceptions/ElevatedSessionAuthorizationException.php
+++ b/src/Exceptions/ElevatedSessionAuthorizationException.php
@@ -3,6 +3,7 @@
 namespace Statamic\Exceptions;
 
 use Illuminate\Http\Request;
+use Statamic\Facades\URL;
 use Statamic\Statamic;
 
 class ElevatedSessionAuthorizationException extends \Exception
@@ -22,6 +23,21 @@ class ElevatedSessionAuthorizationException extends \Exception
             ? cp_route('confirm-password')
             : route('statamic.elevated-session');
 
-        return redirect()->setIntendedUrl($request->fullUrl())->to($redirectUrl);
+        $intendedUrl = $request->isMethod('GET')
+            ? $request->fullUrl()
+            : $this->refererForIntendedUrl($request);
+
+        return redirect()->setIntendedUrl($intendedUrl)->to($redirectUrl);
+    }
+
+    private function refererForIntendedUrl(Request $request)
+    {
+        $referer = $request->headers->get('referer');
+
+        if ($referer && ! URL::isExternalToApplication($referer)) {
+            return $referer;
+        }
+
+        return $request->fullUrl();
     }
 }

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -45,7 +45,15 @@ class ElevatedSessionTest extends TestCase
                 return 'ok';
             })->middleware(Middleware\RequireElevatedSession::class);
 
+            Route::post('/requires-elevated-session', function () {
+                return 'ok';
+            })->middleware(Middleware\RequireElevatedSession::class);
+
             Route::get('/cp/requires-elevated-session', function () {
+                return 'ok';
+            })->middleware(Middleware\CP\RequireElevatedSession::class);
+
+            Route::post('/cp/requires-elevated-session', function () {
                 return 'ok';
             })->middleware(Middleware\CP\RequireElevatedSession::class);
         });
@@ -307,6 +315,54 @@ class ElevatedSessionTest extends TestCase
             ->withElevatedSession(now()->subMinutes(16))
             ->get('/cp/requires-elevated-session')
             ->assertRedirect('/cp/auth/confirm-password');
+    }
+
+    #[Test]
+    public function middleware_uses_referer_as_intended_url_for_post_requests()
+    {
+        $this->actingAs($this->user);
+
+        $this
+            ->withElevatedSession(now()->subMinutes(16))
+            ->post('/cp/requires-elevated-session', [], ['referer' => 'http://localhost/cp/some-form'])
+            ->assertRedirect('/cp/auth/confirm-password')
+            ->assertSessionHas('url.intended', 'http://localhost/cp/some-form');
+    }
+
+    #[Test]
+    public function middleware_falls_back_to_full_url_when_referer_is_external_for_post_requests()
+    {
+        $this->actingAs($this->user);
+
+        $this
+            ->withElevatedSession(now()->subMinutes(16))
+            ->post('/cp/requires-elevated-session', [], ['referer' => 'https://evil.example.com/form'])
+            ->assertRedirect('/cp/auth/confirm-password')
+            ->assertSessionHas('url.intended', 'http://localhost/cp/requires-elevated-session');
+    }
+
+    #[Test]
+    public function middleware_falls_back_to_full_url_when_referer_is_missing_for_post_requests()
+    {
+        $this->actingAs($this->user);
+
+        $this
+            ->withElevatedSession(now()->subMinutes(16))
+            ->post('/cp/requires-elevated-session')
+            ->assertRedirect('/cp/auth/confirm-password')
+            ->assertSessionHas('url.intended', 'http://localhost/cp/requires-elevated-session');
+    }
+
+    #[Test]
+    public function middleware_uses_full_url_as_intended_url_for_get_requests()
+    {
+        $this->actingAs($this->user);
+
+        $this
+            ->withElevatedSession(now()->subMinutes(16))
+            ->get('/cp/requires-elevated-session', ['referer' => 'http://localhost/cp/some-form'])
+            ->assertRedirect('/cp/auth/confirm-password')
+            ->assertSessionHas('url.intended', 'http://localhost/cp/requires-elevated-session');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

When a user submits a POST request to an endpoint protected by `RequireElevatedSession` without an elevated session, they're redirected to the password confirmation page. After confirming, `redirect()->intended()` sends them back to the original URL as a GET, which typically results in 405 Method Not Allowed (or lands on an unrelated GET handler).

The cause: `ElevatedSessionAuthorizationException` was calling `setIntendedUrl($request->fullUrl())` — for a POST, that's the POST-only endpoint.

This change uses the `Referer` header as the intended URL for non-GET requests, so the user lands back on the form page and can resubmit. External referers are rejected via `URL::isExternalToApplication`, and if the referer is missing/external we fall back to `fullUrl()`. GET behavior is unchanged.

Noticed in the 2FA flow (`POST /!/auth/two-factor/enable`) but the fix is general and benefits any POST endpoint behind `RequireElevatedSession`.

## Test plan

- [x] POST to a protected endpoint with a valid `Referer` → intended URL is the referer
- [x] POST with an external `Referer` → falls back to `fullUrl()`
- [x] POST with no `Referer` → falls back to `fullUrl()`
- [x] GET to a protected endpoint → intended URL is still `fullUrl()` (unchanged)
- [x] Full `tests/Auth/ElevatedSessionTest.php` suite passes
- [x] `--group 2fa` suite passes