### PR TITLE
[6.x] Fix perPage limit in relationship stack listings

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -181,7 +181,7 @@ class Entries extends Relationship
             $query->orderBy($sort, $this->getSortDirection($request));
         }
 
-        $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate($perPage = $request->integer('perPage', 15)) : $query->get();
+        $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate($request->integer('perPage', 15)) : $query->get();
 
         $items = $results->map(fn ($item) => $item instanceof Result ? $item->getSearchable() : $item);
 

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -181,7 +181,7 @@ class Entries extends Relationship
             $query->orderBy($sort, $this->getSortDirection($request));
         }
 
-        $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate() : $query->get();
+        $results = ($paginate = $request->boolean('paginate', true)) ? $query->paginate($perPage = $request->integer('perPage', 15)) : $query->get();
 
         $items = $results->map(fn ($item) => $item instanceof Result ? $item->getSearchable() : $item);
 

--- a/src/Fieldtypes/Terms.php
+++ b/src/Fieldtypes/Terms.php
@@ -297,7 +297,7 @@ class Terms extends Relationship
             $query->orderBy($sort, $this->getSortDirection($request));
         }
 
-        return $request->boolean('paginate', true) ? $query->paginate() : $query->get();
+        return $request->boolean('paginate', true) ? $query->paginate($request->integer('perPage', 15)) : $query->get();
     }
 
     private function authorizeTaxonomyAccess(array $taxonomies): void

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -169,7 +169,7 @@ class Users extends Relationship
         };
 
         if ($request->boolean('paginate', true)) {
-            $users = $query->paginate();
+            $users = $query->paginate($request->integer('perPage', 15));
 
             $users->getCollection()->transform($userFields);
 


### PR DESCRIPTION
Add support for the perPage parameter for Entries field.

Before:
<img width="2560" height="1351" alt="image" src="https://github.com/user-attachments/assets/88f1bbfa-240f-480c-b23d-c2573f929b17" />

After: 
<img width="2560" height="1349" alt="image" src="https://github.com/user-attachments/assets/4201e4be-c807-4510-ba45-2f12cf62645c" />

Issue: #14628