### PR TITLE
[6.x] Remove overscroll-behavior-x: contain; on panels

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -743,7 +743,7 @@ autoApplyState();
                 v-text="__('No results')"
             />
 
-            <Panel v-else class="relative overflow-x-auto overscroll-x-contain" style="container-type: scroll-state;">
+            <Panel v-else class="relative overflow-x-auto" style="container-type: scroll-state;">
                 <Table>
                     <template v-for="(slot, slotName) in forwardedTableCellSlots" :key="slotName" #[slotName]="slotProps">
                         <component :is="slot" v-bind="slotProps" />


### PR DESCRIPTION
## Description of the Problem

The UI panel component contains overscroll-x-contain, which disables the browsers default forward/back navigation when hovering over the panel and using a trackpad-like device, even if the panel isn't scrollable.

`overscroll-behavior-x: contain;`—which prevents scroll chaining for neighboring scrolling areas—may be desirable, but the side effect of disabling native navigation is likely _less_ desirable, especially considering most panels won't be horizontally scrollable anyway.

## What this PR Does

- Removes the property, fixing native browser navigation
- Closes https://github.com/statamic/cms/issues/14614

## How to Reproduce

1. Go to a page that has the panel such as Collections > some collection
2. Hover over the panel and use a native navigation gesture such as swipe left to go back
3. Observe how it will not work when hovering over this UI component