### PR TITLE
[6.x] Add `disabled` and `readOnly` props to `TimePicker` component

### DIFF
--- a/resources/js/components/fieldtypes/TimeFieldtype.vue
+++ b/resources/js/components/fieldtypes/TimeFieldtype.vue
@@ -1,11 +1,13 @@
 <template>
-	<Button :text="__('Set Time')" icon="fieldtype-time" v-if="!isReadOnly && !hasTime" @click="addTime" />
+	<Button :text="__('Set Time')" icon="fieldtype-time" v-if="!isReadOnly && !config.disabled && !hasTime" @click="addTime" />
 
     <TimePicker
 	    v-if="hasTime"
         ref="time"
         :model-value="timePickerValue"
         :granularity="useSeconds ? 'second' : 'minute'"
+        :disabled="config.disabled"
+        :read-only="isReadOnly"
         @update:model-value="timePickerUpdated"
     />
 </template>

--- a/resources/js/components/ui/TimePicker/TimePicker.vue
+++ b/resources/js/components/ui/TimePicker/TimePicker.vue
@@ -14,6 +14,10 @@ const props = defineProps({
     granularity: { type: String, default: null },
     /** When `true`, clear and "set to now" buttons are displayed. */
     clearable: { type: Boolean, default: true },
+    /** When `true`, the time picker is disabled. */
+    disabled: { type: Boolean, default: false },
+    /** When `true`, the time picker is read-only. */
+    readOnly: { type: Boolean, default: false },
 });
 
 const setToNow = () => {
@@ -35,12 +39,15 @@ const setToNow = () => {
         v-slot="{ segments }"
         :locale="$date.locale"
         :granularity="granularity"
+        :disabled="disabled || readOnly"
         :class="[
             'flex items-center w-full bg-white dark:bg-gray-900',
             'border border-gray-300 dark:border-gray-700',
             'leading-5 text-gray-600 dark:text-gray-300',
             'shadow-ui-sm not-prose h-10 rounded-lg py-2 px-3 disabled:shadow-none',
             'data-invalid:border-red-500',
+            disabled ? 'disabled:shadow-none disabled:opacity-50' : '',
+            readOnly ? 'border-dashed' : '',
         ]"
     >
         <div class="flex-1 flex items-center">
@@ -56,8 +63,8 @@ const setToNow = () => {
             </template>
         </div>
         <div class="flex items-center gap-1">
-            <Button v-if="clearable" @click="setToNow" type="button" class="[&_svg]:opacity-80! dark:[&_svg]:opacity-70! hover:[&_svg]:opacity-100!" size="xs" v-tooltip="__('Set to now')" icon="time-now" />
-            <Button v-if="clearable" @click="emit('update:modelValue', null)" type="button" class="[&_svg]:opacity-80! dark:[&_svg]:opacity-70! hover:[&_svg]:opacity-100!" v-tooltip="__('Clear')" icon="x" size="xs" />
+            <Button v-if="clearable && !readOnly" @click="setToNow" type="button" class="[&_svg]:opacity-80! dark:[&_svg]:opacity-70! hover:[&_svg]:opacity-100!" size="xs" v-tooltip="__('Set to now')" icon="time-now" :disabled="disabled" />
+            <Button v-if="clearable && !readOnly" @click="emit('update:modelValue', null)" type="button" class="[&_svg]:opacity-80! dark:[&_svg]:opacity-70! hover:[&_svg]:opacity-100!" v-tooltip="__('Clear')" icon="x" size="xs" :disabled="disabled" />
         </div>
     </TimeFieldRoot>
 


### PR DESCRIPTION
This pull request adds `disabled` and `readOnly` props to the `TimePicker` component, mirroring the `DatePicker`. 

I noticed the Time Picker was still interactive when viewing a form submission in the CP.

## Before

<img width="984" height="292" alt="CleanShot 2026-05-07 at 17 08 23" src="https://github.com/user-attachments/assets/0072ef3f-ba12-4b06-a197-20ae9f5e8580" />


## After

<img width="983" height="292" alt="CleanShot 2026-05-07 at 17 05 05" src="https://github.com/user-attachments/assets/7f58240e-c691-43f3-96ac-94ed43fcbacb" />
