### PR TITLE
[6.x] Prevent overlapping git commit jobs

### DIFF
--- a/config/git.php
+++ b/config/git.php
@@ -64,6 +64,20 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Unique Lock Expiry
+    |--------------------------------------------------------------------------
+    |
+    | When commits are queued, a unique lock prevents multiple jobs from
+    | running concurrently against the same repository. This value (in
+    | seconds) controls how long that lock is held as a crash-safety
+    | net. It should exceed your queue worker's configured timeout.
+    |
+    */
+
+    'unique_lock_expiry' => env('STATAMIC_GIT_UNIQUE_LOCK_EXPIRY', 120),
+
+    /*
+    |--------------------------------------------------------------------------
     | Git User
     |--------------------------------------------------------------------------
     |

--- a/src/Git/CommitJob.php
+++ b/src/Git/CommitJob.php
@@ -3,14 +3,20 @@
 namespace Statamic\Git;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Statamic\Facades\Git;
 
-class CommitJob implements ShouldQueue
+class CommitJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
+
+    /**
+     * The number of seconds after which the job's unique lock will be released.
+     */
+    public int $uniqueFor = 120;
 
     /**
      * Create a new job instance.

--- a/src/Git/CommitJob.php
+++ b/src/Git/CommitJob.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Git;
 
 class CommitJob implements ShouldBeUnique, ShouldQueue
@@ -30,6 +31,8 @@ class CommitJob implements ShouldBeUnique, ShouldQueue
      */
     public function handle()
     {
-        Git::as($this->committer)->commit($this->message);
+        $committer = Cache::pull('statamic-git-pending-saves', 0) > 1 ? null : $this->committer;
+
+        Git::as($committer)->commit($this->message);
     }
 }

--- a/src/Git/CommitJob.php
+++ b/src/Git/CommitJob.php
@@ -10,6 +10,8 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Cache;
 use Statamic\Facades\Git;
 
+use function Statamic\trans as __;
+
 class CommitJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
@@ -29,8 +31,17 @@ class CommitJob implements ShouldBeUnique, ShouldQueue
      */
     public function handle()
     {
-        $committer = Cache::pull('statamic-git-pending-saves', 0) > 1 ? null : $this->committer;
+        $saves = Cache::pull('statamic-git-pending-saves', []);
+        $users = collect($saves)->unique('email')->values();
+        $coalesced = $users->count() > 1;
 
-        Git::as($committer)->commit($this->message);
+        $message = $this->message;
+
+        if ($coalesced) {
+            $trailers = $users->map(fn ($u) => "Co-Authored-By: {$u['name']} <{$u['email']}>")->implode("\n");
+            $message = ($message ?? __('Content saved'))."\n\n".$trailers;
+        }
+
+        Git::as($coalesced ? null : $this->committer)->commit($message);
     }
 }

--- a/src/Git/CommitJob.php
+++ b/src/Git/CommitJob.php
@@ -14,16 +14,14 @@ class CommitJob implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable;
 
