### PR TITLE
[6.x] Fix date fieldtype input disappearing with underscore locales

### DIFF
--- a/resources/js/components/FormattingLocale.js
+++ b/resources/js/components/FormattingLocale.js
@@ -1,5 +1,9 @@
 let defaultLocale = null;
 
+export function normalizeLocale(locale) {
+    return typeof locale === 'string' ? locale.replace('_', '-') : locale;
+}
+
 export function getLocale() {
     return defaultLocale ?? Intl.DateTimeFormat().resolvedOptions().locale;
 }
@@ -9,5 +13,5 @@ export function getDefaultLocale() {
 }
 
 export function setDefaultLocale(locale) {
-    defaultLocale = locale;
+    defaultLocale = normalizeLocale(locale);
 }

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { config } from '@api';
 import { computed } from 'vue';
+import { normalizeLocale } from '../../FormattingLocale.js';
 import {
     DatePickerAnchor,
     DatePickerContent,
@@ -105,7 +106,7 @@ const timeZoneLabel = computed(() => {
     const tz = timeZoneName.value;
     if (!tz) return null;
 
-    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.toDate());
+    const parts = new Intl.DateTimeFormat(normalizeLocale(config.get('translationLocale')), { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.toDate());
     return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
 });
 

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { config } from '@api';
 import { computed } from 'vue';
+import { normalizeLocale } from '../../FormattingLocale.js';
 import {
     DateRangePickerCalendar,
     DateRangePickerCell,
@@ -107,7 +108,7 @@ const timeZoneLabel = computed(() => {
     const tz = timeZoneName.value;
     if (!tz) return null;
 
-    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.start.toDate());
+    const parts = new Intl.DateTimeFormat(normalizeLocale(config.get('translationLocale')), { timeZone: tz, timeZoneName: 'short' }).formatToParts(props.modelValue.start.toDate());
     return parts.find((p) => p.type === 'timeZoneName')?.value ?? tz;
 });
 

--- a/resources/js/components/ui/Timezones.vue
+++ b/resources/js/components/ui/Timezones.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue';
 import { dateFormatter, config } from '@api';
 import { getLocalTimeZone } from '@internationalized/date';
+import { normalizeLocale } from '../FormattingLocale.js';
 import Text from './Text.vue';
 
 const props = defineProps({
@@ -29,7 +30,7 @@ const isValid = computed(() => {
 const displayTimezone = computed(() => config.get('displayTimezone') ?? 'UTC');
 
 const formatTimeZone = (timeZone) => {
-    const parts = new Intl.DateTimeFormat(config.get('translationLocale'), {
+    const parts = new Intl.DateTimeFormat(normalizeLocale(config.get('translationLocale')), {
         timeZone,
         timeZoneName: 'short',
     }).formatToParts(start.value);

--- a/resources/js/tests/components/DateFormatter.test.js
+++ b/resources/js/tests/components/DateFormatter.test.js
@@ -213,6 +213,12 @@ test('it can set the default locale via setDefaultLocale', () => {
     expect(new DateFormatter().locale).toBe('de');
 });
 
+test('it normalizes underscored locales to BCP 47 format', () => {
+    DateFormatter.defaultLocale = 'pt_BR';
+    expect(DateFormatter.defaultLocale).toBe('pt-BR');
+    expect(new DateFormatter().locale).toBe('pt-BR');
+});
+
 test.each([
     ['en', 'date', '12/25/2021'],
     ['en', 'time', '12:13 PM'],


### PR DESCRIPTION
## Summary

When the CP language is a 4-character locale like `pt_BR` or `de_CH` and a date field has a timezone configured, the input form was disappearing.

The cause: locales like `pt_BR` use underscores, but BCP 47 (which `Intl.DateTimeFormat` requires) uses hyphens. `new Intl.DateTimeFormat('pt_BR', …)` throws `RangeError: Incorrect locale information provided`. That call lives inside the `timeZoneLabel` computed in `DatePicker.vue` (and the equivalents in `DateRangePicker.vue` / `Timezones.vue`). With `timezone: auto` the computed returns early and never reaches the Intl call, which is why only fields with an explicit timezone broke.

## Changes

- Added a `normalizeLocale()` helper in `FormattingLocale.js` that swaps `_` for `-`, and applied it in `setDefaultLocale()` so `dateFormatter.locale` (and the reka-ui `:locale` prop) always receive a valid BCP 47 tag.
- Wrapped the three direct `config.get('translationLocale')` calls used with `Intl.DateTimeFormat` (`DatePicker.vue`, `DateRangePicker.vue`, `Timezones.vue`) with `normalizeLocale()`.
- Added a regression test in `DateFormatter.test.js`.

Fixes #14637.