### PR TITLE
[6.x] Display timezone in DateRangePicker

### DIFF
--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { config } from '@api';
 import { computed } from 'vue';
 import {
     DateRangePickerCalendar,
@@ -23,6 +24,7 @@ import Card from '../Card/Card.vue';
 import Button from '../Button/Button.vue';
 import Calendar from '../Calendar/Calendar.vue';
 import Icon from '../Icon/Icon.vue';
+import Text from '../Text.vue';
 import { parseAbsoluteToLocal } from '@internationalized/date';
 
 const emit = defineEmits(['update:modelValue']);
@@ -90,6 +92,19 @@ const calendarEvents = computed(() => ({
         emit('update:modelValue', event)
     },
 }));
+
+const timeZoneName = computed(() => props.modelValue?.start?.timeZone ?? null);
+
+const formatTimeZone = (style) => {
+    const tz = timeZoneName.value;
+    if (!tz) return null;
+
+    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: style }).formatToParts(props.modelValue.start.toDate());
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
+};
+
+const timeZoneLabel = computed(() => formatTimeZone('short'));
+const timeZoneTooltip = computed(() => formatTimeZone('long'));
 </script>
 
 <template>
@@ -155,6 +170,13 @@ const calendarEvents = computed(() => ({
                         </DateRangePickerInput>
                     </template>
                     <div class="flex-1" />
+                    <Text
+                        v-if="timeZoneLabel"
+                        class="text-gray-600 dark:text-gray-400 me-1"
+                        size="xs"
+                        v-tooltip="timeZoneTooltip"
+                        :text="timeZoneLabel"
+                    />
                     <Button v-if="!readOnly" @click="emit('update:modelValue', null)" variant="subtle" size="sm" icon="x" class="-me-2" :disabled="disabled" />
                 </div>
             </DateRangePickerField>


### PR DESCRIPTION
The `DatePicker` component shows the timezone label (with a tooltip for the long form) at the right edge of the input, but `DateRangePicker` did not. This PR adds the same display to `DateRangePicker` so users can see which timezone the range is in when selecting one.

Mirrors the convention introduced in #14518: derives the timezone from the model value (using `start` for ranges) and renders a `Text` element with `v-tooltip` for the long form.