### PR TITLE
[6.x] Fix updater crash when addon has no license

### DIFF
--- a/src/Updater/AddonChangelog.php
+++ b/src/Updater/AddonChangelog.php
@@ -23,6 +23,6 @@ class AddonChangelog extends Changelog
 
     protected function isLicensed($version)
     {
-        return version_compare($version, $this->addon->license()->versionLimit() ?? 999999, '<');
+        return version_compare($version, $this->addon->license()?->versionLimit() ?? 999999, '<');
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where navigating to the Updates page in the Control Panel would crash with a `Call to a member function versionLimit() on null` error.

This was happening because `AddonChangelog::isLicensed()` calls `$this->addon->license()->versionLimit()`, but `license()` can return `null` when the addon doesn't have a license in the outpost response.

This PR fixes it by using the nullsafe operator (`?->`) so that when `license()` is `null`, the existing `?? 999999` fallback handles it gracefully.

Fixes #14571