### PR TITLE
[6.x] Avoid rendering time for dates in listings when appropriate

### DIFF
--- a/resources/js/components/fieldtypes/DateIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateIndexFieldtype.vue
@@ -11,12 +11,16 @@ const emit = defineEmits(Fieldtype.emits);
 const props = defineProps(Fieldtype.props);
 const { expose } = Fieldtype.use(emit, props);
 
+const showTimeInValue = computed(() => props.value?.format_has_time && props.value?.time_enabled);
+
+const showTooltip = computed(() => props.value?.format_has_time);
+
 const formatted = computed(() => {
     if (!props.value) {
         return null;
     }
 
-    const formatter = new DateFormatter().options(props.value.time_enabled ? 'datetime' : 'date');
+    const formatter = new DateFormatter().options(showTimeInValue.value ? 'datetime' : 'date');
 
     if (props.value.mode === 'range') {
         let start = new Date(props.value.start);
@@ -29,7 +33,7 @@ const formatted = computed(() => {
 });
 
 const tooltip = computed(() => {
-    if (!props.value) {
+    if (!props.value || !showTooltip.value) {
         return null;
     }
 

--- a/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
@@ -49,6 +49,7 @@ test.each([
         date: '2025-12-25T02:13:00Z',
         mode: 'single',
         time_enabled: true,
+        format_has_time: true,
     });
 
     expect(dateIndexField.vm.formatted).toBe(expected);
@@ -88,7 +89,11 @@ test.each([
 ])('date and time is formatted to the users browser language (%s)', async (lang, expected) => {
     DateFormatter.defaultLocale = lang;
 
-    const dateIndexField = makeDateIndexField({ date: '2025-12-25T13:29:00Z', time_enabled: true });
+    const dateIndexField = makeDateIndexField({
+        date: '2025-12-25T13:29:00Z',
+        time_enabled: true,
+        format_has_time: true,
+    });
 
     expect(dateIndexField.vm.formatted).toBe(expected);
 });
@@ -107,4 +112,41 @@ test.each([
     });
 
     expect(dateIndexField.vm.formatted).toBe(expected);
+});
+
+test('date-only format omits time from value and tooltip', async () => {
+    const dateIndexField = makeDateIndexField({
+        date: '2025-12-25',
+        mode: 'single',
+        time_enabled: false,
+        format_has_time: false,
+    });
+
+    expect(dateIndexField.vm.formatted).toBe('12/25/2025');
+    expect(dateIndexField.vm.tooltip).toBeNull();
+});
+
+test('time-disabled but time-aware format shows date in value and time in tooltip', async () => {
+    const dateIndexField = makeDateIndexField({
+        date: '2025-12-25T02:13:00Z',
+        mode: 'single',
+        time_enabled: false,
+        format_has_time: true,
+    });
+
+    expect(dateIndexField.vm.formatted).toBe('12/25/2025');
+    expect(dateIndexField.vm.tooltip).not.toBeNull();
+    expect(dateIndexField.vm.tooltip).toContain('2025');
+});
+
+test('time-enabled value shows time in both value and tooltip', async () => {
+    const dateIndexField = makeDateIndexField({
+        date: '2025-12-25T02:13:00Z',
+        mode: 'single',
+        time_enabled: true,
+        format_has_time: true,
+    });
+
+    expect(dateIndexField.vm.formatted).toBe('12/25/2025, 2:13 AM');
+    expect(dateIndexField.vm.tooltip).not.toBeNull();
 });

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -253,6 +253,7 @@ class Date extends Fieldtype
         $common = [
             'mode' => $this->config('mode', 'single'),
             'time_enabled' => $this->config('time_enabled'),
+            'format_has_time' => $this->formatHasTime(),
         ];
 
         if ($this->config('mode') === 'range') {

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -436,37 +436,37 @@ class DateTest extends TestCase
                 'UTC',
                 [],
                 '2012-08-29 00:00',
-                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false],
+                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'date with custom format' => [
                 'UTC',
                 ['format' => 'Y--m--d H/i'],
                 '2012--08--29 00/00',
-                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false],
+                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'date in a different timezone' => [
                 'America/New_York', // -0400
                 [],
                 '2012-08-29 00:00',
-                ['date' => '2012-08-29T04:00:00.000Z', 'mode' => 'single', 'time_enabled' => false],
+                ['date' => '2012-08-29T04:00:00.000Z', 'mode' => 'single', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'date with time' => [
                 'UTC',
                 ['time_enabled' => true],
                 '2012-08-29 13:43',
-                ['date' => '2012-08-29T13:43:00.000Z', 'mode' => 'single', 'time_enabled' => true],
+                ['date' => '2012-08-29T13:43:00.000Z', 'mode' => 'single', 'time_enabled' => true, 'format_has_time' => true],
             ],
             'date with time and custom format' => [
                 'UTC',
                 ['time_enabled' => true, 'format' => 'Y--m--d H:i'],
                 '2012--08--29 13:43',
-                ['date' => '2012-08-29T13:43:00.000Z', 'mode' => 'single', 'time_enabled' => true],
+                ['date' => '2012-08-29T13:43:00.000Z', 'mode' => 'single', 'time_enabled' => true, 'format_has_time' => true],
             ],
             'date with time in a different timezone' => [
                 'America/New_York', // -0400
                 ['time_enabled' => true],
                 '2012-08-29 13:43',
-                ['date' => '2012-08-29T17:43:00.000Z', 'mode' => 'single', 'time_enabled' => true],
+                ['date' => '2012-08-29T17:43:00.000Z', 'mode' => 'single', 'time_enabled' => true, 'format_has_time' => true],
             ],
             'null range' => [
                 'UTC',
@@ -478,19 +478,19 @@ class DateTest extends TestCase
                 'UTC',
                 ['mode' => 'range'],
                 ['start' => '2012-08-29 00:00', 'end' => '2013-09-27 00:00'],
-                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2013-09-27T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false],
+                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2013-09-27T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'range with custom format' => [
                 'UTC',
                 ['mode' => 'range', 'format' => 'Y--m--d H/i'],
                 ['start' => '2012--08--29 00/00', 'end' => '2013--09--27 00/00'],
-                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2013-09-27T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false],
+                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2013-09-27T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'range in a different timezone' => [
                 'America/New_York', // -4000
                 ['mode' => 'range'],
                 ['start' => '2012-08-29 00:00', 'end' => '2013-09-27 00:00'],
-                ['start' => '2012-08-29T04:00:00.000Z', 'end' => '2013-09-27T04:00:00.000Z', 'mode' => 'range', 'time_enabled' => false],
+                ['start' => '2012-08-29T04:00:00.000Z', 'end' => '2013-09-27T04:00:00.000Z', 'mode' => 'range', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'range where single date has been provided' => [
                 // e.g. If it was once a non-range field.
@@ -498,56 +498,56 @@ class DateTest extends TestCase
                 'UTC',
                 ['mode' => 'range'],
                 '2012-08-29',
-                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2012-08-29T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false],
+                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2012-08-29T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'range where single date has been provided with custom format' => [
                 'UTC',
                 ['mode' => 'range', 'format' => 'Y--m--d H/i'],
                 '2012--08--29 00/00',
-                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2012-08-29T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false],
+                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2012-08-29T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'date where range has been provided' => [
                 // e.g. If it was once a range field. Use the start date.
                 'UTC',
                 [],
                 ['start' => '2012-08-29 00:00', 'end' => '2013-09-27 00:00'],
-                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false],
+                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'date where range has been provided with custom format' => [
                 'UTC',
                 ['format' => 'Y--m--d H/i'],
                 ['start' => '2012--08--29 00/00', 'end' => '2013--09--27 00/00'],
-                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false],
+                ['date' => '2012-08-29T00:00:00.000Z', 'mode' => 'single', 'time_enabled' => false, 'format_has_time' => true],
             ],
             'range where time has been enabled' => [
                 'UTC',
                 ['mode' => 'range', 'time_enabled' => true],
                 ['start' => '2012-08-29 00:00', 'end' => '2013-09-27 00:00'],
-                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2013-09-27T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => true],
+                ['start' => '2012-08-29T00:00:00.000Z', 'end' => '2013-09-27T00:00:00.000Z', 'mode' => 'range', 'time_enabled' => true, 'format_has_time' => true],
             ],
             'date-only format' => [
                 'UTC',
                 ['format' => 'Y-m-d'],
                 '2012-08-29',
-                ['date' => '2012-08-29', 'mode' => 'single', 'time_enabled' => false],
+                ['date' => '2012-08-29', 'mode' => 'single', 'time_enabled' => false, 'format_has_time' => false],
             ],
             'date-only format in a different timezone' => [
                 'America/New_York',
                 ['format' => 'Y-m-d'],
                 '2012-08-29',
-                ['date' => '2012-08-29', 'mode' => 'single', 'time_enabled' => false],
+                ['date' => '2012-08-29', 'mode' => 'single', 'time_enabled' => false, 'format_has_time' => false],
             ],
             'date-only format range' => [
                 'UTC',
                 ['mode' => 'range', 'format' => 'Y-m-d'],
                 ['start' => '2012-08-29', 'end' => '2013-09-27'],
-                ['start' => '2012-08-29', 'end' => '2013-09-27', 'mode' => 'range', 'time_enabled' => false],
+                ['start' => '2012-08-29', 'end' => '2013-09-27', 'mode' => 'range', 'time_enabled' => false, 'format_has_time' => false],
             ],
             'date-only format range in a different timezone' => [
                 'America/New_York',
                 ['mode' => 'range', 'format' => 'Y-m-d'],
                 ['start' => '2012-08-29', 'end' => '2013-09-27'],
-                ['start' => '2012-08-29', 'end' => '2013-09-27', 'mode' => 'range', 'time_enabled' => false],
+                ['start' => '2012-08-29', 'end' => '2013-09-27', 'mode' => 'range', 'time_enabled' => false, 'format_has_time' => false],
             ],
         ];
     }


### PR DESCRIPTION
The date index fieldtype was deciding whether to render time based on the `time_enabled` config, but a field can have `time_enabled: true` while using a date-only save format (e.g. `Y-m-d`), or vice versa. That mismatch caused meaningless or missing time output.

This switches the index display to use `formatHasTime()` (which inspects the actual save format), and combines it with `time_enabled` to render three cases:

- `format_has_time: false` → date-only value, **no tooltip**
- `format_has_time: true` + `time_enabled: false` → date-only value, full date+time+timezone tooltip
- `format_has_time: true` + `time_enabled: true` → date+time value, full date+time+timezone tooltip