### PR TITLE
[6.x] Fix login redirects

### DIFF
--- a/resources/js/components/global-header/UserDropdown.vue
+++ b/resources/js/components/global-header/UserDropdown.vue
@@ -4,7 +4,7 @@ import { Avatar, Button, DropdownHeader, Badge, Dropdown, DropdownMenu, Dropdown
 import useStatamicPageProps from '@/composables/page-props.js';
 
 const { supportUrl } = useStatamicPageProps();
-const logoutUrl = `${cp_url('auth/logout')}?redirect=${cp_url('/')}`;
+const logoutUrl = `${cp_url('auth/logout')}?redirect=${cp_url('auth/login')}`;
 const user = Statamic.user;
 const isImpersonating = computed((() => user.is_impersonating));
 </script>

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -15,7 +15,6 @@ const props = defineProps([
     'passkeyVerifyUrl',
     'oauthEnabled',
     'providers',
-    'referer',
     'submitUrl',
     'forgotPasswordUrl',
 ])
@@ -42,11 +41,11 @@ const submit = () => {
             errors.value = {};
         },
         onSuccess: (page) => {
-			if (page.component === 'auth/two-factor/Challenge') {
-				return;
-			}
+            if (page.component === 'auth/two-factor/Challenge') {
+                return;
+            }
 
-	        window.location.href = props.referer;
+            window.location.href = page.url;
         },
         onError: () => processing.value = false
     });

--- a/resources/js/pages/auth/Unauthorized.vue
+++ b/resources/js/pages/auth/Unauthorized.vue
@@ -2,7 +2,6 @@
 import Head from '@/pages/layout/Head.vue';
 import Outside from '@/pages/layout/Outside.vue';
 import { AuthCard, Button } from '@ui';
-import { Link } from '@inertiajs/vue3';
 
 defineOptions({ layout: Outside });
 
@@ -19,7 +18,7 @@ defineProps(['isLoggedIn', 'loginUrl', 'logoutUrl']);
     >
         <div class="flex justify-center">
             <Button
-                :as="Link"
+                as="a"
                 variant="primary"
                 :href="isLoggedIn ? logoutUrl : loginUrl"
                 class="w-full"

--- a/src/Exceptions/AuthenticationException.php
+++ b/src/Exceptions/AuthenticationException.php
@@ -22,6 +22,6 @@ class AuthenticationException extends Exception implements Responsable
                 : abort(401);
         }
 
-        return redirect()->route('statamic.cp.login');
+        return redirect()->guest(route('statamic.cp.login'));
     }
 }

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -15,7 +15,6 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 use Statamic\OAuth\Provider;
 use Statamic\Statamic;
-use Statamic\Support\Str;
 
 use function Statamic\trans as __;
 
@@ -43,7 +42,6 @@ class LoginController extends CpController
             'oauthEnabled' => $oauthEnabled,
             'emailLoginEnabled' => $emailLoginEnabled,
             'providers' => $oauthEnabled ? $this->oauthProviders() : [],
-            'referer' => $this->getReferrer($request),
             'forgotPasswordUrl' => cp_route('password.request'),
             'submitUrl' => cp_route('login'),
             'passkeyOptionsUrl' => cp_route('passkeys.auth.options'),
@@ -107,11 +105,7 @@ class LoginController extends CpController
 
     public function redirectPath()
     {
-        $cp = cp_route('index');
-        $referer = request('referer');
-        $referredFromCp = Str::startsWith($referer, $cp) && ! Str::startsWith($referer, $cp.'/auth/');
-
-        return $referredFromCp ? $referer : $cp;
+        return cp_route('index');
     }
 
     protected function authenticated(Request $request, $user)
@@ -142,13 +136,6 @@ class LoginController extends CpController
         $redirect = $request->redirect ?? '/';
 
         return redirect(URL::isExternalToApplication($redirect) ? '/' : $redirect);
-    }
-
-    protected function getReferrer()
-    {
-        $referrer = url()->previous();
-
-        return $referrer === cp_route('unauthorized') ? cp_route('index') : $referrer;
     }
 
     public function username()

--- a/src/Http/Controllers/CP/Auth/PasskeyLoginController.php
+++ b/src/Http/Controllers/CP/Auth/PasskeyLoginController.php
@@ -2,13 +2,12 @@
 
 namespace Statamic\Http\Controllers\CP\Auth;
 
