### PR TITLE
[6.x] Memoize preprocessed fields in Validator

### DIFF
--- a/src/Fields/Validator.php
+++ b/src/Fields/Validator.php
@@ -9,6 +9,7 @@ use Statamic\Support\Str;
 class Validator
 {
     protected $fields;
+    protected $preProcessedFields;
     protected $replacements = [];
     protected $extraRules = [];
     protected $customMessages = [];
@@ -22,8 +23,14 @@ class Validator
     public function fields($fields)
     {
         $this->fields = $fields;
+        $this->preProcessedFields = null;
 
         return $this;
+    }
+
+    protected function preProcessedFields()
+    {
+        return $this->preProcessedFields ??= $this->fields->preProcessValidatables();
     }
 
     public function withRules($rules)
@@ -66,7 +73,7 @@ class Validator
             return collect();
         }
 
-        return $this->fields->preProcessValidatables()->all()->reduce(function ($carry, $field) {
+        return $this->preProcessedFields()->all()->reduce(function ($carry, $field) {
             if (request()->isPrecognitive() && $field->type() == 'assets') {
                 return $carry;
             }
@@ -102,7 +109,7 @@ class Validator
     public function validator()
     {
         return LaravelValidator::make(
-            $this->fields->preProcessValidatables()->values()->all(),
+            $this->preProcessedFields()->values()->all(),
             $this->rules(),
             $this->customMessages,
             $this->attributes()
@@ -116,7 +123,7 @@ class Validator
 
     public function attributes()
     {
-        return $this->fields->preProcessValidatables()->all()->reduce(function ($carry, $field) {
+        return $this->preProcessedFields()->all()->reduce(function ($carry, $field) {
             return $carry->merge($field->validationAttributes());
         }, collect())->all();
     }

--- a/tests/Fields/ValidatorTest.php
+++ b/tests/Fields/ValidatorTest.php
@@ -242,6 +242,22 @@ class ValidatorTest extends TestCase
     }
 
     #[Test]
+    public function it_only_pre_processes_validatables_once_per_validator_call()
+    {
+        $field = Mockery::mock(Field::class);
+        $field->shouldReceive('setValidationContext')->with([])->andReturnSelf();
+        $field->shouldReceive('rules')->andReturn(['one' => ['required']]);
+        $field->shouldReceive('validationAttributes')->andReturn(['one' => 'One']);
+
+        $fields = Mockery::mock(Fields::class);
+        $fields->shouldReceive('preProcessValidatables')->once()->andReturnSelf();
+        $fields->shouldReceive('all')->andReturn(collect([$field]));
+        $fields->shouldReceive('values')->andReturn(collect(['one' => 'foo']));
+
+        (new Validator)->fields($fields)->validator();
+    }
+
+    #[Test]
     public function it_replaces_this_in_sets()
     {
         $replicator = [


### PR DESCRIPTION
When saving an entry, `preProcessValidatable` was being called on every field 3 times. The `Validator::validator()` method calls `$this->fields->preProcessValidatables()` from three places — directly to build the data array, and indirectly through `rules()` and `attributes()` — each of which iterates every field and invokes its fieldtype's `preProcessValidatable()`.

This memoizes the result on the `Validator` instance so the work happens once per validation. The cache is reset in `fields()` so re-setting fields invalidates it.

Closes https://github.com/statamic/cms/issues/14604