### PR TITLE
[6.x] Include missing time chars in `DateFormat::containsTime`

### DIFF
--- a/src/Support/DateFormat.php
+++ b/src/Support/DateFormat.php
@@ -6,6 +6,6 @@ class DateFormat
 {
     public static function containsTime($format)
     {
-        return Str::contains($format, ['G', 'g', 'H', 'h', 'U', 'c', 'r']);
+        return Str::contains($format, ['a', 'A', 'B', 'g', 'G', 'h', 'H', 'i', 's', 'u', 'v', 'U', 'c', 'r']);
     }
 }


### PR DESCRIPTION
The `containsTime` helper was missing several PHP date format characters that represent time:

- `a`, `A` — am/pm markers
- `B` — Swatch internet time
- `i` — minutes
- `s` — seconds
- `u` — microseconds
- `v` — milliseconds

In practice this hasn't been a problem because hours (`G`/`g`/`H`/`h`) are usually present alongside minutes/seconds, but formats like `i:s`, `g:i a`, or just `a` would have been incorrectly reported as not containing time.

Spotted during review of #14552.