### PR TITLE
[6.x] Fix `updateChildPageUris` empty check never short-circuiting

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -508,7 +508,9 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             return;
         }
 
-        if (empty($ids = $page->flattenedPages()->pluck('id'))) {
+        $ids = $page->flattenedPages()->pluck('id');
+
+        if ($ids->isEmpty()) {
             return;
         }
 


### PR DESCRIPTION
This pull request fixes an issue where saving a structured entry would rewrite URIs for every entry in the collection, even when the entry has no child pages.

This was happening because `empty()` was being used to check if the `flattenedPages` collection was empty. Since `empty()` on a Collection object always returns `false` (it's a non-null object), the early return never triggered. This meant `updateEntryUris` was called with an empty Collection, and in the eloquent driver, the `whereIn` filter was skipped — causing every entry's URI to be recomputed.

This PR fixes it by using the Collection's `isEmpty()` method instead of `empty()`.

Fixes #14546