### PR TITLE
[6.x] Adjust translation method usage

### DIFF
--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -25,3 +25,6 @@ jobs:
           testMode: true
           verboseMode: true
           pintVersion: 1.16.0
+
+      - name: Check Statamic\trans imports
+        run: bash scripts/check-trans-import.sh

--- a/resources/views/layout.blade.php
+++ b/resources/views/layout.blade.php
@@ -1,3 +1,7 @@
+@php
+    use function Statamic\trans as __;
+@endphp
+
 <!DOCTYPE html>
 <html
     lang="{{ str_replace('_', '-', Statamic::cpLocale()) }}"

--- a/resources/views/nav/duplicates.blade.php
+++ b/resources/views/nav/duplicates.blade.php
@@ -1,3 +1,7 @@
+@php
+    use function Statamic\trans as __;
+@endphp
+
 <li>
     <a href="{{ $item->url() }}" class="flex items-center gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
         <i>{!! $item->svg() !!}</i>

--- a/resources/views/nav/updates.blade.php
+++ b/resources/views/nav/updates.blade.php
@@ -1,3 +1,7 @@
+@php
+    use function Statamic\trans as __;
+@endphp
+
 <li>
     <inertia-link href="{{ $item->url() }}" class="flex items-center gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
         @cp_svg('icons/updates', 'size-4 shrink-0')

--- a/scripts/check-trans-import.sh
+++ b/scripts/check-trans-import.sh
@@ -41,7 +41,7 @@ while IFS= read -r file; do
 done < <(git ls-files 'src/**/*.php' 'resources/views/**/*.blade.php')
 
 if [ -n "$errors" ]; then
-    echo "Files with missing Statamic\\trans imports (see issue #14609):"
+    echo "Files with missing Statamic\\trans imports (see PR #14610):"
     echo
     printf '%s' "$errors"
     exit 1

--- a/scripts/check-trans-import.sh
+++ b/scripts/check-trans-import.sh
@@ -1,22 +1,48 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -uo pipefail
 
-missing=$(
-    while IFS= read -r file; do
-        if [ "$file" = "src/Statamic.php" ]; then
-            continue
-        fi
+excluded=("src/Statamic.php" "src/namespaced_helpers.php" "src/Translator/MethodDiscovery.php")
 
-        if grep -qE '__[[:space:]]*\([^?]' "$file" && ! grep -qF 'use function Statamic\trans as __;' "$file"; then
-            echo "$file"
-        fi
-    done < <(git ls-files 'src/**/*.php' 'resources/views/**/*.blade.php')
-)
+is_excluded() {
+    local file=$1
+    for ex in "${excluded[@]}"; do
+        [ "$file" = "$ex" ] && return 0
+    done
+    return 1
+}
 
-if [ -n "$missing" ]; then
-    echo "The following files use __() without 'use function Statamic\\trans as __;':"
-    echo "$missing"
+# Returns 0 if the file contains an unqualified call to the given function.
+# Skips method definitions and qualified calls (Foo::fn(), $x->fn(), $fn()).
+has_unqualified_call() {
+    local file=$1
+    local fn=$2
+
+    grep -nE "${fn}[[:space:]]*\(" "$file" 2>/dev/null \
+        | grep -vE "(function[[:space:]]+|::|->|\\\$)${fn}[[:space:]]*\(" \
+        > /dev/null
+}
+
+errors=""
+
+while IFS= read -r file; do
+    is_excluded "$file" && continue
+
+    if grep -qE '__[[:space:]]*\([^?]' "$file" && ! grep -qF 'use function Statamic\trans as __;' "$file"; then
+        errors+="$file: missing 'use function Statamic\\trans as __;'"$'\n'
+    fi
+
+    if has_unqualified_call "$file" "trans" && ! grep -qF 'use function Statamic\trans;' "$file"; then
+        errors+="$file: missing 'use function Statamic\\trans;'"$'\n'
+    fi
+
+    if has_unqualified_call "$file" "trans_choice" && ! grep -qF 'use function Statamic\trans_choice;' "$file"; then
+        errors+="$file: missing 'use function Statamic\\trans_choice;'"$'\n'
+    fi
+done < <(git ls-files 'src/**/*.php' 'resources/views/**/*.blade.php')
+
+if [ -n "$errors" ]; then
+    echo "Files with missing Statamic\\trans imports (see issue #14609):"
     echo
-    echo "Add the import to fix the lang-file/title collision (see issue #14609)."
+    printf '%s' "$errors"
     exit 1
 fi

--- a/scripts/check-trans-import.sh
+++ b/scripts/check-trans-import.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=$(
+    while IFS= read -r file; do
+        if [ "$file" = "src/Statamic.php" ]; then
+            continue
+        fi
+
+        if grep -qE '__[[:space:]]*\([^?]' "$file" && ! grep -qF 'use function Statamic\trans as __;' "$file"; then
+            echo "$file"
+        fi
+    done < <(git ls-files 'src/**/*.php' 'resources/views/**/*.blade.php')
+)
+
+if [ -n "$missing" ]; then
+    echo "The following files use __() without 'use function Statamic\\trans as __;':"
+    echo "$missing"
+    echo
+    echo "Add the import to fix the lang-file/title collision (see issue #14609)."
+    exit 1
+fi

--- a/src/Actions/AssignGroups.php
+++ b/src/Actions/AssignGroups.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\UserGroup;
 
