### PR TITLE
[6.x] Lazy load Inertia page components

### DIFF
--- a/resources/js/bootstrap/statamic.js
+++ b/resources/js/bootstrap/statamic.js
@@ -198,9 +198,11 @@ export default {
         const bladeContent = el?.innerHTML || '';
         const _this = this;
 
+        const corePages = import.meta.glob('../pages/**/*.vue');
+
         await createInertiaApp({
             id: 'statamic',
-            resolve: name => {
+            resolve: async name => {
                 if (name === 'NonInertiaPage') {
                     return {
                         default: {
@@ -211,8 +213,8 @@ export default {
                 }
 
                 // Resolve core pages
-                const pages = import.meta.glob('../pages/**/*.vue', { eager: true });
-                let page = pages[`../pages/${name}.vue`];
+                const pageImport = corePages[`../pages/${name}.vue`];
+                let page = pageImport ? await pageImport() : null;
 
                 // Resolve addon pages
                 if (!page) {


### PR DESCRIPTION
## Summary

Switches the Inertia page resolver from eager to lazy `import.meta.glob`, so each CP page is split into its own chunk and fetched on demand.

The previous version eagerly imported every `.vue` file under `resources/js/pages/` into the main bundle. Now `import.meta.glob` returns a map of dynamic imports, and the resolver awaits the matching one.

This is one part extracted from #14512

## Impact

The initial `index-*.js` bundle drops from ~230 KB to ~94 KB on a fresh load. Per-page navigation cost is unchanged in practice — the chunk fetch overlaps with Inertia's existing data request.

## Test plan

- [x] Production build splits pages into per-page chunks
- [x] Navigation between pages works on Slow 3G with no broken UI (only the expected loading bar)
- [x] Offline navigation behavior matches the previous branch (request fails, no regression)
- [x] Addon page resolution (`inertia.get(name)`) still works
- [x] `NonInertiaPage` Blade fallback still renders