### PR TITLE
[6.x] Simplify crop aspect ratio config formats

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -188,8 +188,8 @@ return [
     |--------------------------------------------------------------------------
     |
     | Configure the aspect ratio presets available in the Control Panel image
-    | crop editor. Ratios may be provided as "W:H" strings, keyed values, or
-    | arrays with custom labels and ratio values.
+    | crop editor. Each entry may be a "W:H" string (e.g. "16:9") or an array
+    | with a custom label and ratio: ['label' => 'Wide', 'ratio' => '16:9'].
     |
     */
 

--- a/src/Assets/CropAspectRatios.php
+++ b/src/Assets/CropAspectRatios.php
@@ -39,7 +39,6 @@ class CropAspectRatios
             return null;
         }
 
-        $label = is_string($key) ? $key : (string) $entry;
         $value = self::ratioToFloat($entry);
 
         if ($value === null) {
@@ -49,7 +48,7 @@ class CropAspectRatios
         }
 
         return [
-            'label' => $label,
+            'label' => __((string) $entry),
             'value' => $value,
         ];
     }
@@ -60,7 +59,7 @@ class CropAspectRatios
      */
     private static function parseArrayEntry(array $entry, mixed $key): ?array
     {
-        $label = $entry['label'] ?? (is_string($key) ? $key : null);
+        $label = $entry['label'] ?? null;
         $ratio = $entry['ratio'] ?? null;
 
         $labelIsStringable = is_string($label) || is_numeric($label) || $label instanceof \Stringable;
@@ -80,7 +79,7 @@ class CropAspectRatios
         }
 
         return [
-            'label' => (string) $label,
+            'label' => __((string) $label),
             'value' => $value,
         ];
     }

--- a/src/Assets/CropAspectRatios.php
+++ b/src/Assets/CropAspectRatios.php
@@ -4,6 +4,8 @@ namespace Statamic\Assets;
 
 use Illuminate\Support\Facades\Log;
 
+use function Statamic\trans as __;
+
 class CropAspectRatios
 {
     /**

--- a/tests/Assets/CropAspectRatiosTest.php
+++ b/tests/Assets/CropAspectRatiosTest.php
@@ -38,16 +38,20 @@ class CropAspectRatiosTest extends TestCase
     }
 
     #[Test]
-    public function it_supports_keyed_ratio_entries()
+    public function it_translates_labels()
     {
+        app('translator')->addLines([
+            'crop.wide' => 'Wide Screen',
+        ], 'en');
+
         config()->set('statamic.assets.crop_aspect_ratios', [
-            'Portrait' => '9:16',
-            'A4' => '210:297',
+            ['label' => 'crop.wide', 'ratio' => '16:9'],
+            ['label' => 'Square', 'ratio' => '1:1'],
         ]);
 
         $this->assertSame([
-            ['label' => 'Portrait', 'value' => 9 / 16],
-            ['label' => 'A4', 'value' => 210 / 297],
+            ['label' => 'Wide Screen', 'value' => 16 / 9],
+            ['label' => 'Square', 'value' => 1.0],
         ], CropAspectRatios::all());
     }
 

--- a/tests/Http/View/Composers/JavascriptComposerTest.php
+++ b/tests/Http/View/Composers/JavascriptComposerTest.php
@@ -17,7 +17,7 @@ class JavascriptComposerTest extends TestCase
     public function it_provides_crop_aspect_ratios_to_script_config()
     {
         config()->set('statamic.assets.crop_aspect_ratios', [
-            'Portrait' => '9:16',
+            '9:16',
             ['label' => 'US Letter', 'ratio' => '8.5:11'],
         ]);
 
@@ -33,7 +33,7 @@ class JavascriptComposerTest extends TestCase
         $json = Statamic::jsonVariables(request());
 
         $this->assertSame([
-            ['label' => 'Portrait', 'value' => 9 / 16],
+            ['label' => '9:16', 'value' => 9 / 16],
             ['label' => 'US Letter', 'value' => 8.5 / 11],
         ], $json['cropAspectRatios']);
     }


### PR DESCRIPTION
While writing the docs for #14630 I thought of some tweaks.

The original implementation accepted several overlapping ways to define crop aspect ratios. This trims it down to two supported shapes:

- `'16:9'` — a plain `W:H` string (label is the ratio itself)
- `['label' => 'Wide', 'ratio' => '16:9']` — array form with a custom label

Removed:
- Keyed-string entries (`'Portrait' => '9:16'`) — lost ordering and didn't translate well to non-PHP config formats.
- Array-key as label fallback (`'Wide' => ['ratio' => '16:9']`).

Numeric ratios (e.g. `1.618`) are still accepted both as bare list entries and inside the array form.

Labels are now passed through `__()` at resolve time, so they can be translation keys. Calling `__()` directly in the config file wouldn't work because (a) the CP locale isn't set when config evaluates and (b) `php artisan config:cache` would bake the build-time locale into the deploy. Resolving in `CropAspectRatios::all()` (called per-request from `JavascriptComposer`) sidesteps both.