### PR TITLE
[6.x] Avoid per-icon requests in the Icon storybook

### DIFF
--- a/resources/js/stories/Icon.stories.ts
+++ b/resources/js/stories/Icon.stories.ts
@@ -3,6 +3,25 @@ import {CardPanel, Icon, Input, registerIconSetFromStrings} from '@ui';
 import {computed, ref} from 'vue';
 import {icons} from "@/stories/icons";
 
+// Inline all SVGs into the Storybook bundle so the AllIcons grid doesn't fire
+// hundreds of requests (which Cloudflare flags as abuse). The CP bundle keeps
+// the lazy glob in registry.js.
+const eagerIcons = import.meta.glob('../../svg/icons/*.svg', {
+    eager: true,
+    query: '?raw',
+    import: 'default',
+}) as Record<string, string>;
+
+registerIconSetFromStrings(
+    'default',
+    Object.fromEntries(
+        Object.entries(eagerIcons).map(([path, svg]) => [
+            path.split('/').pop()!.replace('.svg', ''),
+            svg,
+        ])
+    )
+);
+
 registerIconSetFromStrings('storybook', {
     spark: `
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">


### PR DESCRIPTION
## Summary

The `AllIcons` story in `Icon.stories.ts` renders all 537+ icons in the default set. Because the default set is registered with a *lazy* `import.meta.glob` (in `resources/js/components/ui/Icon/registry.js`), each icon triggers its own dynamic import. Cloudflare's abuse protection then 403s most of them, leaving the docs page broken.

This PR overrides the default set inside `Icon.stories.ts` with an eager glob (`{ eager: true, query: '?raw', import: 'default' }`) and re-registers it via `registerIconSetFromStrings`, so the Icon component takes the string-loading path and never makes HTTP requests for SVGs.

The change is scoped to the Storybook bundle — `Icon.stories.ts` is not part of the Control Panel entry, so the CP continues to lazy-load icons as before.

## Test plan

- [ ] Run `npm run storybook` and open **Components / Icon / Available Icons**.
- [ ] Confirm all icons render and there are no per-icon requests / 403s in the Network tab.
- [ ] Confirm the regular CP build still lazy-loads icons (no behavior change there).