### PR TITLE
[6.x] Fix LivePreview listener leak and simplify Grid row updates

### DIFF
--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -98,15 +98,11 @@ export default {
 
     methods: {
         updated(handle, value) {
-            let row = JSON.parse(JSON.stringify(this.values));
-            row[handle] = value;
-            this.$emit('updated', this.index, row);
+            this.$emit('updated', this.index, { ...this.values, [handle]: value });
         },
 
         metaUpdated(handle, value) {
-            let meta = clone(this.meta);
-            meta[handle] = value;
-            this.$emit('meta-updated', meta);
+            this.$emit('meta-updated', { ...this.meta, [handle]: value });
         },
 
         fieldPath(handle) {

--- a/resources/js/components/ui/LivePreview/LivePreview.vue
+++ b/resources/js/components/ui/LivePreview/LivePreview.vue
@@ -295,10 +295,14 @@ const keybinding = ref(
     }),
 );
 
-onUnmounted(() => keybinding.value.destroy());
+const refreshHandler = () => { if (props.enabled) update(); };
+const refreshEvent = `live-preview.${name.value}.refresh`;
 
-Statamic.$events.$on(`live-preview.${name.value}.refresh`, () => {
-    if (props.enabled) update();
+Statamic.$events.$on(refreshEvent, refreshHandler);
+
+onUnmounted(() => {
+    keybinding.value.destroy();
+    Statamic.$events.$off(refreshEvent, refreshHandler);
 });
 </script>
 


### PR DESCRIPTION
Two small fixes/improvements extracted from https://github.com/statamic/cms/pull/14512

### LivePreview event-listener leak

`resources/js/components/ui/LivePreview/LivePreview.vue` registers a `live-preview.<name>.refresh` handler on `Statamic.$events` but never `$off`s it on unmount, so navigating between live-preview-enabled entries leaks listeners. Hoisted the handler into a named const and `$off` it in `onUnmounted` alongside the existing `keybinding.value.destroy()`.

### Grid Row shallow spread

`resources/js/components/fieldtypes/grid/Row.vue` was deep-cloning the row/meta object on every field update (via `JSON.parse(JSON.stringify(...))` and `clone()`) just to set a single key. Replaced with a shallow spread, which is enough since downstream consumers don't mutate the emitted object.

Since `updated` fires on every keystroke, the deep clone was walking the entire row's nested data (Bard docs, nested Replicator sets, etc.) on each character. The spread is a one-level copy, which on heavy rows is the difference between a noticeable typing lag and none.