### PR TITLE
[6.x] Fix grid header overlapping nav

### DIFF
--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -12,7 +12,7 @@
         }
 
         thead th {
-            @apply sticky -top-2 table-cell z-(--z-index-draggable) border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-gray-700 dark:bg-gray-925 dark:text-gray-100;
+            @apply sticky -top-2 table-cell z-(--z-index-above) border-b bg-gray-50 p-2 text-sm font-medium text-gray-900 dark:border-gray-700 dark:bg-gray-925 dark:text-gray-100;
             /* Prevent the sticky toolbar from hitting the very end of container, which causes it to overlap the container's border-radius */
             margin-block-end: 8px;
             /* Pull the subsequent element up to compensate for this */

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -116,7 +116,7 @@
 @media (width < theme(--breakpoint-lg)) {
     .nav-main {
         /* Always visible but off-screen by default */
-        @apply flex;
+        @apply flex z-6;
         @apply bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700;
     }
 

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -116,7 +116,8 @@
 @media (width < theme(--breakpoint-lg)) {
     .nav-main {
         /* Always visible but off-screen by default */
-        @apply flex z-6;
+        z-index: var(--z-index-max);
+        @apply flex;
         @apply bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700;
     }
 

--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -116,7 +116,6 @@
 @media (width < theme(--breakpoint-lg)) {
     .nav-main {
         /* Always visible but off-screen by default */
-        z-index: var(--z-index-max);
         @apply flex;
         @apply bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700;
     }


### PR DESCRIPTION
Fix grid header overlaps navigation

Before:
<img width="1924" height="1700" alt="image" src="https://github.com/user-attachments/assets/80e26dd1-ce9f-42f3-abec-e8f76ffec278" />

After:
<img width="986" height="639" alt="image" src="https://github.com/user-attachments/assets/b751cdec-1d66-4a46-b00c-ac03388037f0" />

Fixes #14608