### PR TITLE
[6.x] Field margin balance

### DIFF
--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -110,7 +110,11 @@ const hasErrors = computed(() => {
                 </slot>
                 <slot name="actions" />
             </div>
-            <div v-if="label || (instructions && !instructionsBelow) || ($slots.label && !$slots.actions)" data-ui-field-text :class="inline ? 'mb-0' : 'mb-2'">
+            <div
+                v-if="(!$slots.actions && (label || (instructions && !instructionsBelow) || $slots.label)) || ($slots.actions && instructions && !instructionsBelow)"
+                data-ui-field-text
+                :class="inline ? 'mb-0' : 'mb-2'"
+            >
                 <slot v-if="!$slots.actions" name="label">
                     <Label v-if="label" v-bind="labelProps" class="flex-1" />
                 </slot>

--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -113,7 +113,7 @@ onUnmounted(() => passkey.cancel());
                     <template #actions>
                         <Link
                             :href="forgotPasswordUrl"
-                            class="text-ui-accent-text text-sm hover:text-ui-accent-text/80"
+                            class="text-ui-accent-text mb-1.5 text-sm hover:text-ui-accent-text/80"
                             tabindex="6"
                             v-text="__('Forgot password?')"
                         />


### PR DESCRIPTION
## Description of the Problem

I noticed a couple of issues on the login page with field margins.

- The "Forgot password?" link did not have any bottom margin on it, making it slightly off-balance compared to the Password label (see the red line below)
- There was a blank div slot with `mb-2` below it, causing extra margin.

<img width="2528" height="2146" alt="2026-04-29 at 10 01 50@2x" src="https://github.com/user-attachments/assets/174656c3-edee-4076-8b25-3ea3e519a875" />

## What this PR Does

- Makes sure the slot is not empty before outputting
- Add some margin to the Forgot Password link

You can see the email/password/forgot password labels are correctly balanced now:

<img width="2528" height="2146" alt="2026-04-29 at 09 56 06@2x" src="https://github.com/user-attachments/assets/a2d3541c-6c1c-4989-a14d-d3755188ea83" />

## How to Reproduce

1. Go to /cp/login