### PR TITLE
[6.x] Fix asset selector drag-to-upload covering footer but not handling drops

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -1,10 +1,10 @@
 <template>
     <div ref="browser" class="h-full" @keydown.shift="shiftDown" @keyup="clearShift">
         <Uploader
-            ref="uploader"
+            ref="internalUploader"
             :container="container.id"
             :path="path"
-            :enabled="!preventDragging && canUpload"
+            :enabled="!uploader && !preventDragging && canUpload"
             @updated="uploadsUpdated"
             @upload-complete="uploadCompleted"
             @error="uploadError"
@@ -272,6 +272,10 @@ export default {
             type: Array,
             default: () => [],
         },
+        uploader: {
+            type: Object,
+            default: null,
+        },
     },
 
     setup() {
@@ -476,8 +480,9 @@ export default {
             this.loadAssets();
         },
 
-        path() {
+        path(path) {
             this.loadAssets();
+            this.$emit('path-changed', path);
         },
 
         searchQuery() {
@@ -676,7 +681,7 @@ export default {
         },
 
         openFileBrowser() {
-            this.$refs.uploader.browse();
+            (this.uploader || this.$refs.internalUploader).browse();
         },
 
         selectFolder(path) {

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -88,6 +88,7 @@
 </template>
 
 <script>
+import { markRaw } from 'vue';
 import AssetBrowser from './Browser/Browser.vue'
 import Uploader from './Uploader.vue'
 import {
@@ -155,7 +156,7 @@ export default {
     },
 
     mounted() {
-        this.uploaderInstance = this.$refs.uploader;
+        this.uploaderInstance = markRaw(this.$refs.uploader);
     },
 
     computed: {

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -1,7 +1,6 @@
 <template>
     <Uploader
         ref="uploader"
-        class="*:h-full"
         :container="container.id"
         :path="currentPath"
         :enabled="container.can_upload"

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -1,6 +1,7 @@
 <template>
     <Uploader
         ref="uploader"
+        class="*:h-full"
         :container="container.id"
         :path="currentPath"
         :enabled="container.can_upload"

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -1,75 +1,95 @@
 <template>
-    <div class="h-full">
-        <div class="flex h-full min-h-0 flex-col">
-            <div class="flex flex-1 flex-col gap-4 overflow-auto p-4">
-                <AssetBrowser
-                    :container="container"
-                    :initial-per-page="$config.get('paginationSize')"
-                    :initial-columns="columns"
-                    :selected-path="folder"
-                    :selected-assets="browserSelections"
-                    :restrict-folder-navigation="restrictFolderNavigation"
-                    :max-files="maxFiles"
-                    :query-scopes="queryScopes"
-                    :autoselect-uploads="true"
-                    allow-selecting-existing-upload
-                    :allow-bulk-actions="false"
-                    @selections-updated="selectionsUpdated"
-                    @edit-asset="toggleAssetSelection"
-                    @initialized="focusSearchInput"
-                >
-                    <template #initializing>
-                        <div class="flex flex-1">
-                            <div class="absolute inset-0 z-200 flex items-center justify-center text-center">
-                                <Icon name="loading" />
-                            </div>
-                        </div>
-                    </template>
-
-                    <template #header="{ canUpload, openFileBrowser, canCreateFolders, startCreatingFolder, mode, modeChanged }">
-                        <div class="flex items-center gap-2 sm:gap-3 mb-4">
-                            <div class="flex flex-1 items-center gap-2 sm:gap-3">
-                                <Search ref="search" />
-                            </div>
-
-                            <Button v-if="canUpload" :text="__('Upload')" icon="upload" @click="openFileBrowser" />
-                            <Button v-if="canCreateFolders" :text="__('Create Folder')" icon="folder-add" @click="startCreatingFolder" />
-
-                            <ToggleGroup :model-value="mode" @update:model-value="modeChanged">
-                                <ToggleItem icon="layout-grid" value="grid" />
-                                <ToggleItem icon="layout-list" value="table" />
-                            </ToggleGroup>
-                        </div>
-                    </template>
-                </AssetBrowser>
+    <Uploader
+        ref="uploader"
+        :container="container.id"
+        :path="currentPath"
+        :enabled="container.can_upload"
+        @updated="(uploads) => $refs.browser?.uploadsUpdated(uploads)"
+        @upload-complete="(asset) => $refs.browser?.uploadCompleted(asset)"
+        @error="(upload, uploads) => $refs.browser?.uploadError(upload, uploads)"
+        v-slot="{ dragging }"
+    >
+        <div class="relative h-full">
+            <div class="drag-notification" v-show="dragging">
+                <Icon name="upload-cloud-large" class="m-4 size-13" />
+                <span>{{ __('Drop File to Upload') }}</span>
             </div>
 
-            <div class="flex items-center justify-between border-t bg-gray-100 dark:bg-gray-850 dark:border-gray-700 px-4 py-2 sm:p-4">
-                <div
-                    class="dark:text-gray-200 text-sm text-gray-700"
-                    v-text="
-                        hasMaxFiles
-                            ? __n(':count/:max selected', browserSelections, { max: maxFiles })
-                            : __n(':count asset selected|:count assets selected', browserSelections)
-                    "
-                />
+            <div class="flex h-full min-h-0 flex-col">
+                <div class="flex flex-1 flex-col gap-4 overflow-auto p-4">
+                    <AssetBrowser
+                        ref="browser"
+                        :container="container"
+                        :initial-per-page="$config.get('paginationSize')"
+                        :initial-columns="columns"
+                        :selected-path="folder"
+                        :selected-assets="browserSelections"
+                        :restrict-folder-navigation="restrictFolderNavigation"
+                        :max-files="maxFiles"
+                        :query-scopes="queryScopes"
+                        :autoselect-uploads="true"
+                        :uploader="uploaderInstance"
+                        allow-selecting-existing-upload
+                        :allow-bulk-actions="false"
+                        @selections-updated="selectionsUpdated"
+                        @edit-asset="toggleAssetSelection"
+                        @initialized="focusSearchInput"
+                        @path-changed="currentPath = $event"
+                    >
+                        <template #initializing>
+                            <div class="flex flex-1">
+                                <div class="absolute inset-0 z-200 flex items-center justify-center text-center">
+                                    <Icon name="loading" />
+                                </div>
+                            </div>
+                        </template>
 
-                <div class="flex items-center space-x-3">
-                    <Button variant="ghost" @click="close">
-                        {{ __('Cancel') }}
-                    </Button>
+                        <template #header="{ canUpload, openFileBrowser, canCreateFolders, startCreatingFolder, mode, modeChanged }">
+                            <div class="flex items-center gap-2 sm:gap-3 mb-4">
+                                <div class="flex flex-1 items-center gap-2 sm:gap-3">
+                                    <Search ref="search" />
+                                </div>
 
-                    <Button variant="primary" @click="select">
-                        {{ __('Select') }}
-                    </Button>
+                                <Button v-if="canUpload" :text="__('Upload')" icon="upload" @click="openFileBrowser" />
+                                <Button v-if="canCreateFolders" :text="__('Create Folder')" icon="folder-add" @click="startCreatingFolder" />
+
+                                <ToggleGroup :model-value="mode" @update:model-value="modeChanged">
+                                    <ToggleItem icon="layout-grid" value="grid" />
+                                    <ToggleItem icon="layout-list" value="table" />
+                                </ToggleGroup>
+                            </div>
+                        </template>
+                    </AssetBrowser>
+                </div>
+
+                <div class="flex items-center justify-between border-t bg-gray-100 dark:bg-gray-850 dark:border-gray-700 px-4 py-2 sm:p-4">
+                    <div
+                        class="dark:text-gray-200 text-sm text-gray-700"
+                        v-text="
+                            hasMaxFiles
+                                ? __n(':count/:max selected', browserSelections, { max: maxFiles })
+                                : __n(':count asset selected|:count assets selected', browserSelections)
+                        "
+                    />
+
+                    <div class="flex items-center space-x-3">
+                        <Button variant="ghost" @click="close">
+                            {{ __('Cancel') }}
+                        </Button>
+
+                        <Button variant="primary" @click="select">
+                            {{ __('Select') }}
+                        </Button>
+                    </div>
                 </div>
             </div>
         </div>
-    </div>
+    </Uploader>
 </template>
 
 <script>
 import AssetBrowser from './Browser/Browser.vue'
+import Uploader from './Uploader.vue'
 import {
     Button,
     ToggleGroup,
@@ -92,6 +112,7 @@ export default {
 
     components: {
         Uploads,
+        Uploader,
         PanelHeader, Grid,
         Slider,
         ListingPagination, Breadcrumbs,
@@ -128,7 +149,13 @@ export default {
             // We only want selection changes to be reflected in the fieldtype once the user is ready to commit
             // them. They should be able to cancel at any time and have their updated selections discarded.
             browserSelections: this.selected,
+            currentPath: this.folder,
+            uploaderInstance: null,
         };
+    },
+
+    mounted() {
+        this.uploaderInstance = this.$refs.uploader;
     },
 
     computed: {

--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -14,17 +14,23 @@ export default {
             ref: 'nativeFileField',
         });
 
+        const events = this.enabled
+            ? {
+                  onDragenter: this.dragenter,
+                  onDragover: this.dragover,
+                  onDragleave: this.dragleave,
+                  onDrop: this.drop,
+              }
+            : {};
+
         return h(
             'div',
             {
                 class: 'h-full',
-                onDragenter: this.dragenter,
-                onDragover: this.dragover,
-                onDragleave: this.dragleave,
-                onDrop: this.drop,
+                ...events,
             },
             [
-                h('div', { class: { 'pointer-events-none': this.dragging } }, [
+                h('div', { class: ['h-full', { 'pointer-events-none': this.dragging }] }, [
                     fileField,
                     ...this.$slots.default({ dragging: this.enabled ? this.dragging : false }),
                 ]),

--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -30,7 +30,7 @@ export default {
                 ...events,
             },
             [
-                h('div', { class: { 'pointer-events-none': this.dragging } }, [
+                h('div', { class: ['h-full', { 'pointer-events-none': this.dragging }] }, [
                     fileField,
                     ...this.$slots.default({ dragging: this.enabled ? this.dragging : false }),
                 ]),

--- a/resources/js/components/assets/Uploader.vue
+++ b/resources/js/components/assets/Uploader.vue
@@ -30,7 +30,7 @@ export default {
                 ...events,
             },
             [
-                h('div', { class: ['h-full', { 'pointer-events-none': this.dragging }] }, [
+                h('div', { class: { 'pointer-events-none': this.dragging } }, [
                     fileField,
                     ...this.$slots.default({ dragging: this.enabled ? this.dragging : false }),
                 ]),


### PR DESCRIPTION
This pull request fixes an issue where dragging a file onto the asset selector flyout's footer area would open the file in a new browser tab instead of uploading it, and leave the "Drop File to Upload" overlay stuck.

This was happening because the drag-to-upload overlay used `absolute inset-0` which visually covered the entire stack (including the footer), but the actual drop handler only existed on the `Uploader` component wrapping the browser content — not the footer. Dropping on the footer had no handler to call `preventDefault()`, so the browser's default behavior kicked in.

This PR fixes it by moving the `Uploader` wrapper from inside the `Browser` component up to the `Selector` component, so it wraps the entire flyout content including the footer. When an external uploader is provided to the `Browser`, its internal one is disabled (drag events are unbound so they bubble up to the parent). The standalone asset browser page is unaffected since it still uses its own internal uploader.

An alternate approach would be to confine the overlay to the stack's content area so it doesn't lay on top of the footer, but making the whole stack droppable felt like the better UX.

Fixes #14536