### PR TITLE
[6.x] Fix Modify::__toString() throwing TypeError for non-string scalar values

### DIFF
--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -118,7 +118,7 @@ class Modify implements \IteratorAggregate
         if (! is_array($this->value)) {
             throw new ModifierException(sprintf(
                 'Attempted to access modified value as an array, but encountered [%s]',
-                is_string($this->value) ? 'string' : get_class($this->value)
+                get_debug_type($this->value)
             ));
         }
 

--- a/src/Modifiers/Modify.php
+++ b/src/Modifiers/Modify.php
@@ -90,13 +90,19 @@ class Modify implements \IteratorAggregate
      */
     public function __toString()
     {
-        if (! is_string($this->value) && ! method_exists($this->value, '__toString')) {
-            throw new ModifierException(
-                'Attempted to access modified value as a string, but encountered ['.get_class($this->value).']'
-            );
+        $value = $this->value;
+
+        if ($value === null || is_scalar($value)) {
+            return (string) $value;
         }
 
-        return (string) $this->value;
+        if (is_object($value) && method_exists($value, '__toString')) {
+            return (string) $value;
+        }
+
+        throw new ModifierException(
+            'Attempted to access modified value as a string, but encountered ['.get_debug_type($value).']'
+        );
     }
 
     /**

--- a/tests/Modifiers/FluentModifyTest.php
+++ b/tests/Modifiers/FluentModifyTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Modifiers;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Fields\Values;
 use Statamic\Modifiers\Modifier;
+use Statamic\Modifiers\ModifierException;
 use Statamic\Modifiers\Modify;
 use Tests\TestCase;
 
@@ -36,6 +38,42 @@ class FluentModifyTest extends TestCase
         $result = Modify::value($values)->fetch();
 
         $this->assertSame($values, $result);
+    }
+
+    #[Test]
+    #[DataProvider('scalarValues')]
+    public function it_casts_scalar_and_null_values_to_string($value, $expected)
+    {
+        $this->assertSame($expected, (string) Modify::value($value));
+    }
+
+    public static function scalarValues()
+    {
+        return [
+            'integer zero' => [0, '0'],
+            'positive integer' => [42, '42'],
+            'negative integer' => [-7, '-7'],
+            'float' => [1.5, '1.5'],
+            'true' => [true, '1'],
+            'false' => [false, ''],
+            'null' => [null, ''],
+            'string' => ['hello', 'hello'],
+        ];
+    }
+
+    #[Test]
+    public function it_casts_a_modified_integer_chain_result_to_string()
+    {
+        $this->assertSame('5', (string) Modify::value(0)->add(5));
+    }
+
+    #[Test]
+    public function it_throws_when_casting_an_array_to_string()
+    {
+        $this->expectException(ModifierException::class);
+        $this->expectExceptionMessage('Attempted to access modified value as a string, but encountered [array]');
+
+        (string) Modify::value(['foo' => 'bar']);
     }
 
     #[Test]

--- a/tests/Modifiers/FluentModifyTest.php
+++ b/tests/Modifiers/FluentModifyTest.php
@@ -77,6 +77,15 @@ class FluentModifyTest extends TestCase
     }
 
     #[Test]
+    public function it_throws_modifier_exception_when_iterating_over_a_scalar()
+    {
+        $this->expectException(ModifierException::class);
+        $this->expectExceptionMessage('Attempted to access modified value as an array, but encountered [int]');
+
+        iterator_to_array(Modify::value(42));
+    }
+
+    #[Test]
     public function values_instances_get_converted_to_an_array_when_passing_to_a_modifier()
     {
         (new class extends Modifier


### PR DESCRIPTION
Closes #14671.

`Statamic\Modifiers\Modify::__toString()` was calling `method_exists($this->value, '__toString')` without first checking that `$this->value` is an object or string. PHP 8+ made `method_exists()` strictly typed, so it throws a `TypeError` on ints, floats, bools, null, and arrays. That means something like `(string) Statamic::modify(0)->formatMoney()` blows up any time the chain returns an int, which is exactly what Cargo's `formatMoney` modifier does for a zero price.

### Fix
- Cast scalars (`int`/`float`/`bool`/`string`) and `null` to string directly.
- Only call `method_exists()` when the value is actually an object.
- The fallback `ModifierException` now uses `get_debug_type()` instead of `get_class()`, so the error path doesn't itself throw when the value is an array or scalar.

### Tests
Added to `tests/Modifiers/FluentModifyTest.php`:
- Data provider covering `0`, positive/negative ints, a float, `true`/`false`, `null`, and plain strings.
- `Modify::value(0)->add(5)` → `"5"` (the example from #14671).
- Arrays still throw `ModifierException` with the expected message.