-use Illuminate\Http\Request;
 use Statamic\Http\Controllers\User\PasskeyLoginController as Controller;
 
 class PasskeyLoginController extends Controller
 {
-    protected function successRedirectUrl(Request $request): string
+    protected function defaultRedirectUrl(): string
     {
-        return $request->session()->pull('url.intended', cp_route('index'));
+        return cp_route('index');
     }
 }

--- a/src/Http/Controllers/CP/Auth/PasskeyLoginController.php
+++ b/src/Http/Controllers/CP/Auth/PasskeyLoginController.php
@@ -3,18 +3,12 @@
 namespace Statamic\Http\Controllers\CP\Auth;
 
 use Illuminate\Http\Request;
-use Statamic\Facades\URL;
 use Statamic\Http\Controllers\User\PasskeyLoginController as Controller;
-use Statamic\Support\Str;
 
 class PasskeyLoginController extends Controller
 {
     protected function successRedirectUrl(Request $request): string
     {
-        $referer = $request->input('referer');
-
-        return Str::contains($referer, '/'.config('statamic.cp.route')) && ! URL::isExternalToApplication($referer)
-            ? $referer
-            : cp_route('index');
+        return $request->session()->pull('url.intended', cp_route('index'));
     }
 }

--- a/src/Http/Controllers/CP/Auth/TwoFactorChallengeController.php
+++ b/src/Http/Controllers/CP/Auth/TwoFactorChallengeController.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Http\Controllers\CP\Auth;
 
-use Illuminate\Http\Request;
 use Statamic\Http\Controllers\TwoFactorChallengeController as Controller;
 use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
@@ -21,9 +20,9 @@ class TwoFactorChallengeController extends Controller
         return cp_route('two-factor-challenge');
     }
 
-    protected function redirectPath(Request $request)
+    protected function defaultRedirectPath(): string
     {
-        return $request->session()->pull('url.intended', cp_route('index'));
+        return cp_route('index');
     }
 
     protected function failedRedirectPath()

--- a/src/Http/Controllers/CP/Auth/TwoFactorChallengeController.php
+++ b/src/Http/Controllers/CP/Auth/TwoFactorChallengeController.php
@@ -6,7 +6,6 @@ use Illuminate\Http\Request;
 use Statamic\Http\Controllers\TwoFactorChallengeController as Controller;
 use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
