### PR TITLE
[6.x] Fix relationship selector footer not sticking to bottom of stack

### DIFF
--- a/resources/js/components/inputs/relationship/Selector.vue
+++ b/resources/js/components/inputs/relationship/Selector.vue
@@ -3,6 +3,7 @@
         <div class="flex h-full min-h-0 flex-col">
             <Listing
                 v-if="filters != null && view === 'list'"
+                class="flex flex-1 flex-col min-h-0"
                 :url="selectionsUrl"
                 :filters="filters"
                 :max-selections="maxSelections"
@@ -100,7 +101,7 @@
                 </div>
             </template>
 
-            <footer class="flex items-center justify-between border-t dark:border-gray-900 bg-gray-100 dark:bg-gray-800 p-4 rounded-es-xl">
+            <footer class="flex shrink-0 items-center justify-between border-t dark:border-gray-900 bg-gray-100 dark:bg-gray-800 p-4 rounded-es-xl">
                 <ui-badge
                     v-text="
                         hasMaxSelections


### PR DESCRIPTION
This pull request fixes an issue where the relationship selector's footer bar (with the Select/Cancel buttons) was not fixed to the bottom of the stack, causing it to be pushed off-screen when the listing content was tall.

This was happening because the Listings refactor (#11868) replaced the old `<data-list>` component with the new `<Listing>` component, whose root `<div>` doesn't have any flex properties. This meant the listing content could grow unbounded within the flex column layout, pushing the footer below the viewport.

This PR fixes it by adding `flex flex-1 flex-col min-h-0` to the `<Listing>` component so it participates in the flex layout and constrains its height, and `shrink-0` to the footer so it never gets compressed.

## Before

<img width="1326" height="800" alt="CleanShot 2026-04-29 at 10 41 40" src="https://github.com/user-attachments/assets/8b2db892-b711-4efa-96d9-c0272ba05ba3" />


## After

<img width="1326" height="800" alt="CleanShot 2026-04-29 at 10 41 22" src="https://github.com/user-attachments/assets/a4bff27d-2a82-4a54-b690-1a320632453b" />


---

Fixes #14568