### PR TITLE
[6.x] Fix read-only state in publish forms

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -82,6 +82,7 @@
             :origin-meta="originMeta"
             :errors="errors"
             :site="site"
+            :read-only="readOnly"
             v-model:modified-fields="localizedFields"
             :track-dirty-state="trackDirtyState"
             :sync-field-confirmation-text="syncFieldConfirmationText"

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -80,6 +80,7 @@
             :origin-meta="originMeta"
             :errors="errors"
             :site="site"
+            :read-only="readOnly"
             v-model:modified-fields="localizedFields"
             :sync-field-confirmation-text="syncFieldConfirmationText"
             remember-tab

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -64,6 +64,7 @@
             :origin-meta="originMeta"
             :errors="errors"
             :site="site"
+            :read-only="readOnly"
             v-model:modified-fields="localizedFields"
             :sync-field-confirmation-text="syncFieldConfirmationText"
             :remember-tab="!isInline"


### PR DESCRIPTION
This pull request fixes an issue where fields in read-only publish forms (entries, terms, and globals) remained editable for users without edit permissions, despite the "Read Only" badge being displayed.

This was happening because the `readOnly` state was tracked in the component data but never passed down to the `PublishContainer` as a prop.

This PR fixes it by adding the `:read-only="readOnly"` prop to the `PublishContainer` in the entries, terms, and globals publish forms.

Fixes #14622