-use Statamic\Support\Str;
 
 class TwoFactorChallengeController extends Controller
 {
@@ -24,11 +23,7 @@ class TwoFactorChallengeController extends Controller
 
     protected function redirectPath(Request $request)
     {
-        $cp = cp_route('index');
-        $referer = $request->input('referer');
-        $referredFromCp = Str::startsWith($referer, $cp) && ! Str::startsWith($referer, $cp.'/auth/');
-
-        return $referredFromCp ? $referer : $cp;
+        return $request->session()->pull('url.intended', cp_route('index'));
     }
 
     protected function failedRedirectPath()

--- a/src/Http/Controllers/CP/Auth/TwoFactorSetupController.php
+++ b/src/Http/Controllers/CP/Auth/TwoFactorSetupController.php
@@ -16,10 +16,10 @@ class TwoFactorSetupController extends Controller
     protected function redirectPath()
     {
         $cp = cp_route('index');
-        $referer = request('referer');
-        $referredFromCp = Str::startsWith($referer, $cp) && ! Str::startsWith($referer, $cp.'/auth/');
+        $intended = redirect()->getIntendedUrl();
+        $isCpUrl = $intended && Str::startsWith($intended, $cp) && ! Str::startsWith($intended, $cp.'/auth/');
 
-        return $referredFromCp ? $referer : $cp;
+        return $isCpUrl ? $intended : $cp;
     }
 
     protected function routes($user): array

--- a/src/Http/Controllers/Concerns/HandlesLogins.php
+++ b/src/Http/Controllers/Concerns/HandlesLogins.php
@@ -60,20 +60,14 @@ trait HandlesLogins
 
     protected function twoFactorChallengeResponse(Request $request, User $user)
     {
-        $request->session()->forget('login.redirect');
-
-        $session = [
+        $request->session()->put([
             'login.id' => $user->getKey(),
             'login.remember' => $request->boolean('remember'),
-        ];
+        ]);
 
-        if ($redirect = $request->input('_redirect')) {
-            if (! URL::isExternalToApplication($redirect)) {
-                $session['login.redirect'] = $redirect;
-            }
+        if (($redirect = $request->input('_redirect')) && ! URL::isExternalToApplication($redirect)) {
+            redirect()->setIntendedUrl($redirect);
         }
-
-        $request->session()->put($session);
 
         TwoFactorAuthenticationChallenged::dispatch($user);
 

--- a/src/Http/Controllers/TwoFactorChallengeController.php
+++ b/src/Http/Controllers/TwoFactorChallengeController.php
@@ -87,11 +87,13 @@ class TwoFactorChallengeController extends Controller
 
     protected function redirectPath(Request $request)
     {
+        $intended = $request->session()->pull('url.intended', $this->defaultRedirectPath());
+
         if (($redirect = $request->input('_redirect')) && ! URL::isExternalToApplication($redirect)) {
             return $redirect;
         }
 
-        return $request->session()->pull('url.intended', $this->defaultRedirectPath());
+        return $intended;
     }
 
     protected function defaultRedirectPath(): string

--- a/src/Http/Controllers/TwoFactorChallengeController.php
+++ b/src/Http/Controllers/TwoFactorChallengeController.php
@@ -58,13 +58,15 @@ class TwoFactorChallengeController extends Controller
 
         $request->session()->regenerate();
 
+        $redirect = $this->redirectPath($request);
+
         if ($request->inertia() || $request->expectsJson()) {
             return $request->inertia()
-                ? Inertia::location($this->redirectPath($request))
+                ? Inertia::location($redirect)
                 : response('Authenticated');
         }
 
-        return redirect()->intended($this->redirectPath($request));
+        return redirect($redirect);
     }
 
     protected function sendFailedResponse(TwoFactorChallengeRequest $request)
@@ -85,18 +87,15 @@ class TwoFactorChallengeController extends Controller
 
     protected function redirectPath(Request $request)
     {
-        if ($redirect = $request->input('_redirect')) {
-            if (! URL::isExternalToApplication($redirect)) {
-                return $redirect;
-            }
+        if (($redirect = $request->input('_redirect')) && ! URL::isExternalToApplication($redirect)) {
+            return $redirect;
         }
 
-        if ($redirect = $request->session()->pull('login.redirect')) {
-            if (! URL::isExternalToApplication($redirect)) {
-                return $redirect;
-            }
-        }
+        return redirect()->intended($this->defaultRedirectPath())->getTargetUrl();
+    }
 
+    protected function defaultRedirectPath(): string
+    {
         return route('statamic.site');
     }
 

--- a/src/Http/Controllers/TwoFactorChallengeController.php
+++ b/src/Http/Controllers/TwoFactorChallengeController.php
@@ -91,7 +91,7 @@ class TwoFactorChallengeController extends Controller
             return $redirect;
         }
 
-        return redirect()->intended($this->defaultRedirectPath())->getTargetUrl();
+        return $request->session()->pull('url.intended', $this->defaultRedirectPath());
     }
 
     protected function defaultRedirectPath(): string

--- a/src/Http/Controllers/TwoFactorSetupController.php
+++ b/src/Http/Controllers/TwoFactorSetupController.php
@@ -33,19 +33,11 @@ class TwoFactorSetupController extends Controller
 
     protected function redirectPath()
     {
-        if ($redirect = request('redirect')) {
-            if (! URL::isExternalToApplication($redirect)) {
-                return $redirect;
-            }
+        if (($redirect = request('redirect')) && ! URL::isExternalToApplication($redirect)) {
+            return $redirect;
         }
 
-        if ($redirect = session()->get('login.redirect')) {
-            if (! URL::isExternalToApplication($redirect)) {
-                return $redirect;
-            }
-        }
-
-        return route('statamic.site');
+        return redirect()->getIntendedUrl() ?? route('statamic.site');
     }
 
     protected function routes($user): array

--- a/src/Http/Controllers/User/LoginController.php
+++ b/src/Http/Controllers/User/LoginController.php
@@ -29,21 +29,20 @@ class LoginController extends Controller
             return $this->twoFactorChallengeResponse($request, $user);
         }
 
-        $redirect = $request->input('_redirect');
-        $redirect = $redirect && ! URL::isExternalToApplication($redirect) ? $redirect : null;
-
-        // If 2FA setup is required, stash the redirect so the setup flow can use it after completion.
-        if (TwoFactor::enabled() && $user->isTwoFactorAuthenticationRequired() && ! $user->hasEnabledTwoFactorAuthentication()) {
-            $request->session()->forget('login.redirect');
-
-            if ($redirect) {
-                $request->session()->put('login.redirect', $redirect);
-            }
+        // An explicit form redirect overrides any URL stashed by the auth middleware.
+        if (($redirect = $request->input('_redirect')) && ! URL::isExternalToApplication($redirect)) {
+            redirect()->setIntendedUrl($redirect);
         }
 
         $this->authenticate($request, $user);
 
-        return redirect($redirect ?? route('statamic.site'))->withSuccess(__('Login successful.'));
+        // Preserve the intended URL for the setup flow to consume after the user completes setup.
+        if (TwoFactor::enabled() && $user->isTwoFactorAuthenticationRequired() && ! $user->hasEnabledTwoFactorAuthentication()) {
+            return redirect(redirect()->getIntendedUrl() ?? route('statamic.site'))
+                ->withSuccess(__('Login successful.'));
+        }
+
+        return redirect()->intended(route('statamic.site'))->withSuccess(__('Login successful.'));
     }
 
     private function checkPasskeyEnforcement(Request $request)

--- a/src/Http/Controllers/User/PasskeyLoginController.php
+++ b/src/Http/Controllers/User/PasskeyLoginController.php
@@ -42,8 +42,15 @@ class PasskeyLoginController extends Controller
 
     protected function successRedirectUrl(Request $request): string
     {
-        $redirect = $request->input('redirect', '/');
+        if (($redirect = $request->input('redirect')) && ! URL::isExternalToApplication($redirect)) {
+            return $redirect;
+        }
 
-        return URL::isExternalToApplication($redirect) ? '/' : $redirect;
+        return $request->session()->pull('url.intended', $this->defaultRedirectUrl());
+    }
+
+    protected function defaultRedirectUrl(): string
+    {
+        return '/';
     }
 }

