### PR TITLE
[6.x] Add --preset option to `assets:generate-presets`

### DIFF
--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Support\Facades\Log;
 use Statamic\Console\RunsInPlease;
 use Statamic\Facades\AssetContainer;
+use Statamic\Facades\Image;
 use Statamic\Jobs\GeneratePresetImageManipulation;
 use Statamic\Support\Arr;
 
@@ -65,6 +66,12 @@ class AssetsGeneratePresets extends Command
         }
 
         $filterPreset = $this->option('preset');
+
+        if ($filterPreset !== null && $filterPreset !== 'cp_thumbnail' && ! array_key_exists($filterPreset, Image::manipulationPresets())) {
+            error("The preset \"{$filterPreset}\" does not exist.");
+
+            return 1;
+        }
 
         AssetContainer::all()->filter(function ($container) use ($excludedContainers) {
             return ! in_array($container->handle(), $excludedContainers ?? []);

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -25,6 +25,7 @@ class AssetsGeneratePresets extends Command
      * @var string
      */
     protected $signature = 'statamic:assets:generate-presets
+        {--preset= : Only generate a specific preset. Use "cp_thumbnail" to generate all cp_thumbnail_small_* presets.}
         {--queue : Queue the image generation.}
         {--excluded-containers= : Comma separated list of container handles to exclude.}';
 
@@ -63,11 +64,13 @@ class AssetsGeneratePresets extends Command
             $excludedContainers = explode(',', $excludedContainers);
         }
 
+        $filterPreset = $this->option('preset');
+
         AssetContainer::all()->filter(function ($container) use ($excludedContainers) {
             return ! in_array($container->handle(), $excludedContainers ?? []);
-        })->sortBy('title')->each(function ($container) {
+        })->sortBy('title')->each(function ($container) use ($filterPreset) {
             note('Generating presets for <comment>'.$container->title().'</comment>...');
-            $this->generatePresets($container);
+            $this->generatePresets($container, $filterPreset);
             $this->newLine();
         });
     }
@@ -76,18 +79,20 @@ class AssetsGeneratePresets extends Command
      * Generate presets for a container.
      *
      * @param  \Statamic\Contracts\Assets\AssetContainer  $container
+     * @param  string|null  $filterPreset
      * @return void
      */
-    protected function generatePresets($container)
+    protected function generatePresets($container, ?string $filterPreset = null)
     {
         $assets = $container->assets()->filter->isImage();
         $counts = [];
 
-        // The amount of extra cp presets for each asset. The amount will
-        // be consistent across assets, but just not the preset names.
-        $cpPresets = config('statamic.cp.enabled') ? 1 : 0;
-
-        $steps = (count($container->warmPresets()) + $cpPresets) * count($assets);
+        if ($filterPreset === null) {
+            $cpPresets = config('statamic.cp.enabled') ? 1 : 0;
+            $steps = (count($container->warmPresets()) + $cpPresets) * count($assets);
+        } else {
+            $steps = $assets->sum(fn ($asset) => count($this->filterPresets($asset->warmPresets(), $filterPreset)));
+        }
 
         if ($steps > 0) {
             $progress = progress(
@@ -98,7 +103,7 @@ class AssetsGeneratePresets extends Command
             $progress->start();
 
             foreach ($assets as $asset) {
-                foreach ($asset->warmPresets() as $preset) {
+                foreach ($this->filterPresets($asset->warmPresets(), $filterPreset) as $preset) {
                     $counts[$preset] = ($counts[$preset] ?? 0) + 1;
                     $progress->label("Generating $preset for {$asset->basename()}...");
 
@@ -134,5 +139,18 @@ class AssetsGeneratePresets extends Command
         }
 
         $this->output->newLine();
+    }
+
+    protected function filterPresets(array $presets, ?string $filterPreset): array
+    {
+        if ($filterPreset === null) {
+            return $presets;
+        }
+
+        if ($filterPreset === 'cp_thumbnail') {
+            return array_values(array_filter($presets, fn ($p) => str_starts_with($p, 'cp_thumbnail_small_')));
+        }
+
+        return in_array($filterPreset, $presets) ? [$filterPreset] : [];
     }
 }

--- a/src/Console/Commands/AssetsGeneratePresets.php
+++ b/src/Console/Commands/AssetsGeneratePresets.php
@@ -79,7 +79,6 @@ class AssetsGeneratePresets extends Command
      * Generate presets for a container.
      *
      * @param  \Statamic\Contracts\Assets\AssetContainer  $container
-     * @param  string|null  $filterPreset
      * @return void
      */
     protected function generatePresets($container, ?string $filterPreset = null)

--- a/tests/Console/Commands/AssetsGeneratePresetsTest.php
+++ b/tests/Console/Commands/AssetsGeneratePresetsTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\AssetContainer;
+use Statamic\Facades\YAML;
+use Statamic\Jobs\GeneratePresetImageManipulation;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class AssetsGeneratePresetsTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('test');
+        Bus::fake();
+    }
+
+    private function makeContainer(string $handle = 'test', array $warmPresets = ['preset_one', 'preset_two'])
+    {
+        $container = AssetContainer::make($handle)->disk('test');
+        $container->warmPresets($warmPresets);
+        $container->save();
+
+        return $container;
+    }
+
+    private function putLandscapeImage(string $path = 'image.jpg')
+    {
+        Storage::disk('test')->put($path, '');
+        Storage::disk('test')->put(
+            dirname($path).'/.meta/'.basename($path).'.yaml',
+            YAML::dump(['width' => 20, 'height' => 10])
+        );
+    }
+
+    #[Test]
+    public function it_generates_all_presets_when_no_filter_is_given()
+    {
+        $this->makeContainer();
+        $this->putLandscapeImage();
+
+        $this->artisan('statamic:assets:generate-presets');
+
+        Bus::assertDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'preset_one');
+        Bus::assertDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'preset_two');
+        Bus::assertDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'cp_thumbnail_small_landscape');
+    }
+
+    #[Test]
+    public function it_only_generates_cp_thumbnail_presets_when_cp_thumbnail_filter_is_given()
+    {
+        $this->makeContainer();
+        $this->putLandscapeImage();
+
+        $this->artisan('statamic:assets:generate-presets --preset=cp_thumbnail');
+
+        Bus::assertDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'cp_thumbnail_small_landscape');
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'preset_one');
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'preset_two');
+    }
+
+    #[Test]
+    public function it_generates_only_the_specified_preset()
+    {
+        $this->makeContainer();
+        $this->putLandscapeImage();
+
+        $this->artisan('statamic:assets:generate-presets --preset=preset_one');
+
+        Bus::assertDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'preset_one');
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'preset_two');
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'cp_thumbnail_small_landscape');
+    }
+
+    #[Test]
+    public function it_generates_nothing_when_the_preset_does_not_exist()
+    {
+        $this->makeContainer();
+        $this->putLandscapeImage();
+
+        $this->artisan('statamic:assets:generate-presets --preset=nonexistent');
+
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class);
+    }
+
+    #[Test]
+    public function it_skips_non_image_assets()
+    {
+        $this->makeContainer();
+        Storage::disk('test')->put('document.txt', 'hello');
+
+        $this->artisan('statamic:assets:generate-presets');
+
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class);
+    }
+
+    #[Test]
+    public function it_excludes_specified_containers()
+    {
+        Storage::fake('other');
+
+        $this->makeContainer('test', ['preset_one']);
+        AssetContainer::make('excluded')->disk('other')->warmPresets(['preset_one'])->save();
+
+        $this->putLandscapeImage();
+        Storage::disk('other')->put('image.jpg', '');
+        Storage::disk('other')->put('.meta/image.jpg.yaml', YAML::dump(['width' => 20, 'height' => 10]));
+
+        $this->artisan('statamic:assets:generate-presets --excluded-containers=excluded');
+
+        Bus::assertDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->asset->container()->handle() === 'test');
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class, fn ($job) => $job->asset->container()->handle() === 'excluded');
+    }
+}

