### PR TITLE
[6.x] Fix SavePipeline initial debounce delay

### DIFF
--- a/resources/js/components/ui/Publish/SavePipeline.js
+++ b/resources/js/components/ui/Publish/SavePipeline.js
@@ -15,6 +15,9 @@ export class Pipeline {
     }
 
     async through(steps) {
+        // 150ms is the debounce time for fieldtype updates
+        const initialPromise = new Promise((resolve) => setTimeout(resolve, 151));
+
         return [new Start(), ...steps, new Finish()].reduce(async (promise, step) => {
             const payload = await promise;
 
@@ -32,10 +35,6 @@ export class Pipeline {
         }, initialPromise);
     }
 }
-
-const initialPromise = new Promise((resolve) => {
-    setTimeout(() => resolve(), 151); // 150ms is the debounce time for fieldtype updates
-});
 
 export class PipelineStopped extends Error {
     constructor(payload) {


### PR DESCRIPTION
## Summary

`SavePipeline.js` declares an `initialPromise` at module scope that's intended to delay the start of each save by 151ms so trailing fieldtype debounces (150ms) have time to fire before the publish container is read. Because the `setTimeout` runs once at module load, the promise resolves ~151ms after the JS bundle evaluates. By the time any user actually clicks save, the promise is already settled and `await initialPromise` returns synchronously — the guard the comment describes is effectively dead code.

This moves `initialPromise` inside `through()` so a fresh delay runs on every save invocation, restoring the originally intended behavior.

## Why it matters

Any fieldtype that debounces its `update`/`updateMeta` call relies on the trailing debounce firing before the save pipeline reads `container.value.visibleValues` in the `Request` step. Without the 151ms guard, a user can:

1. Type into a debounced field.
2. Hit cmd+s within 150ms of the last keystroke.
3. Save fires, reads the container before the trailing debounce has flushed, and persists the previous value.

Note: this adds ~150ms latency to every save in the CP (entries, terms, globals, users, forms, blueprints, etc.). That's the intended behavior per the original comment, but it's a real perceptible change worth calling out.

## Test plan

- [x] Open an entry with a debounced field, type a value and immediately press cmd+s — confirm the typed value persists (no trailing characters lost).
- [x] Sanity-check a normal save (no typing in flight) still feels responsive.
- [x] Confirm `*.saving` / `*.saved` Statamic hooks still run in the expected order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)