### PR TITLE
[6.x] Work around new GitHub token format breaking CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,15 @@ jobs:
           ini-values: short_open_tag=on
           coverage: none
 
+      # Workaround for new GitHub token format breaking Composer 2.9.7's token
+      # regex (composer/composer#12849). shivammathur/setup-php writes the
+      # GITHUB_TOKEN into Composer's global auth.json; remove it so Composer
+      # never tries to validate it.
+      - name: Remove Composer github-oauth credentials
+        if: steps.should-run-tests.outputs.result == 'true'
+        shell: bash
+        run: rm -f ~/.composer/auth.json ~/.config/composer/auth.json "$APPDATA/Composer/auth.json"
+
       - name: Install dependencies
         uses: nick-invision/retry@v3
         if: steps.should-run-tests.outputs.result == 'true'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,15 +74,10 @@ jobs:
           extensions: fileinfo, exif, gd, pdo, sqlite, pdo_sqlite
           ini-values: short_open_tag=on
           coverage: none
-
-      # Workaround for new GitHub token format breaking Composer 2.9.7's token
-      # regex (composer/composer#12849). shivammathur/setup-php writes the
-      # GITHUB_TOKEN into Composer's global auth.json; remove it so Composer
-      # never tries to validate it.
-      - name: Remove Composer github-oauth credentials
-        if: steps.should-run-tests.outputs.result == 'true'
-        shell: bash
-        run: rm -f ~/.composer/auth.json ~/.config/composer/auth.json "$APPDATA/Composer/auth.json"
+          # Pass an empty token so setup-php doesn't write GITHUB_TOKEN into
+          # Composer's auth config. Composer 2.9.7's regex rejects the new
+          # GITHUB_TOKEN format (composer/composer#12849).
+          github-token: ''
 
       - name: Install dependencies
         uses: nick-invision/retry@v3


### PR DESCRIPTION
GitHub started rolling out a new installation token format on 2026-04-27 (see [changelog](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/)). The new `ghs_APPID_JWT` token contains base64url characters, including `-`. Composer 2.9.7's token validation regex (`^[.A-Za-z0-9_]+$` in `BaseIO.php`) does not allow `-`, so the auto-set `GITHUB_TOKEN` now sporadically fails the `composer require` step with:

```
Your github oauth token for github.com contains invalid characters: "***"
```

Upstream issue: composer/composer#12849.

Passing an empty `github-token` to `shivammathur/setup-php` stops it from writing `GITHUB_TOKEN` into Composer's auth config, so Composer never sees the new-format token. Composer will fall back to unauthenticated GitHub API calls during dependency resolution, which is fine for our public-only dependency graph.

Once Composer ships a patched release, we can revert this.