--- a/src/Http/Controllers/User/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/User/TwoFactorAuthenticationController.php
@@ -102,19 +102,11 @@ class TwoFactorAuthenticationController extends CpController
     {
         $successKey = "{$formName}.success";
 
-        if ($redirect = $request->input('_redirect')) {
-            if (! URL::isExternalToApplication($redirect)) {
-                return redirect($redirect)->with($successKey, $message);
-            }
+        if (($redirect = $request->input('_redirect')) && ! URL::isExternalToApplication($redirect)) {
+            return redirect($redirect)->with($successKey, $message);
         }
 
-        if ($loginRedirect = $request->session()->pull('login.redirect')) {
-            if (! URL::isExternalToApplication($loginRedirect)) {
-                return redirect($loginRedirect)->with($successKey, $message);
-            }
-        }
-
-        return back()->with($successKey, $message);
+        return redirect()->intended(back()->getTargetUrl())->with($successKey, $message);
     }
 
     protected function confirmUrl()

--- a/src/Http/Middleware/CP/RedirectIfTwoFactorSetupIncomplete.php
+++ b/src/Http/Middleware/CP/RedirectIfTwoFactorSetupIncomplete.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Http\Middleware\CP;
 
-use Illuminate\Http\Request;
 use Statamic\Http\Middleware\RedirectIfTwoFactorSetupIncomplete as Middleware;
 
 class RedirectIfTwoFactorSetupIncomplete extends Middleware
@@ -12,10 +11,8 @@ class RedirectIfTwoFactorSetupIncomplete extends Middleware
         return 'statamic.cp.two-factor-setup';
     }
 
-    protected function redirectUrl(Request $request): string
+    protected function redirectUrl(): string
     {
-        return route($this->redirectRoute(), [
-            'referer' => $request->fullUrl(),
-        ]);
+        return route($this->redirectRoute());
     }
 }

--- a/src/Http/Middleware/RedirectIfTwoFactorSetupIncomplete.php
+++ b/src/Http/Middleware/RedirectIfTwoFactorSetupIncomplete.php
@@ -23,7 +23,9 @@ class RedirectIfTwoFactorSetupIncomplete
                 app(EnableTwoFactorAuthentication::class)($user);
             }
 
-            return redirect($this->redirectUrl($request));
+            redirect()->setIntendedUrl($request->fullUrl());
+
+            return redirect($this->redirectUrl());
         }
 
         return $next($request);
@@ -41,15 +43,9 @@ class RedirectIfTwoFactorSetupIncomplete
         return $currentPath === $customPath;
     }
 
-    protected function redirectUrl(Request $request): string
+    protected function redirectUrl(): string
     {
-        if ($url = config('statamic.users.two_factor_setup_url')) {
-            return $url;
-        }
-
-        return route($this->redirectRoute(), [
-            'referer' => $request->fullUrl(),
-        ]);
+        return config('statamic.users.two_factor_setup_url') ?? route($this->redirectRoute());
     }
 
     protected function redirectRoute(): string

--- a/tests/Auth/LoginTest.php
+++ b/tests/Auth/LoginTest.php
@@ -135,6 +135,14 @@ class LoginTest extends TestCase
     }
 
     #[Test]
