### PR TITLE
[6.x] Fix date-only index fieldtype shifting across timezones

### DIFF
--- a/resources/js/components/fieldtypes/DateIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateIndexFieldtype.vue
@@ -20,7 +20,10 @@ const formatted = computed(() => {
         return null;
     }
 
-    const formatter = new DateFormatter().options(showTimeInValue.value ? 'datetime' : 'date');
+    const options = { preset: showTimeInValue.value ? 'datetime' : 'date' };
+    if (!props.value.format_has_time) options.timeZone = 'UTC';
+
+    const formatter = new DateFormatter().options(options);
 
     if (props.value.mode === 'range') {
         let start = new Date(props.value.start);

--- a/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
@@ -109,7 +109,7 @@ test.each([
 ])('date is formatted to the users browser language (%s)', async (lang, expected) => {
     DateFormatter.defaultLocale = lang;
 
-    const dateIndexField = makeDateIndexField({ date: '2025-12-25T13:29:00Z' });
+    const dateIndexField = makeDateIndexField({ date: '2025-12-25T13:29:00Z', format_has_time: true });
 
     expect(dateIndexField.vm.formatted).toBe(expected);
 });
@@ -141,6 +141,7 @@ test.each([
         start: '2025-12-25T02:13:00Z',
         end: '2025-12-28T03:59:00Z',
         mode: 'range',
+        format_has_time: true,
     });
 
     expect(dateIndexField.vm.formatted).toBe(expected);

--- a/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
@@ -31,9 +31,40 @@ test.each([
     process.env.TZ = tz;
 
     const dateIndexField = makeDateIndexField({
-        date: '2025-12-25',
-        time: '02:13',
+        date: '2025-12-25T02:13:00Z',
         mode: 'single',
+        format_has_time: true,
+    });
+
+    expect(dateIndexField.vm.formatted).toBe(expected);
+});
+
+test.each([
+    ['UTC', '12/25/2025'],
+    ['America/New_York', '12/25/2025'],
+])('date-only value does not shift across timezones (%s)', async (tz, expected) => {
+    process.env.TZ = tz;
+
+    const dateIndexField = makeDateIndexField({
+        date: '2025-12-25',
+        mode: 'single',
+        format_has_time: false,
+    });
+
+    expect(dateIndexField.vm.formatted).toBe(expected);
+});
+
+test.each([
+    ['UTC', '12/25/2025 – 12/28/2025'],
+    ['America/New_York', '12/25/2025 – 12/28/2025'],
+])('date-only range does not shift across timezones (%s)', async (tz, expected) => {
+    process.env.TZ = tz;
+
+    const dateIndexField = makeDateIndexField({
+        start: '2025-12-25',
+        end: '2025-12-28',
+        mode: 'range',
+        format_has_time: false,
     });
 
     expect(dateIndexField.vm.formatted).toBe(expected);
@@ -65,6 +96,7 @@ test.each([
         start: '2025-12-25T02:13:00Z',
         end: '2025-12-28T03:59:00Z',
         mode: 'range',
+        format_has_time: true,
     });
 
     expect(dateIndexField.vm.formatted).toBe(expected);


### PR DESCRIPTION
## Summary

When a date field's format has no time component, `Date::preProcessIndexDate()` sends the value to the index fieldtype as a `Y-m-d` string. `new Date("2025-12-25")` parses that as UTC midnight, and `Intl.DateTimeFormat` then renders it in the local browser timezone — so anyone west of UTC saw the previous day in listings.

This passes `timeZone: 'UTC'` to the formatter when `format_has_time` is false, so the day stays put. The condition hinges on `format_has_time` only (matching the data shape produced by the backend); the `format_has_time=true, time_enabled=false` case still has a real ISO moment baked in, so local TZ formatting remains correct there.

## Test plan

- [x] `npx vitest run resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js` — added `date-only value does not shift across timezones` and `date-only range does not shift across timezones`; updated existing TZ-localization tests to set `format_has_time: true` so they continue exercising the with-time TZ shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)