### PR TITLE
[6.x] Show crop dimensions in the crop editor

### DIFF
--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -459,9 +459,9 @@ function close() {
                 <div
                     v-if="cropDimensions"
                     class="absolute top-5 end-5 z-10 rounded-md bg-gray-900/75 px-2 py-1 text-xs font-medium text-white tabular-nums pointer-events-none"
-                    :aria-label="__('Crop dimensions')"
+                    :aria-label="__('Dimensions')"
                 >
-                    {{ cropDimensions.width }} &times; {{ cropDimensions.height }} px
+                    {{ __('messages.width_x_height', { width: cropDimensions.width, height: cropDimensions.height }) }}
                 </div>
             </div>
 

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -460,9 +460,9 @@ function close() {
                     v-if="cropDimensions"
                     class="absolute top-5 end-5 z-10 rounded-md bg-gray-900/75 px-2 py-1 text-xs font-medium text-white tabular-nums pointer-events-none"
                     :aria-label="__('Dimensions')"
-                >
-                    {{ __('messages.width_x_height', { width: cropDimensions.width, height: cropDimensions.height }) }}
-                </div>
+                    v-text="__('messages.width_x_height', { width: cropDimensions.width, height: cropDimensions.height })"
+                />
+
             </div>
 
             <!-- Footer -->

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -38,6 +38,7 @@ const showConfirmation = ref(false);
 const uploading = ref(false);
 const pendingBlob = ref(null);
 const pendingMimeType = ref(null);
+const cropDimensions = ref(null);
 
 const aspectRatios = ref(Statamic.$config.get('cropAspectRatios') || []);
 
@@ -67,6 +68,7 @@ function resetState() {
     uploading.value = false;
     pendingBlob.value = null;
     pendingMimeType.value = null;
+    cropDimensions.value = null;
 }
 
 function destroyCropper() {
@@ -118,7 +120,15 @@ function createCropper(imageElement) {
         cropstart: onCropStart,
         cropmove: onCropMove,
         cropend: onCropEnd,
+        crop: onCrop,
     });
+}
+
+function onCrop(event) {
+    cropDimensions.value = {
+        width: Math.round(event.detail.width),
+        height: Math.round(event.detail.height),
+    };
 }
 
 function onCropStart() {
@@ -445,6 +455,13 @@ function close() {
             <div class="bg-gray-300 p-3 inset-shadow-xs dark:bg-gray-850 flex flex-1 flex-col overflow-auto relative min-h-0 w-full items-center justify-center" role="img" :aria-label="__('Image crop area')">
                 <div class="h-full w-full min-h-0 flex items-center justify-center overflow-hidden">
                     <img ref="image" :src="asset.preview" :crossorigin="crossOrigin" :alt="__('Image to crop')" class="max-w-full max-h-full" @error="onImageError" />
+                </div>
+                <div
+                    v-if="cropDimensions"
+                    class="absolute top-5 end-5 z-10 rounded-md bg-gray-900/75 px-2 py-1 text-xs font-medium text-white tabular-nums pointer-events-none"
+                    :aria-label="__('Crop dimensions')"
+                >
+                    {{ cropDimensions.width }} &times; {{ cropDimensions.height }} px
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary

Displays the live pixel dimensions of the current crop selection as a floating badge in the top-right corner of the crop area, so users can confirm they aren't accidentally producing a low-resolution image.

The dimensions update in real time as the crop box is moved or resized, using cropperjs's `crop` event (which provides `width`/`height` in the image's natural pixel dimensions).

<img width="1103" height="820" alt="CleanShot 2026-05-12 at 10 43 51" src="https://github.com/user-attachments/assets/f19caf6f-7089-4761-8241-69c4ca30f0a1" />

Closes [statamic/ideas#1460](https://github.com/statamic/ideas/issues/1460).