### PR TITLE
[6.x] Fix error when typing in a required date range field

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -143,6 +143,10 @@ export default {
                 return this.update(null);
             }
 
+            if (this.isRange && (!value.start || !value.end)) {
+                return;
+            }
+
             if (!this.formatHasTime) {
                 if (this.isRange) {
                     return this.update({

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -110,7 +110,7 @@ const timeZoneTooltip = computed(() => formatTimeZone('long'));
 <template>
     <div class="group/input relative block w-full" data-ui-input>
         <DateRangePickerRoot
-            :modelValue="modelValue"
+            :modelValue="modelValue ?? { start: undefined, end: undefined }"
             :granularity="granularity"
             :locale="$date.locale"
             :disabled="disabled || readOnly"

--- a/resources/js/tests/components/fieldtypes/DateFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateFieldtype.test.js
@@ -116,6 +116,23 @@ test('date-only format formats date correctly', async () => {
     expect(formatted).toBe('2025-06-05');
 });
 
+test.each([
+    [{ start: { year: 2025, month: 12, day: 25 }, end: undefined }],
+    [{ start: undefined, end: { year: 2025, month: 12, day: 31 } }],
+])('partial range update is ignored', async (value) => {
+    const dateField = makeDateField({
+        meta: { formatHasTime: false },
+        config: {
+            mode: 'range',
+            earliest_date: { date: null, time: null },
+            latest_date: { date: null, time: null },
+        },
+    });
+
+    expect(() => dateField.vm.datePickerUpdated(value)).not.toThrow();
+    expect(dateField.emitted('update:value')).toBeUndefined();
+});
+
 test('date-only range format is not affected by timezone', async () => {
     process.env.TZ = 'America/New_York';
 


### PR DESCRIPTION
## What & Why

When a `date` fieldtype is configured with `mode: range` and `required: true`, the picker is shown immediately (before any value is entered). Two errors could occur while the user typed dates into the field:

1. **`TypeError: Cannot read properties of null (reading 'start')`** — reka-ui's `DateRangePickerField` compares the incoming date against `rootContext.modelValue.value.start`, but doesn't null-check `modelValue.value` first. Since `DateRangePickerRoot` was receiving `null` (the fieldtype's initial empty value), this threw immediately when the first date segment was completed.

2. **`TypeError: Cannot read properties of undefined (reading 'set')`** — reka-ui fires `update:modelValue` with a partial range (`{ start: <Date>, end: undefined }`) as soon as the first date is fully typed. The fieldtype's `datePickerUpdated` method didn't account for this and crashed trying to call `.set()` on the undefined `end`.

## Changes

- **`DateRangePicker.vue`** — coerce a `null` modelValue to `{ start: undefined, end: undefined }` before passing to `DateRangePickerRoot`, matching reka's own default and preventing the null-access crash inside `DateRangePickerField`.

- **`DateFieldtype.vue`** — bail out of `datePickerUpdated` early when in range mode and either `start` or `end` is missing; a partial range isn't a saveable value.

- **`DateFieldtype.test.js`** — two new test cases covering start-only and end-only partial ranges, asserting no throw and no `update:value` emission.