### PR TITLE
[6.x] Fix cache invalidation when using custom fields in URI route

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -215,9 +215,11 @@ class CollectionEntriesStore extends ChildStore
                 break;
             }
 
-            $itemFromDisk = $this->makeItemFromFile($path, $contents);
+            // Only parse the ID from the file rather than using makeItemFromFile,
+            // which would put a stale entry into the structure-entries blink store.
+            $id = Arr::get(YAML::file($path)->parse($contents), 'id');
 
-            if ($item->id() == $itemFromDisk->id()) {
+            if ($item->id() == $id) {
                 break;
             }
 
@@ -269,7 +271,7 @@ class CollectionEntriesStore extends ChildStore
 
     private function updateEntriesWithinIndex($index, $ids)
     {
-        if (empty($ids)) {
+        if (collect($ids)->isEmpty()) {
             return $index->update();
         }
 
@@ -281,7 +283,7 @@ class CollectionEntriesStore extends ChildStore
 
     private function updateEntriesWithinStore($ids)
     {
-        if (empty($ids)) {
+        if (collect($ids)->isEmpty()) {
             $ids = $this->paths()->keys();
         }
 

--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -44,6 +44,8 @@ class CollectionStructure extends Structure
             ->keyBy->reference()
             ->get($entry->id());
 
+        $page?->setEntry($entry);
+
         return optional($page)->uri();
     }
 

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -139,10 +139,12 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Cont
         if (is_object($reference)) {
             throw_unless($id = $reference->id(), new \Exception('Cannot set an entry without an ID'));
             Blink::store('structure-entries')->put($id, $reference);
+            Blink::store('structure-uris')->forget($id);
             $reference = $id;
         }
 
         $this->reference = $reference;
+        $this->routeData = null;
 
         return $this;
     }

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -703,6 +703,31 @@ class EntryTest extends TestCase
     }
 
     #[Test]
+    public function structured_entry_uri_updates_when_custom_field_in_route_changes()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://domain.com/', 'locale' => 'en_US'],
+        ]);
+
+        $collection = tap((new Collection)->handle('pages')->routes('{slug}/{test}'))->save();
+
+        $entry = tap((new Entry)->id('1')->locale('en')->collection($collection)->slug('page')->set('test', 'foo'))->save();
+
+        $collection->structureContents(['expects_root' => false])->save();
+        $collection->structure()->in('en')->tree([['entry' => '1']])->save();
+
+        // Warm the structure caches like they would be in production.
+        Blink::store('entry-uris')->flush();
+        $this->assertEquals('/page/foo', $entry->uri());
+
+        $entry->set('test', 'bar');
+        $entry->save();
+
+        Blink::store('entry-uris')->flush();
+        $this->assertEquals('/page/bar', $entry->uri());
+    }
+
+    #[Test]
     public function it_gets_and_sets_supplemental_data()
     {
         $entry = new Entry;

--- a/tests/Data/Structures/CollectionStructureTest.php
+++ b/tests/Data/Structures/CollectionStructureTest.php
@@ -175,6 +175,7 @@ class CollectionStructureTest extends StructureTestCase
 
         $page = $this->mock(Page::class);
         $page->shouldReceive('reference')->andReturn('the-entry-id');
+        $page->shouldReceive('setEntry')->once()->andReturnSelf();
         $page->shouldReceive('uri')->andReturn('/the-uri-from-the-page');
 
         $tree = $this->mock(Tree::class);


### PR DESCRIPTION
This pull request fixes an issue where structured entries using custom fields in their route (e.g. `{test}`) would have stale URIs after saving.

This was happening because `CollectionStructure::entryUri()` retrieves a `Page` from cached `flattenedPages`, and that `Page` caches its `routeData` on the instance. When the entry is saved with updated field values, the same `Page` object is reused with stale route data, causing the URI to reflect the old field value instead of the new one.

This PR fixes it by:
* Calling `$page->setEntry($entry)` in `CollectionStructure::entryUri()` to ensure the page uses the fresh entry being saved
* Resetting the cached `routeData` and `structure-uris` blink in `Page::setEntry()` so stale values are discarded
* Replacing the `makeItemFromFile()` call in `CollectionEntriesStore::writeItemToDisk()` with a direct YAML ID parse, avoiding a side effect that put stale entries into the `structure-entries` blink store
* Fixing `empty($ids)` checks in `updateEntriesWithinIndex()` and `updateEntriesWithinStore()` to use `collect($ids)->isEmpty()`, since `empty()` always returns `false` for Collection objects

Fixes #14145