### PR TITLE
[6.x] Wrap FieldAction instances with markRaw

### DIFF
--- a/resources/js/components/field-actions/toFieldActions.js
+++ b/resources/js/components/field-actions/toFieldActions.js
@@ -1,7 +1,8 @@
+import { markRaw } from 'vue';
 import FieldAction from './FieldAction.js';
 
 export default function toFieldActions(binding, payload, extraActions = []) {
     return [...Statamic.$fieldActions.get(binding), ...extraActions]
-        .map((action) => new FieldAction(action, payload))
+        .map((action) => markRaw(new FieldAction(action, payload)))
         .filter((action) => action.visible);
 }

--- a/resources/js/tests/toFieldActions.test.js
+++ b/resources/js/tests/toFieldActions.test.js
@@ -1,0 +1,46 @@
+import { test, expect, beforeEach, afterEach } from 'vitest';
+import { ref, reactive } from 'vue';
+import toFieldActions from '../components/field-actions/toFieldActions.js';
+
+let originalStatamic;
+
+beforeEach(() => {
+    originalStatamic = globalThis.Statamic;
+    globalThis.Statamic = {
+        $fieldActions: {
+            get: () => [
+                { title: 'Quick', quick: true, run: () => {} },
+                { title: 'Slow', quick: false, run: () => {} },
+                { title: 'Hidden', quick: false, visible: false, run: () => {} },
+            ],
+        },
+    };
+});
+
+afterEach(() => {
+    globalThis.Statamic = originalStatamic;
+});
+
+test('returns FieldAction instances safe for reactive containers (ref)', () => {
+    const actions = toFieldActions('some-binding', {});
+    const r = ref(actions);
+
+    // Without markRaw, accessing a getter that reads a private field
+    // throws "can't access private field or method: object is not the right class".
+    expect(() => r.value[0].quick).not.toThrow();
+    expect(r.value[0].quick).toBe(true);
+    expect(r.value[1].quick).toBe(false);
+});
+
+test('returns FieldAction instances safe for reactive containers (reactive)', () => {
+    const actions = toFieldActions('some-binding', {});
+    const state = reactive({ list: actions });
+
+    expect(() => state.list[0].quick).not.toThrow();
+    expect(state.list.filter((a) => !a.quick).map((a) => a.title)).toEqual(['Slow']);
+});
+
+test('filters out non-visible actions', () => {
+    const actions = toFieldActions('some-binding', {});
+    expect(actions.map((a) => a.title)).toEqual(['Quick', 'Slow']);
+});


### PR DESCRIPTION
Wraps each `FieldAction` instance returned by `toFieldActions` with Vue's `markRaw` so the reactive system doesn't proxy them.

`FieldAction` is a class that uses private fields. When an instance ends up inside a reactive container (e.g. `ref([...])` or `reactive({ list: [...] })`), Vue wraps it in a Proxy and getters that read private fields throw:

> can't access private field or method: object is not the right class

`markRaw` opts the instance out of reactive proxying, which is the official Vue 3 fix for class instances that shouldn't be proxied.

It also adds some tests.

This was a small part extracted from https://github.com/statamic/cms/pull/14512