### PR TITLE
[6.x] Add Timezones components

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -28,7 +28,7 @@ const storybookConfig = {
     selectedSite: 'default',
     lang: 'en',
     translationLocale: 'en',
-    appTimezone: 'UTC',
+    displayTimezone: 'UTC',
     asciiReplaceExtraSymbols: false,
     charmap: { currency: {}, currency_short: {} },
 };

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,8 +14,24 @@ import PortalVue from 'portal-vue';
 import FullscreenHeader from '@/components/publish/FullscreenHeader.vue';
 import Portal from '@/components/portals/Portal.vue';
 import PortalTargets from '@/components/portals/PortalTargets.vue';
-import {keys, portals, slug, stacks} from '@api';
+import {config as statamicConfig, keys, portals, slug, stacks} from '@api';
 import useGlobalEventBus from '@/composables/global-event-bus';
+
+const storybookConfig = {
+    linkToDocs: true,
+    paginationSize: 50,
+    paginationSizeOptions: [10, 25, 50, 100, 500],
+    sites: [{
+        handle: 'default',
+        lang: 'en',
+    }],
+    selectedSite: 'default',
+    lang: 'en',
+    translationLocale: 'en',
+    appTimezone: 'UTC',
+    asciiReplaceExtraSymbols: false,
+    charmap: { currency: {}, currency_short: {} },
+};
 
 // Intercept Inertia navigation and log to Actions tab.
 router.on('before', (event) => {
@@ -26,25 +42,12 @@ router.on('before', (event) => {
 setup(async (app) => {
   window.__ = translate;
   window.__n = translateChoice;
+  statamicConfig.initialize(storybookConfig);
 
   window.Statamic = {
       $config: {
           get(key) {
-              const config = {
-                  linkToDocs: true,
-                  paginationSize: 50,
-                  paginationSizeOptions: [10, 25, 50, 100, 500],
-                  sites: [{
-                      handle: 'default',
-                      lang: 'en',
-                  }],
-                  selectedSite: 'default',
-                  lang: 'en',
-                  asciiReplaceExtraSymbols: false,
-                  charmap: { currency: {}, currency_short: {} },
-              };
-
-              return config[key] ?? null;
+              return storybookConfig[key] ?? null;
           }
       },
       $commandPalette: {

--- a/packages/cms/src/ui.js
+++ b/packages/cms/src/ui.js
@@ -117,6 +117,8 @@ export const {
     Text,
     Textarea,
     TimePicker,
+    TimezoneHoverCard,
+    Timezones,
     ToggleGroup,
     ToggleItem,
     Widget,

--- a/resources/js/bootstrap/cms/ui.js
+++ b/resources/js/bootstrap/cms/ui.js
@@ -117,6 +117,8 @@ export {
     Text,
     Textarea,
     TimePicker,
+    TimezoneHoverCard,
+    Timezones,
     ToggleGroup,
     ToggleItem,
     Widget,

--- a/resources/js/components/fieldtypes/DateIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateIndexFieldtype.vue
@@ -1,9 +1,15 @@
 <template>
     <div v-if="showTimezoneCard">
         <template v-if="isRange">
-            <TimezoneHoverCard :date="value.start" side="top"><span v-text="formattedStart"></span></TimezoneHoverCard><span> – </span><TimezoneHoverCard :date="value.end" side="top"><span v-text="formattedEnd"></span></TimezoneHoverCard>
+            <TimezoneHoverCard :date="value.start" side="top" :offset="10">
+                <span v-text="formattedStart"></span>
+            </TimezoneHoverCard>
+            <span> – </span>
+            <TimezoneHoverCard :date="value.end" side="top" :offset="10">
+                <span v-text="formattedEnd"></span>
+            </TimezoneHoverCard>
         </template>
-        <TimezoneHoverCard v-else :date="value.date" side="top">
+        <TimezoneHoverCard v-else :date="value.date" side="top" :offset="10">
             <span v-text="formatted"></span>
         </TimezoneHoverCard>
     </div>

--- a/resources/js/components/fieldtypes/DateIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateIndexFieldtype.vue
@@ -1,18 +1,7 @@
 <template>
-    <div v-if="showTimezoneCard">
-        <template v-if="isRange">
-            <TimezoneHoverCard :date="value.start" side="top" :offset="10">
-                <span v-text="formattedStart"></span>
-            </TimezoneHoverCard>
-            <span> – </span>
-            <TimezoneHoverCard :date="value.end" side="top" :offset="10">
-                <span v-text="formattedEnd"></span>
-            </TimezoneHoverCard>
-        </template>
-        <TimezoneHoverCard v-else :date="value.date" side="top" :offset="10">
-            <span v-text="formatted"></span>
-        </TimezoneHoverCard>
-    </div>
+    <TimezoneHoverCard v-if="showTimezoneCard" :date="hoverCardDate" side="top" :offset="10">
+        <span v-text="formatted"></span>
+    </TimezoneHoverCard>
     <div v-else v-text="formatted"></div>
 </template>
 
@@ -52,6 +41,8 @@ const formatter = computed(() => {
 const formattedStart = computed(() => formatter.value.date(new Date(props.value.start)).toString());
 
 const formattedEnd = computed(() => formatter.value.date(new Date(props.value.end)).toString());
+
+const hoverCardDate = computed(() => isRange.value ? props.value : props.value.date);
 
 const formatted = computed(() => {
     if (!props.value) {

--- a/resources/js/components/fieldtypes/DateIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateIndexFieldtype.vue
@@ -1,10 +1,19 @@
 <template>
-    <div v-text="formatted" v-tooltip="tooltip"></div>
+    <div v-if="showTimezoneCard">
+        <template v-if="isRange">
+            <TimezoneHoverCard :date="value.start" side="top"><span v-text="formattedStart"></span></TimezoneHoverCard><span> – </span><TimezoneHoverCard :date="value.end" side="top"><span v-text="formattedEnd"></span></TimezoneHoverCard>
+        </template>
+        <TimezoneHoverCard v-else :date="value.date" side="top">
+            <span v-text="formatted"></span>
+        </TimezoneHoverCard>
+    </div>
+    <div v-else v-text="formatted"></div>
 </template>
 
 <script setup>
 import Fieldtype from '@/components/fieldtypes/index-fieldtype.js';
 import DateFormatter from '@/components/DateFormatter.js';
+import { TimezoneHoverCard } from '@ui';
 import { computed } from 'vue';
 
 const emit = defineEmits(Fieldtype.emits);
@@ -19,47 +28,35 @@ const timezoneOption = computed(() => {
 
 const showTimeInValue = computed(() => props.value?.format_has_time && props.value?.time_enabled);
 
-const showTooltip = computed(() => props.value?.format_has_time);
+const showTimezoneCard = computed(() => props.value?.format_has_time);
+
+const isRange = computed(() => props.value?.mode === 'range');
+
+const formatter = computed(() => {
+    const options = { preset: showTimeInValue.value ? 'datetime' : 'date' };
+    if (!props.value?.format_has_time) {
+        options.timeZone = 'UTC';
+    } else {
+        Object.assign(options, timezoneOption.value);
+    }
+
+    return new DateFormatter().options(options);
+});
+
+const formattedStart = computed(() => formatter.value.date(new Date(props.value.start)).toString());
+
+const formattedEnd = computed(() => formatter.value.date(new Date(props.value.end)).toString());
 
 const formatted = computed(() => {
     if (!props.value) {
         return null;
     }
 
-    const options = { preset: showTimeInValue.value ? 'datetime' : 'date' };
-    if (!props.value.format_has_time) {
-        options.timeZone = 'UTC';
-    } else {
-        Object.assign(options, timezoneOption.value);
+    if (isRange.value) {
+        return formattedStart.value + ' – ' + formattedEnd.value;
     }
 
-    const formatter = new DateFormatter().options(options);
-
-    if (props.value.mode === 'range') {
-        let start = new Date(props.value.start);
-        let end = new Date(props.value.end);
-
-        return formatter.date(start) + ' – ' + formatter.date(end);
-    }
-
-    return formatter.date(props.value.date).toString();
-});
-
-const tooltip = computed(() => {
-    if (!props.value || !showTooltip.value) {
-        return null;
-    }
-
-    const formatter = new DateFormatter().options({ dateStyle: 'long', timeStyle: 'long', ...timezoneOption.value });
-
-    if (props.value.mode === 'range') {
-        let start = new Date(props.value.start);
-        let end = new Date(props.value.end);
-
-        return formatter.date(start) + ' – ' + formatter.date(end);
-    }
-
-    return formatter.date(props.value.date).toString();
+    return formatter.value.date(props.value.date).toString();
 });
 
 defineExpose(expose);

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -26,6 +26,7 @@ import Button from '../Button/Button.vue';
 import Calendar from '../Calendar/Calendar.vue';
 import Icon from '../Icon/Icon.vue';
 import Text from '../Text.vue';
+import TimezoneHoverCard from '../TimezoneHoverCard.vue';
 
 const emit = defineEmits(['update:modelValue']);
 
@@ -99,16 +100,13 @@ const calendarEvents = computed(() => ({
 
 const timeZoneName = computed(() => props.modelValue?.timeZone ?? null);
 
-const formatTimeZone = (style) => {
+const timeZoneLabel = computed(() => {
     const tz = timeZoneName.value;
     if (!tz) return null;
 
-    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: style }).formatToParts(props.modelValue.toDate());
+    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.toDate());
     return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
-};
-
-const timeZoneLabel = computed(() => formatTimeZone('short'));
-const timeZoneTooltip = computed(() => formatTimeZone('long'));
+});
 
 const isInvalid = computed(() => {
     // Check if the component has invalid state from form validation
@@ -202,13 +200,14 @@ const getInputLabel = (part) => {
                                 </div>
                             </template>
                         </div>
-                        <Text
+                        <TimezoneHoverCard
                             v-if="timeZoneLabel"
-                            class="text-gray-600 dark:text-gray-400 me-1"
-                            size="xs"
-                            v-tooltip="timeZoneTooltip"
-                            :text="timeZoneLabel"
-                        />
+                            :date="modelValue.toDate()"
+                            :additional-timezones="[{ timezone: timeZoneName, label: __('This field') }]"
+                            side="top"
+                        >
+                            <Text class="text-gray-600 dark:text-gray-400 me-1" size="xs" :text="timeZoneLabel" />
+                        </TimezoneHoverCard>
                         <Button
                             v-if="clearable && !readOnly"
                             @click="emit('update:modelValue', null)"

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -25,6 +25,7 @@ import Button from '../Button/Button.vue';
 import Calendar from '../Calendar/Calendar.vue';
 import Icon from '../Icon/Icon.vue';
 import Text from '../Text.vue';
+import TimezoneHoverCard from '../TimezoneHoverCard.vue';
 import { parseAbsoluteToLocal } from '@internationalized/date';
 
 const emit = defineEmits(['update:modelValue']);
@@ -95,16 +96,18 @@ const calendarEvents = computed(() => ({
 
 const timeZoneName = computed(() => props.modelValue?.start?.timeZone ?? null);
 
-const formatTimeZone = (style) => {
+const timeZoneLabel = computed(() => {
     const tz = timeZoneName.value;
     if (!tz) return null;
 
-    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: style }).formatToParts(props.modelValue.start.toDate());
+    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.start.toDate());
     return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
-};
+});
 
-const timeZoneLabel = computed(() => formatTimeZone('short'));
-const timeZoneTooltip = computed(() => formatTimeZone('long'));
+const hoverCardDate = computed(() => {
+    if (!props.modelValue?.start || !props.modelValue?.end) return null;
+    return { start: props.modelValue.start.toDate(), end: props.modelValue.end.toDate() };
+});
 </script>
 
 <template>
@@ -170,13 +173,14 @@ const timeZoneTooltip = computed(() => formatTimeZone('long'));
                         </DateRangePickerInput>
                     </template>
                     <div class="flex-1" />
-                    <Text
-                        v-if="timeZoneLabel"
-                        class="text-gray-600 dark:text-gray-400 me-1"
-                        size="xs"
-                        v-tooltip="timeZoneTooltip"
-                        :text="timeZoneLabel"
-                    />
+                    <TimezoneHoverCard
+                        v-if="timeZoneLabel && hoverCardDate"
+                        :date="hoverCardDate"
+                        :additional-timezones="[{ timezone: timeZoneName, label: __('This field') }]"
+                        side="top"
+                    >
+                        <Text class="text-gray-600 dark:text-gray-400 me-1" size="xs" :text="timeZoneLabel" />
+                    </TimezoneHoverCard>
                     <Button v-if="!readOnly" @click="emit('update:modelValue', null)" variant="subtle" size="sm" icon="x" class="-me-2" :disabled="disabled" />
                 </div>
             </DateRangePickerField>

--- a/resources/js/components/ui/TimezoneHoverCard.vue
+++ b/resources/js/components/ui/TimezoneHoverCard.vue
@@ -5,6 +5,8 @@ import Timezones from './Timezones.vue';
 const props = defineProps({
     /** The date to display across timezones. Forwarded to `<Timezones>`. Accepts a `Date`, ISO string, epoch number, or a `{ start, end }` range object. */
     date: { type: [String, Date, Number, Object], required: true },
+    /** Extra `{ timezone, label }` rows to render above the defaults. Forwarded to `<Timezones>`. */
+    additionalTimezones: { type: Array, default: () => [] },
 });
 </script>
 
@@ -13,6 +15,6 @@ const props = defineProps({
         <template #trigger>
             <span><slot /></span>
         </template>
-        <Timezones :date />
+        <Timezones :date :additional-timezones="additionalTimezones" />
     </HoverCard>
 </template>

--- a/resources/js/components/ui/TimezoneHoverCard.vue
+++ b/resources/js/components/ui/TimezoneHoverCard.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { useAttrs } from 'vue';
+import HoverCard from './HoverCard.vue';
+import Timezones from './Timezones.vue';
+
+defineOptions({ inheritAttrs: false });
+
+const props = defineProps({
+    /** The date to display across timezones. Forwarded to `<Timezones>`. Accepts a `Date`, ISO string, or epoch number. */
+    date: { type: [String, Date, Number], required: true },
+    /** The preferred alignment against the trigger. May change when collisions occur. <br><br> Options: `start`, `center`, `end` */
+    align: { type: String, default: 'center' },
+    /** The delay in milliseconds before the hover card opens. */
+    delay: { type: Number, default: 200 },
+    /** The distance in pixels from the trigger. */
+    offset: { type: Number, default: 25 },
+    /** The preferred side of the trigger to render against when open. <br><br> Options: `top`, `bottom`, `left`, `right` */
+    side: { type: String, default: 'left' },
+});
+
+// `HoverCardTrigger` uses `as-child`, so the default slot must render a
+// single root element. Unknown attrs (e.g. `class`) flow to this wrapper.
+const attrs = useAttrs();
+</script>
+
+<template>
+    <HoverCard :side :align :delay :offset inset>
+        <template #trigger>
+            <span v-bind="attrs"><slot /></span>
+        </template>
+        <Timezones :date />
+    </HoverCard>
+</template>

--- a/resources/js/components/ui/TimezoneHoverCard.vue
+++ b/resources/js/components/ui/TimezoneHoverCard.vue
@@ -13,7 +13,7 @@ const props = defineProps({
 <template>
     <HoverCard>
         <template #trigger>
-            <span><slot /></span>
+            <slot />
         </template>
         <Timezones :date :additional-timezones="additionalTimezones" />
     </HoverCard>

--- a/resources/js/components/ui/TimezoneHoverCard.vue
+++ b/resources/js/components/ui/TimezoneHoverCard.vue
@@ -3,8 +3,8 @@ import HoverCard from './HoverCard.vue';
 import Timezones from './Timezones.vue';
 
 const props = defineProps({
-    /** The date to display across timezones. Forwarded to `<Timezones>`. Accepts a `Date`, ISO string, or epoch number. */
-    date: { type: [String, Date, Number], required: true },
+    /** The date to display across timezones. Forwarded to `<Timezones>`. Accepts a `Date`, ISO string, epoch number, or a `{ start, end }` range object. */
+    date: { type: [String, Date, Number, Object], required: true },
 });
 </script>
 

--- a/resources/js/components/ui/TimezoneHoverCard.vue
+++ b/resources/js/components/ui/TimezoneHoverCard.vue
@@ -24,7 +24,7 @@ const attrs = useAttrs();
 </script>
 
 <template>
-    <HoverCard :side :align :delay :offset inset>
+    <HoverCard :side :align :delay :offset>
         <template #trigger>
             <span v-bind="attrs"><slot /></span>
         </template>

--- a/resources/js/components/ui/TimezoneHoverCard.vue
+++ b/resources/js/components/ui/TimezoneHoverCard.vue
@@ -1,32 +1,17 @@
 <script setup>
-import { useAttrs } from 'vue';
 import HoverCard from './HoverCard.vue';
 import Timezones from './Timezones.vue';
-
-defineOptions({ inheritAttrs: false });
 
 const props = defineProps({
     /** The date to display across timezones. Forwarded to `<Timezones>`. Accepts a `Date`, ISO string, or epoch number. */
     date: { type: [String, Date, Number], required: true },
-    /** The preferred alignment against the trigger. May change when collisions occur. <br><br> Options: `start`, `center`, `end` */
-    align: { type: String, default: 'center' },
-    /** The delay in milliseconds before the hover card opens. */
-    delay: { type: Number, default: 200 },
-    /** The distance in pixels from the trigger. */
-    offset: { type: Number, default: 25 },
-    /** The preferred side of the trigger to render against when open. <br><br> Options: `top`, `bottom`, `left`, `right` */
-    side: { type: String, default: 'left' },
 });
-
-// `HoverCardTrigger` uses `as-child`, so the default slot must render a
-// single root element. Unknown attrs (e.g. `class`) flow to this wrapper.
-const attrs = useAttrs();
 </script>
 
 <template>
-    <HoverCard :side :align :delay :offset>
+    <HoverCard>
         <template #trigger>
-            <span v-bind="attrs"><slot /></span>
+            <span><slot /></span>
         </template>
         <Timezones :date />
     </HoverCard>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -11,32 +11,20 @@ const props = defineProps({
 
 const normalizedDate = computed(() => new Date(props.date));
 
-const appTimezone = computed(() => {
-    try {
-        return config.get('appTimezone') ?? 'UTC';
-    } catch (e) {
-        return 'UTC';
-    }
-});
+const isValid = computed(() => !isNaN(normalizedDate.value.getTime()));
+
+const appTimezone = computed(() => config.get('appTimezone') ?? 'UTC');
 
 const formatTimeZone = (timeZone) => {
-    try {
-        const parts = new Intl.DateTimeFormat(config.get('translationLocale'), {
-            timeZone,
-            timeZoneName: 'short',
-        }).formatToParts(normalizedDate.value);
-        return parts.find((p) => p.type === 'timeZoneName')?.value ?? timeZone;
-    } catch (e) {
-        return timeZone;
-    }
+    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), {
+        timeZone,
+        timeZoneName: 'short',
+    }).formatToParts(normalizedDate.value);
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? timeZone;
 };
 
 const formatDateTime = (timeZone) => {
-    try {
-        return new Intl.DateTimeFormat(dateFormatter.locale, { dateStyle: 'long', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
-    } catch (e) {
-        return '';
-    }
+    return new Intl.DateTimeFormat(dateFormatter.locale, { dateStyle: 'long', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
 };
 
 const rows = computed(() => [
@@ -47,7 +35,7 @@ const rows = computed(() => [
 </script>
 
 <template>
-    <div class="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-sm">
+    <div v-if="isValid" class="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-sm">
         <template v-for="(row, index) in rows" :key="index">
             <div class="flex items-center gap-4">
                 <Text :text="formatTimeZone(row.timeZone)" variant="strong" />

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { dateFormatter } from '@api';
+import { dateFormatter, config } from '@api';
 import { getLocalTimeZone } from '@internationalized/date';
 import Text from './Text.vue';
 
@@ -15,7 +15,7 @@ const locale = computed(() => dateFormatter.locale);
 
 const appTimezone = computed(() => {
     try {
-        return window.Statamic?.$config?.get('appTimezone') ?? 'UTC';
+        return config.get('appTimezone') ?? 'UTC';
     } catch (e) {
         return 'UTC';
     }

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -54,12 +54,10 @@ const rows = computed(() => [
 </script>
 
 <template>
-    <div v-if="isValid" class="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-sm">
+    <div v-if="isValid" class="grid grid-cols-[auto_auto_auto] gap-x-3 gap-y-1 text-sm">
         <template v-for="(row, index) in rows" :key="index">
-            <div class="flex items-center gap-4">
-                <Text :text="formatTimeZone(row.timeZone)" variant="strong" />
-                <Text :text="row.sublabel" variant="subtle" />
-            </div>
+            <Text :text="formatTimeZone(row.timeZone)" variant="strong" />
+            <Text :text="row.sublabel" variant="subtle" />
             <Text :text="formatDateTime(row.timeZone)" />
         </template>
     </div>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue';
 import { config } from '@api';
 import { getLocalTimeZone } from '@internationalized/date';
-import Heading from './Heading.vue';
+import Text from './Text.vue';
 
 const props = defineProps({
     /** The date to display across timezones. Accepts a `Date`, ISO string, or epoch number. */
@@ -57,15 +57,14 @@ const rows = computed(() => [
 </script>
 
 <template>
-    <div class="bg-white dark:bg-gray-850 rounded-xl ring ring-gray-200 dark:ring-x-0 dark:ring-b-0 dark:ring-gray-700/80 shadow-ui-md px-4 sm:px-4.5 py-5 space-y-2">
-        <Heading :text="__('Time conversion')" />
-        <div class="grid grid-cols-[auto_auto_auto_auto] gap-x-3 gap-y-1 text-sm">
-            <template v-for="(row, index) in rows" :key="index">
-                <div class="font-mono text-gray-500 dark:text-gray-400">{{ formatTimeZone(row.timeZone) }}</div>
-                <div class="text-gray-500 dark:text-gray-400">{{ row.sublabel }}</div>
-                <div>{{ formatTime(row.timeZone) }}</div>
-                <div class="text-gray-500 dark:text-gray-400">{{ formatDate(row.timeZone) }}</div>
-            </template>
-        </div>
+    <div class="grid grid-cols-[auto_auto_auto] gap-x-3 gap-y-1 text-sm">
+        <template v-for="(row, index) in rows" :key="index">
+            <div class="flex items-center gap-4">
+                <Text :text="formatTimeZone(row.timeZone)" variant="strong" />
+                <Text :text="row.sublabel" variant="subtle" />
+            </div>
+            <Text :text="formatTime(row.timeZone)" />
+            <Text :text="formatDate(row.timeZone)" />
+        </template>
     </div>
 </template>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -11,8 +11,6 @@ const props = defineProps({
 
 const normalizedDate = computed(() => new Date(props.date));
 
-const locale = computed(() => dateFormatter.locale);
-
 const appTimezone = computed(() => {
     try {
         return config.get('appTimezone') ?? 'UTC';
@@ -23,7 +21,7 @@ const appTimezone = computed(() => {
 
 const formatTimeZone = (timeZone) => {
     try {
-        const parts = new Intl.DateTimeFormat(locale.value, {
+        const parts = new Intl.DateTimeFormat(config.get('translationLocale'), {
             timeZone,
             timeZoneName: 'short',
         }).formatToParts(normalizedDate.value);
@@ -35,7 +33,7 @@ const formatTimeZone = (timeZone) => {
 
 const formatDateTime = (timeZone) => {
     try {
-        return new Intl.DateTimeFormat(locale.value, { dateStyle: 'long', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
+        return new Intl.DateTimeFormat(dateFormatter.locale, { dateStyle: 'long', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
     } catch (e) {
         return '';
     }

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -47,9 +47,9 @@ const formatDateTime = (timeZone) => {
 
 const rows = computed(() => {
     const all = [
-        ...props.additionalTimezones.map((row) => ({ timeZone: row.timezone, sublabel: row.label })),
-        { timeZone: getLocalTimeZone(), sublabel: __('Your time') },
         { timeZone: displayTimezone.value, sublabel: __('Site time') },
+        { timeZone: getLocalTimeZone(), sublabel: __('Your time') },
+        ...props.additionalTimezones.map((row) => ({ timeZone: row.timezone, sublabel: row.label })),
     ];
 
     const seen = new Set();

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -33,17 +33,9 @@ const formatTimeZone = (timeZone) => {
     }
 };
 
-const formatTime = (timeZone) => {
+const formatDateTime = (timeZone) => {
     try {
-        return new Intl.DateTimeFormat(locale.value, { timeStyle: 'medium', timeZone }).format(normalizedDate.value);
-    } catch (e) {
-        return '';
-    }
-};
-
-const formatDate = (timeZone) => {
-    try {
-        return new Intl.DateTimeFormat(locale.value, { dateStyle: 'long', timeZone }).format(normalizedDate.value);
+        return new Intl.DateTimeFormat(locale.value, { dateStyle: 'long', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
     } catch (e) {
         return '';
     }
@@ -57,14 +49,13 @@ const rows = computed(() => [
 </script>
 
 <template>
-    <div class="grid grid-cols-[auto_auto_auto] gap-x-3 gap-y-1 text-sm">
+    <div class="grid grid-cols-[auto_auto] gap-x-3 gap-y-1 text-sm">
         <template v-for="(row, index) in rows" :key="index">
             <div class="flex items-center gap-4">
                 <Text :text="formatTimeZone(row.timeZone)" variant="strong" />
                 <Text :text="row.sublabel" variant="subtle" />
             </div>
-            <Text :text="formatTime(row.timeZone)" />
-            <Text :text="formatDate(row.timeZone)" />
+            <Text :text="formatDateTime(row.timeZone)" />
         </template>
     </div>
 </template>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -45,20 +45,29 @@ const formatDateTime = (timeZone) => {
     return isRange.value ? formatter.formatRange(start.value, end.value) : formatter.format(start.value);
 };
 
-const rows = computed(() => [
-    ...props.additionalTimezones.map((row) => ({ timeZone: row.timezone, sublabel: row.label })),
-    { timeZone: getLocalTimeZone(), sublabel: __('Your computer') },
-    { timeZone: appTimezone.value, sublabel: __('Application') },
-    { timeZone: 'UTC', sublabel: null },
-]);
+const rows = computed(() => {
+    const all = [
+        ...props.additionalTimezones.map((row) => ({ timeZone: row.timezone, sublabel: row.label })),
+        { timeZone: getLocalTimeZone(), sublabel: __('Your computer') },
+        { timeZone: appTimezone.value, sublabel: __('Application') },
+        { timeZone: 'UTC', sublabel: null },
+    ];
+
+    const seen = new Set();
+    return all.map((row) => {
+        const isDuplicate = seen.has(row.timeZone);
+        seen.add(row.timeZone);
+        return { ...row, isDuplicate };
+    });
+});
 </script>
 
 <template>
     <div v-if="isValid" class="grid grid-cols-[auto_auto_auto] gap-x-3 gap-y-1 text-sm">
         <template v-for="(row, index) in rows" :key="index">
-            <Text :text="formatTimeZone(row.timeZone)" variant="strong" />
-            <Text :text="row.sublabel" variant="subtle" />
-            <Text :text="formatDateTime(row.timeZone)" />
+            <Text :text="formatTimeZone(row.timeZone)" variant="strong" :class="{ 'opacity-50': row.isDuplicate }" />
+            <Text :text="row.sublabel" variant="subtle" :class="{ 'opacity-50': row.isDuplicate }" />
+            <Text :text="formatDateTime(row.timeZone)" :class="{ 'opacity-50': row.isDuplicate }" />
         </template>
     </div>
 </template>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -50,7 +50,6 @@ const rows = computed(() => {
         ...props.additionalTimezones.map((row) => ({ timeZone: row.timezone, sublabel: row.label })),
         { timeZone: getLocalTimeZone(), sublabel: __('Your time') },
         { timeZone: displayTimezone.value, sublabel: __('Site time') },
-        { timeZone: 'UTC', sublabel: null },
     ];
 
     const seen = new Set();

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -65,9 +65,9 @@ const rows = computed(() => {
 <template>
     <div v-if="isValid" class="grid grid-cols-[auto_auto_auto] gap-x-3 gap-y-1 text-sm">
         <template v-for="(row, index) in rows" :key="index">
-            <Text :text="formatTimeZone(row.timeZone)" variant="strong" :class="{ 'opacity-50': row.isDuplicate }" />
-            <Text :text="row.sublabel" variant="subtle" :class="{ 'opacity-50': row.isDuplicate }" />
-            <Text :text="formatDateTime(row.timeZone)" :class="{ 'opacity-50': row.isDuplicate }" />
+            <Text :text="formatTimeZone(row.timeZone)" :variant="row.isDuplicate ? 'subtle' : 'strong'" />
+            <Text :text="row.sublabel" variant="subtle" />
+            <Text :text="formatDateTime(row.timeZone)" :variant="row.isDuplicate ? 'subtle' : 'default'" />
         </template>
     </div>
 </template>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -7,6 +7,8 @@ import Text from './Text.vue';
 const props = defineProps({
     /** The date to display across timezones. Accepts a `Date`, ISO string, epoch number, or a `{ start, end }` range object. */
     date: { type: [String, Date, Number, Object], required: true },
+    /** Extra `{ timezone, label }` rows to render above the defaults. */
+    additionalTimezones: { type: Array, default: () => [] },
 });
 
 const isRange = computed(() => {
@@ -44,6 +46,7 @@ const formatDateTime = (timeZone) => {
 };
 
 const rows = computed(() => [
+    ...props.additionalTimezones.map((row) => ({ timeZone: row.timezone, sublabel: row.label })),
     { timeZone: getLocalTimeZone(), sublabel: __('Your computer') },
     { timeZone: appTimezone.value, sublabel: __('Application') },
     { timeZone: 'UTC', sublabel: null },

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -1,0 +1,71 @@
+<script setup>
+import { computed } from 'vue';
+import { config } from '@api';
+import { getLocalTimeZone } from '@internationalized/date';
+import Heading from './Heading.vue';
+
+const props = defineProps({
+    /** The date to display across timezones. Accepts a `Date`, ISO string, or epoch number. */
+    date: { type: [String, Date, Number], required: true },
+});
+
+const normalizedDate = computed(() => new Date(props.date));
+
+const locale = computed(() => config.get('translationLocale'));
+
+const appTimezone = computed(() => {
+    try {
+        return window.Statamic?.$config?.get('appTimezone') ?? 'UTC';
+    } catch (e) {
+        return 'UTC';
+    }
+});
+
+const formatTimeZone = (timeZone) => {
+    try {
+        const parts = new Intl.DateTimeFormat(locale.value, {
+            timeZone,
+            timeZoneName: 'short',
+        }).formatToParts(normalizedDate.value);
+        return parts.find((p) => p.type === 'timeZoneName')?.value ?? timeZone;
+    } catch (e) {
+        return timeZone;
+    }
+};
+
+const formatTime = (timeZone) => {
+    try {
+        return new Intl.DateTimeFormat(locale.value, { timeStyle: 'medium', timeZone }).format(normalizedDate.value);
+    } catch (e) {
+        return '';
+    }
+};
+
+const formatDate = (timeZone) => {
+    try {
+        return new Intl.DateTimeFormat(locale.value, { dateStyle: 'long', timeZone }).format(normalizedDate.value);
+    } catch (e) {
+        return '';
+    }
+};
+
+const rows = computed(() => [
+    { timeZone: getLocalTimeZone(), sublabel: __('Your computer') },
+    { timeZone: appTimezone.value, sublabel: __('App timezone') },
+    { timeZone: 'UTC', sublabel: null },
+]);
+</script>
+
+<template>
+    <div class="bg-white dark:bg-gray-850 rounded-xl ring ring-gray-200 dark:ring-x-0 dark:ring-b-0 dark:ring-gray-700/80 shadow-ui-md px-4 sm:px-4.5 py-5 space-y-2">
+        <Heading :text="__('Time conversion')" />
+        <div class="grid grid-cols-[auto_auto_auto_auto] gap-x-3 gap-y-1 text-sm">
+            <template v-for="(row, index) in rows" :key="index">
+                <div class="font-mono text-gray-500 dark:text-gray-400">{{ formatTimeZone(row.timeZone) }}</div>
+                <div class="text-gray-500 dark:text-gray-400">{{ row.sublabel }}</div>
+                <div>{{ formatTime(row.timeZone) }}</div>
+                <div class="text-gray-500 dark:text-gray-400">{{ formatDate(row.timeZone) }}</div>
+            </template>
+        </div>
+    </div>
+</template>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -5,13 +5,24 @@ import { getLocalTimeZone } from '@internationalized/date';
 import Text from './Text.vue';
 
 const props = defineProps({
-    /** The date to display across timezones. Accepts a `Date`, ISO string, or epoch number. */
-    date: { type: [String, Date, Number], required: true },
+    /** The date to display across timezones. Accepts a `Date`, ISO string, epoch number, or a `{ start, end }` range object. */
+    date: { type: [String, Date, Number, Object], required: true },
 });
 
-const normalizedDate = computed(() => new Date(props.date));
+const isRange = computed(() => {
+    const value = props.date;
+    return value !== null && typeof value === 'object' && !(value instanceof Date) && 'start' in value && 'end' in value;
+});
 
-const isValid = computed(() => !isNaN(normalizedDate.value.getTime()));
+const start = computed(() => new Date(isRange.value ? props.date.start : props.date));
+
+const end = computed(() => isRange.value ? new Date(props.date.end) : null);
+
+const isValid = computed(() => {
+    if (isNaN(start.value.getTime())) return false;
+    if (isRange.value && isNaN(end.value.getTime())) return false;
+    return true;
+});
 
 const appTimezone = computed(() => config.get('appTimezone') ?? 'UTC');
 
@@ -19,12 +30,17 @@ const formatTimeZone = (timeZone) => {
     const parts = new Intl.DateTimeFormat(config.get('translationLocale'), {
         timeZone,
         timeZoneName: 'short',
-    }).formatToParts(normalizedDate.value);
+    }).formatToParts(start.value);
     return parts.find((p) => p.type === 'timeZoneName')?.value ?? timeZone;
 };
 
 const formatDateTime = (timeZone) => {
-    return new Intl.DateTimeFormat(dateFormatter.locale, { dateStyle: 'medium', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
+    const formatter = new Intl.DateTimeFormat(dateFormatter.locale, {
+        dateStyle: isRange.value ? 'short' : 'medium',
+        timeStyle: 'medium',
+        timeZone,
+    });
+    return isRange.value ? formatter.formatRange(start.value, end.value) : formatter.format(start.value);
 };
 
 const rows = computed(() => [

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -24,7 +24,7 @@ const formatTimeZone = (timeZone) => {
 };
 
 const formatDateTime = (timeZone) => {
-    return new Intl.DateTimeFormat(dateFormatter.locale, { dateStyle: 'long', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
+    return new Intl.DateTimeFormat(dateFormatter.locale, { dateStyle: 'medium', timeStyle: 'medium', timeZone }).format(normalizedDate.value);
 };
 
 const rows = computed(() => [

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -43,7 +43,7 @@ const formatDateTime = (timeZone) => {
 
 const rows = computed(() => [
     { timeZone: getLocalTimeZone(), sublabel: __('Your computer') },
-    { timeZone: appTimezone.value, sublabel: __('App timezone') },
+    { timeZone: appTimezone.value, sublabel: __('Application') },
     { timeZone: 'UTC', sublabel: null },
 ]);
 </script>

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { config } from '@api';
+import { dateFormatter } from '@api';
 import { getLocalTimeZone } from '@internationalized/date';
 import Text from './Text.vue';
 
@@ -11,7 +11,7 @@ const props = defineProps({
 
 const normalizedDate = computed(() => new Date(props.date));
 
-const locale = computed(() => config.get('translationLocale'));
+const locale = computed(() => dateFormatter.locale);
 
 const appTimezone = computed(() => {
     try {

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -26,7 +26,7 @@ const isValid = computed(() => {
     return true;
 });
 
-const appTimezone = computed(() => config.get('appTimezone') ?? 'UTC');
+const displayTimezone = computed(() => config.get('displayTimezone') ?? 'UTC');
 
 const formatTimeZone = (timeZone) => {
     const parts = new Intl.DateTimeFormat(config.get('translationLocale'), {
@@ -48,8 +48,8 @@ const formatDateTime = (timeZone) => {
 const rows = computed(() => {
     const all = [
         ...props.additionalTimezones.map((row) => ({ timeZone: row.timezone, sublabel: row.label })),
-        { timeZone: getLocalTimeZone(), sublabel: __('Your computer') },
-        { timeZone: appTimezone.value, sublabel: __('Application') },
+        { timeZone: getLocalTimeZone(), sublabel: __('Your time') },
+        { timeZone: displayTimezone.value, sublabel: __('Site time') },
         { timeZone: 'UTC', sublabel: null },
     ];
 

--- a/resources/js/components/ui/index.js
+++ b/resources/js/components/ui/index.js
@@ -85,6 +85,8 @@ export { default as TabTrigger } from './Tabs/Trigger.vue';
 export { default as Text } from './Text.vue';
 export { default as Textarea } from './Textarea.vue';
 export { default as TimePicker } from './TimePicker/TimePicker.vue';
+export { default as TimezoneHoverCard } from './TimezoneHoverCard.vue';
+export { default as Timezones } from './Timezones.vue';
 export { default as ToggleGroup } from './Toggle/Group.vue';
 export { default as ToggleItem } from './Toggle/Item.vue';
 

--- a/resources/js/stories/Timezones.stories.ts
+++ b/resources/js/stories/Timezones.stories.ts
@@ -40,7 +40,7 @@ export const _DocsIntro: Story = {
 };
 
 const hoverCardCode = `
-<TimezoneHoverCard :date="date" :side="side" :align="align">
+<TimezoneHoverCard :date="date">
     <span class="underline decoration-dotted">Hover the underlined text</span>
 </TimezoneHoverCard>
 `;
@@ -49,18 +49,6 @@ export const _HoverCard: Story = {
     tags: ['!dev'],
     args: {
         date: exampleDate,
-        side: 'bottom',
-        align: 'center',
-    },
-    argTypes: {
-        side: {
-            control: 'select',
-            options: ['top', 'bottom', 'left', 'right'],
-        },
-        align: {
-            control: 'select',
-            options: ['start', 'center', 'end'],
-        },
     },
     parameters: {
         docs: {
@@ -72,7 +60,7 @@ export const _HoverCard: Story = {
     render: (args) => ({
         components: { TimezoneHoverCard },
         setup() {
-            return { date: args.date, side: args.side, align: args.align };
+            return { date: args.date };
         },
         template: `
             <div class="flex justify-center p-12">

--- a/resources/js/stories/Timezones.stories.ts
+++ b/resources/js/stories/Timezones.stories.ts
@@ -1,0 +1,111 @@
+import type {Meta, StoryObj} from '@storybook/vue3';
+import {Timezones, TimezoneHoverCard} from '@ui';
+
+const exampleDate = '2026-05-05T12:00:00.000Z';
+
+const meta = {
+    title: 'Overlays/Timezones',
+    component: Timezones,
+    argTypes: {
+        date: {
+            control: 'text',
+        },
+    },
+} satisfies Meta<typeof Timezones>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultCode = `
+<Timezones :date="date" />
+`;
+
+export const _DocsIntro: Story = {
+    tags: ['!dev'],
+    args: {
+        date: exampleDate,
+    },
+    parameters: {
+        docs: {
+            source: { code: `<Timezones date="${exampleDate}" />` }
+        }
+    },
+    render: (args) => ({
+        components: { Timezones },
+        setup() {
+            return { date: args.date };
+        },
+        template: defaultCode,
+    }),
+};
+
+const hoverCardCode = `
+<TimezoneHoverCard :date="date" :side="side" :align="align">
+    <span class="underline decoration-dotted">Hover the underlined text</span>
+</TimezoneHoverCard>
+`;
+
+export const _HoverCard: Story = {
+    tags: ['!dev'],
+    args: {
+        date: exampleDate,
+        side: 'bottom',
+        align: 'center',
+    },
+    argTypes: {
+        side: {
+            control: 'select',
+            options: ['top', 'bottom', 'left', 'right'],
+        },
+        align: {
+            control: 'select',
+            options: ['start', 'center', 'end'],
+        },
+    },
+    parameters: {
+        docs: {
+            source: {
+                code: `<TimezoneHoverCard date="${exampleDate}">Hover the underlined text</TimezoneHoverCard>`
+            }
+        }
+    },
+    render: (args) => ({
+        components: { TimezoneHoverCard },
+        setup() {
+            return { date: args.date, side: args.side, align: args.align };
+        },
+        template: `
+            <div class="flex justify-center p-12">
+                ${hoverCardCode}
+            </div>
+        `,
+    }),
+};
+
+const customDateCode = `
+<Timezones :date="isoString" />
+<Timezones :date="dateObject" />
+`;
+
+export const _CustomDate: Story = {
+    tags: ['!dev'],
+    parameters: {
+        docs: {
+            source: { code: customDateCode }
+        }
+    },
+    render: () => ({
+        components: { Timezones },
+        setup() {
+            return {
+                isoString: exampleDate,
+                dateObject: new Date(exampleDate),
+            };
+        },
+        template: `
+            <div class="space-y-4">
+                ${customDateCode}
+            </div>
+        `,
+    }),
+};

--- a/resources/js/stories/Timezones.stories.ts
+++ b/resources/js/stories/Timezones.stories.ts
@@ -2,6 +2,7 @@ import type {Meta, StoryObj} from '@storybook/vue3';
 import {Timezones, TimezoneHoverCard} from '@ui';
 
 const exampleDate = '2026-05-05T12:00:00.000Z';
+const exampleRange = { start: '2026-05-05T12:00:00.000Z', end: '2026-05-08T17:30:00.000Z' };
 
 const meta = {
     title: 'Overlays/Timezones',
@@ -67,6 +68,26 @@ export const _HoverCard: Story = {
                 ${hoverCardCode}
             </div>
         `,
+    }),
+};
+
+const rangeCode = `
+<Timezones :date="{ start, end }" />
+`;
+
+export const _Range: Story = {
+    tags: ['!dev'],
+    parameters: {
+        docs: {
+            source: { code: rangeCode }
+        }
+    },
+    render: () => ({
+        components: { Timezones },
+        setup() {
+            return { range: exampleRange };
+        },
+        template: `<Timezones :date="range" />`,
     }),
 };
 

--- a/resources/js/stories/Timezones.stories.ts
+++ b/resources/js/stories/Timezones.stories.ts
@@ -53,9 +53,7 @@ export const _HoverCard: Story = {
     },
     parameters: {
         docs: {
-            source: {
-                code: `<TimezoneHoverCard date="${exampleDate}">Hover the underlined text</TimezoneHoverCard>`
-            }
+            source: { code: hoverCardCode }
         }
     },
     render: (args) => ({

--- a/resources/js/stories/Timezones.stories.ts
+++ b/resources/js/stories/Timezones.stories.ts
@@ -87,6 +87,24 @@ const customDateCode = `
 <Timezones :date="dateObject" />
 `;
 
+export const _Invalid: Story = {
+    args: {
+        date: "not a date",
+    },
+    render: (args) => ({
+        components: { Timezones },
+        setup() {
+            return { date: args.date };
+        },
+        template: `
+            <div>
+                <p class="mb-2 text-sm">Nothing should render below:</p>
+                <Timezones :date="date" />
+            </div>
+        `,
+    }),
+};
+
 export const _CustomDate: Story = {
     tags: ['!dev'],
     parameters: {

--- a/resources/js/stories/docs/Timezones.mdx
+++ b/resources/js/stories/docs/Timezones.mdx
@@ -9,6 +9,10 @@ Displays a given instant rendered across the user's local timezone, the configur
 ## Overview
 <Canvas of={TimezonesStories._DocsIntro} sourceState={'shown'} />
 
+## Range
+Pass a `{ start, end }` object to render a date range. The value column uses locale-aware formatting that collapses repeated parts (e.g. shared month or year).
+<Canvas of={TimezonesStories._Range} sourceState={'shown'} />
+
 ## Hover Card
 This is a convenience wrapper component that displays the timezones in a hover card. You can provide any of [HoverCard](?path=/docs/overlays-hovercard--docs)'s props.
 <Canvas of={TimezonesStories._HoverCard} sourceState={'shown'} />

--- a/resources/js/stories/docs/Timezones.mdx
+++ b/resources/js/stories/docs/Timezones.mdx
@@ -1,0 +1,16 @@
+import { Canvas, Meta, ArgTypes } from '@storybook/addon-docs/blocks';
+import * as TimezonesStories from '../Timezones.stories';
+
+<Meta of={TimezonesStories} />
+
+# Timezones
+Displays a given instant rendered across the user's local timezone, the configured app timezone, and UTC.
+
+## Overview
+<Canvas of={TimezonesStories._DocsIntro} sourceState={'shown'} />
+
+## Hover Card
+<Canvas of={TimezonesStories._HoverCard} sourceState={'shown'} />
+
+## Arguments
+<ArgTypes of={TimezonesStories} />

--- a/resources/js/stories/docs/Timezones.mdx
+++ b/resources/js/stories/docs/Timezones.mdx
@@ -10,6 +10,7 @@ Displays a given instant rendered across the user's local timezone, the configur
 <Canvas of={TimezonesStories._DocsIntro} sourceState={'shown'} />
 
 ## Hover Card
+This is a convenience wrapper component that displays the timezones in a hover card. You can provide any of [HoverCard](?path=/docs/overlays-hovercard--docs)'s props.
 <Canvas of={TimezonesStories._HoverCard} sourceState={'shown'} />
 
 ## Arguments

--- a/resources/js/tests/Package.test.js
+++ b/resources/js/tests/Package.test.js
@@ -208,6 +208,8 @@ it('exports ui', async () => {
         'Tabs',
         'Textarea',
         'TimePicker',
+        'TimezoneHoverCard',
+        'Timezones',
         'ToggleGroup',
         'ToggleItem',
         'registerIconSet',

--- a/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateIndexFieldtype.test.js
@@ -147,7 +147,7 @@ test.each([
     expect(dateIndexField.vm.formatted).toBe(expected);
 });
 
-test('date-only format omits time from value and tooltip', async () => {
+test('date-only format omits time and hides the timezone hover card', async () => {
     const dateIndexField = makeDateIndexField({
         date: '2025-12-25',
         mode: 'single',
@@ -156,10 +156,10 @@ test('date-only format omits time from value and tooltip', async () => {
     });
 
     expect(dateIndexField.vm.formatted).toBe('12/25/2025');
-    expect(dateIndexField.vm.tooltip).toBeNull();
+    expect(dateIndexField.vm.showTimezoneCard).toBe(false);
 });
 
-test('time-disabled but time-aware format shows date in value and time in tooltip', async () => {
+test('time-disabled but time-aware format shows date in value and exposes the timezone hover card', async () => {
     const dateIndexField = makeDateIndexField({
         date: '2025-12-25T02:13:00Z',
         mode: 'single',
@@ -168,11 +168,10 @@ test('time-disabled but time-aware format shows date in value and time in toolti
     });
 
     expect(dateIndexField.vm.formatted).toBe('12/25/2025');
-    expect(dateIndexField.vm.tooltip).not.toBeNull();
-    expect(dateIndexField.vm.tooltip).toContain('2025');
+    expect(dateIndexField.vm.showTimezoneCard).toBe(true);
 });
 
-test('time-enabled value shows time in both value and tooltip', async () => {
+test('time-enabled value shows time in value and exposes the timezone hover card', async () => {
     const dateIndexField = makeDateIndexField({
         date: '2025-12-25T02:13:00Z',
         mode: 'single',
@@ -181,5 +180,5 @@ test('time-enabled value shows time in both value and tooltip', async () => {
     });
 
     expect(dateIndexField.vm.formatted).toBe('12/25/2025, 2:13 AM');
-    expect(dateIndexField.vm.tooltip).not.toBeNull();
+    expect(dateIndexField.vm.showTimezoneCard).toBe(true);
 });

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -82,6 +82,7 @@ class JavascriptComposer
             'setPreviewImages' => Sets::previewImageConfig(),
             'linkToDocs' => config('statamic.cp.link_to_docs'),
             'defaultTheme' => $this->defaultTheme(),
+            'appTimezone' => config('app.timezone'),
         ];
     }
 

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -82,7 +82,7 @@ class JavascriptComposer
             'setPreviewImages' => Sets::previewImageConfig(),
             'linkToDocs' => config('statamic.cp.link_to_docs'),
             'defaultTheme' => $this->defaultTheme(),
-            'appTimezone' => config('app.timezone'),
+            'displayTimezone' => Statamic::displayTimezone(),
         ];
     }
 


### PR DESCRIPTION
Adds a new `Timezones` UI component that displays a given instant rendered across the user's local timezone, the configured app timezone, and UTC. Also adds `TimezoneHoverCard`, a thin wrapper that surfaces the Timezones grid inside a HoverCard.

This gets used for dates in listings:

<img width="381" height="155" alt="CleanShot 2026-05-06 at 14 44 03" src="https://github.com/user-attachments/assets/9f15adb9-ce80-41ca-ba5f-c7be92e280f1" />

And on date fields. Notice it gets an extra "this field" row. Also notice that repeated timezones are dimmed to reduce noise.

<img width="441" height="234" alt="CleanShot 2026-05-06 at 16 20 55" src="https://github.com/user-attachments/assets/e6467cc2-20a7-4476-a025-f7eccc49d505" />
