### PR TITLE
[6.x] Harden OrderBys

### DIFF
--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -19,6 +19,7 @@ use Statamic\Http\Resources\CP\Assets\Folder;
 use Statamic\Http\Resources\CP\Assets\FolderAsset;
 use Statamic\Http\Resources\CP\Assets\SearchedAssetsCollection;
 use Statamic\Http\Resources\CP\Concerns\HasRequestedColumns;
+use Statamic\Query\OrderBy;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Support\Arr;
 
@@ -108,8 +109,7 @@ class BrowserController extends CpController
         $totalAssets = $folder->queryAssets()->count();
         $totalItems = $totalAssets + $totalFolders;
 
-        if ($request->sort) {
-            $sort = $request->sort;
+        if ($sort = OrderBy::column($request->sort)) {
             $order = $request->order ?? 'asc';
         } else {
             $sort = $container->sortField();
@@ -190,8 +190,8 @@ class BrowserController extends CpController
             $query->where('folder', $path);
         }
 
-        if ($request->sort) {
-            $query->orderBy($request->sort, $request->order ?? 'asc');
+        if ($sort = OrderBy::column($request->sort)) {
+            $query->orderBy($sort, $request->order ?? 'asc');
         }
 
         $this->applyQueryScopes($query, $request->all());


### PR DESCRIPTION
This adds some `OrderBy::column()` calls that were left off from 0317f4c2 's merge commit.
It was originally in #14474