### PR TITLE
[6.x] Allow overriding date format preset options

### DIFF
--- a/resources/js/components/DateFormatter.js
+++ b/resources/js/components/DateFormatter.js
@@ -148,6 +148,14 @@ export default class DateFormatter {
             return this.#presets[options];
         }
 
+        if (options.preset) {
+            const { preset, ...overrides } = options;
+
+            if (!this.#presets[preset]) throw new Error(`Invalid date format: ${preset}`);
+
+            return { ...this.#presets[preset], ...overrides };
+        }
+
         return options;
     }
 }

--- a/resources/js/tests/components/DateFormatter.test.js
+++ b/resources/js/tests/components/DateFormatter.test.js
@@ -229,6 +229,20 @@ test('an invalid preset throws an error', () => {
     expect(() => new DateFormatter().options('foo')).toThrow('Invalid date format: foo');
 });
 
+test('it can override preset options', () => {
+    expect(new DateFormatter().options({ preset: 'datetime', month: 'short' }).toString()).toBe(
+        'Dec 25, 2021, 12:13 PM',
+    );
+
+    expect(new DateFormatter().options({ preset: 'datetime', timeZone: 'Australia/Sydney' }).toString()).toBe(
+        '12/25/2021, 11:13 PM',
+    );
+});
+
+test('an invalid preset key throws an error when overriding', () => {
+    expect(() => new DateFormatter().options({ preset: 'foo', month: 'short' })).toThrow('Invalid date format: foo');
+});
+
 test.each([
     // All the different diffs of time. It defaults to 'year' specificity.
     ['now', 'en', { relative: true }, '2021-12-25T12:13:14Z', 'now'],


### PR DESCRIPTION
`DateFormatter` exposes a few named presets (`datetime`, `date`, `time`) that can be passed to `.options()` as a shortcut. Previously, if you wanted to use a preset but tweak a single field, you had to inline the entire options object.

This change lets you pass an options object with a `preset` key alongside any other `Intl.DateTimeFormat` options, which get merged on top of the preset.

```js
new DateFormatter().options({ preset: 'datetime', timeZone: 'Australia/Sydney' });
new DateFormatter().options({ preset: 'datetime', month: 'short' });
```

The string-shorthand form (`.options('datetime')`) and plain options-object form continue to work as before.