+    public function it_stores_the_intended_url_when_redirected_to_login()
+    {
+        $this
+            ->get(cp_route('collections.index'))
+            ->assertSessionHas('url.intended', 'http://localhost/cp/collections');
+    }
+
+    #[Test]
     public function it_can_logout()
     {
         $this

--- a/tests/Auth/LoginTest.php
+++ b/tests/Auth/LoginTest.php
@@ -118,23 +118,6 @@ class LoginTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_referer_url()
-    {
-        $user = $this->user();
-
-        $this
-            ->assertGuest()
-            ->post(cp_route('login'), [
-                'email' => $user->email(),
-                'password' => 'secret',
-                'referer' => 'http://localhost/cp/cp/collections',
-            ])
-            ->assertRedirect('http://localhost/cp/cp/collections');
-
-        $this->assertAuthenticatedAs($user);
-    }
-
-    #[Test]
     public function it_redirects_to_intended_url()
     {
         $user = $this->user();

--- a/tests/Feature/Auth/PasskeyLoginTest.php
+++ b/tests/Feature/Auth/PasskeyLoginTest.php
@@ -93,47 +93,17 @@ class PasskeyLoginTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_referer_after_successful_login()
-    {
-        $user = $this->createUser();
-        $refererUrl = 'http://localhost/cp/collections';
-        WebAuthn::shouldReceive('getUserFromCredentials')->once()->andReturn($user);
-        WebAuthn::shouldReceive('validateAssertion')->once()->andReturnTrue();
-
-        $this
-            ->loginRequest(['referer' => $refererUrl])
-            ->assertOk()
-            ->assertJson(['redirect' => $refererUrl]);
-
-        $this->assertAuthenticatedAs($user);
-    }
-
-    #[Test]
-    public function it_does_not_redirect_to_non_cp_referer()
+    public function it_redirects_to_intended_url_after_successful_login()
     {
         $user = $this->createUser();
         WebAuthn::shouldReceive('getUserFromCredentials')->once()->andReturn($user);
         WebAuthn::shouldReceive('validateAssertion')->once()->andReturnTrue();
 
         $this
-            ->loginRequest(['referer' => 'http://localhost/some-other-page'])
+            ->withSession(['url.intended' => 'http://localhost/cp/collections'])
+            ->loginRequest()
             ->assertOk()
-            ->assertJson(['redirect' => cp_route('index')]);
-
-        $this->assertAuthenticatedAs($user);
-    }
-
-    #[Test]
-    public function it_does_not_redirect_to_external_cp_referer()
-    {
-        $user = $this->createUser();
-        WebAuthn::shouldReceive('getUserFromCredentials')->once()->andReturn($user);
-        WebAuthn::shouldReceive('validateAssertion')->once()->andReturnTrue();
-
-        $this
-            ->loginRequest(['referer' => 'https://evil.com/cp/collections'])
-            ->assertOk()
-            ->assertJson(['redirect' => cp_route('index')]);
+            ->assertJson(['redirect' => 'http://localhost/cp/collections']);
 
         $this->assertAuthenticatedAs($user);
     }

--- a/tests/Feature/Users/TwoFactorChallengeTest.php
+++ b/tests/Feature/Users/TwoFactorChallengeTest.php
@@ -158,22 +158,6 @@ class TwoFactorChallengeTest extends TestCase
     }
 
     #[Test]
-    public function it_redirects_to_referer_url_after_successful_challenge()
-    {
-        $user = $this->userWithTwoFactorEnabled();
-
-        $this
-            ->session(['login.id' => $user->id()])
-            ->post(cp_route('two-factor-challenge'), [
-                'code' => $this->getOneTimeCode($user),
-                'referer' => 'http://localhost/cp/collections',
-            ])
-            ->assertRedirect('http://localhost/cp/collections');
-
-        $this->assertAuthenticatedAs($user);
-    }
-
-    #[Test]
     public function it_redirects_to_intended_url_after_successful_challenge()
     {
         $user = $this->userWithTwoFactorEnabled();

--- a/tests/Feature/Users/TwoFactorRoutesTest.php
+++ b/tests/Feature/Users/TwoFactorRoutesTest.php
@@ -63,7 +63,8 @@ class TwoFactorRoutesTest extends TestCase
         $this
             ->actingAs($user)
             ->get(cp_route('dashboard'))
-            ->assertRedirect(cp_route('two-factor-setup', ['referer' => cp_route('dashboard')]));
+            ->assertRedirect(cp_route('two-factor-setup'))
+            ->assertSessionHas('url.intended', cp_route('dashboard'));
     }
 
     #[Test]
@@ -93,7 +94,8 @@ class TwoFactorRoutesTest extends TestCase
         $this
             ->actingAs($user)
             ->get(cp_route('dashboard'))
-            ->assertRedirect(cp_route('two-factor-setup', ['referer' => cp_route('dashboard')]));
+            ->assertRedirect(cp_route('two-factor-setup'))
+            ->assertSessionHas('url.intended', cp_route('dashboard'));
     }
 
     #[Test]
