### PR TITLE
[6.x] Fix the scrollbars showing all the time on the calendar view

### DIFF
--- a/resources/js/components/entries/calendar/Month.vue
+++ b/resources/js/components/entries/calendar/Month.vue
@@ -128,7 +128,7 @@ const selectDate = (date) => {
                                 </div>
                             </div>
 
-                            <div class="space-y-1.5 flex-1 overflow-scroll overscroll-contain h-full w-full hidden @3xl:block">
+                            <div class="space-y-1.5 flex-1 overflow-auto overscroll-contain h-full w-full hidden @3xl:block">
                                 <CalendarEntry
                                     v-for="entry in getEntriesForDate(weekDate)"
                                     :key="entry.id"


### PR DESCRIPTION
## Description of the Problem

Because all the calendar day views have `overflow-scroll`, if you use a device that always shows scrollbars—such as some Windows devices or if you set macOS to System Settings > Appearance > Show scroll bars > When scrolling—you'll see scrollbars on every single day.

This issue is reported here https://github.com/statamic/cms/issues/14625

<img width="3420" height="2146" alt="2026-05-12 at 15 12 42@2x" src="https://github.com/user-attachments/assets/476c7941-8558-4070-a8ba-bc0a02a7871e" />

## What this PR Does

- Switches `overflow-scroll` for `overflow-auto`, meaning scrollbars will appear only if necessary.
- Closes #14625 

### After

<img width="3420" height="2146" alt="2026-05-12 at 15 12 59@2x" src="https://github.com/user-attachments/assets/d65ac70e-7260-48cb-b192-330ad5adec47" />

## How to Reproduce

1. Go to a dated collection listing such as a blog, and switch to the calendar view
2. Make sure you have scrollbars showing. If you're on macOS, set macOS to System Settings > Appearance > Show scroll bars > When scrolling
3. See all the scrollbars