### PR TITLE
[6.x] Fix HoverCard arrow not displaying

### DIFF
--- a/resources/js/components/ui/HoverCard.vue
+++ b/resources/js/components/ui/HoverCard.vue
@@ -28,7 +28,7 @@ const props = defineProps({
 
 const HoverCardContentClasses = cva({
     base: [
-        'rounded-xl bg-white dark:bg-gray-800 outline-hidden overflow-hidden',
+        'rounded-xl bg-white dark:bg-gray-800 outline-hidden',
         'border border-gray-200 dark:border-white/10 dark:border-b-0 shadow-lg',
         'duration-100 will-change-[transform,opacity]',
         'data-[state=open]:animate-in data-[state=closed]:animate-out',
@@ -84,7 +84,7 @@ function updateOpen(value) {
                 :side
             >
                 <slot v-bind="slotProps" />
-                <HoverCardArrow v-if="arrow" class="fill-white stroke-gray-300" />
+                <HoverCardArrow v-if="arrow" class="fill-white stroke-gray-300 dark:fill-gray-800 dark:stroke-white/10" />
             </HoverCardContent>
         </HoverCardPortal>
     </HoverCardRoot>


### PR DESCRIPTION
## Summary

The `HoverCardArrow` was hidden because `overflow-hidden` was being applied to the `HoverCardContent`, which clipped the arrow that renders outside the content's bounds.

Also added dark mode classes to the arrow so it matches the card's dark background.

<img width="745" height="401" alt="CleanShot 2026-05-06 at 14 09 10" src="https://github.com/user-attachments/assets/bc7c01b9-8f0f-4120-a2dc-e609333244d8" />