@@ -106,7 +108,8 @@ class TwoFactorRoutesTest extends TestCase
         $this
             ->actingAs($user)
             ->get('/test-frontend-route')
-            ->assertRedirect(route('statamic.two-factor-setup', ['referer' => url('/test-frontend-route')]));
+            ->assertRedirect(route('statamic.two-factor-setup'))
+            ->assertSessionHas('url.intended', url('/test-frontend-route'));
     }
 
     #[Test]
@@ -121,7 +124,8 @@ class TwoFactorRoutesTest extends TestCase
         $this
             ->actingAs($user)
             ->get('/test-frontend-route')
-            ->assertRedirect(route('statamic.two-factor-setup', ['referer' => url('/test-frontend-route')]));
+            ->assertRedirect(route('statamic.two-factor-setup'))
+            ->assertSessionHas('url.intended', url('/test-frontend-route'));
 
         $this->assertNotNull($user->fresh()->two_factor_secret);
     }
@@ -138,7 +142,8 @@ class TwoFactorRoutesTest extends TestCase
         $this
             ->actingAs($user)
             ->get('/test-frontend-route')
-            ->assertRedirect(route('statamic.two-factor-setup', ['referer' => url('/test-frontend-route')]));
+            ->assertRedirect(route('statamic.two-factor-setup'))
+            ->assertSessionHas('url.intended', url('/test-frontend-route'));
 
         $this->assertEquals($existing, $user->fresh()->two_factor_secret);
     }

--- a/tests/Feature/Users/TwoFactorSetupTest.php
+++ b/tests/Feature/Users/TwoFactorSetupTest.php
@@ -52,7 +52,7 @@ class TwoFactorSetupTest extends TestCase
 
         $this
             ->actingAs($user)
-            ->withSession(['login.redirect' => '/dashboard'])
+            ->withSession(['url.intended' => '/dashboard'])
             ->get(route('statamic.two-factor-setup'))
             ->assertInertia(fn ($page) => $page->where('redirect', '/dashboard'));
 

--- a/tests/Feature/Users/TwoFactorSetupTest.php
+++ b/tests/Feature/Users/TwoFactorSetupTest.php
@@ -35,13 +35,12 @@ class TwoFactorSetupTest extends TestCase
     }
 
     #[Test]
-    public function redirect_url_is_referer()
+    public function redirect_url_is_intended_url()
     {
         $this
             ->actingAs($this->user())
-            ->get(cp_route('two-factor-setup', [
-                'referer' => 'http://localhost/cp/collections',
-            ]))
+            ->withSession(['url.intended' => 'http://localhost/cp/collections'])
+            ->get(cp_route('two-factor-setup'))
             ->assertInertia(fn ($page) => $page->where('redirect', 'http://localhost/cp/collections'));
     }
 

--- a/tests/Tags/User/DisableTwoFactorFormTest.php
+++ b/tests/Tags/User/DisableTwoFactorFormTest.php
@@ -137,7 +137,7 @@ class DisableTwoFactorFormTest extends TestCase
     }
 
     #[Test]
-    public function it_prefers_redirect_param_over_login_redirect_in_session()
+    public function it_prefers_redirect_param_over_intended_url_in_session()
     {
         $user = $this->userWithTwoFactorEnabled();
 
@@ -145,7 +145,7 @@ class DisableTwoFactorFormTest extends TestCase
             ->actingAs($user)
             ->session([
                 'statamic_elevated_session' => now()->timestamp,
-                'login.redirect' => '/dashboard',
+                'url.intended' => '/dashboard',
             ])
             ->delete(route('statamic.users.two-factor.disable'), [
                 '_redirect' => '/account',

--- a/tests/Tags/User/LoginFormTest.php
+++ b/tests/Tags/User/LoginFormTest.php
@@ -362,7 +362,7 @@ EOT
     }
 
     #[Test]
-    public function it_stores_redirect_in_session_for_two_factor_challenge()
+    public function it_stores_redirect_as_intended_url_for_two_factor_challenge()
     {
         User::make()
             ->id(1)
@@ -384,12 +384,55 @@ EOT
                 'password' => 'chewy',
                 '_redirect' => '/dashboard',
             ])
-            ->assertSessionHas('login.redirect', '/dashboard');
+            ->assertSessionHas('url.intended', '/dashboard');
     }
 
     #[Test]
