### PR TITLE
[6.x] Fix read-only/disabled states in `Radio` component

### DIFF
--- a/resources/js/components/ui/Radio/Item.vue
+++ b/resources/js/components/ui/Radio/Item.vue
@@ -7,6 +7,7 @@ const props = defineProps({
     disabled: { type: Boolean, default: false },
     /** Label text to display next to the radio button */
     label: { type: String, default: null },
+    readOnly: { type: Boolean, default: false },
     /** Value of the radio button */
     value: { type: [String, Number, Boolean], required: true },
 });
@@ -19,7 +20,7 @@ const id = useId();
         <RadioGroupItem
             :id
             :value="value"
-            :disabled
+            :disabled="readOnly || disabled"
             class="
                 shadow-ui-xs mt-0.5 size-4 cursor-default rounded-full
                 focus:focus-outline border border-gray-400/75 dark:border-none with-contrast:border-gray-100 bg-white outline-hidden


### PR DESCRIPTION
This pull request fixes the read-only and disabled states on the `Radio` component, aligning it with the `Checkbox` component's existing implementation.

Previously, the `RadioFieldtype` was passing `:read-only="isReadOnly"` to each `Radio` item, but the prop didn't exist on the component so it was silently ignored. This meant radio buttons remained interactive in read-only contexts. The `disabled` prop also wasn't being combined with read-only state like it is in the `Checkbox` component.

This PR fixes it by adding a `readOnly` prop to `Radio/Item.vue` and passing `:disabled="readOnly || disabled"` to reka-ui's `RadioGroupItem`, matching the pattern already used by `Checkbox/Item.vue`.

## Before

<img width="163" height="129" alt="CleanShot 2026-05-07 at 17 27 10" src="https://github.com/user-attachments/assets/0c806e9d-b882-4305-bb46-e5a86af01158" />


## After

<img width="163" height="129" alt="CleanShot 2026-05-07 at 17 26 56" src="https://github.com/user-attachments/assets/10218035-53fc-4dd0-9ee5-396e10dfa398" />
