### PR TITLE
[6.x] Make active nav anchor position more accurate

### DIFF
--- a/resources/css/core/layout.css
+++ b/resources/css/core/layout.css
@@ -28,11 +28,11 @@
     }
 
     ul li ul {
-        @apply ml-3.5 pl-3.5 translate-x-px my-1.5 text-[0.8125rem] min-w-0 flex-col gap-1.5 border-s border-gray-300 dark:border-gray-700;
+        @apply ml-3.5 translate-x-px my-1.5 text-[0.8125rem] min-w-0 flex-col gap-1.5 border-s border-gray-300 dark:border-gray-700;
     }
 
     ul li ul li a {
-        @apply py-0 hover:bg-transparent;
+        @apply py-0 ps-5 hover:bg-transparent;
     }
 
     ul li ul li a.active {
@@ -79,12 +79,11 @@
             &::before {
                 content: '';
                 position: absolute;
-                width: anchor-size(height);
                 height: calc(anchor-size(height) + 0.5px);
                 @apply border-s border-s-black;
                 translate: -100% 0;
                 position-anchor: --active;
-                left: calc(anchor(left) + 0.25rem - 0.5px);
+                left: anchor(left);
                 top: anchor(top);
                 transition-property: top, left;
                 transition-duration: 0.2s;


### PR DESCRIPTION
## Description of the Problem

The anchor position that handles the "current nav" menu was positioned a little incorrectly.
This was only exposed when a line wrapped, as detailed here https://github.com/statamic/cms/issues/14597

<img width="374" height="646" alt="image" src="https://github.com/user-attachments/assets/f622eeed-d5e3-4e2a-8fac-05cb157df7bd" />

## What this PR Does

- Corrects the anchor position so multiple lines doesn't throw it off
- Closes https://github.com/statamic/cms/issues/14597

## How to Reproduce

1. Change a nav item to a long word and make it the current page