### PR TITLE
[6.x] Fix /index.php request poisoning Site::absoluteUrl

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -469,6 +469,13 @@ class URL
     {
         $rootUrl = url()->to('/');
 
+        // When the request hits the front controller directly (e.g. /index.php),
+        // Laravel's root URL ends with the script name. Strip it so the site's
+        // absolute URL stays invariant to whether the request came through it.
+        if ($script = pathinfo(request()->getScriptName())['basename'] ?? null) {
+            $rootUrl = Str::removeRight($rootUrl, '/'.$script);
+        }
+
         return self::tidy($rootUrl);
     }
 }

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -560,6 +560,26 @@ class UrlTest extends TestCase
     }
 
     #[Test]
+    public function making_urls_absolute_ignores_front_controller_in_request_root()
+    {
+        $this->setSiteValue('en', 'url', '/');
+
+        $request = \Illuminate\Http\Request::create(
+            'http://absolute-url-resolved-from-request.com/index.php',
+            'GET',
+            [],
+            [],
+            [],
+            ['SCRIPT_NAME' => '/index.php', 'SCRIPT_FILENAME' => 'index.php', 'PHP_SELF' => '/index.php']
+        );
+        $this->app->instance('request', $request);
+        \Illuminate\Support\Facades\URL::setRequest($request);
+
+        $this->assertSame('http://absolute-url-resolved-from-request.com', URL::makeAbsolute('/'));
+        $this->assertSame('http://absolute-url-resolved-from-request.com/foo', URL::makeAbsolute('/foo'));
+    }
+
+    #[Test]
     #[DataProvider('relativeProvider')]
     public function it_makes_urls_relative($url, $expected)
     {


### PR DESCRIPTION
## Summary

Fixes #14644.

On a Statamic 6 site without `resources/sites.yaml`, a direct request to `/index.php` was returning the homepage with a 200 instead of a 404, and every link in the rendered response was prefixed with `/index.php/...`. With full static caching, that response got written to disk and served on every subsequent `/index.php` hit indefinitely — and crawlers then spidered the `/index.php/{slug}` link graph, poisoning more cached entries.

## Root cause

PR #11840 changed `Site::absoluteUrl()` from `request()->getSchemeAndHttpHost() . $url` to `URL::makeAbsolute($url)`. The old form was invariant to request entry point; the new form delegates to `URL::getRequestRootUrl()`, which calls Laravel's `url()->to('/')` — and that includes the base URL (e.g. `/index.php`) when the request hits the front controller directly. So on a `/index.php` request, the site's "absolute URL" inflated to `https://host/index.php`. `Data::findByRequestUrl()` then stripped that off the request URL, leaving `''` → normalized to `/` → matched the homepage entry → 200.

## Fix

Strip the front-controller script name from `URL::getRequestRootUrl()` so the result stays invariant to whether the request hit `/index.php` or `/`. Same pattern is already used in `URL::prependSiteUrl()` (line 152–156), so this is consistent with existing convention. Uses `pathinfo(request()->getScriptName())['basename']` rather than hardcoding `index.php`, in case the front controller has been renamed.

This addresses the root cause for all sites with a relative URL — both the missing-`sites.yaml` fallback case _and_ users who explicitly configure `url: /` in `sites.yaml`.

## Verification

Restores Statamic 5 behavior. Confirmed end-to-end via `php -S`:

| URL | Before fix | After fix |
|---|---|---|
| `/` | 200 | 200 |
| `/index.php` | 200 (homepage) | 404 |
| `/about/staff` | 200 | 200 |
| `/index.php/about/staff` | 200 (poisoned) | 404 |

## Test plan

- [x] New unit test `making_urls_absolute_ignores_front_controller_in_request_root` covers the regression.
- [x] Verified the test fails without the patch (returns `…com/index.php`) and passes with it.
- [x] Full `tests/Facades/UrlTest.php` (450 tests), `tests/Sites`, `tests/StaticCaching`, `tests/Data`, `tests/Routing` all pass.
- [x] End-to-end verified against `php -S` with a real Statamic site.
- [x] Pint passes.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>