-    public function it_does_not_stash_login_redirect_when_two_factor_is_not_enforced()
+    public function it_redirects_to_intended_url_when_no_redirect_param_is_provided()
     {
+        User::make()
+            ->id(1)
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->withSession(['url.intended' => '/protected'])
+            ->post('/!/auth/login', [
+                'token' => 'test-token',
+                'email' => 'san@holo.com',
+                'password' => 'chewy',
+            ])
+            ->assertRedirect('/protected')
+            ->assertSessionMissing('url.intended');
+    }
+
+    #[Test]
+    public function it_prefers_redirect_param_over_intended_url()
+    {
+        User::make()
+            ->id(1)
+            ->email('san@holo.com')
+            ->password('chewy')
+            ->save();
+
+        $this
+            ->withSession(['url.intended' => '/protected'])
+            ->post('/!/auth/login', [
+                'token' => 'test-token',
+                'email' => 'san@holo.com',
+                'password' => 'chewy',
+                '_redirect' => '/dashboard',
+            ])
+            ->assertRedirect('/dashboard')
+            ->assertSessionMissing('url.intended');
+    }
+
+    #[Test]
+    public function it_stashes_redirect_as_intended_url_when_two_factor_setup_is_required()
+    {
+        config()->set('statamic.users.two_factor_enforced_roles', ['*']);
+
         User::make()
             ->id(1)
             ->email('san@holo.com')
@@ -404,73 +447,7 @@ EOT
                 '_redirect' => '/dashboard',
             ])
             ->assertRedirect('/dashboard')
-            ->assertSessionMissing('login.redirect');
-    }
-
-    #[Test]
-    public function it_stashes_login_redirect_when_two_factor_setup_is_required()
-    {
-        config()->set('statamic.users.two_factor_enforced_roles', ['*']);
-
-        User::make()
-            ->id(1)
-            ->email('san@holo.com')
-            ->password('chewy')
-            ->save();
-
-        $this
-            ->post('/!/auth/login', [
-                'token' => 'test-token',
-                'email' => 'san@holo.com',
-                'password' => 'chewy',
-                '_redirect' => '/dashboard',
-            ])
-            ->assertSessionHas('login.redirect', '/dashboard');
-    }
-
-    #[Test]
-    public function it_clears_stale_login_redirect_on_two_factor_challenge()
-    {
-        User::make()
-            ->id(1)
-            ->email('san@holo.com')
-            ->password('chewy')
-            ->data([
-                'two_factor_confirmed_at' => now()->timestamp,
-                'two_factor_secret' => encrypt(app(TwoFactorAuthenticationProvider::class)->generateSecretKey()),
-                'two_factor_recovery_codes' => encrypt(json_encode(Collection::times(8, fn () => RecoveryCode::generate())->all())),
-            ])
-            ->save();
-
-        $this
-            ->withSession(['login.redirect' => '/stale'])
-            ->post('/!/auth/login', [
-                'token' => 'test-token',
-                'email' => 'san@holo.com',
-                'password' => 'chewy',
-            ])
-            ->assertSessionMissing('login.redirect');
-    }
-
-    #[Test]
-    public function it_clears_stale_login_redirect_when_two_factor_setup_is_required()
-    {
-        config()->set('statamic.users.two_factor_enforced_roles', ['*']);
-
-        User::make()
-            ->id(1)
-            ->email('san@holo.com')
-            ->password('chewy')
-            ->save();
-
-        $this
-            ->withSession(['login.redirect' => '/stale'])
-            ->post('/!/auth/login', [
-                'token' => 'test-token',
-                'email' => 'san@holo.com',
-                'password' => 'chewy',
-            ])
-            ->assertSessionMissing('login.redirect');
+            ->assertSessionHas('url.intended', '/dashboard');
     }
 
     #[Test]