+use function Statamic\trans as __;
+
 class AssignGroups extends Action
 {
     public $icon = 'add-group';

--- a/src/Actions/AssignRoles.php
+++ b/src/Actions/AssignRoles.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\Role;
 
+use function Statamic\trans as __;
+
 class AssignRoles extends Action
 {
     public $icon = 'permissions';

--- a/src/Actions/CopyAssetUrl.php
+++ b/src/Actions/CopyAssetUrl.php
@@ -4,6 +4,8 @@ namespace Statamic\Actions;
 
 use Statamic\Contracts\Assets\Asset;
 
+use function Statamic\trans as __;
+
 class CopyAssetUrl extends Action
 {
     protected $icon = 'clipboard';

--- a/src/Actions/CopyPasswordResetLink.php
+++ b/src/Actions/CopyPasswordResetLink.php
@@ -6,6 +6,8 @@ use Exception;
 use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Contracts\Auth\User as UserContract;
 
+use function Statamic\trans as __;
+
 class CopyPasswordResetLink extends Action
 {
     protected $confirm = false;

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -5,6 +5,7 @@ namespace Statamic\Actions;
 use Statamic\Contracts;
 
 use function Statamic\trans as __;
+use function Statamic\trans_choice;
 
 class Delete extends Action
 {

--- a/src/Actions/Delete.php
+++ b/src/Actions/Delete.php
@@ -4,6 +4,8 @@ namespace Statamic\Actions;
 
 use Statamic\Contracts;
 
+use function Statamic\trans as __;
+
 class Delete extends Action
 {
     protected $dangerous = true;

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -7,6 +7,7 @@ use Statamic\Facades\User;
 use Statamic\Statamic;
 
 use function Statamic\trans as __;
+use function Statamic\trans_choice;
 
 class DeleteMultisiteEntry extends Delete
 {

--- a/src/Actions/DeleteMultisiteEntry.php
+++ b/src/Actions/DeleteMultisiteEntry.php
@@ -6,6 +6,8 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\User;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class DeleteMultisiteEntry extends Delete
 {
     public function visibleTo($item)

--- a/src/Actions/DisableTwoFactorAuthentication.php
+++ b/src/Actions/DisableTwoFactorAuthentication.php
@@ -4,6 +4,8 @@ namespace Statamic\Actions;
 
 use Statamic\Contracts\Auth\User;
 
+use function Statamic\trans as __;
+
 class DisableTwoFactorAuthentication extends Action
 {
     protected $dangerous = true;

--- a/src/Actions/DownloadAsset.php
+++ b/src/Actions/DownloadAsset.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Actions\Concerns\MakesZips;
 use Statamic\Contracts\Assets\Asset;
 
+use function Statamic\trans as __;
+
 class DownloadAsset extends Action
 {
     use MakesZips;

--- a/src/Actions/DownloadAssetFolder.php
+++ b/src/Actions/DownloadAssetFolder.php
@@ -6,6 +6,8 @@ use Statamic\Actions\Concerns\MakesZips;
 use Statamic\Contracts\Assets\AssetFolder;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class DownloadAssetFolder extends Action
 {
     use MakesZips;

--- a/src/Actions/DuplicateAsset.php
+++ b/src/Actions/DuplicateAsset.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Storage;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Facades\Asset as Assets;
 
+use function Statamic\trans as __;
+
 class DuplicateAsset extends Action
 {
     protected $icon = 'duplicate';

--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Entry as Entries;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
 
+use function Statamic\trans as __;
+
 class DuplicateEntry extends Action
 {
     protected $icon = 'duplicate';

--- a/src/Actions/DuplicateForm.php
+++ b/src/Actions/DuplicateForm.php
@@ -8,6 +8,8 @@ use Statamic\Rules\Handle;
 use Statamic\Rules\UniqueFormHandle;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class DuplicateForm extends Action
 {
     protected $icon = 'duplicate';

--- a/src/Actions/DuplicateTerm.php
+++ b/src/Actions/DuplicateTerm.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Str;
 use Statamic\Contracts\Taxonomies\Term;
 use Statamic\Facades\Term as Terms;
 
+use function Statamic\trans as __;
+
 class DuplicateTerm extends Action
 {
     protected $icon = 'duplicate';

--- a/src/Actions/Impersonate.php
+++ b/src/Actions/Impersonate.php
@@ -9,6 +9,8 @@ use Statamic\Events\ImpersonationStarted;
 use Statamic\Facades\CP\Toast;
 use Statamic\Facades\User;
 
+use function Statamic\trans as __;
+
 class Impersonate extends Action
 {
     public $icon = 'mask';

--- a/src/Actions/MoveAsset.php
+++ b/src/Actions/MoveAsset.php
@@ -6,6 +6,8 @@ use Statamic\Contracts\Assets\Asset;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Blink;
 
+use function Statamic\trans as __;
+
 class MoveAsset extends Action
 {
     protected $icon = 'move-folder';

--- a/src/Actions/MoveAssetFolder.php
+++ b/src/Actions/MoveAssetFolder.php
@@ -6,6 +6,8 @@ use Statamic\Contracts\Assets\AssetFolder;
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Blink;
 
+use function Statamic\trans as __;
+
 class MoveAssetFolder extends Action
 {
     protected $icon = 'move-folder';

--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\User;
 
+use function Statamic\trans as __;
+
 class Publish extends Action
 {
     protected $icon = 'eye';

--- a/src/Actions/Publish.php
+++ b/src/Actions/Publish.php
@@ -6,6 +6,7 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\User;
 
 use function Statamic\trans as __;
+use function Statamic\trans_choice;
 
 class Publish extends Action
 {

--- a/src/Actions/RenameAsset.php
+++ b/src/Actions/RenameAsset.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Rules\AvailableAssetFilename;
 
+use function Statamic\trans as __;
+
 class RenameAsset extends Action
 {
     protected $icon = 'rename';

--- a/src/Actions/RenameAssetFolder.php
+++ b/src/Actions/RenameAssetFolder.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Contracts\Assets\AssetFolder;
 use Statamic\Rules\AlphaDashSpace;
 
+use function Statamic\trans as __;
+
 class RenameAssetFolder extends Action
 {
     protected $icon = 'folder-edit';

--- a/src/Actions/ReplaceAsset.php
+++ b/src/Actions/ReplaceAsset.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Facades;
 
+use function Statamic\trans as __;
+
 class ReplaceAsset extends Action
 {
     protected $icon = 'replace';

--- a/src/Actions/ReuploadAsset.php
+++ b/src/Actions/ReuploadAsset.php
@@ -7,6 +7,8 @@ use Statamic\Contracts\Assets\Asset;
 use Statamic\Exceptions\FileExtensionMismatch;
 use Statamic\Exceptions\ValidationException;
 
+use function Statamic\trans as __;
+
 class ReuploadAsset extends Action
 {
     protected $icon = 'upload-cloud';

--- a/src/Actions/ReuploadAsset.php
+++ b/src/Actions/ReuploadAsset.php
@@ -7,6 +7,7 @@ use Statamic\Contracts\Assets\Asset;
 use Statamic\Exceptions\FileExtensionMismatch;
 use Statamic\Exceptions\ValidationException;
 
+use function Statamic\trans;
 use function Statamic\trans as __;
 
 class ReuploadAsset extends Action

--- a/src/Actions/SendPasswordReset.php
+++ b/src/Actions/SendPasswordReset.php
@@ -4,6 +4,8 @@ namespace Statamic\Actions;
 
 use Statamic\Contracts\Auth\User as UserContract;
 
+use function Statamic\trans as __;
+
 class SendPasswordReset extends Action
 {
     public $icon = 'mail';

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -6,6 +6,7 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\User;
 
 use function Statamic\trans as __;
+use function Statamic\trans_choice;
 
 class Unpublish extends Action
 {

--- a/src/Actions/Unpublish.php
+++ b/src/Actions/Unpublish.php
@@ -5,6 +5,8 @@ namespace Statamic\Actions;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\User;
 
+use function Statamic\trans as __;
+
 class Unpublish extends Action
 {
     protected $icon = 'eye-slash';

--- a/src/Addons/AddonRepository.php
+++ b/src/Addons/AddonRepository.php
@@ -17,8 +17,6 @@ class AddonRepository
     {
         $method = is_array($addon) ? 'makeFromPackage' : 'make';
 
-        $foo = trans('wat');
-
         return Addon::$method($addon);
     }
 

--- a/src/Addons/AddonRepository.php
+++ b/src/Addons/AddonRepository.php
@@ -17,6 +17,8 @@ class AddonRepository
     {
         $method = is_array($addon) ? 'makeFromPackage' : 'make';
 
+        $foo = trans('wat');
+
         return Addon::$method($addon);
     }
 

--- a/src/Addons/Settings.php
+++ b/src/Addons/Settings.php
@@ -20,6 +20,8 @@ abstract class Settings implements Contract
     {
         $this->addon = $addon;
         $this->setValues($settings);
+
+        $foo = trans_choice('foo', 8);
     }
 
     public function addon(): Addon

--- a/src/Addons/Settings.php
+++ b/src/Addons/Settings.php
@@ -20,8 +20,6 @@ abstract class Settings implements Contract
     {
         $this->addon = $addon;
         $this->setValues($settings);
-
-        $foo = trans_choice('foo', 8);
     }
 
     public function addon(): Addon

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -31,6 +31,8 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
+use function Statamic\trans as __;
+
 class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, Augmentable, ContainsQueryableValues
 {
     use ExistsAsFile, FluentlyGetsAndSets, HasAugmentedInstance;

--- a/src/Auth/Permissions.php
+++ b/src/Auth/Permissions.php
@@ -4,6 +4,8 @@ namespace Statamic\Auth;
 
 use Facades\Statamic\Auth\CorePermissions;
 
+use function Statamic\trans as __;
+
 class Permissions
 {
     protected $extensions = [];

--- a/src/Auth/Protect/Protectors/Password/Controller.php
+++ b/src/Auth/Protect/Protectors/Password/Controller.php
@@ -9,6 +9,8 @@ use Statamic\Facades\Site;
 use Statamic\Http\Controllers\Controller as BaseController;
 use Statamic\View\View;
 
+use function Statamic\trans as __;
+
 class Controller extends BaseController
 {
     protected $tokenData;

--- a/src/Auth/ResetsPasswords.php
+++ b/src/Auth/ResetsPasswords.php
@@ -14,6 +14,8 @@ use Illuminate\Validation\Rules\Password as PasswordRules;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\URL;
 
+use function Statamic\trans;
+
 /**
  * A copy of Illuminate\Auth\ResetsPasswords.
  * (but it doesn't import the RedirectsUsers trait).

--- a/src/Auth/SendsPasswordResetEmails.php
+++ b/src/Auth/SendsPasswordResetEmails.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\URL;
 
+use function Statamic\trans;
 use function Statamic\trans as __;
 
 /**

--- a/src/Auth/SendsPasswordResetEmails.php
+++ b/src/Auth/SendsPasswordResetEmails.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Password;
 use Illuminate\Validation\ValidationException;
 use Statamic\Facades\URL;
 
+use function Statamic\trans as __;
+
 /**
  * A copy of Illuminate\Auth\SendsPasswordResetEmails.
  *

--- a/src/Auth/TwoFactor/ConfirmTwoFactorAuthentication.php
+++ b/src/Auth/TwoFactor/ConfirmTwoFactorAuthentication.php
@@ -5,6 +5,8 @@ namespace Statamic\Auth\TwoFactor;
 use Illuminate\Validation\ValidationException;
 use Statamic\Auth\User;
 
+use function Statamic\trans as __;
+
 class ConfirmTwoFactorAuthentication
 {
     public function __construct(private TwoFactorAuthenticationProvider $provider)

--- a/src/Auth/User.php
+++ b/src/Auth/User.php
@@ -49,6 +49,8 @@ use Statamic\Search\Searchable;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 abstract class User implements Arrayable, ArrayAccess, Augmentable, Authenticatable, AuthorizableContract, CanResetPasswordContract, ContainsQueryableValues, HasLocalePreference, ResolvesValuesContract, SearchableContract, UserContract
 {
     use Authorizable, CanResetPassword, ContainsComputedData, HasAugmentedInstance, HasAvatar, HasDirtyState, Notifiable, ResolvesValues, Searchable, TracksQueriedColumns, TracksQueriedRelations;

--- a/src/Auth/UserGroupRepository.php
+++ b/src/Auth/UserGroupRepository.php
@@ -7,6 +7,8 @@ use Statamic\Contracts\Auth\UserGroupRepository as RepositoryContract;
 use Statamic\Events\UserGroupBlueprintFound;
 use Statamic\Facades\Blueprint;
 
+use function Statamic\trans as __;
+
 abstract class UserGroupRepository implements RepositoryContract
 {
     public function find($id): ?UserGroupContract

--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -12,6 +12,8 @@ use Statamic\OAuth\Provider;
 use Statamic\Query\Scopes\AllowsScopes;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 abstract class UserRepository implements RepositoryContract
 {
     use AllowsScopes, StoresComputedFieldCallbacks;

--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -14,6 +14,8 @@ use Statamic\Support\Str;
 use Statamic\Tags\Concerns;
 use Statamic\Tags\Tags;
 
+use function Statamic\trans as __;
+
 class UserTags extends Tags
 {
     use Concerns\GetsFormSession,

--- a/src/Auth/WebAuthn/WebAuthn.php
+++ b/src/Auth/WebAuthn/WebAuthn.php
@@ -16,6 +16,8 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
 use Webauthn\PublicKeyCredentialUserEntity;
 
+use function Statamic\trans as __;
+
 class WebAuthn
 {
     public function __construct(

--- a/src/CP/Breadcrumbs/Breadcrumbs.php
+++ b/src/CP/Breadcrumbs/Breadcrumbs.php
@@ -7,6 +7,8 @@ use Statamic\CP\Navigation\NavItem;
 use Statamic\Facades\CP\Nav;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class Breadcrumbs
 {
     public static $pushed = [];

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -12,6 +12,8 @@ use Statamic\Support\Str;
 use Statamic\Support\Svg;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 
+use function Statamic\trans as __;
+
 class NavItem
 {
     use FluentlyGetsAndSets;

--- a/src/CommandPalette/Palette.php
+++ b/src/CommandPalette/Palette.php
@@ -11,6 +11,8 @@ use Statamic\Facades\User;
 use Statamic\Fields\Fieldset;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Palette
 {
     protected $items;

--- a/src/Console/Commands/MakeUser.php
+++ b/src/Console/Commands/MakeUser.php
@@ -16,6 +16,7 @@ use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\password;
 use function Laravel\Prompts\text;
+use function Statamic\trans as __;
 
 class MakeUser extends Command
 {

--- a/src/Dictionaries/Countries.php
+++ b/src/Dictionaries/Countries.php
@@ -4,6 +4,8 @@ namespace Statamic\Dictionaries;
 
 use Illuminate\Support\Collection;
 
+use function Statamic\trans as __;
+
 class Countries extends BasicDictionary
 {
     protected string $valueKey = 'iso3';

--- a/src/Dictionaries/Currencies.php
+++ b/src/Dictionaries/Currencies.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Dictionaries;
 
+use function Statamic\trans as __;
+
 class Currencies extends BasicDictionary
 {
     protected string $valueKey = 'code';

--- a/src/Dictionaries/File.php
+++ b/src/Dictionaries/File.php
@@ -6,6 +6,8 @@ use League\Flysystem\PathTraversalDetected;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\YAML;
 
+use function Statamic\trans as __;
+
 class File extends BasicDictionary
 {
     protected array $keywords = ['files', 'file', 'json', 'csv', 'yaml', 'yml'];

--- a/src/Dictionaries/Languages.php
+++ b/src/Dictionaries/Languages.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Dictionaries;
 
+use function Statamic\trans as __;
+
 class Languages extends BasicDictionary
 {
     protected string $valueKey = 'code';

--- a/src/Events/AddonSettingsSaved.php
+++ b/src/Events/AddonSettingsSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AddonSettingsSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $settings)

--- a/src/Events/AssetContainerDeleted.php
+++ b/src/Events/AssetContainerDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetContainerDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $container)

--- a/src/Events/AssetContainerSaved.php
+++ b/src/Events/AssetContainerSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetContainerSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $container)

--- a/src/Events/AssetDeleted.php
+++ b/src/Events/AssetDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $asset)

--- a/src/Events/AssetFolderDeleted.php
+++ b/src/Events/AssetFolderDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetFolderDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $folder)

--- a/src/Events/AssetFolderSaved.php
+++ b/src/Events/AssetFolderSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetFolderSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $folder)

--- a/src/Events/AssetReferencesUpdated.php
+++ b/src/Events/AssetReferencesUpdated.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetReferencesUpdated extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $asset)

--- a/src/Events/AssetReuploaded.php
+++ b/src/Events/AssetReuploaded.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetReuploaded extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $asset, public $originalFilename)

--- a/src/Events/AssetSaved.php
+++ b/src/Events/AssetSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $asset)

--- a/src/Events/AssetUploaded.php
+++ b/src/Events/AssetUploaded.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class AssetUploaded extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $asset, public $originalFilename)

--- a/src/Events/BlueprintDeleted.php
+++ b/src/Events/BlueprintDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class BlueprintDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $blueprint)

--- a/src/Events/BlueprintReset.php
+++ b/src/Events/BlueprintReset.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class BlueprintReset extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $blueprint)

--- a/src/Events/BlueprintSaved.php
+++ b/src/Events/BlueprintSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class BlueprintSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $blueprint)

--- a/src/Events/CollectionDeleted.php
+++ b/src/Events/CollectionDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class CollectionDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $collection)

--- a/src/Events/CollectionSaved.php
+++ b/src/Events/CollectionSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class CollectionSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $collection)

--- a/src/Events/CollectionTreeDeleted.php
+++ b/src/Events/CollectionTreeDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class CollectionTreeDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $tree)

--- a/src/Events/CollectionTreeSaved.php
+++ b/src/Events/CollectionTreeSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class CollectionTreeSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $tree)

--- a/src/Events/DefaultPreferencesSaved.php
+++ b/src/Events/DefaultPreferencesSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class DefaultPreferencesSaved extends Event implements ProvidesCommitMessage
 {
     public function commitMessage()

--- a/src/Events/DuplicateIdRegenerated.php
+++ b/src/Events/DuplicateIdRegenerated.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class DuplicateIdRegenerated extends Event implements ProvidesCommitMessage
 {
     public function commitMessage()

--- a/src/Events/EntryDeleted.php
+++ b/src/Events/EntryDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class EntryDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $entry)

--- a/src/Events/EntrySaved.php
+++ b/src/Events/EntrySaved.php
@@ -5,6 +5,8 @@ namespace Statamic\Events;
 use Facades\Statamic\Entries\InitiatorStack;
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class EntrySaved extends Event implements ProvidesCommitMessage
 {
     public $initiator;

--- a/src/Events/EntryScheduleReached.php
+++ b/src/Events/EntryScheduleReached.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class EntryScheduleReached extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $entry)

--- a/src/Events/FieldsetDeleted.php
+++ b/src/Events/FieldsetDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class FieldsetDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $fieldset)

--- a/src/Events/FieldsetReset.php
+++ b/src/Events/FieldsetReset.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class FieldsetReset extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $fieldset)

--- a/src/Events/FieldsetSaved.php
+++ b/src/Events/FieldsetSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class FieldsetSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $fieldset)

--- a/src/Events/FormDeleted.php
+++ b/src/Events/FormDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class FormDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $form)

--- a/src/Events/FormSaved.php
+++ b/src/Events/FormSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class FormSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $form)

--- a/src/Events/GlobalSetDeleted.php
+++ b/src/Events/GlobalSetDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class GlobalSetDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $globals)

--- a/src/Events/GlobalSetSaved.php
+++ b/src/Events/GlobalSetSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class GlobalSetSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $globals)

--- a/src/Events/GlobalVariablesDeleted.php
+++ b/src/Events/GlobalVariablesDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class GlobalVariablesDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $variables)

--- a/src/Events/GlobalVariablesSaved.php
+++ b/src/Events/GlobalVariablesSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class GlobalVariablesSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $variables)

--- a/src/Events/NavDeleted.php
+++ b/src/Events/NavDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class NavDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $nav)

--- a/src/Events/NavSaved.php
+++ b/src/Events/NavSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class NavSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $nav)

--- a/src/Events/NavTreeDeleted.php
+++ b/src/Events/NavTreeDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class NavTreeDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $tree)

--- a/src/Events/NavTreeSaved.php
+++ b/src/Events/NavTreeSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class NavTreeSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $tree)

--- a/src/Events/RevisionDeleted.php
+++ b/src/Events/RevisionDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class RevisionDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $revision)

--- a/src/Events/RevisionSaved.php
+++ b/src/Events/RevisionSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class RevisionSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $revision)

--- a/src/Events/RoleDeleted.php
+++ b/src/Events/RoleDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class RoleDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $role)

--- a/src/Events/RoleSaved.php
+++ b/src/Events/RoleSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class RoleSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $role)

--- a/src/Events/SiteDeleted.php
+++ b/src/Events/SiteDeleted.php
@@ -5,6 +5,8 @@ namespace Statamic\Events;
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 use Statamic\Sites\Site;
 
+use function Statamic\trans as __;
+
 class SiteDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public Site $site)

--- a/src/Events/SiteSaved.php
+++ b/src/Events/SiteSaved.php
@@ -5,6 +5,8 @@ namespace Statamic\Events;
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 use Statamic\Sites\Site;
 
+use function Statamic\trans as __;
+
 class SiteSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public Site $site)

--- a/src/Events/SubmissionDeleted.php
+++ b/src/Events/SubmissionDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class SubmissionDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $submission)

--- a/src/Events/SubmissionSaved.php
+++ b/src/Events/SubmissionSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class SubmissionSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $submission)

--- a/src/Events/TaxonomyDeleted.php
+++ b/src/Events/TaxonomyDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class TaxonomyDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $taxonomy)

--- a/src/Events/TaxonomySaved.php
+++ b/src/Events/TaxonomySaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class TaxonomySaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $taxonomy)

--- a/src/Events/TermDeleted.php
+++ b/src/Events/TermDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class TermDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $term)

--- a/src/Events/TermReferencesUpdated.php
+++ b/src/Events/TermReferencesUpdated.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class TermReferencesUpdated extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $term)

--- a/src/Events/TermSaved.php
+++ b/src/Events/TermSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class TermSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $term)

--- a/src/Events/UserDeleted.php
+++ b/src/Events/UserDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class UserDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $user)

--- a/src/Events/UserGroupDeleted.php
+++ b/src/Events/UserGroupDeleted.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class UserGroupDeleted extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $group)

--- a/src/Events/UserGroupSaved.php
+++ b/src/Events/UserGroupSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class UserGroupSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $group)

--- a/src/Events/UserSaved.php
+++ b/src/Events/UserSaved.php
@@ -4,6 +4,8 @@ namespace Statamic\Events;
 
 use Statamic\Contracts\Git\ProvidesCommitMessage;
 
+use function Statamic\trans as __;
+
 class UserSaved extends Event implements ProvidesCommitMessage
 {
     public function __construct(public $user)

--- a/src/Exceptions/ElevatedSessionAuthorizationException.php
+++ b/src/Exceptions/ElevatedSessionAuthorizationException.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Statamic\Facades\URL;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class ElevatedSessionAuthorizationException extends \Exception
 {
     public function __construct()

--- a/src/Fields/Fieldset.php
+++ b/src/Fields/Fieldset.php
@@ -25,6 +25,8 @@ use Statamic\Facades\Taxonomy;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Fieldset implements ContainsQueryableValues
 {
     protected $handle;

--- a/src/Fieldtypes/Arr.php
+++ b/src/Fieldtypes/Arr.php
@@ -8,6 +8,8 @@ use Statamic\Fields\Fieldtype;
 use Statamic\GraphQL\Types\ArrayType;
 use Statamic\Support\Arr as SupportArr;
 
+use function Statamic\trans as __;
+
 class Arr extends Fieldtype
 {
     protected $categories = ['structured'];

--- a/src/Fieldtypes/AssetFolder.php
+++ b/src/Fieldtypes/AssetFolder.php
@@ -5,6 +5,8 @@ namespace Statamic\Fieldtypes;
 use Statamic\Facades\AssetContainer;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class AssetFolder extends Relationship
 {
     protected $component = 'asset_folder';

--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -23,6 +23,8 @@ use Statamic\Query\Scopes\Filter;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Assets extends Fieldtype
 {
     use UpdatesReferences;

--- a/src/Fieldtypes/Assets/DimensionsRule.php
+++ b/src/Fieldtypes/Assets/DimensionsRule.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function Statamic\trans as __;
+
 class DimensionsRule implements CastableToValidationString, Rule
 {
     protected $parameters;

--- a/src/Fieldtypes/Assets/ImageRule.php
+++ b/src/Fieldtypes/Assets/ImageRule.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function Statamic\trans as __;
+
 class ImageRule implements CastableToValidationString, Rule
 {
     protected $parameters;

--- a/src/Fieldtypes/Assets/MaxRule.php
+++ b/src/Fieldtypes/Assets/MaxRule.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes\Assets;
 
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class MaxRule extends SizeBasedRule
 {
     /**

--- a/src/Fieldtypes/Assets/MimesRule.php
+++ b/src/Fieldtypes/Assets/MimesRule.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function Statamic\trans as __;
+
 class MimesRule implements CastableToValidationString, Rule
 {
     protected $parameters;

--- a/src/Fieldtypes/Assets/MimetypesRule.php
+++ b/src/Fieldtypes/Assets/MimetypesRule.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Asset;
 use Statamic\Statamic;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function Statamic\trans as __;
+
 class MimetypesRule implements CastableToValidationString, Rule
 {
     protected $parameters;

--- a/src/Fieldtypes/Assets/MinRule.php
+++ b/src/Fieldtypes/Assets/MinRule.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes\Assets;
 
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class MinRule extends SizeBasedRule
 {
     /**

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -26,6 +26,8 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\Hookable;
 
+use function Statamic\trans as __;
+
 class Bard extends Replicator
 {
     use Concerns\ResolvesStatamicUrls, Hookable;

--- a/src/Fieldtypes/ButtonGroup.php
+++ b/src/Fieldtypes/ButtonGroup.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class ButtonGroup extends Fieldtype
 {
     use HasSelectOptions;

--- a/src/Fieldtypes/Checkboxes.php
+++ b/src/Fieldtypes/Checkboxes.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Checkboxes extends Fieldtype
 {
     use HasSelectOptions {

--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -7,6 +7,8 @@ use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Fieldtype;
 use Statamic\GraphQL\Types\CodeType;
 
+use function Statamic\trans as __;
+
 class Code extends Fieldtype
 {
     protected $categories = ['text'];

--- a/src/Fieldtypes/Color.php
+++ b/src/Fieldtypes/Color.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Color extends Fieldtype
 {
     protected $categories = ['special'];

--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -15,6 +15,8 @@ use Statamic\Query\Scopes\Filters\Fields\Date as DateFilter;
 use Statamic\Rules\DateFieldtype as ValidationRule;
 use Statamic\Support\DateFormat;
 
+use function Statamic\trans as __;
+
 class Date extends Fieldtype
 {
     protected $categories = ['special'];

--- a/src/Fieldtypes/Dictionary.php
+++ b/src/Fieldtypes/Dictionary.php
@@ -11,6 +11,8 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Dictionary extends Fieldtype
 {
     protected $categories = ['controls', 'relationship'];

--- a/src/Fieldtypes/DictionaryFields.php
+++ b/src/Fieldtypes/DictionaryFields.php
@@ -7,6 +7,8 @@ use Statamic\Fields\Fields;
 use Statamic\Fields\Fieldtype;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class DictionaryFields extends Fieldtype
 {
     protected $selectable = false;

--- a/src/Fieldtypes/Files.php
+++ b/src/Fieldtypes/Files.php
@@ -12,6 +12,8 @@ use Statamic\Fieldtypes\Assets\MinRule;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Files extends Fieldtype
 {
     protected $selectable = false;

--- a/src/Fieldtypes/Floatval.php
+++ b/src/Fieldtypes/Floatval.php
@@ -6,6 +6,8 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\Query\Scopes\Filters\Fields\Floatval as FloatFilter;
 
+use function Statamic\trans as __;
+
 class Floatval extends Fieldtype
 {
     protected $categories = ['number'];

--- a/src/Fieldtypes/GlobalSetSites.php
+++ b/src/Fieldtypes/GlobalSetSites.php
@@ -5,6 +5,8 @@ namespace Statamic\Fieldtypes;
 use Illuminate\Contracts\Validation\Rule as ValidationRule;
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class GlobalSetSites extends Fieldtype
 {
     protected $selectable = false;

--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -13,6 +13,8 @@ use Statamic\Query\Scopes\Filters\Fields\Grid as GridFilter;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Grid extends Fieldtype
 {
     use AddsEntryValidationReplacements;

--- a/src/Fieldtypes/Group.php
+++ b/src/Fieldtypes/Group.php
@@ -11,6 +11,8 @@ use Statamic\GraphQL\Types\GroupType;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Group extends Fieldtype
 {
     use UpdatesReferences;

--- a/src/Fieldtypes/Hidden.php
+++ b/src/Fieldtypes/Hidden.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Hidden extends Fieldtype
 {
     protected $categories = ['special'];

--- a/src/Fieldtypes/Html.php
+++ b/src/Fieldtypes/Html.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Html extends Fieldtype
 {
     protected $categories = ['special'];

--- a/src/Fieldtypes/Icon.php
+++ b/src/Fieldtypes/Icon.php
@@ -6,6 +6,8 @@ use Statamic\Facades\Icon as Icons;
 use Statamic\Fields\Fieldtype;
 use Statamic\Icons\IconSet;
 
+use function Statamic\trans as __;
+
 class Icon extends Fieldtype
 {
     protected $categories = ['media'];

--- a/src/Fieldtypes/Integer.php
+++ b/src/Fieldtypes/Integer.php
@@ -6,6 +6,8 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\Query\Scopes\Filters\Fields\Integer as IntegerFilter;
 
+use function Statamic\trans as __;
+
 class Integer extends Fieldtype
 {
     protected $categories = ['number'];

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -15,6 +15,8 @@ use Statamic\Fieldtypes\Link\ArrayableLink;
 use Statamic\GraphQL\Types\LinkValueType;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Link extends Fieldtype
 {
     use UpdatesReferences;

--- a/src/Fieldtypes/Lists.php
+++ b/src/Fieldtypes/Lists.php
@@ -5,6 +5,8 @@ namespace Statamic\Fieldtypes;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Lists extends Fieldtype
 {
     protected $categories = ['structured'];

--- a/src/Fieldtypes/Markdown.php
+++ b/src/Fieldtypes/Markdown.php
@@ -8,6 +8,8 @@ use Statamic\Fields\Fieldtype;
 use Statamic\Query\Scopes\Filters\Fields\Markdown as MarkdownFilter;
 use Statamic\Support\Html;
 
+use function Statamic\trans as __;
+
 class Markdown extends Fieldtype
 {
     use Concerns\ResolvesStatamicUrls, UpdatesReferences;

--- a/src/Fieldtypes/Radio.php
+++ b/src/Fieldtypes/Radio.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Radio extends Fieldtype
 {
     use HasSelectOptions;

--- a/src/Fieldtypes/Range.php
+++ b/src/Fieldtypes/Range.php
@@ -5,6 +5,8 @@ namespace Statamic\Fieldtypes;
 use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Range extends Fieldtype
 {
     protected $categories = ['controls'];

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -10,6 +10,8 @@ use Statamic\Facades\Scope;
 use Statamic\Fields\Fieldtype;
 use Statamic\Query\OrderBy;
 
+use function Statamic\trans as __;
+
 abstract class Relationship extends Fieldtype
 {
     protected static $preloadable = true;

--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -15,6 +15,8 @@ use Statamic\Query\Scopes\Filters\Fields\Replicator as ReplicatorFilter;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Replicator extends Fieldtype
 {
     use AddsEntryValidationReplacements, UpdatesReferences;

--- a/src/Fieldtypes/Revealer.php
+++ b/src/Fieldtypes/Revealer.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Revealer extends Fieldtype
 {
     protected $categories = ['controls', 'special'];

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Select extends Fieldtype
 {
     use HasSelectOptions;

--- a/src/Fieldtypes/Sets.php
+++ b/src/Fieldtypes/Sets.php
@@ -12,6 +12,8 @@ use Statamic\Fields\Fieldtype;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Sets extends Fieldtype
 {
     protected $selectable = false;

--- a/src/Fieldtypes/Slug.php
+++ b/src/Fieldtypes/Slug.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Fieldtypes;
 
+use function Statamic\trans as __;
+
 class Slug extends Text
 {
     protected $categories = ['special'];

--- a/src/Fieldtypes/Table.php
+++ b/src/Fieldtypes/Table.php
@@ -6,6 +6,8 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\GraphQL\Types\TableRowType;
 
+use function Statamic\trans as __;
+
 class Table extends Fieldtype
 {
     protected $categories = ['structured'];

--- a/src/Fieldtypes/Taggable.php
+++ b/src/Fieldtypes/Taggable.php
@@ -6,6 +6,8 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Taggable extends Fieldtype
 {
     protected $categories = ['structured'];

--- a/src/Fieldtypes/Template.php
+++ b/src/Fieldtypes/Template.php
@@ -5,6 +5,8 @@ namespace Statamic\Fieldtypes;
 use Statamic\Fields\Fieldtype;
 use Statamic\Query\Scopes\Filters\Fields\Template as TemplateFilter;
 
+use function Statamic\trans as __;
+
 class Template extends Fieldtype
 {
     protected $categories = ['special'];

--- a/src/Fieldtypes/Text.php
+++ b/src/Fieldtypes/Text.php
@@ -5,6 +5,8 @@ namespace Statamic\Fieldtypes;
 use Statamic\Fields\Fieldtype;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Text extends Fieldtype
 {
     protected $categories = ['text'];

--- a/src/Fieldtypes/Textarea.php
+++ b/src/Fieldtypes/Textarea.php
@@ -5,6 +5,8 @@ namespace Statamic\Fieldtypes;
 use Statamic\Fields\Fieldtype;
 use Statamic\Query\Scopes\Filters\Fields\Textarea as TextareaFilter;
 
+use function Statamic\trans as __;
+
 class Textarea extends Fieldtype
 {
     protected $categories = ['text'];

--- a/src/Fieldtypes/Time.php
+++ b/src/Fieldtypes/Time.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Date;
 use Statamic\Fields\Fieldtype;
 use Statamic\Rules\TimeFieldtype as ValidationRule;
 
+use function Statamic\trans as __;
+
 class Time extends Fieldtype
 {
     protected $categories = ['special'];

--- a/src/Fieldtypes/Toggle.php
+++ b/src/Fieldtypes/Toggle.php
@@ -6,6 +6,8 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\Query\Scopes\Filters\Fields\Toggle as ToggleFilter;
 
+use function Statamic\trans as __;
+
 class Toggle extends Fieldtype
 {
     protected $categories = ['controls'];

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -16,6 +16,8 @@ use Statamic\Query\Scopes\Filters\Fields\User as UserFilter;
 use Statamic\Search\Result;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Users extends Relationship
 {
     protected $statusIcons = false;

--- a/src/Fieldtypes/Video.php
+++ b/src/Fieldtypes/Video.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Video extends Fieldtype
 {
     protected $categories = ['media'];

--- a/src/Fieldtypes/Width.php
+++ b/src/Fieldtypes/Width.php
@@ -4,6 +4,8 @@ namespace Statamic\Fieldtypes;
 
 use Statamic\Fields\Fieldtype;
 
+use function Statamic\trans as __;
+
 class Width extends Fieldtype
 {
     use HasSelectOptions;

--- a/src/Fieldtypes/Yaml.php
+++ b/src/Fieldtypes/Yaml.php
@@ -6,6 +6,8 @@ use Statamic\Facades\GraphQL;
 use Statamic\Fields\Fieldtype;
 use Statamic\Yaml\ParseException;
 
+use function Statamic\trans as __;
+
 class Yaml extends Fieldtype
 {
     protected $categories = ['special'];

--- a/src/Forms/Exporters/CsvExporter.php
+++ b/src/Forms/Exporters/CsvExporter.php
@@ -6,6 +6,8 @@ use League\Csv\Writer;
 use SplTempFileObject;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class CsvExporter extends Exporter
 {
     private Writer $writer;

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -12,6 +12,8 @@ use Statamic\Facades\Path;
 use Statamic\Facades\User;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Git
 {
     private ?UserContract $authenticatedUser;

--- a/src/Http/Controllers/ActivateAccountController.php
+++ b/src/Http/Controllers/ActivateAccountController.php
@@ -7,6 +7,8 @@ use Statamic\Auth\Passwords\PasswordReset;
 use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 
+use function Statamic\trans as __;
+
 class ActivateAccountController extends ResetPasswordController
 {
     public function __construct()

--- a/src/Http/Controllers/Auth/ElevatedSessionController.php
+++ b/src/Http/Controllers/Auth/ElevatedSessionController.php
@@ -13,6 +13,8 @@ use Statamic\Facades\WebAuthn;
 use Statamic\Http\Controllers\Controller;
 use Statamic\Http\Requests\Auth\ElevatedSessionConfirmationRequest;
 
+use function Statamic\trans as __;
+
 class ElevatedSessionController extends Controller
 {
     public function showForm(Request $request)

--- a/src/Http/Controllers/CP/ActionController.php
+++ b/src/Http/Controllers/CP/ActionController.php
@@ -9,6 +9,8 @@ use Statamic\Facades\User;
 use Statamic\Support\Arr;
 use Symfony\Component\HttpFoundation\Response;
 
+use function Statamic\trans as __;
+
 abstract class ActionController extends CpController
 {
     public function run(Request $request)

--- a/src/Http/Controllers/CP/Assets/AssetContainersController.php
+++ b/src/Http/Controllers/CP/Assets/AssetContainersController.php
@@ -10,6 +10,8 @@ use Statamic\Facades\Blueprint;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\Handle;
 
+use function Statamic\trans as __;
+
 class AssetContainersController extends CpController
 {
     public function show($container)

--- a/src/Http/Controllers/CP/Assets/BrowserController.php
+++ b/src/Http/Controllers/CP/Assets/BrowserController.php
@@ -24,6 +24,8 @@ use Statamic\Query\OrderBy;
 use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class BrowserController extends CpController
 {
     use HasRequestedColumns, QueriesFilters, RedirectsToFirstAssetContainer;

--- a/src/Http/Controllers/CP/Assets/FoldersController.php
+++ b/src/Http/Controllers/CP/Assets/FoldersController.php
@@ -11,6 +11,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Assets\Folder;
 use Statamic\Rules\AlphaDashSpace;
 
+use function Statamic\trans as __;
+
 class FoldersController extends CpController
 {
     public function store(Request $request, $container)

--- a/src/Http/Controllers/CP/Auth/ElevatedSessionController.php
+++ b/src/Http/Controllers/CP/Auth/ElevatedSessionController.php
@@ -8,6 +8,8 @@ use Inertia\Inertia;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\Auth\ElevatedSessionController as BaseController;
 
+use function Statamic\trans as __;
+
 class ElevatedSessionController extends BaseController
 {
     public function status(Request $request)

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -16,6 +16,7 @@ use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 use Statamic\OAuth\Provider;
 use Statamic\Statamic;
 
+use function Statamic\trans;
 use function Statamic\trans as __;
 
 class LoginController extends CpController

--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -12,6 +12,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Structures\TreeBuilder;
 use Statamic\Support\Arr;
 
+use function Statamic\trans;
+
 class CollectionTreeController extends CpController
 {
     public function index(Request $request, Collection $collection)

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -24,6 +24,8 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\Hookable;
 
+use function Statamic\trans as __;
+
 class EntriesController extends CpController
 {
     use ExtractsFromEntryFields,

--- a/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
+++ b/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
@@ -7,6 +7,8 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Revisions\Revision;
 
+use function Statamic\trans as __;
+
 class RestoreEntryRevisionController extends CpController
 {
     public function __invoke(Request $request, $collection, $entry)

--- a/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
+++ b/src/Http/Controllers/CP/Collections/ScaffoldCollectionController.php
@@ -8,6 +8,8 @@ use Statamic\Contracts\Entries\Collection as CollectionContract;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\View\Scaffolding\TemplateGenerator;
 
+use function Statamic\trans as __;
+
 class ScaffoldCollectionController extends CpController
 {
     public function index($collection)

--- a/src/Http/Controllers/CP/CpController.php
+++ b/src/Http/Controllers/CP/CpController.php
@@ -10,6 +10,8 @@ use Statamic\Exceptions\ElevatedSessionAuthorizationException;
 use Statamic\Http\Controllers\Controller;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 /**
  * The base control panel controller.
  */

--- a/src/Http/Controllers/CP/DuplicatesController.php
+++ b/src/Http/Controllers/CP/DuplicatesController.php
@@ -9,6 +9,8 @@ use Statamic\Facades\File;
 use Statamic\Facades\Stache;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class DuplicatesController extends CpController
 {
     public function index()

--- a/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
+++ b/src/Http/Controllers/CP/Fields/ManagesBlueprints.php
@@ -14,6 +14,8 @@ use Statamic\Fields\FieldTransformer;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 trait ManagesBlueprints
 {
     use ManagesFields;

--- a/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
@@ -10,6 +10,8 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class GlobalVariablesController extends CpController
 {
     public function edit(Request $request, $id)

--- a/src/Http/Controllers/CP/Globals/GlobalsController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalsController.php
@@ -15,6 +15,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\Handle;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class GlobalsController extends CpController
 {
     public function index()

--- a/src/Http/Controllers/CP/LicensingController.php
+++ b/src/Http/Controllers/CP/LicensingController.php
@@ -5,6 +5,8 @@ namespace Statamic\Http\Controllers\CP;
 use Inertia\Inertia;
 use Statamic\Licensing\LicenseManager as Licenses;
 
+use function Statamic\trans as __;
+
 class LicensingController extends CpController
 {
     public function show(Licenses $licenses)

--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -19,6 +19,8 @@ use Statamic\Query\Scopes\Filter;
 use Statamic\Rules\Handle;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class NavigationController extends CpController
 {
     public function index()

--- a/src/Http/Controllers/CP/Navigation/NavigationPagesController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationPagesController.php
@@ -8,6 +8,8 @@ use Statamic\Fields\Blueprint;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Structures\Page;
 
+use function Statamic\trans as __;
+
 class NavigationPagesController extends CpController
 {
     /**

--- a/src/Http/Controllers/CP/Preferences/DefaultPreferenceController.php
+++ b/src/Http/Controllers/CP/Preferences/DefaultPreferenceController.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Statamic\Facades\Preference;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class DefaultPreferenceController extends CpController
 {
     use ManagesPreferences;

--- a/src/Http/Controllers/CP/Preferences/ManagesPreferences.php
+++ b/src/Http/Controllers/CP/Preferences/ManagesPreferences.php
@@ -12,6 +12,8 @@ use Statamic\Facades\User;
 use Statamic\Jobs\ReportThemeUsage;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 trait ManagesPreferences
 {
     protected function view(string $title, string $actionUrl, array $preferences)

--- a/src/Http/Controllers/CP/Preferences/Nav/Concerns/HasNavBuilder.php
+++ b/src/Http/Controllers/CP/Preferences/Nav/Concerns/HasNavBuilder.php
@@ -11,6 +11,8 @@ use Statamic\Facades\User;
 use Statamic\Http\Resources\CP\Nav\Nav as NavResource;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 trait HasNavBuilder
 {
     protected function navBuilder($nav = null, $props = [])

--- a/src/Http/Controllers/CP/Preferences/Nav/DefaultNavController.php
+++ b/src/Http/Controllers/CP/Preferences/Nav/DefaultNavController.php
@@ -7,6 +7,8 @@ use Statamic\Facades\CP\Nav;
 use Statamic\Facades\Preference;
 use Statamic\Http\Controllers\Controller;
 
+use function Statamic\trans as __;
+
 class DefaultNavController extends Controller
 {
     use Concerns\HasNavBuilder;

--- a/src/Http/Controllers/CP/Preferences/Nav/NavController.php
+++ b/src/Http/Controllers/CP/Preferences/Nav/NavController.php
@@ -9,6 +9,8 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\Controller;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class NavController extends Controller
 {
     public function index()

--- a/src/Http/Controllers/CP/Preferences/Nav/UserNavController.php
+++ b/src/Http/Controllers/CP/Preferences/Nav/UserNavController.php
@@ -7,6 +7,8 @@ use Statamic\Facades\CP\Nav;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\Controller;
 
+use function Statamic\trans as __;
+
 class UserNavController extends Controller
 {
     use Concerns\HasNavBuilder;

--- a/src/Http/Controllers/CP/Preferences/PreferenceController.php
+++ b/src/Http/Controllers/CP/Preferences/PreferenceController.php
@@ -10,6 +10,8 @@ use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class PreferenceController extends CpController
 {
     public function index()

--- a/src/Http/Controllers/CP/Preferences/UserPreferenceController.php
+++ b/src/Http/Controllers/CP/Preferences/UserPreferenceController.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class UserPreferenceController extends CpController
 {
     use ManagesPreferences;

--- a/src/Http/Controllers/CP/SelectSiteController.php
+++ b/src/Http/Controllers/CP/SelectSiteController.php
@@ -4,6 +4,8 @@ namespace Statamic\Http\Controllers\CP;
 
 use Statamic\Facades\Site;
 
+use function Statamic\trans as __;
+
 class SelectSiteController extends CpController
 {
     public function select($handle)

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -18,6 +18,8 @@ use Statamic\Query\Scopes\Filters\Concerns\QueriesFilters;
 use Statamic\Rules\Slug;
 use Statamic\Rules\UniqueTermValue;
 
+use function Statamic\trans as __;
+
 class TermsController extends CpController
 {
     use ExtractsFromTermFields,

--- a/src/Http/Controllers/CP/Users/UserGroupsController.php
+++ b/src/Http/Controllers/CP/Users/UserGroupsController.php
@@ -11,6 +11,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Middleware\RequireStatamicPro;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class UserGroupsController extends CpController
 {
     public function __construct()

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -24,6 +24,8 @@ use Statamic\Rules\UniqueUserValue;
 use Statamic\Search\Result;
 use Symfony\Component\Mailer\Exception\TransportException;
 
+use function Statamic\trans as __;
+
 class UsersController extends CpController
 {
     use ExtractsFromUserFields,

--- a/src/Http/Controllers/CP/Utilities/CacheController.php
+++ b/src/Http/Controllers/CP/Utilities/CacheController.php
@@ -14,6 +14,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\StaticCaching\Cacher;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class CacheController extends CpController
 {
     public function index()

--- a/src/Http/Controllers/CP/Utilities/EmailController.php
+++ b/src/Http/Controllers/CP/Utilities/EmailController.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Mail;
 use Statamic\Mail\Test;
 
+use function Statamic\trans as __;
+
 class EmailController
 {
     public function send(Request $request)

--- a/src/Http/Controllers/CP/Utilities/GitController.php
+++ b/src/Http/Controllers/CP/Utilities/GitController.php
@@ -6,6 +6,8 @@ use Inertia\Inertia;
 use Statamic\Facades\Git;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class GitController extends CpController
 {
     public function index()

--- a/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
+++ b/src/Http/Controllers/CP/Utilities/UpdateSearchController.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Search;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class UpdateSearchController extends CpController
 {
     public function update(Request $request)

--- a/src/Http/Controllers/Concerns/HandlesLogins.php
+++ b/src/Http/Controllers/Concerns/HandlesLogins.php
@@ -11,6 +11,8 @@ use Statamic\Contracts\Auth\User;
 use Statamic\Events\TwoFactorAuthenticationChallenged;
 use Statamic\Facades\URL;
 
+use function Statamic\trans;
+
 trait HandlesLogins
 {
     use ThrottlesLogins;

--- a/src/Http/Controllers/FormController.php
+++ b/src/Http/Controllers/FormController.php
@@ -19,6 +19,8 @@ use Statamic\Http\Requests\FrontendFormRequest;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class FormController extends Controller
 {
     /**

--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -13,6 +13,8 @@ use Statamic\Facades\URL;
 use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Http\Middleware\CP\RedirectIfAuthorized;
 
+use function Statamic\trans as __;
+
 class ResetPasswordController extends Controller
 {
     use ResetsPasswords;

--- a/src/Http/Controllers/User/LoginController.php
+++ b/src/Http/Controllers/User/LoginController.php
@@ -13,6 +13,8 @@ use Statamic\Http\Controllers\Concerns\HandlesLogins;
 use Statamic\Http\Controllers\Controller;
 use Statamic\Http\Requests\UserLoginRequest;
 
+use function Statamic\trans as __;
+
 class LoginController extends Controller
 {
     use HandlesLogins;

--- a/src/Http/Controllers/User/PasskeyController.php
+++ b/src/Http/Controllers/User/PasskeyController.php
@@ -9,6 +9,8 @@ use Statamic\Facades\User;
 use Statamic\Facades\WebAuthn;
 use Statamic\Http\Controllers\Controller;
 
+use function Statamic\trans as __;
+
 class PasskeyController extends Controller
 {
     public function create()

--- a/src/Http/Controllers/User/PasswordController.php
+++ b/src/Http/Controllers/User/PasswordController.php
@@ -7,6 +7,8 @@ use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Requests\UserPasswordRequest;
 
+use function Statamic\trans as __;
+
 class PasswordController
 {
     public function __invoke(UserPasswordRequest $request)

--- a/src/Http/Controllers/User/ProfileController.php
+++ b/src/Http/Controllers/User/ProfileController.php
@@ -6,6 +6,8 @@ use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Requests\UserProfileRequest;
 
+use function Statamic\trans as __;
+
 class ProfileController
 {
     public function __invoke(UserProfileRequest $request)

--- a/src/Http/Controllers/User/RegisterController.php
+++ b/src/Http/Controllers/User/RegisterController.php
@@ -13,6 +13,8 @@ use Statamic\Facades\User;
 use Statamic\Http\Requests\UserRegisterRequest;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class RegisterController
 {
     public function __invoke(UserRegisterRequest $request)

--- a/src/Http/Controllers/User/TwoFactorAuthenticationController.php
+++ b/src/Http/Controllers/User/TwoFactorAuthenticationController.php
@@ -11,6 +11,8 @@ use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class TwoFactorAuthenticationController extends CpController
 {
     public function enable(Request $request, EnableTwoFactorAuthentication $enable)

--- a/src/Http/Controllers/User/TwoFactorRecoveryCodesController.php
+++ b/src/Http/Controllers/User/TwoFactorRecoveryCodesController.php
@@ -9,6 +9,8 @@ use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class TwoFactorRecoveryCodesController extends CpController
 {
     public function show(Request $request)

--- a/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
@@ -15,6 +15,8 @@ use Statamic\Facades\User;
 use Statamic\Licensing\LicenseManager;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class HandleAuthenticatedInertiaRequests
 {
     public function handle(Request $request, Closure $next)

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -7,6 +7,8 @@ use Inertia\Middleware;
 use Statamic\CP\Toasts\Manager;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class HandleInertiaRequests extends Middleware
 {
     protected $rootView = 'statamic::layout';

--- a/src/Http/Middleware/CP/RedirectIfAuthorized.php
+++ b/src/Http/Middleware/CP/RedirectIfAuthorized.php
@@ -6,6 +6,8 @@ use Closure;
 use Illuminate\Support\Facades\Auth;
 use Statamic\Facades\User;
 
+use function Statamic\trans as __;
+
 class RedirectIfAuthorized
 {
     /**

--- a/src/Http/Middleware/RequireStatamicPro.php
+++ b/src/Http/Middleware/RequireStatamicPro.php
@@ -6,6 +6,8 @@ use Closure;
 use Statamic\Exceptions\StatamicProAuthorizationException;
 use Statamic\Statamic;
 
+use function Statamic\trans as __;
+
 class RequireStatamicPro
 {
     public function handle($request, Closure $next)

--- a/src/Http/Middleware/StacheLock.php
+++ b/src/Http/Middleware/StacheLock.php
@@ -5,6 +5,8 @@ namespace Statamic\Http\Middleware;
 use Closure;
 use Statamic\Facades\Stache;
 
+use function Statamic\trans as __;
+
 class StacheLock
 {
     public function handle($request, Closure $next)

--- a/src/Http/Requests/Auth/ElevatedSessionConfirmationRequest.php
+++ b/src/Http/Requests/Auth/ElevatedSessionConfirmationRequest.php
@@ -4,6 +4,8 @@ namespace Statamic\Http\Requests\Auth;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+use function Statamic\trans as __;
+
 class ElevatedSessionConfirmationRequest extends FormRequest
 {
     public function authorize(): bool

--- a/src/Http/Requests/TwoFactorChallengeRequest.php
+++ b/src/Http/Requests/TwoFactorChallengeRequest.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Auth\TwoFactor\TwoFactorAuthenticationProvider;
 
+use function Statamic\trans as __;
+
 class TwoFactorChallengeRequest extends FormRequest
 {
     /**

--- a/src/Http/Requests/UserLoginRequest.php
+++ b/src/Http/Requests/UserLoginRequest.php
@@ -10,6 +10,8 @@ use Illuminate\Validation\ValidationException;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 
+use function Statamic\trans as __;
+
 class UserLoginRequest extends FormRequest
 {
     use Localizable;

--- a/src/Http/Requests/UserRegisterRequest.php
+++ b/src/Http/Requests/UserRegisterRequest.php
@@ -13,6 +13,8 @@ use Statamic\Facades\URL;
 use Statamic\Facades\User;
 use Statamic\Rules\UniqueUserValue;
 
+use function Statamic\trans as __;
+
 class UserRegisterRequest extends FormRequest
 {
     use Localizable;

--- a/src/Http/Resources/CP/Assets/SearchedAssetsCollection.php
+++ b/src/Http/Resources/CP/Assets/SearchedAssetsCollection.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Resources\Json\ResourceCollection;
 use Statamic\CP\Column;
 use Statamic\Http\Resources\CP\Concerns\HasRequestedColumns;
 
+use function Statamic\trans as __;
+
 class SearchedAssetsCollection extends ResourceCollection
 {
     use HasRequestedColumns;

--- a/src/Http/Resources/CP/Entries/EntriesFieldtypeEntries.php
+++ b/src/Http/Resources/CP/Entries/EntriesFieldtypeEntries.php
@@ -6,6 +6,8 @@ use Illuminate\Pagination\AbstractPaginator;
 use Statamic\CP\Column;
 use Statamic\Fieldtypes\Entries as EntriesFieldtype;
 
+use function Statamic\trans as __;
+
 class EntriesFieldtypeEntries extends Entries
 {
     private EntriesFieldtype $fieldtype;

--- a/src/Http/Resources/CP/Taxonomies/TermsFieldtypeTerms.php
+++ b/src/Http/Resources/CP/Taxonomies/TermsFieldtypeTerms.php
@@ -6,6 +6,8 @@ use Illuminate\Pagination\AbstractPaginator;
 use Statamic\CP\Column;
 use Statamic\Fieldtypes\Terms as TermsFieldtype;
 
+use function Statamic\trans as __;
+
 class TermsFieldtypeTerms extends Terms
 {
     private TermsFieldtype $fieldtype;

--- a/src/Http/Resources/CP/Users/ListedUser.php
+++ b/src/Http/Resources/CP/Users/ListedUser.php
@@ -5,6 +5,8 @@ namespace Statamic\Http\Resources\CP\Users;
 use Illuminate\Http\Resources\Json\JsonResource;
 use Statamic\Facades\User;
 
+use function Statamic\trans as __;
+
 class ListedUser extends JsonResource
 {
     protected $blueprint;

--- a/src/Http/Resources/CP/Users/Users.php
+++ b/src/Http/Resources/CP/Users/Users.php
@@ -9,6 +9,8 @@ use Statamic\Http\Resources\CP\Concerns\HasRequestedColumns;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Users extends ResourceCollection
 {
     use HasRequestedColumns;

--- a/src/Licensing/AddonLicense.php
+++ b/src/Licensing/AddonLicense.php
@@ -5,6 +5,8 @@ namespace Statamic\Licensing;
 use Statamic\Facades\Addon;
 use Statamic\Support\Arr;
 
+use function Statamic\trans;
+
 class AddonLicense extends License
 {
     protected $package;

--- a/src/Licensing/License.php
+++ b/src/Licensing/License.php
@@ -4,6 +4,8 @@ namespace Statamic\Licensing;
 
 use Statamic\Support\Arr;
 
+use function Statamic\trans;
+
 abstract class License
 {
     protected $response;

--- a/src/Licensing/LicenseManager.php
+++ b/src/Licensing/LicenseManager.php
@@ -7,6 +7,8 @@ use Illuminate\Support\MessageBag;
 use Statamic\Events\LicensesRefreshed;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class LicenseManager
 {
     protected $outpost;

--- a/src/Licensing/LicenseManager.php
+++ b/src/Licensing/LicenseManager.php
@@ -8,6 +8,7 @@ use Statamic\Events\LicensesRefreshed;
 use Statamic\Support\Arr;
 
 use function Statamic\trans as __;
+use function Statamic\trans_choice;
 
 class LicenseManager
 {

--- a/src/Licensing/StatamicLicense.php
+++ b/src/Licensing/StatamicLicense.php
@@ -5,6 +5,8 @@ namespace Statamic\Licensing;
 use Statamic\Statamic;
 use Statamic\Support\Arr;
 
+use function Statamic\trans;
+
 class StatamicLicense extends License
 {
     public function pro()

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -37,6 +37,8 @@ use Statamic\Support\Traits\ChecksDumpability;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 use Stringy\StaticStringy as Stringy;
 
+use function Statamic\trans as __;
+
 class CoreModifiers extends Modifier
 {
     use ChecksDumpability {

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -37,7 +37,9 @@ use Statamic\Support\Traits\ChecksDumpability;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 use Stringy\StaticStringy as Stringy;
 
+use function Statamic\trans;
 use function Statamic\trans as __;
+use function Statamic\trans_choice;
 
 class CoreModifiers extends Modifier
 {

--- a/src/Notifications/ActivateAccount.php
+++ b/src/Notifications/ActivateAccount.php
@@ -5,6 +5,8 @@ namespace Statamic\Notifications;
 use Illuminate\Notifications\Messages\MailMessage;
 use Statamic\Auth\Passwords\PasswordReset as PasswordResetManager;
 
+use function Statamic\trans as __;
+
 class ActivateAccount extends PasswordReset
 {
     public static $subject;

--- a/src/Notifications/ElevatedSessionVerificationCode.php
+++ b/src/Notifications/ElevatedSessionVerificationCode.php
@@ -5,6 +5,8 @@ namespace Statamic\Notifications;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
+use function Statamic\trans as __;
+
 class ElevatedSessionVerificationCode extends Notification
 {
     public function __construct(public string $verificationCode)

--- a/src/Notifications/PasswordReset.php
+++ b/src/Notifications/PasswordReset.php
@@ -7,6 +7,8 @@ use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Statamic\Auth\Passwords\PasswordReset as PasswordResetManager;
 
+use function Statamic\trans as __;
+
 class PasswordReset extends Notification
 {
     use Queueable;

--- a/src/Preferences/Preferences.php
+++ b/src/Preferences/Preferences.php
@@ -7,6 +7,8 @@ use Facades\Statamic\Preferences\CorePreferences;
 use Illuminate\Support\Arr;
 use Statamic\Facades\User;
 
+use function Statamic\trans as __;
+
 class Preferences
 {
     protected $dotted = [];

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -28,6 +28,8 @@ use Statamic\Statamic;
 use Statamic\Tokens\Handlers\LivePreview;
 use Statamic\View\Scaffolding\TemplateGenerator;
 
+use function Statamic\trans as __;
+
 class AppServiceProvider extends ServiceProvider
 {
     protected $root = __DIR__.'/../..';

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -31,6 +31,8 @@ use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\PublicKeyCredentialRpEntity;
 
+use function Statamic\trans_choice;
+
 class AuthServiceProvider extends ServiceProvider
 {
     protected $policies = [

--- a/src/Query/Scopes/Filters/AssetProperties.php
+++ b/src/Query/Scopes/Filters/AssetProperties.php
@@ -9,6 +9,8 @@ use Statamic\Query\Scopes\Filters\Fields\FileSize;
 use Statamic\Query\Scopes\Filters\Fields\FileType;
 use Statamic\Query\Scopes\Filters\Fields\Orientation;
 
+use function Statamic\trans as __;
+
 class AssetProperties extends Fields
 {
     public static function title()

--- a/src/Query/Scopes/Filters/Blueprint.php
+++ b/src/Query/Scopes/Filters/Blueprint.php
@@ -7,6 +7,8 @@ use Statamic\Facades\Taxonomy;
 use Statamic\Query\Scopes\Filter;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Blueprint extends Filter
 {
     protected $pinned = true;

--- a/src/Query/Scopes/Filters/Collection.php
+++ b/src/Query/Scopes/Filters/Collection.php
@@ -7,6 +7,8 @@ use Statamic\Facades;
 use Statamic\Facades\User;
 use Statamic\Query\Scopes\Filter;
 
+use function Statamic\trans as __;
+
 class Collection extends Filter
 {
     protected $pinned = true;

--- a/src/Query/Scopes/Filters/Fields/Bard.php
+++ b/src/Query/Scopes/Filters/Fields/Bard.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Bard extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Date.php
+++ b/src/Query/Scopes/Filters/Fields/Date.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Illuminate\Support\Carbon;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Date extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Dimensions.php
+++ b/src/Query/Scopes/Filters/Fields/Dimensions.php
@@ -4,6 +4,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Illuminate\Support\Arr;
 
+use function Statamic\trans as __;
+
 /**
  * Handle width, height, shortest side, longest side queries.
  */

--- a/src/Query/Scopes/Filters/Fields/Duration.php
+++ b/src/Query/Scopes/Filters/Fields/Duration.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Illuminate\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 /**
  * Integer filter but with a "seconds" appended to the input for clarity
  */

--- a/src/Query/Scopes/Filters/Fields/Entries.php
+++ b/src/Query/Scopes/Filters/Fields/Entries.php
@@ -6,6 +6,8 @@ use Statamic\Facades;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Entries extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
@@ -6,6 +6,8 @@ use Statamic\Extend\HasFields;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class FieldtypeFilter
 {
     use HasFields;

--- a/src/Query/Scopes/Filters/Fields/FileSize.php
+++ b/src/Query/Scopes/Filters/Fields/FileSize.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Illuminate\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 /**
  * Special integer field that takes input in KB, queries in bytes, and displays a human-readable badge.
  */

--- a/src/Query/Scopes/Filters/Fields/FileType.php
+++ b/src/Query/Scopes/Filters/Fields/FileType.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Illuminate\Support\Arr;
 use Statamic\Support\FileTypes;
 
+use function Statamic\trans as __;
+
 class FileType extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Grid.php
+++ b/src/Query/Scopes/Filters/Fields/Grid.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Grid extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Number.php
+++ b/src/Query/Scopes/Filters/Fields/Number.php
@@ -4,6 +4,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 abstract class Number extends FieldtypeFilter
 {
     abstract protected function valueFieldtype();

--- a/src/Query/Scopes/Filters/Fields/Orientation.php
+++ b/src/Query/Scopes/Filters/Fields/Orientation.php
@@ -4,6 +4,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Illuminate\Support\Arr;
 
+use function Statamic\trans as __;
+
 /**
  * Landscape, portrait, square orientation queries.
  */

--- a/src/Query/Scopes/Filters/Fields/Replicator.php
+++ b/src/Query/Scopes/Filters/Fields/Replicator.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Replicator extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Template.php
+++ b/src/Query/Scopes/Filters/Fields/Template.php
@@ -4,6 +4,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Template extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Terms.php
+++ b/src/Query/Scopes/Filters/Fields/Terms.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Statamic\Facades;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Terms extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Textarea.php
+++ b/src/Query/Scopes/Filters/Fields/Textarea.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Textarea extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/Toggle.php
+++ b/src/Query/Scopes/Filters/Fields/Toggle.php
@@ -4,6 +4,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 
 use Illuminate\Support\Arr;
 
+use function Statamic\trans as __;
+
 class Toggle extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Fields/User.php
+++ b/src/Query/Scopes/Filters/Fields/User.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters\Fields;
 use Statamic\Facades\User as Users;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class User extends FieldtypeFilter
 {
     public function fieldItems()

--- a/src/Query/Scopes/Filters/Status.php
+++ b/src/Query/Scopes/Filters/Status.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters;
 use Statamic\Facades\Collection;
 use Statamic\Query\Scopes\Filter;
 
+use function Statamic\trans as __;
+
 class Status extends Filter
 {
     public $pinned = true;

--- a/src/Query/Scopes/Filters/UserGroup.php
+++ b/src/Query/Scopes/Filters/UserGroup.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters;
 use Statamic\Facades;
 use Statamic\Query\Scopes\Filter;
 
+use function Statamic\trans as __;
+
 class UserGroup extends Filter
 {
     protected $pinned = true;

--- a/src/Query/Scopes/Filters/UserRole.php
+++ b/src/Query/Scopes/Filters/UserRole.php
@@ -5,6 +5,8 @@ namespace Statamic\Query\Scopes\Filters;
 use Statamic\Facades\Role;
 use Statamic\Query\Scopes\Filter;
 
+use function Statamic\trans as __;
+
 class UserRole extends Filter
 {
     protected $pinned = true;

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -14,6 +14,8 @@ use Statamic\Facades\User;
 use Statamic\Facades\YAML;
 use Statamic\Support\Str;
 
+use function Statamic\trans as __;
+
 class Sites
 {
     protected $sites;

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -424,6 +424,15 @@ class Statamic
         return $line;
     }
 
+    public static function transChoice($key, $number, $replace = [], $locale = null)
+    {
+        if (is_array(\__($key, $replace, $locale))) {
+            return $key;
+        }
+
+        return \trans_choice($key, $number, $replace, $locale);
+    }
+
     public static function isWorker()
     {
         if (! App::runningInConsole()) {

--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -23,6 +23,8 @@ use Statamic\StaticCaching\NoCache\Session;
 use Statamic\StaticCaching\Replacer;
 use Statamic\StaticCaching\ResponseStatus;
 
+use function Statamic\trans as __;
+
 class Cache
 {
     /**

--- a/src/StaticCaching/NoCache/CsrfTokenController.php
+++ b/src/StaticCaching/NoCache/CsrfTokenController.php
@@ -7,6 +7,7 @@ class CsrfTokenController
     public function __invoke()
     {
         return [
+            'foo' => __('bar'),
             'csrf' => csrf_token(),
         ];
     }

--- a/src/StaticCaching/NoCache/CsrfTokenController.php
+++ b/src/StaticCaching/NoCache/CsrfTokenController.php
@@ -7,7 +7,6 @@ class CsrfTokenController
     public function __invoke()
     {
         return [
-            'foo' => __('bar'),
             'csrf' => csrf_token(),
         ];
     }

--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -8,6 +8,8 @@ use Statamic\Facades\Compare;
 use Stringy\StaticStringy;
 use voku\helper\ASCII;
 
+use function Statamic\trans;
+
 /** @mixin \Illuminate\Support\Str */
 class Str
 {

--- a/src/Tags/Trans.php
+++ b/src/Tags/Trans.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Tags;
 
+use function Statamic\trans as __;
+
 class Trans extends Tags
 {
     /**

--- a/src/Tags/TransChoice.php
+++ b/src/Tags/TransChoice.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Tags;
 
+use function Statamic\trans_choice;
+
 class TransChoice extends Tags
 {
     /**

--- a/src/namespaced_helpers.php
+++ b/src/namespaced_helpers.php
@@ -6,3 +6,8 @@ function trans($key, $replace = [], $locale = null)
 {
     return Statamic::trans($key, $replace, $locale);
 }
+
+function trans_choice($key, $number, $replace = [], $locale = null)
+{
+    return Statamic::transChoice($key, $number, $replace, $locale);
+}

--- a/tests/StatamicTest.php
+++ b/tests/StatamicTest.php
@@ -100,6 +100,40 @@ class StatamicTest extends TestCase
     }
 
     #[Test]
+    public function it_translates_a_string()
+    {
+        app('translator')->addNamespace('package', __DIR__.'/__fixtures__/lang');
+
+        $this->assertEquals('Hello', Statamic::trans('package::messages.hello'));
+        $this->assertEquals('Hello, Bob', Statamic::trans('package::messages.hello_name', ['name' => 'Bob']));
+    }
+
+    #[Test]
+    public function trans_returns_the_key_when_the_value_is_an_array()
+    {
+        app('translator')->addNamespace('package', __DIR__.'/__fixtures__/lang');
+
+        $this->assertEquals('package::messages', Statamic::trans('package::messages'));
+    }
+
+    #[Test]
+    public function it_pluralizes_with_trans_choice()
+    {
+        app('translator')->addNamespace('package', __DIR__.'/__fixtures__/lang');
+
+        $this->assertEquals('There is one apple', Statamic::transChoice('package::messages.apples', 1));
+        $this->assertEquals('There are 5 apples', Statamic::transChoice('package::messages.apples', 5));
+    }
+
+    #[Test]
+    public function trans_choice_returns_the_key_when_the_value_is_an_array()
+    {
+        app('translator')->addNamespace('package', __DIR__.'/__fixtures__/lang');
+
+        $this->assertEquals('package::messages', Statamic::transChoice('package::messages', 1));
+    }
+
+    #[Test]
     public function it_aliases_query_builders()
     {
         app()->bind('statamic.queries.test', function () {

--- a/tests/__fixtures__/lang/en/messages.php
+++ b/tests/__fixtures__/lang/en/messages.php
@@ -3,4 +3,5 @@
 return [
     'hello' => 'Hello',
     'hello_name' => 'Hello, :name',
+    'apples' => 'There is one apple|There are :count apples',
 ];


### PR DESCRIPTION
## What & Why

Fixes a lang-file/title collision where a translation key resolving to an array (e.g. a lang-file group whose name collides with a string key) caused incorrect output. Statamic's `Statamic\trans()` wrapper detects this case and falls back to returning the key, but only if call sites actually route through the wrapper — Laravel's global `trans()`, `__()`, and `trans_choice()` do not have this protection.

This has happened many times in the past. We've fixed the specifically reported locations, but this keeps popping up, so this PR addresses it.

#2341, #4852, #6326, #7672, #14609
#5144, #6331, #9525

## Changes

### Helpers
- Added a `Statamic\trans_choice()` namespaced helper (and `Statamic::transChoice()` static method) that mirrors the existing `Statamic\trans()` — returning the key when the lookup resolves to an array, otherwise delegating to Laravel's `trans_choice()` for normal pluralization.

### Call-site imports
- Added `use function Statamic\trans as __;` to every file using `__()` (240 files) — routes the alias through Statamic's wrapper.
- Added `use function Statamic\trans;` to files calling `trans()` directly without the alias.
- Added `use function Statamic\trans_choice;` to files calling `trans_choice()` directly.

PHP's `use function` rebinds unqualified calls at compile time, so no call-site rewrites were needed — just imports.

### CI enforcement
- Added `scripts/check-trans-import.sh` which scans `src/**/*.php` and `resources/views/**/*.blade.php` for unqualified `__()`, `trans()`, and `trans_choice()` calls and fails if the corresponding `use function Statamic\…` import is missing.
- Wired into `.github/workflows/code-style-lint.yml` to run on every push.

### Tests
- Added tests for `Statamic::trans` and `Statamic::transChoice` covering the happy path and the array-collision fallback.


Closes #14609