### PR TITLE
[6.x] Fix crash on Updates page when an addon has no license

### DIFF
--- a/src/Updater/AddonChangelog.php
+++ b/src/Updater/AddonChangelog.php
@@ -23,6 +23,6 @@ class AddonChangelog extends Changelog
 
     protected function isLicensed($version)
     {
-        return version_compare($version, $this->addon->license()->versionLimit() ?? 999999, '<');
+        return version_compare($version, $this->addon->license()?->versionLimit() ?? 999999, '<');
     }
 }


### PR DESCRIPTION
Closing as a duplicate of #14573 — same one-line `?->` null-safe fix, already opened by @duncanmcclean. I missed it because I searched the issues tracker but not open PRs. Apologies for the noise.

Original problem report and full repro: #14571.
