### PR TITLE
[6.x] Fix CP login bouncing after Inertia auto-follow

### DIFF
--- a/resources/js/pages/auth/Login.vue
+++ b/resources/js/pages/auth/Login.vue
@@ -40,13 +40,6 @@ const submit = () => {
             processing.value = true;
             errors.value = {};
         },
-        onSuccess: (page) => {
-            if (page.component === 'auth/two-factor/Challenge') {
-                return;
-            }
-
-            window.location.href = page.url;
-        },
         onError: () => processing.value = false
     });
 }

--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -111,9 +111,13 @@ class LoginController extends CpController
 
     protected function authenticated(Request $request, $user)
     {
-        return $request->expectsJson()
-            ? response('Authenticated')
-            : redirect()->intended($this->redirectPath());
+        if ($request->expectsJson()) {
+            return response('Authenticated');
+        }
+
+        $url = redirect()->intended($this->redirectPath())->getTargetUrl();
+
+        return $request->inertia() ? Inertia::location($url) : redirect($url);
     }
 
     protected function credentials(Request $request)

--- a/tests/Auth/LoginTest.php
+++ b/tests/Auth/LoginTest.php
@@ -135,6 +135,44 @@ class LoginTest extends TestCase
     }
 
     #[Test]
+    public function inertia_login_returns_a_full_page_redirect()
+    {
+        // Inertia would otherwise auto-follow a 302 with X-Inertia headers and swap to
+        // the dashboard component without the protected props it needs to render.
+        // Returning 409 + X-Inertia-Location forces a full browser navigation instead.
+        $user = $this->user();
+
+        $this
+            ->assertGuest()
+            ->post(cp_route('login'), [
+                'email' => $user->email(),
+                'password' => 'secret',
+            ], ['X-Inertia' => 'true'])
+            ->assertStatus(409)
+            ->assertHeader('X-Inertia-Location', cp_route('index'));
+
+        $this->assertAuthenticatedAs($user);
+    }
+
+    #[Test]
+    public function inertia_login_redirects_to_intended_url_via_full_page_redirect()
+    {
+        $user = $this->user();
+
+        $this
+            ->assertGuest()
+            ->session(['url.intended' => 'http://localhost/cp/cp/collections'])
+            ->post(cp_route('login'), [
+                'email' => $user->email(),
+                'password' => 'secret',
+            ], ['X-Inertia' => 'true'])
+            ->assertStatus(409)
+            ->assertHeader('X-Inertia-Location', 'http://localhost/cp/cp/collections');
+
+        $this->assertAuthenticatedAs($user);
+    }
+
+    #[Test]
     public function it_stores_the_intended_url_when_redirected_to_login()
     {
         $this


### PR DESCRIPTION
Fixes #14631.

## Summary

After a successful CP login, Inertia would auto-follow the `302` redirect to `/cp/dashboard` with `X-Inertia` headers. The middleware intentionally strips protected props (`sessionExpiry`, `licensing`, `selectedSiteUrl`, `supportUrl`) from Inertia responses to prevent them leaking to Outside-layout views. That meant the dashboard's first mount (post-login) received no `sessionExpiry`, and `SessionExpiry.vue`'s eager destructure `{ warnAt, ... } = sessionExpiry` threw `Cannot read properties of undefined (reading 'warnAt')` during the page swap.

The existing `window.location.href = page.url` in `Login.vue`'s `onSuccess` was meant to prevent this by forcing a full reload, but `onSuccess` only fires *after* the swap — so the crash had already happened. In most environments the reload still won the race and users didn't notice; under Cypress, slow networks, or proxied setups it didn't, and the browser ended up on a frontend route.

## Changes

- `LoginController::authenticated()` now returns `Inertia::location($url)` (a `409` + `X-Inertia-Location` header) for Inertia requests, so the Inertia client does a real browser navigation instead of an in-place page swap. Same pattern already used in `TwoFactorChallengeController::store()`.
- Removed the now-unreachable `onSuccess` callback in `Login.vue`. The 2FA branch only existed to skip the (now-gone) `window.location.href` line.
- Added regression tests covering the Inertia 409 response for both the default redirect path and a stashed `url.intended`.

The middleware's protected-props isolation is preserved unchanged.

## Test plan

- [x] `phpunit tests/Auth/LoginTest.php` (14 passing)
- [x] Manually log into the CP via the standard form; lands on the dashboard with no console errors
- [x] Log in with 2FA enabled; redirected to the challenge page, then to the dashboard after submitting a code
- [x] Log in with an invalid password; sees validation errors on the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)