### PR TITLE
[6.x] Fix validation bypass via spoofed Precognition-Validate-Only header

### DIFF
--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Fields;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Validator as LaravelValidator;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
@@ -186,12 +185,10 @@ class Validator
     {
         $request = request();
 
-        if (! $request->headers->has('Precognition')) {
+        if (! $request->isPrecognitive()) {
             return $rules;
         }
 
-        return Collection::make($rules)
-            ->only(explode(',', $request->header('Precognition')))
-            ->all();
+        return $request->filterPrecognitiveRules($rules);
     }
 }

--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -186,12 +186,12 @@ class Validator
     {
         $request = request();
 
-        if (! $request->headers->has('Precognition-Validate-Only')) {
+        if (! $request->headers->has('Precognition')) {
             return $rules;
         }
 
         return Collection::make($rules)
-            ->only(explode(',', $request->header('Precognition-Validate-Only')))
+            ->only(explode(',', $request->header('Precognition')))
             ->all();
     }
 }

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -934,6 +934,18 @@ EOT
     }
 
     #[Test]
+    public function it_validates_precognitive_requests()
+    {
+        $this
+            ->withPrecognition()
+            ->withHeaders(['Precognition-Validate-Only' => 'email'])
+            ->postJson('/!/forms/contact', ['email' => ''])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['email'])
+            ->assertJsonMissingValidationErrors(['message']);
+    }
+
+    #[Test]
     public function it_wont_submit_form_when_precognition_validate_only_header_is_spoofed()
     {
         $this->assertEmpty(Form::find('contact')->submissions());

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -951,9 +951,7 @@ EOT
         $this->assertEmpty(Form::find('contact')->submissions());
 
         $this
-            ->withHeaders([
-                'Precognition-Validate-Only' => 'foo',
-            ])
+            ->withHeaders(['Precognition-Validate-Only' => 'foo'])
             ->post('/!/forms/contact', [])
             ->assertSessionHasErrors(['email'], null, 'form.contact')
             ->assertLocation('/');

--- a/tests/Tags/Form/FormCreateAlpineTest.php
+++ b/tests/Tags/Form/FormCreateAlpineTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Tags\Form;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Form;
 use Statamic\Statamic;
 
 class FormCreateAlpineTest extends FormTestCase
@@ -930,6 +931,22 @@ EOT
         ];
 
         $this->assertFieldRendersHtml(['<input id="[[form-handle]]-form-name-field" type="text" name="name" value="" x-model="form.name" @change="form.validate(\'name\')">'], $config, [], ['js' => 'alpine_precognition']);
+    }
+
+    #[Test]
+    public function it_wont_submit_form_when_precognition_validate_only_header_is_spoofed()
+    {
+        $this->assertEmpty(Form::find('contact')->submissions());
+
+        $this
+            ->withHeaders([
+                'Precognition-Validate-Only' => 'foo',
+            ])
+            ->post('/!/forms/contact', [])
+            ->assertSessionHasErrors(['email'], null, 'form.contact')
+            ->assertLocation('/');
+
+        $this->assertEmpty(Form::find('contact')->submissions());
     }
 
     private function jsonEncode($data)


### PR DESCRIPTION
This pull request fixes an issue where server-side validation could be bypassed by sending a `Precognition-Validate-Only` header on a non-precognitive request.

This was happening because `filterPrecognitiveRules` was checking for the `Precognition-Validate-Only` header instead of the `Precognition` header. A request with only `Precognition-Validate-Only` (and no `Precognition: true`) would pass through Laravel's `HandlePrecognitiveRequests` middleware as a real submission, but Statamic's validator would still filter rules based on that header — effectively dropping all validation.

This PR fixes it by checking the `Precognition` header instead, which is the header that actually indicates a precognitive request.

As a side effect of delegating to Laravel's `Request::filterPrecognitiveRules()`, precognition now correctly validates targeted subsets of nested form fields (grid, replicator, array, etc.). Laravel's JS client sends patterns like `address.*` or `items.*.qty` in the `Precognition-Validate-Only` header, and the helper compiles those into per-segment regex matches. The previous implementation used `Collection::only()`, which did literal-key lookups — so a request asking to validate `address.*` matched no rule keys (the actual keys look like `address.line1`, `address.city`) and stripped all rules, meaning precognition silently validated nothing for these field types. After this change those requests validate the intended subset.

Fixes #14556