### PR TITLE
[6.x] Debounce LinkFieldtype URL writes

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -40,6 +40,8 @@
 <script>
 import Fieldtype from './Fieldtype.vue';
 import { Input, Select } from '@/components/ui';
+import debounce from '@/util/debounce.js';
+import { markRaw } from 'vue';
 
 export default {
     components: { Input, Text, Select },
@@ -58,6 +60,13 @@ export default {
             selectedAssets: this.meta.initialSelectedAssets,
             metaChanging: false,
         };
+    },
+
+    created() {
+        this.syncUrlDebounced = markRaw(debounce((url) => {
+            this.update(url);
+            this.updateMeta({ ...this.meta, initialUrl: url });
+        }, 150));
     },
 
     computed: {
@@ -116,12 +125,11 @@ export default {
 
         urlValue(url) {
             if (this.metaChanging) return;
-
-            this.update(url);
-            this.updateMeta({ ...this.meta, initialUrl: url });
+            this.syncUrlDebounced(url);
         },
 
         meta(meta, oldMeta) {
+            if (meta === oldMeta) return;
             if (JSON.stringify(meta) === JSON.stringify(oldMeta)) return;
 
             this.metaChanging = true;


### PR DESCRIPTION
## Summary

Reduces churn in the Link fieldtype with two small changes scoped to `resources/js/components/fieldtypes/LinkFieldtype.vue`:

- Wraps the URL-sync logic in a 150ms `debounce` (created in `created()` and `markRaw`-wrapped so Vue 3 doesn't proxy the function and break the debounce internals). Typing in the URL field no longer fires `update` + `updateMeta` on every keystroke.
- Adds an identity short-circuit (`meta === oldMeta`) ahead of the existing `JSON.stringify` check in the `meta` watcher so unchanged meta references skip the deep comparison entirely.

This is one slice of the broader CP performance improvements from #14512