### PR TITLE
[6.x] Fix asset browser actions inside selector stack

### DIFF
--- a/resources/js/bootstrap/App.vue
+++ b/resources/js/bootstrap/App.vue
@@ -57,6 +57,10 @@ export default {
         Statamic.$callbacks.add('removeFromSelections', function (ids) {
             Statamic.$events.$emit('removeFromSelections', ids);
         });
+
+        Statamic.$callbacks.add('replaceInSelections', function (replacements) {
+            Statamic.$events.$emit('replaceInSelections', replacements);
+        });
     },
 
     methods: {

--- a/resources/js/components/portals/Portals.js
+++ b/resources/js/components/portals/Portals.js
@@ -21,7 +21,7 @@ export default class Portals {
     destroy(id) {
         const i = this.portals.value.findIndex((portal) => portal.id === id);
 
-        this.portals.value.splice(i, 1);
+        if (i !== -1) this.portals.value.splice(i, 1);
     }
 
     stacks() {

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -239,7 +239,14 @@ watch(
 
 const removeFromSelections = (ids) => selections.value = selections.value.filter(selection => !ids.includes(selection));
 Statamic.$events.$on('removeFromSelections', removeFromSelections);
-onBeforeUnmount(() => Statamic.$events.$off('removeFromSelections', removeFromSelections));
+
+const replaceInSelections = (replacements) => selections.value = selections.value.map(selection => replacements[selection] ?? selection);
+Statamic.$events.$on('replaceInSelections', replaceInSelections);
+
+onBeforeUnmount(() => {
+    Statamic.$events.$off('removeFromSelections', removeFromSelections);
+    Statamic.$events.$off('replaceInSelections', replaceInSelections);
+});
 
 const rawParameters = computed(() => ({
     page: currentPage.value,

--- a/src/Actions/MoveAsset.php
+++ b/src/Actions/MoveAsset.php
@@ -39,10 +39,13 @@ class MoveAsset extends Action
 
     public function run($assets, $values)
     {
-        $ids = $assets->each->move($values['folder'])->map->id()->all();
+        $oldIds = $assets->map->id()->all();
+
+        $newIds = $assets->each->move($values['folder'])->map->id()->all();
 
         return [
-            'ids' => $ids,
+            'ids' => $newIds,
+            'callback' => ['replaceInSelections', array_combine($oldIds, $newIds)],
         ];
     }
 

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -43,10 +43,13 @@ class RenameAsset extends Action
 
     public function run($assets, $values)
     {
-        $ids = $assets->each->rename($values['filename'], true)->map->id()->all();
+        $oldIds = $assets->map->id()->all();
+
+        $newIds = $assets->each->rename($values['filename'], true)->map->id()->all();
 
         return [
-            'ids' => $ids,
+            'ids' => $newIds,
+            'callback' => ['replaceInSelections', array_combine($oldIds, $newIds)],
         ];
     }
 


### PR DESCRIPTION
This pull request fixes a couple of issues when using asset actions (delete, rename, move) from the three-dot menu inside the asset browser when opened from an assets fieldtype.

* Fixes issue where performing an action (eg. delete, rename) from the asset browser closes the selector stack, preventing it from being reopened.
   * This was happening because the `ConfirmationModal`'s close timer and component unmount could both call `cleanup()`, causing `Portals.destroy()` to be called twice with the same ID. The second call resulted in `findIndex` returning `-1`, and `splice(-1, 1)` silently removed the last portal in the array — which was the parent stack's portal target.
   * I've fixed it by guarding `Portals.destroy()` against a `-1` index.
   * Fixes #14052
* Fixes issue where renaming or moving an asset inside the browser doesn't update the selection state, causing the count to be wrong and the renamed asset to not be selected.
   * This was happening because the `RenameAsset` and `MoveAsset` actions didn't return a callback to update selections with the new asset IDs.
   * I've fixed it by adding a `replaceInSelections` callback (following the existing `removeFromSelections` pattern used by the Delete action) that maps old asset IDs to new ones in the Listing's selections.