### PR TITLE
[6.x] Show date fieldtype when searching for range

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -18,7 +18,7 @@ use Statamic\Support\DateFormat;
 class Date extends Fieldtype
 {
     protected $categories = ['special'];
-    protected $keywords = ['datetime', 'time'];
+    protected $keywords = ['datetime', 'time', 'range'];
 
     const DEFAULT_DATE_FORMAT = 'Y-m-d';
     const DEFAULT_DATETIME_FORMAT = 'Y-m-d H:i';


### PR DESCRIPTION
When wanting to add a `date` fieldtype in the `range` mode I end up searching for `range`, which only shows the range fieldtype. Now the date fieldtype will appear in results.