### PR TITLE
[6.x] Update setup-cp-vite to install Vite 8

### DIFF
--- a/src/Console/Commands/SetupCpVite.php
+++ b/src/Console/Commands/SetupCpVite.php
@@ -53,11 +53,11 @@ class SetupCpVite extends Command
 
                 $installedDependencies = collect($contents['dependencies'] ?? [])->merge($contents['devDependencies'] ?? []);
 
-                if (! $installedDependencies->contains('vite')) {
-                    $contents['devDependencies']['vite'] = '^7.0.4';
+                if (! $installedDependencies->has('vite')) {
+                    $contents['devDependencies']['vite'] = '^8.0.0';
                 }
 
-                if (! $installedDependencies->contains('@statamic/cms')) {
+                if (! $installedDependencies->has('@statamic/cms')) {
                     $contents['dependencies']['@statamic/cms'] = 'file:./vendor/statamic/cms/resources/dist-package';
                 }
 

--- a/tests/Console/Commands/SetupCpViteTest.php
+++ b/tests/Console/Commands/SetupCpViteTest.php
@@ -60,7 +60,35 @@ JSON);
     },
     "devDependencies": {
         "postcss": "^8.4.24",
-        "vite": "^7.0.4"
+        "vite": "^8.0.0"
+    }
+JSON, $this->files->get(base_path('package.json')));
+    }
+
+    #[Test]
+    public function it_does_not_override_existing_vite_or_statamic_cms_dependencies()
+    {
+        $this->files->put(base_path('package.json'), <<<'JSON'
+{
+    "dependencies": {
+        "@statamic/cms": "file:./some/other/path"
+    },
+    "devDependencies": {
+        "vite": "^9.0.0"
+    }
+}
+JSON);
+
+        $this
+            ->artisan('statamic:setup-cp-vite')
+            ->expectsOutputToContain('Installed dependencies');
+
+        $this->assertStringContainsString(<<<'JSON'
+    "dependencies": {
+        "@statamic/cms": "file:./some/other/path"
+    },
+    "devDependencies": {
+        "vite": "^9.0.0"
     }
 JSON, $this->files->get(base_path('package.json')));
     }


### PR DESCRIPTION
Fixes #14558.

A fresh install of Statamic uses Vite 8, but running `statamic:setup-cp-vite` was regressing the version back to Vite 7.

## Changes

- Bumped the version installed by `statamic:setup-cp-vite` from `^7.0.4` to `^8.0.0` so it matches what the starter kit ships with.
- Fixed the existing-dependency detection. The check used `Collection::contains('vite')`, which inspects values, not keys. Since `dependencies`/`devDependencies` are keyed by package name with version strings as values (e.g. `"vite": "^8.0.0"`), the check always evaluated to `false` and the command always overwrote whatever version was already installed. Switched to `Collection::has()` so an existing `vite` (or `@statamic/cms`) dependency is left alone. This is what was causing the silent regression on fresh installs.
- Added a regression test covering the case where both packages are already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)