### PR TITLE
[6.x] Resolve Entries and Assets GraphQL types

### DIFF
--- a/src/Fieldtypes/Assets/Assets.php
+++ b/src/Fieldtypes/Assets/Assets.php
@@ -18,6 +18,7 @@ use Statamic\Facades\User;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fieldtypes\UpdatesReferences;
 use Statamic\GraphQL\Types\AssetInterface;
+use Statamic\GraphQL\Types\AssetType;
 use Statamic\Http\Resources\CP\Assets\AssetsFieldtypeAsset as AssetResource;
 use Statamic\Query\Scopes\Filter;
 use Statamic\Support\Arr;
@@ -492,7 +493,12 @@ class Assets extends Fieldtype
 
     public function toGqlType()
     {
-        $type = GraphQL::type(AssetInterface::NAME);
+        $handle = $this->configuredContainerHandle();
+        $container = $handle ? AssetContainer::find($handle) : null;
+
+        $type = $container
+            ? GraphQL::type(AssetType::buildName($container))
+            : GraphQL::type(AssetInterface::NAME);
 
         if ($this->config('max_files') !== 1) {
             $type = GraphQL::listOf($type);

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -17,6 +17,9 @@ use Statamic\Facades\Scope;
 use Statamic\Facades\Search;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
+use Statamic\GraphQL\Types\EntriesSelectType;
+use Statamic\GraphQL\Types\EntryInterface;
+use Statamic\GraphQL\Types\EntryType;
 use Statamic\Http\Resources\CP\Entries\EntriesFieldtypeEntries;
 use Statamic\Http\Resources\CP\Entries\EntriesFieldtypeEntry as EntryResource;
 use Statamic\Query\OrderBy;
@@ -27,11 +30,7 @@ use Statamic\Query\Scopes\Filters\Fields\Entries as EntriesFilter;
 use Statamic\Query\StatusQueryBuilder;
 use Statamic\Search\Index;
 use Statamic\Search\Result;
-use Statamic\GraphQL\Types\EntriesSelectType;
-use Statamic\GraphQL\Types\EntryInterface;
-use Statamic\GraphQL\Types\EntryType;
 use Statamic\Support\Arr;
-use Statamic\Support\Str;
 
 use function Statamic\trans as __;
 

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -27,7 +27,11 @@ use Statamic\Query\Scopes\Filters\Fields\Entries as EntriesFilter;
 use Statamic\Query\StatusQueryBuilder;
 use Statamic\Search\Index;
 use Statamic\Search\Result;
+use Statamic\GraphQL\Types\EntriesSelectType;
+use Statamic\GraphQL\Types\EntryInterface;
+use Statamic\GraphQL\Types\EntryType;
 use Statamic\Support\Arr;
+use Statamic\Support\Str;
 
 use function Statamic\trans as __;
 
@@ -452,9 +456,43 @@ class Entries extends Relationship
             : $collections;
     }
 
+    public function addGqlTypes()
+    {
+        $collections = $this->config('collections');
+
+        if (empty($collections)) {
+            return;
+        }
+
+        $typeNames = collect($collections)
+            ->flatMap(function ($handle) {
+                $collection = Collection::findByHandle($handle);
+
+                if (! $collection) {
+                    return [];
+                }
+
+                return $collection->entryBlueprints()
+                    ->map(fn ($blueprint) => EntryType::buildName($collection, $blueprint));
+            })
+            ->unique()
+            ->values()
+            ->all();
+
+        if (empty($typeNames)) {
+            return;
+        }
+
+        GraphQL::addType(new EntriesSelectType(EntriesSelectType::buildName($collections), $typeNames));
+    }
+
     public function toGqlType()
     {
-        $type = GraphQL::type('EntryInterface');
+        $collections = $this->config('collections');
+
+        $type = empty($collections)
+            ? GraphQL::type(EntryInterface::NAME)
+            : GraphQL::type(EntriesSelectType::buildName($collections));
 
         if ($this->config('max_items') !== 1) {
             $type = GraphQL::listOf($type);

--- a/src/GraphQL/Types/EntriesSelectType.php
+++ b/src/GraphQL/Types/EntriesSelectType.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Statamic\GraphQL\Types;
+
+use Rebing\GraphQL\Support\UnionType;
+use Statamic\Facades\GraphQL;
+use Statamic\Support\Str;
+
+class EntriesSelectType extends UnionType
+{
+    public $name;
+    public $typeNames;
+
+    public function __construct(string $name, array $typeNames)
+    {
+        $this->attributes['name'] = $name;
+        $this->name = $name;
+        $this->typeNames = $typeNames;
+    }
+
+    public static function buildName(array $collections): string
+    {
+        sort($collections);
+
+        return 'Entries_'.implode('_', array_map(fn ($c) => Str::studly($c), $collections));
+    }
+
+    public function types(): array
+    {
+        return array_map(fn ($name) => GraphQL::type($name), $this->typeNames);
+    }
+
+    public function resolveType($entry)
+    {
+        return GraphQL::type(EntryType::buildName($entry->collection(), $entry->blueprint()));
+    }
+}

--- a/tests/Fieldtypes/AssetsTest.php
+++ b/tests/Fieldtypes/AssetsTest.php
@@ -9,6 +9,7 @@ use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Assets\QueryBuilder;
 use Statamic\Data\AugmentedCollection;
 use Statamic\Facades\AssetContainer;
+use Statamic\Facades\GraphQL;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Assets\Assets;
 use Statamic\Fieldtypes\Assets\DimensionsRule;
@@ -17,6 +18,7 @@ use Statamic\Fieldtypes\Assets\MaxRule;
 use Statamic\Fieldtypes\Assets\MimesRule;
 use Statamic\Fieldtypes\Assets\MimetypesRule;
 use Statamic\Fieldtypes\Assets\MinRule;
+use Statamic\GraphQL\Types\AssetInterface;
 use Tests\Fieldtypes\Concerns\TestsQueryableValueWithMaxItems;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -216,6 +218,35 @@ class AssetsTest extends TestCase
         $this->assertIsArray($replaced);
         $this->assertCount(1, $replaced);
         $this->assertEquals('file', $replaced[0]);
+    }
+
+    #[Test]
+    public function it_uses_the_asset_interface_gql_type_when_multiple_containers_exist_and_none_is_configured()
+    {
+        Storage::fake('other', ['url' => '/other']);
+        AssetContainer::make('other')->disk('other')->save();
+
+        GraphQL::shouldReceive('type')->with(AssetInterface::NAME)->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+        GraphQL::shouldReceive('listOf')->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+
+        $this->fieldtype()->toGqlType();
+    }
+
+    #[Test]
+    public function it_uses_the_concrete_asset_gql_type_when_a_container_is_configured()
+    {
+        GraphQL::shouldReceive('type')->with('Asset_Test')->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+
+        $this->fieldtype(['container' => 'test', 'max_files' => 1])->toGqlType();
+    }
+
+    #[Test]
+    public function it_uses_the_concrete_asset_gql_type_when_only_one_container_exists()
+    {
+        // configuredContainerHandle() resolves to the sole container even without explicit config.
+        GraphQL::shouldReceive('type')->with('Asset_Test')->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+
+        $this->fieldtype(['max_files' => 1])->toGqlType();
     }
 
     public function fieldtype($config = [])

--- a/tests/Fieldtypes/EntriesTest.php
+++ b/tests/Fieldtypes/EntriesTest.php
@@ -12,9 +12,12 @@ use Statamic\Contracts\Query\Builder;
 use Statamic\Data\AugmentedCollection;
 use Statamic\Entries\EntryCollection;
 use Statamic\Facades;
+use Statamic\Facades\GraphQL;
 use Statamic\Facades\Site;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Entries;
+use Statamic\GraphQL\Types\EntriesSelectType;
+use Statamic\GraphQL\Types\EntryInterface;
 use Tests\Fieldtypes\Concerns\TestsQueryableValueWithMaxItems;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -374,6 +377,53 @@ class EntriesTest extends TestCase
         $this->assertInstanceOf(Builder::class, $augmented);
         $this->assertEveryItemIsInstanceOf(Entry::class, $augmented->get());
         $this->assertEquals(['one', 'two', 'three', 'four'], $augmented->get()->map->slug()->all());
+    }
+
+    #[Test]
+    public function it_uses_the_entry_interface_gql_type_when_no_collections_are_configured()
+    {
+        GraphQL::shouldReceive('type')->with(EntryInterface::NAME)->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+        GraphQL::shouldReceive('listOf')->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+
+        $this->fieldtype()->toGqlType();
+    }
+
+    #[Test]
+    public function it_uses_a_narrowed_gql_union_type_when_collections_are_configured()
+    {
+        GraphQL::shouldReceive('type')->with('Entries_Blog')->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+        GraphQL::shouldReceive('listOf')->once()->andReturn(\Mockery::mock(\GraphQL\Type\Definition\Type::class));
+
+        $this->fieldtype(['collections' => ['blog']])->toGqlType();
+    }
+
+    #[Test]
+    public function it_sorts_collection_handles_when_building_the_gql_union_type_name()
+    {
+        $this->assertEquals('Entries_Blog_Events', EntriesSelectType::buildName(['events', 'blog']));
+        $this->assertEquals('Entries_Blog_Events', EntriesSelectType::buildName(['blog', 'events']));
+    }
+
+    #[Test]
+    public function it_registers_a_narrowed_gql_union_type_containing_only_blueprints_from_configured_collections()
+    {
+        GraphQL::shouldReceive('addType')->once()->withArgs(function ($type) {
+            return $type instanceof EntriesSelectType
+                && $type->name === 'Entries_Blog'
+                && $type->typeNames === ['Entry_Blog_Blog'];
+        });
+
+        $this->fieldtype(['collections' => ['blog']])->addGqlTypes();
+    }
+
+    #[Test]
+    public function it_does_not_register_a_gql_union_type_when_no_collections_are_configured()
+    {
+        GraphQL::spy();
+
+        $this->fieldtype()->addGqlTypes();
+
+        GraphQL::shouldNotHaveReceived('addType');
     }
 
     public function fieldtype($config = [], $parent = null)


### PR DESCRIPTION
Found it hard to write a succinct title for this one 🤔 

This PR updates the Entries fieldtype to return a EntriesSelectType when specific collections are requested on the field type. It also updates the Assets fieldtype to return an AssetType when a container is specified on the field.

Potentially breaking, but gives better cues to the GraphQL consumer as to what to expect. 

Don't feel bad about closing this if you'd prefer to tackle it in a different way.

Closes https://github.com/statamic/cms/issues/12974