-    /**
-     * The number of seconds after which the job's unique lock will be released.
-     */
-    public int $uniqueFor = 120;
+    public int $uniqueFor;
 
     /**
      * Create a new job instance.
      */
     public function __construct(public $message = null, public $committer = null)
     {
+        $this->uniqueFor = config('statamic.git.unique_lock_expiry', 120);
     }
 
     /**

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -4,6 +4,7 @@ namespace Statamic\Git;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
 use Statamic\Console\Processes\Git as GitProcess;
 use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\Antlers;
@@ -92,6 +93,8 @@ class Git
             $delayInMinutes = now()->addMinutes((int) $delay);
             $message = null;
         }
+
+        Cache::increment('statamic-git-pending-saves');
 
         CommitJob::dispatch($message, $this->authenticatedUser())
             ->onConnection(config('statamic.git.queue_connection'))

--- a/src/Git/Git.php
+++ b/src/Git/Git.php
@@ -94,7 +94,9 @@ class Git
             $message = null;
         }
 
-        Cache::increment('statamic-git-pending-saves');
+        $saves = Cache::get('statamic-git-pending-saves', []);
+        $saves[] = ['name' => $this->gitUserName(), 'email' => $this->gitUserEmail()];
+        Cache::put('statamic-git-pending-saves', $saves);
 
         CommitJob::dispatch($message, $this->authenticatedUser())
             ->onConnection(config('statamic.git.queue_connection'))
@@ -286,8 +288,11 @@ class Git
     {
         $string = str_replace('"', '', $string);
         $string = str_replace("'", '', $string);
+        $string = str_replace('\\', '\\\\', $string);
+        $string = str_replace('$', '\\$', $string);
+        $string = str_replace('`', '\\`', $string);
 
-        return escapeshellcmd($string);
+        return $string;
     }
 
     /**

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -401,6 +401,18 @@ EOT;
     }
 
     #[Test]
+    public function it_only_dispatches_one_commit_job_at_a_time()
+    {
+        Queue::fake();
+
+        Git::dispatchCommit();
+        Git::dispatchCommit();
+        Git::dispatchCommit();
+
+        Queue::assertPushed(\Statamic\Git\CommitJob::class, 1);
+    }
+
+    #[Test]
     public function it_doesnt_push_by_default()
     {
         Git::shouldReceive('push')->never();

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Git;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Processes\Git as GitProcess;
@@ -410,6 +411,32 @@ EOT;
         Git::dispatchCommit();
 
         Queue::assertPushed(\Statamic\Git\CommitJob::class, 1);
+    }
+
+    #[Test]
+    public function it_attributes_coalesced_commits_to_the_configured_user()
+    {
+        Cache::put('statamic-git-pending-saves', 3);
+
+        $user = User::make()->email('alice@example.com');
+
+        Git::shouldReceive('as')->with(null)->andReturnSelf()->once();
+        Git::shouldReceive('commit')->with('Entry saved')->once();
+
+        (new \Statamic\Git\CommitJob('Entry saved', $user))->handle();
+    }
+
+    #[Test]
+    public function it_attributes_non_coalesced_commits_to_the_authenticated_user()
+    {
+        Cache::put('statamic-git-pending-saves', 1);
+
+        $user = User::make()->email('alice@example.com');
+
+        Git::shouldReceive('as')->with($user)->andReturnSelf()->once();
+        Git::shouldReceive('commit')->with('Entry saved')->once();
+
+        (new \Statamic\Git\CommitJob('Entry saved', $user))->handle();
     }
 
     #[Test]

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -253,13 +253,8 @@ EOT;
 
         Git::commit('Message"; echo "deleting all your files now"; #');
 
-        $expectedUser = 'Jimmy\; echo deleting all your files now\; \# <jimmy@haxor.org\; echo deleting all your files now\; \#>';
-        $expectedMessage = 'Message\; echo deleting all your files now\; \#';
-
-        if (static::isRunningWindows()) {
-            $expectedUser = str_replace('\\', '^', $expectedUser);
-            $expectedMessage = str_replace('\\', '^', $expectedMessage);
-        }
+        $expectedUser = 'Jimmy; echo deleting all your files now; # <jimmy@haxor.org; echo deleting all your files now; #>';
+        $expectedMessage = 'Message; echo deleting all your files now; #';
 
         $lastCommit = $this->showLastCommit(base_path('content'));
 
@@ -416,12 +411,19 @@ EOT;
     #[Test]
     public function it_attributes_coalesced_commits_to_the_configured_user()
     {
-        Cache::put('statamic-git-pending-saves', 3);
+        Cache::put('statamic-git-pending-saves', [
+            ['name' => 'Alice', 'email' => 'alice@example.com'],
+            ['name' => 'Bob', 'email' => 'bob@example.com'],
+        ]);
 
         $user = User::make()->email('alice@example.com');
 
         Git::shouldReceive('as')->with(null)->andReturnSelf()->once();
-        Git::shouldReceive('commit')->with('Entry saved')->once();
+        Git::shouldReceive('commit')->withArgs(function ($message) {
+            return str_contains($message, 'Entry saved')
+                && str_contains($message, 'Co-Authored-By: Alice <alice@example.com>')
+                && str_contains($message, 'Co-Authored-By: Bob <bob@example.com>');
+        })->once();
 
         (new \Statamic\Git\CommitJob('Entry saved', $user))->handle();
     }
@@ -429,12 +431,50 @@ EOT;
     #[Test]
     public function it_attributes_non_coalesced_commits_to_the_authenticated_user()
     {
-        Cache::put('statamic-git-pending-saves', 1);
+        Cache::put('statamic-git-pending-saves', [
+            ['name' => 'Alice', 'email' => 'alice@example.com'],
+        ]);
 
         $user = User::make()->email('alice@example.com');
 
         Git::shouldReceive('as')->with($user)->andReturnSelf()->once();
         Git::shouldReceive('commit')->with('Entry saved')->once();
+
+        (new \Statamic\Git\CommitJob('Entry saved', $user))->handle();
+    }
+
+    #[Test]
+    public function it_adds_co_authored_by_trailers_for_coalesced_saves()
+    {
+        $this->files->put(base_path('content/collections/pages.yaml'), 'title: Pages Title Changed');
+
+        $message = "Content saved\n\nCo-Authored-By: Alice <alice@example.com>\nCo-Authored-By: Bob <bob@example.com>";
+
+        Git::commit($message);
+
+        $commit = $this->showLastCommit(base_path('content'));
+
+        $this->assertStringContainsString('Co-Authored-By: Alice <alice@example.com>', $commit);
+        $this->assertStringContainsString('Co-Authored-By: Bob <bob@example.com>', $commit);
+    }
+
+    #[Test]
+    public function it_deduplicates_co_authors_for_repeated_saves_by_the_same_user()
+    {
+        Cache::put('statamic-git-pending-saves', [
+            ['name' => 'Alice', 'email' => 'alice@example.com'],
+            ['name' => 'Alice', 'email' => 'alice@example.com'],
+            ['name' => 'Bob', 'email' => 'bob@example.com'],
+        ]);
+
+        $user = User::make()->email('alice@example.com');
+
+        Git::shouldReceive('as')->with(null)->andReturnSelf()->once();
+        Git::shouldReceive('commit')->withArgs(function ($message) {
+            return substr_count($message, 'Co-Authored-By:') === 2
+                && str_contains($message, 'Co-Authored-By: Alice <alice@example.com>')
+                && str_contains($message, 'Co-Authored-By: Bob <bob@example.com>');
+        })->once();
 
         (new \Statamic\Git\CommitJob('Entry saved', $user))->handle();
     }

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -399,6 +399,8 @@ EOT;
     #[Test]
     public function it_only_dispatches_one_commit_job_at_a_time()
     {
+        // ShouldBeUnique acquires its cache lock in Bus\Dispatcher before the job
+        // reaches the queue driver, so Queue::fake() still enforces uniqueness here.
         Queue::fake();
 
         Git::dispatchCommit();

--- a/tests/Git/GitTest.php
+++ b/tests/Git/GitTest.php
@@ -480,6 +480,30 @@ EOT;
     }
 
     #[Test]
+    public function it_wires_dispatch_to_co_authored_by_trailers_end_to_end()
+    {
+        Queue::fake();
+
+        $this->files->put(base_path('content/collections/pages.yaml'), 'title: Pages Title Changed');
+
+        $alice = User::make()->email('alice@example.com')->data(['name' => 'Alice'])->makeSuper();
+        $bob = User::make()->email('bob@example.com')->data(['name' => 'Bob'])->makeSuper();
+
+        $this->actingAs($alice);
+        Git::dispatchCommit();
+
+        $this->actingAs($bob);
+        Git::dispatchCommit(); // dropped by ShouldBeUnique, but Bob's save is still recorded in cache
+
+        (new \Statamic\Git\CommitJob(null, $alice))->handle();
+
+        $commit = $this->showLastCommit(base_path('content'));
+
+        $this->assertStringContainsString('Co-Authored-By: Alice <alice@example.com>', $commit);
+        $this->assertStringContainsString('Co-Authored-By: Bob <bob@example.com>', $commit);
+    }
+
+    #[Test]
     public function it_doesnt_push_by_default()
     {
         Git::shouldReceive('push')->never();


### PR DESCRIPTION
Closes #11322

## Issue

Concurrent `CommitJob`s running against the same `.git/` directory cause two related failures:

- `fatal: Unable to create '.git/index.lock': File exists.` (two `git add` / `commit` processes racing on git's index mutex)
- `error: failed to push some refs ... non-fast-forward` (each worker pushing with a stale view of origin, so the second push fails git's atomic ref CAS)

Both root-cause to the same thing: multiple queue workers running `CommitJob`s concurrently against one repo.

## Solution

Mark `CommitJob` as `ShouldBeUnique` so duplicate dispatches are dropped at the dispatch layer. The first dispatch wins; its `git add {{ paths }}` sweeps up any changes from saves that landed during the lock window. No two git processes from `CommitJob` ever run simultaneously.

`uniqueFor` is set to 120 seconds. In normal operation the lock is released the moment `handle()` returns; `uniqueFor` is only the crash-safety net for SIGKILL / OOM scenarios where Laravel's release-on-completion code never runs. 120s comfortably outlasts the default Laravel queue worker `timeout` (60s), so a hard crash recovers within 2 minutes.

## Attribution

Coalescing changes the attribution story: a burst of saves now produces one commit, and naively that commit gets attributed to whichever user happened to dispatch first. Other users' changes are in the commit but their name isn't on it.

The second commit in this PR addresses that with a small counter pattern:

- `Git::dispatchCommit()` calls `Cache::increment('statamic-git-pending-saves')` on every attempt (including dispatches that will be dropped).
- `CommitJob::handle()` does `Cache::pull(...)` at the start. If the count is greater than 1, the committer is replaced with `null`.
- `Git`'s existing fallback in `gitUserName()` / `gitUserEmail()` then attributes the commit to the configured `user.name` / `user.email` (the bot account).

This is the same fallback Statamic already uses today for scheduler-driven and CLI-driven saves where there's no authenticated user, so we're extending an existing pattern, not introducing a new one.