### PR TITLE
[6.x] Fix flaky TracksLastModified file timestamp test

### DIFF
--- a/tests/Data/TracksLastModifiedTest.php
+++ b/tests/Data/TracksLastModifiedTest.php
@@ -38,6 +38,8 @@ class TracksLastModifiedTest extends TestCase
     #[Test]
     public function it_gets_last_updated_at_from_file()
     {
+        $this->freezeTime();
+
         $this->assertFalse($this->entry->has('updated_at'));
         $this->assertEquals($this->entry->fileLastModified()->timestamp, $this->entry->lastModified()->timestamp);
     }


### PR DESCRIPTION
The `it_gets_last_updated_at_from_file` test in `TracksLastModifiedTest` is intermittently flaky on CI.

The entry under test is never saved, so its file doesn't exist on disk. Both `fileLastModified()` and `lastModified()` fall through to `Carbon::now()`. If the second-tick rolls over between the two calls, the timestamps differ by 1 and the assertion fails (e.g. `1778265757` vs `1778265756`).

Freezing time at the start of the test pins both calls to the same instant.