### PR TITLE
[6.x] Restore selected site when resuming session

### DIFF
--- a/resources/js/components/SessionExpiry.vue
+++ b/resources/js/components/SessionExpiry.vue
@@ -300,6 +300,12 @@ export default {
             this.$toast.success(__('Logged in'));
             this.restartCountdown();
             this.updateCsrfToken();
+            this.restoreSelectedSite();
+        },
+
+        restoreSelectedSite() {
+            const site = Statamic.$config.get('selectedSite');
+            if (site) this.$axios.get(cp_url(`select-site/${site}`));
         },
     },
 };


### PR DESCRIPTION
This pull request fixes an issue where the site switcher resets to the first site after session expiry, even though the UI still shows the previously selected site.

This was happening because when a user re-authenticates via the session expiry modal, a new server-side session is created without the `statamic.cp.selected-site` value. The Vue state still held the correct site, but the server defaulted to the first authorized site, causing a mismatch.

This PR fixes it by restoring the selected site on the server after re-authentication, using the site handle still held in the frontend config.

Fixes #14400