--- a/tests/Console/Commands/AssetsGeneratePresetsTest.php
+++ b/tests/Console/Commands/AssetsGeneratePresetsTest.php
@@ -103,6 +103,20 @@ class AssetsGeneratePresetsTest extends TestCase
     }
 
     #[Test]
+    public function it_queues_jobs_when_queue_option_is_used()
+    {
+        config(['queue.default' => 'redis']);
+
+        $this->makeContainer('test', ['preset_one']);
+        $this->putLandscapeImage();
+
+        $this->artisan('statamic:assets:generate-presets --queue');
+
+        Bus::assertDispatched(GeneratePresetImageManipulation::class, fn ($job) => $job->preset === 'preset_one');
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class);
+    }
+
+    #[Test]
     public function it_excludes_specified_containers()
     {
         Storage::fake('other');

--- a/tests/Console/Commands/AssetsGeneratePresetsTest.php
+++ b/tests/Console/Commands/AssetsGeneratePresetsTest.php
@@ -73,6 +73,19 @@ class AssetsGeneratePresetsTest extends TestCase
     }
 
     #[Test]
+    public function it_generates_nothing_when_cp_thumbnail_filter_is_used_but_cp_is_disabled()
+    {
+        config(['statamic.cp.enabled' => false]);
+
+        $this->makeContainer();
+        $this->putLandscapeImage();
+
+        $this->artisan('statamic:assets:generate-presets --preset=cp_thumbnail');
+
+        Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class);
+    }
+
+    #[Test]
     public function it_generates_only_the_specified_preset()
     {
         $this->makeContainer();

--- a/tests/Console/Commands/AssetsGeneratePresetsTest.php
+++ b/tests/Console/Commands/AssetsGeneratePresetsTest.php
@@ -21,6 +21,11 @@ class AssetsGeneratePresetsTest extends TestCase
 
         Storage::fake('test');
         Bus::fake();
+
+        config(['statamic.assets.image_manipulation.presets' => [
+            'preset_one' => ['w' => 100],
+            'preset_two' => ['w' => 200],
+        ]]);
     }
 
     private function makeContainer(string $handle = 'test', array $warmPresets = ['preset_one', 'preset_two'])
@@ -81,12 +86,14 @@ class AssetsGeneratePresetsTest extends TestCase
     }
 
     #[Test]
-    public function it_generates_nothing_when_the_preset_does_not_exist()
+    public function it_errors_when_the_preset_does_not_exist()
     {
         $this->makeContainer();
         $this->putLandscapeImage();
 
-        $this->artisan('statamic:assets:generate-presets --preset=nonexistent');
+        $this->artisan('statamic:assets:generate-presets --preset=nonexistent')
+            ->expectsOutputToContain('The preset "nonexistent" does not exist.')
+            ->assertExitCode(1);
 
         Bus::assertNotDispatchedSync(GeneratePresetImageManipulation::class);
     }


### PR DESCRIPTION
This PR adds the ability to specify the preset you want to generate on `php please assets:generate-presets`, eg:

`php please assets:generate-presets --preset=my_preset`

there is also a special case for cp_thumbmail (which is our use case) which regenerates those, as they have a different name depending on the orientation.

`php please assets:generate-presets --preset=cp_thumbnail`