--- a/tests/Tags/User/TwoFactorChallengeFormTest.php
+++ b/tests/Tags/User/TwoFactorChallengeFormTest.php
@@ -193,14 +193,14 @@ class TwoFactorChallengeFormTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_login_redirect_from_session_when_no_redirect_param()
+    public function it_uses_intended_url_from_session_when_no_redirect_param()
     {
         $user = $this->userWithTwoFactorEnabled();
 
         $this
             ->session([
                 'login.id' => $user->id(),
-                'login.redirect' => '/account',
+                'url.intended' => '/account',
             ])
             ->post(route('statamic.two-factor-challenge'), [
                 'code' => $this->getOneTimeCode($user),

--- a/tests/Tags/User/TwoFactorChallengeFormTest.php
+++ b/tests/Tags/User/TwoFactorChallengeFormTest.php
@@ -210,6 +210,26 @@ class TwoFactorChallengeFormTest extends TestCase
         $this->assertAuthenticatedAs($user);
     }
 
+    #[Test]
+    public function it_clears_intended_url_from_session_when_redirect_param_wins()
+    {
+        $user = $this->userWithTwoFactorEnabled();
+
+        $this
+            ->session([
+                'login.id' => $user->id(),
+                'url.intended' => '/account',
+            ])
+            ->post(route('statamic.two-factor-challenge'), [
+                'code' => $this->getOneTimeCode($user),
+                '_redirect' => '/dashboard',
+            ])
+            ->assertRedirect('/dashboard')
+            ->assertSessionMissing('url.intended');
+
+        $this->assertAuthenticatedAs($user);
+    }
+
     private function user()
     {
         return tap(User::make()->makeSuper()->email('test@example.com'))->save();

--- a/tests/Tags/User/TwoFactorSetupFormTest.php
+++ b/tests/Tags/User/TwoFactorSetupFormTest.php
@@ -221,7 +221,7 @@ class TwoFactorSetupFormTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_login_redirect_from_session_when_redirect_param_is_empty()
+    public function it_uses_intended_url_from_session_when_redirect_param_is_empty()
     {
         $user = $this->userWithTwoFactorPending();
 
@@ -229,7 +229,7 @@ class TwoFactorSetupFormTest extends TestCase
             ->actingAs($user)
             ->session([
                 'statamic_elevated_session' => now()->timestamp,
-                'login.redirect' => '/account',
+                'url.intended' => '/account',
             ])
             ->post(route('statamic.users.two-factor.confirm'), [
                 'code' => $this->getOneTimeCode($user),


### PR DESCRIPTION
## Summary

When an unauthenticated user visits a protected URL, they're redirected to the login page. After logging in, they should land back on the URL they originally tried to reach — but they were being sent to the home page (CP or site) instead.

This affected every login method on both the CP and the frontend: regular password login, passkey login, two-factor challenge (TOTP and recovery code), and the two-factor setup flow.

## Changes

**CP**

- `AuthenticationException` now redirects via `redirect()->guest(...)`, which stores the originally requested URL in the session as `url.intended`.
- `LoginController::authenticated()` already called `redirect()->intended(...)`, which now has a target to recall.
- Removed dead `referer` query plumbing (`getReferrer()`, the `referer` Inertia prop, and the conditional in `redirectPath()`). The Inertia login form never POSTed a `referer` field, so the server-side check was always null.
- `Login.vue` now hard-reloads to `page.url` (the URL Inertia ended up at after following the server's redirect) instead of the unused `props.referer`. The full page load is preserved so the destination CP page boots with all its initial props. The two-factor challenge early return in `onSuccess` is preserved so that flow stays an Inertia transition.
- The passkey and two-factor challenge controllers now also honor `url.intended` (previously they used a `referer` form input that the JS never sent for passkey, and a hand-rolled session key for 2FA).

**Frontend**

- `User/LoginController`, `User/PasskeyLoginController`, `TwoFactorChallengeController`, `TwoFactorSetupController`, and `User/TwoFactorAuthenticationController` all route through `url.intended` instead of the short-lived `login.redirect` session key introduced last week.
- The auth middleware already redirects via `redirect()->guest(...)`, so frontend forms without an explicit `_redirect` input now land on the originally requested URL after login.
- Explicit `_redirect` form inputs still win — they're written into `url.intended` so they survive multi-step flows (e.g. login → 2FA challenge, login → 2FA setup).

**Internal**

- The parallel `login.redirect` session key has been removed entirely. Everything now uses Laravel's standard `url.intended`, accessed via `redirect()->setIntendedUrl()`, `redirect()->getIntendedUrl()`, and `redirect()->intended()`.
- `login.redirect` was only introduced last week (unreleased), so removing it is not a compatibility break.
- CP subclasses now override only the default fallback URL via small `defaultRedirectPath()` / `defaultRedirectUrl()` hooks, instead of duplicating the whole resolution logic.