### PR TITLE
[6.x] Collapse equal range endpoints in NumberFormatter

### DIFF
--- a/resources/js/components/NumberFormatter.js
+++ b/resources/js/components/NumberFormatter.js
@@ -36,11 +36,13 @@ export default class NumberFormatter {
 
     toString() {
         try {
-            if (this.#rangeEnd !== undefined) {
-                return Intl.NumberFormat(this.locale, this.#options).formatRange(this.#number, this.#rangeEnd);
+            const formatter = Intl.NumberFormat(this.locale, this.#options);
+
+            if (this.#rangeEnd !== undefined && this.#rangeEnd !== this.#number) {
+                return formatter.formatRange(this.#number, this.#rangeEnd);
             }
 
-            return Intl.NumberFormat(this.locale, this.#options).format(this.#number);
+            return formatter.format(this.#number);
         } catch (e) {
             return 'Invalid Number';
         }

--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -4,6 +4,7 @@ const normalizeInputOptions = HasInputOptions.methods.normalizeInputOptions;
 import { flatten, sortBy, range } from 'lodash-es';
 import Select from './Select/Select.vue';
 import Button from './Button/Button.vue';
+import NumberFormatter from '@/components/NumberFormatter.js';
 import { computed } from 'vue';
 
 const emit = defineEmits(['page-selected', 'per-page-changed']);
@@ -81,8 +82,8 @@ const fromItem = computed(() => props.resourceMeta.from || 0);
 const toItem = computed(() => Math.min(props.resourceMeta.to, totalItems.value));
 const formattedRange = computed(() => {
     return fromItem.value === toItem.value
-        ? Statamic.$number.format(fromItem.value)
-        : Statamic.$number.formatRange(fromItem.value, toItem.value);
+        ? NumberFormatter.format(fromItem.value)
+        : NumberFormatter.formatRange(fromItem.value, toItem.value);
 });
 
 function selectPage(page) {

--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -4,7 +4,7 @@ const normalizeInputOptions = HasInputOptions.methods.normalizeInputOptions;
 import { flatten, sortBy, range } from 'lodash-es';
 import Select from './Select/Select.vue';
 import Button from './Button/Button.vue';
-import { numberFormatter } from '@api';
+import { numberFormatter as $number } from '@api';
 import { computed } from 'vue';
 
 const emit = defineEmits(['page-selected', 'per-page-changed']);
@@ -82,8 +82,8 @@ const fromItem = computed(() => props.resourceMeta.from || 0);
 const toItem = computed(() => Math.min(props.resourceMeta.to, totalItems.value));
 const formattedRange = computed(() => {
     return fromItem.value === toItem.value
-        ? numberFormatter.format(fromItem.value)
-        : numberFormatter.formatRange(fromItem.value, toItem.value);
+        ? $number.format(fromItem.value)
+        : $number.formatRange(fromItem.value, toItem.value);
 });
 
 function selectPage(page) {

--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -79,6 +79,11 @@ const showPerPageSelector = computed(() => props.showPerPageSelector && isPerPag
 const totalItems = computed(() => props.resourceMeta.total);
 const fromItem = computed(() => props.resourceMeta.from || 0);
 const toItem = computed(() => Math.min(props.resourceMeta.to, totalItems.value));
+const formattedRange = computed(() => {
+    return fromItem.value === toItem.value
+        ? Statamic.$number.format(fromItem.value)
+        : Statamic.$number.formatRange(fromItem.value, toItem.value);
+});
 
 function selectPage(page) {
     if (page === currentPage.value) {
@@ -156,7 +161,7 @@ function getRange(start, end) {
         <div class="flex flex-1 items-center">
             <div class="text-sm text-gray-600 dark:text-gray-500" v-if="showTotals && totalItems > 0">
                 {{ __(':range of :total', {
-                    range: $number.formatRange(fromItem, toItem),
+                    range: formattedRange,
                     total: $number.format(totalItems)
                 }) }}
             </div>

--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -4,7 +4,6 @@ const normalizeInputOptions = HasInputOptions.methods.normalizeInputOptions;
 import { flatten, sortBy, range } from 'lodash-es';
 import Select from './Select/Select.vue';
 import Button from './Button/Button.vue';
-import { numberFormatter as $number } from '@api';
 import { computed } from 'vue';
 
 const emit = defineEmits(['page-selected', 'per-page-changed']);
@@ -80,11 +79,6 @@ const showPerPageSelector = computed(() => props.showPerPageSelector && isPerPag
 const totalItems = computed(() => props.resourceMeta.total);
 const fromItem = computed(() => props.resourceMeta.from || 0);
 const toItem = computed(() => Math.min(props.resourceMeta.to, totalItems.value));
-const formattedRange = computed(() => {
-    return fromItem.value === toItem.value
-        ? $number.format(fromItem.value)
-        : $number.formatRange(fromItem.value, toItem.value);
-});
 
 function selectPage(page) {
     if (page === currentPage.value) {
@@ -162,7 +156,7 @@ function getRange(start, end) {
         <div class="flex flex-1 items-center">
             <div class="text-sm text-gray-600 dark:text-gray-500" v-if="showTotals && totalItems > 0">
                 {{ __(':range of :total', {
-                    range: formattedRange,
+                    range: $number.formatRange(fromItem, toItem),
                     total: $number.format(totalItems)
                 }) }}
             </div>

--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -4,7 +4,7 @@ const normalizeInputOptions = HasInputOptions.methods.normalizeInputOptions;
 import { flatten, sortBy, range } from 'lodash-es';
 import Select from './Select/Select.vue';
 import Button from './Button/Button.vue';
-import NumberFormatter from '@/components/NumberFormatter.js';
+import { numberFormatter } from '@api';
 import { computed } from 'vue';
 
 const emit = defineEmits(['page-selected', 'per-page-changed']);
@@ -82,8 +82,8 @@ const fromItem = computed(() => props.resourceMeta.from || 0);
 const toItem = computed(() => Math.min(props.resourceMeta.to, totalItems.value));
 const formattedRange = computed(() => {
     return fromItem.value === toItem.value
-        ? NumberFormatter.format(fromItem.value)
-        : NumberFormatter.formatRange(fromItem.value, toItem.value);
+        ? numberFormatter.format(fromItem.value)
+        : numberFormatter.formatRange(fromItem.value, toItem.value);
 });
 
 function selectPage(page) {

--- a/resources/js/tests/components/NumberFormatter.test.js
+++ b/resources/js/tests/components/NumberFormatter.test.js
@@ -203,6 +203,17 @@ describe('formatRange', () => {
     test('it normalizes string inputs', () => {
         expect(new NumberFormatter().formatRange('1000', '5000')).toBe('1,000–5,000');
     });
+
+    test('it formats a single number when the range endpoints are equal', () => {
+        expect(new NumberFormatter().formatRange(1, 1)).toBe('1');
+        expect(new NumberFormatter().formatRange('5', 5)).toBe('5');
+        expect(new NumberFormatter().formatRange(0.5, 0.5, 'percent')).toBe('50%');
+    });
+
+    test('it keeps the approximation when endpoints differ but format identically', () => {
+        expect(new NumberFormatter().formatRange(1, 1.3, { maximumFractionDigits: 0 })).toBe('~1');
+        expect(new NumberFormatter().formatRange(1.231, 1.234, { maximumFractionDigits: 2 })).toBe('~1.23');
+    });
 });
 
 describe('range via array syntax', () => {


### PR DESCRIPTION
`NumberFormatter.formatRange()` (and the underlying `Intl.NumberFormat.formatRange()`) prefixes the output with an "approximately" sign (`~`) whenever the start and end values format to the same string — including when they are strictly equal.

This updates `NumberFormatter` so that when the range endpoints are strictly equal, it falls back to a regular `format()` call and returns a single number with no `~` prefix. When the endpoints differ but happen to round to the same display value, the `~` is preserved (since that's the case it's meant to signal).

Resolves the paginator UI specifically: a listing with one item now reads `1 of 1` instead of `~1 of 1`. Any other range usage in the CP gets the same treatment for free.