### PR TITLE
[6.x] Hide redundant 'This field' timezone row in date pickers

### DIFF
--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -27,6 +27,7 @@ import Calendar from '../Calendar/Calendar.vue';
 import Icon from '../Icon/Icon.vue';
 import Text from '../Text.vue';
 import TimezoneHoverCard from '../TimezoneHoverCard.vue';
+import { getAdditionalTimezones } from './util.js';
 
 const emit = defineEmits(['update:modelValue']);
 
@@ -107,6 +108,8 @@ const timeZoneLabel = computed(() => {
     const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.toDate());
     return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
 });
+
+const additionalTimezones = computed(() => getAdditionalTimezones(timeZoneName.value));
 
 const isInvalid = computed(() => {
     // Check if the component has invalid state from form validation
@@ -203,7 +206,7 @@ const getInputLabel = (part) => {
                         <TimezoneHoverCard
                             v-if="timeZoneLabel"
                             :date="modelValue.toDate()"
-                            :additional-timezones="[{ timezone: timeZoneName, label: __('This field') }]"
+                            :additional-timezones="additionalTimezones"
                             side="top"
                         >
                             <Text class="text-gray-600 dark:text-gray-400 me-1" size="xs" :text="timeZoneLabel" />

--- a/resources/js/components/ui/DatePicker/util.js
+++ b/resources/js/components/ui/DatePicker/util.js
@@ -1,0 +1,9 @@
+import { config } from '@api';
+import { getLocalTimeZone } from '@internationalized/date';
+
+export function getAdditionalTimezones(timeZone) {
+    if (!timeZone) return [];
+    if (timeZone === (config.get('displayTimezone') ?? 'UTC')) return [];
+    if (timeZone === getLocalTimeZone()) return [];
+    return [{ timezone: timeZone, label: __('This field') }];
+}

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -27,6 +27,7 @@ import Icon from '../Icon/Icon.vue';
 import Text from '../Text.vue';
 import TimezoneHoverCard from '../TimezoneHoverCard.vue';
 import { parseAbsoluteToLocal } from '@internationalized/date';
+import { getAdditionalTimezones } from '../DatePicker/util.js';
 
 const emit = defineEmits(['update:modelValue']);
 
@@ -110,6 +111,8 @@ const timeZoneLabel = computed(() => {
     return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
 });
 
+const additionalTimezones = computed(() => getAdditionalTimezones(timeZoneName.value));
+
 const hoverCardDate = computed(() => {
     if (!props.modelValue?.start || !props.modelValue?.end) return null;
     return { start: props.modelValue.start.toDate(), end: props.modelValue.end.toDate() };
@@ -182,7 +185,7 @@ const hoverCardDate = computed(() => {
                     <TimezoneHoverCard
                         v-if="timeZoneLabel && hoverCardDate"
                         :date="hoverCardDate"
-                        :additional-timezones="[{ timezone: timeZoneName, label: __('This field') }]"
+                        :additional-timezones="additionalTimezones"
                         side="top"
                     >
                         <Text class="text-gray-600 dark:text-gray-400 me-1" size="xs" :text="timeZoneLabel" />


### PR DESCRIPTION
## Summary

In #14612 the date and date-range pickers gained a "This field" row in the timezone hover card. When the field's timezone matches "Site time" or your computer's local time, that extra row is just a duplicate and makes the hover card more confusing rather than more informative.

This change skips passing the additional row to `TimezoneHoverCard` when the field's timezone equals either the configured `displayTimezone` or `getLocalTimeZone()`. The small timezone label below the input still renders so the field's zone remains visible.

The dedup logic is extracted into `resources/js/components/ui/DatePicker/util.js` so both `DatePicker.vue` and `DateRangePicker.vue` share it.

## Test plan

- [x] Open a date field whose timezone matches the site's display timezone — hover card shows only Site time / Your time
- [x] Open a date field whose timezone matches the browser's local timezone — hover card shows only Site time / Your time
- [x] Open a date field whose timezone differs from both — hover card shows the "This field" row
- [x] Repeat above with a date range field