### PR TITLE
[6.x] Better collapsible sections

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -7,6 +7,7 @@ import {
     Heading,
     Subheading,
     Card,
+    Icon,
 } from '@ui';
 import FieldsProvider from './FieldsProvider.vue';
 import Fields from './Fields.vue';
@@ -14,6 +15,8 @@ import ShowField from '@/components/field-conditions/ShowField.js';
 import { injectContainerContext } from './Container.vue';
 import markdown from '@/util/markdown.js';
 import { computed } from 'vue';
+import { Primitive } from 'reka-ui';
+import { Motion } from 'motion-v';
 
 const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField } = injectContainerContext();
 const tab = injectTabContext();
@@ -40,7 +43,6 @@ function renderInstructions(instructions) {
 
 function toggleSection(section) {
     if (section.collapsible) {
-        section.collapsibleAnimated = true;
         section.collapsed = !section.collapsed;
     }
 }
@@ -73,10 +75,7 @@ function toggleSection(section) {
             </PanelHeader>
             <div
                 class="publish-section-collapsible grid"
-                :class="[
-                    section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded',
-                    { 'publish-section-collapsible--animate': section.collapsibleAnimated },
-                ]"
+                :class="section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded'"
             >
                 <div class="publish-section-collapsible__inner min-h-0">
                     <Card :class="{ 'p-0!': asConfig }">
@@ -93,7 +92,7 @@ function toggleSection(section) {
 </template>
 
 <style scoped>
-[class*='publish-section-collapsible'] {
+[class*="publish-section-collapsible"] {
     --speed: 250ms;
     --timing: ease;
 
@@ -102,40 +101,23 @@ function toggleSection(section) {
     }
 }
 
-.publish-section-collapsible--expanded:not(.publish-section-collapsible--animate) {
-    grid-template-rows: 1fr;
-}
-
-.publish-section-collapsible--collapsed:not(.publish-section-collapsible--animate) {
-    grid-template-rows: 0fr;
-}
-
-.publish-section-collapsible--expanded:not(.publish-section-collapsible--animate) .publish-section-collapsible__inner {
-    visibility: visible;
-    overflow: visible;
-}
-
-.publish-section-collapsible--collapsed:not(.publish-section-collapsible--animate) .publish-section-collapsible__inner {
-    visibility: hidden;
-    overflow: clip;
-}
-
-.publish-section-collapsible--animate.publish-section-collapsible--expanded {
+.publish-section-collapsible--expanded {
+    /* We can animate collapse/expand using grid rows */
     animation: expand-rows var(--speed) var(--timing) forwards;
 }
 
-.publish-section-collapsible--animate.publish-section-collapsible--collapsed {
+.publish-section-collapsible--collapsed {
     animation: collapse-rows var(--speed) var(--timing) forwards;
 }
 
-.publish-section-collapsible--animate.publish-section-collapsible--expanded .publish-section-collapsible__inner {
+.publish-section-collapsible--expanded .publish-section-collapsible__inner {
     animation:
         make-visible 0ms 0ms forwards,
         unset-overflow 0ms var(--speed) forwards;
     overflow: clip;
 }
 
-.publish-section-collapsible--animate.publish-section-collapsible--collapsed .publish-section-collapsible__inner {
+.publish-section-collapsible--collapsed .publish-section-collapsible__inner {
     animation:
         clip-overflow 0ms var(--speed) forwards,
         make-invisible 0ms var(--speed) forwards;

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -74,18 +74,116 @@ function toggleSection(section) {
                 />
             </PanelHeader>
             <div
-                style="--tw-ease: ease;"
-                class="h-auto visible transition-[height,visibility] duration-[250ms,2s]"
-                :class="{ 'h-0! invisible! overflow-clip': section.collapsed }"
+                class="publish-section-collapsible grid"
+                :class="section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded'"
             >
-                <Card :class="{ 'p-0!': asConfig }">
-                    <FieldsProvider :fields="section.fields">
-                        <slot :section="section">
-                            <Fields />
-                        </slot>
-                    </FieldsProvider>
-                </Card>
+                <div class="publish-section-collapsible__inner min-h-0">
+                    <Card :class="{ 'p-0!': asConfig }">
+                        <FieldsProvider :fields="section.fields">
+                            <slot :section="section">
+                                <Fields />
+                            </slot>
+                        </FieldsProvider>
+                    </Card>
+                </div>
             </div>
         </Panel>
     </div>
 </template>
+
+<style scoped>
+.publish-section-collapsible--expanded {
+    animation: publish-section-expand 250ms ease forwards;
+    grid-template-rows: 1fr;
+}
+
+.publish-section-collapsible--collapsed {
+    animation: publish-section-collapse 250ms ease forwards;
+    grid-template-rows: 0fr;
+}
+
+.publish-section-collapsible--expanded .publish-section-collapsible__inner {
+    animation:
+        publish-section-expand-visibility 0ms 0ms forwards,
+        publish-section-expand-overflow 0ms 250ms forwards;
+    overflow: clip;
+}
+
+.publish-section-collapsible--collapsed .publish-section-collapsible__inner {
+    /* border: 3px solid blue!important; */
+    animation:
+        publish-section-collapse-overflow 0ms 250ms forwards,
+        publish-section-collapse-visibility 0ms 250ms forwards;
+    overflow: clip;
+}
+
+@keyframes publish-section-expand {
+    from {
+        grid-template-rows: 0fr;
+    }
+
+    to {
+        grid-template-rows: 1fr;
+    }
+}
+
+@keyframes publish-section-expand-visibility {
+    to {
+        visibility: visible;
+    }
+}
+
+@keyframes publish-section-expand-overflow {
+    to {
+        overflow: visible;
+    }
+}
+
+@keyframes publish-section-collapse {
+    from {
+        grid-template-rows: 1fr;
+    }
+
+    to {
+        grid-template-rows: 0fr;
+    }
+}
+
+@keyframes publish-section-collapse-overflow {
+    to {
+        overflow: clip;
+    }
+}
+
+@keyframes publish-section-collapse-visibility {
+    to {
+        visibility: hidden;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .publish-section-collapsible--expanded,
+    .publish-section-collapsible--collapsed {
+        animation: none;
+    }
+
+    .publish-section-collapsible--expanded {
+        grid-template-rows: 1fr;
+    }
+
+    .publish-section-collapsible--collapsed {
+        grid-template-rows: 0fr;
+    }
+
+    .publish-section-collapsible--expanded .publish-section-collapsible__inner {
+        visibility: visible;
+        overflow: visible;
+    }
+
+    .publish-section-collapsible--collapsed .publish-section-collapsible__inner {
+        animation: none;
+        visibility: hidden;
+        overflow: clip;
+    }
+}
+</style>

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -92,54 +92,55 @@ function toggleSection(section) {
 </template>
 
 <style scoped>
+[class*="publish-section-collapsible"] {
+    --speed: 250ms;
+    --timing: ease;
+}
+
 .publish-section-collapsible--expanded {
-    animation: publish-section-expand 250ms ease forwards;
-    grid-template-rows: 1fr;
+    /* We can animate collapse/expand using grid rows */
+    animation: expand-rows var(--speed) var(--timing) forwards;
 }
 
 .publish-section-collapsible--collapsed {
-    animation: publish-section-collapse 250ms ease forwards;
-    grid-template-rows: 0fr;
+    animation: collapse-rows var(--speed) var(--timing) forwards;
 }
 
 .publish-section-collapsible--expanded .publish-section-collapsible__inner {
     animation:
-        publish-section-expand-visibility 0ms 0ms forwards,
-        publish-section-expand-overflow 0ms 250ms forwards;
+        make-visible 0ms 0ms forwards,
+        unset-overflow 0ms var(--speed) forwards;
     overflow: clip;
 }
 
 .publish-section-collapsible--collapsed .publish-section-collapsible__inner {
-    /* border: 3px solid blue!important; */
     animation:
-        publish-section-collapse-overflow 0ms 250ms forwards,
-        publish-section-collapse-visibility 0ms 250ms forwards;
+        clip-overflow 0ms var(--speed) forwards,
+        make-invisible 0ms var(--speed) forwards;
     overflow: clip;
 }
 
-@keyframes publish-section-expand {
+@keyframes make-visible {
     from {
-        grid-template-rows: 0fr;
+        visibility: hidden;
     }
 
-    to {
-        grid-template-rows: 1fr;
-    }
-}
-
-@keyframes publish-section-expand-visibility {
     to {
         visibility: visible;
     }
 }
 
-@keyframes publish-section-expand-overflow {
+@keyframes make-invisible {
+    from {
+        visibility: visible;
+    }
+
     to {
-        overflow: visible;
+        visibility: hidden;
     }
 }
 
-@keyframes publish-section-collapse {
+@keyframes collapse-rows {
     from {
         grid-template-rows: 1fr;
     }
@@ -149,21 +150,33 @@ function toggleSection(section) {
     }
 }
 
-@keyframes publish-section-collapse-overflow {
+@keyframes expand-rows {
+    from {
+        grid-template-rows: 0fr;
+    }
+
+    to {
+        grid-template-rows: 1fr;
+    }
+}
+
+@keyframes clip-overflow {
     to {
         overflow: clip;
     }
 }
 
-@keyframes publish-section-collapse-visibility {
+@keyframes unset-overflow {
     to {
-        visibility: hidden;
+        overflow: visible;
     }
 }
 
 @media (prefers-reduced-motion: reduce) {
     .publish-section-collapsible--expanded,
-    .publish-section-collapsible--collapsed {
+    .publish-section-collapsible--collapsed,
+    .publish-section-collapsible--expanded .publish-section-collapsible__inner,
+    .publish-section-collapsible--collapsed .publish-section-collapsible__inner {
         animation: none;
     }
 
@@ -181,7 +194,6 @@ function toggleSection(section) {
     }
 
     .publish-section-collapsible--collapsed .publish-section-collapsible__inner {
-        animation: none;
         visibility: hidden;
         overflow: clip;
     }

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -93,7 +93,11 @@ function toggleSection(section) {
 
 <style scoped>
 [class*="publish-section-collapsible"] {
-    --speed: 250ms;
+    --speed: 0ms;
+    /* Only setting the animation speed when the panel is hovered prevents the animation triggering on page load. */
+    [data-ui-panel]:hover & {
+        --speed: 250ms;
+    }
     --timing: ease;
 
     @media (prefers-reduced-motion: reduce) {

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -95,6 +95,10 @@ function toggleSection(section) {
 [class*="publish-section-collapsible"] {
     --speed: 250ms;
     --timing: ease;
+
+    @media (prefers-reduced-motion: reduce) {
+        --speed: 0ms;
+    }
 }
 
 .publish-section-collapsible--expanded {
@@ -120,82 +124,10 @@ function toggleSection(section) {
     overflow: clip;
 }
 
-@keyframes make-visible {
-    from {
-        visibility: hidden;
-    }
-
-    to {
-        visibility: visible;
-    }
-}
-
-@keyframes make-invisible {
-    from {
-        visibility: visible;
-    }
-
-    to {
-        visibility: hidden;
-    }
-}
-
-@keyframes collapse-rows {
-    from {
-        grid-template-rows: 1fr;
-    }
-
-    to {
-        grid-template-rows: 0fr;
-    }
-}
-
-@keyframes expand-rows {
-    from {
-        grid-template-rows: 0fr;
-    }
-
-    to {
-        grid-template-rows: 1fr;
-    }
-}
-
-@keyframes clip-overflow {
-    to {
-        overflow: clip;
-    }
-}
-
-@keyframes unset-overflow {
-    to {
-        overflow: visible;
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .publish-section-collapsible--expanded,
-    .publish-section-collapsible--collapsed,
-    .publish-section-collapsible--expanded .publish-section-collapsible__inner,
-    .publish-section-collapsible--collapsed .publish-section-collapsible__inner {
-        animation: none;
-    }
-
-    .publish-section-collapsible--expanded {
-        grid-template-rows: 1fr;
-    }
-
-    .publish-section-collapsible--collapsed {
-        grid-template-rows: 0fr;
-    }
-
-    .publish-section-collapsible--expanded .publish-section-collapsible__inner {
-        visibility: visible;
-        overflow: visible;
-    }
-
-    .publish-section-collapsible--collapsed .publish-section-collapsible__inner {
-        visibility: hidden;
-        overflow: clip;
-    }
-}
+@keyframes make-visible   { from { visibility: hidden; } to { visibility: visible; } }
+@keyframes make-invisible { from { visibility: visible; } to { visibility: hidden; } }
+@keyframes collapse-rows  { from { grid-template-rows: 1fr; } to { grid-template-rows: 0fr; } }
+@keyframes expand-rows    { from { grid-template-rows: 0fr; } to { grid-template-rows: 1fr; } }
+@keyframes clip-overflow  { to { overflow: clip; } }
+@keyframes unset-overflow { to { overflow: visible; } }
 </style>

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -115,9 +115,7 @@ function toggleSection(section) {
 }
 
 .publish-section-collapsible--expanded .publish-section-collapsible__inner {
-    animation:
-        make-visible 0ms 0ms forwards,
-        unset-overflow 0ms var(--speed) forwards;
+    animation: calc(var(--speed) * 2) var(--timing) section-fade-in both;
     overflow: clip;
 }
 
@@ -128,10 +126,9 @@ function toggleSection(section) {
     overflow: clip;
 }
 
-@keyframes make-visible   { from { visibility: hidden; } to { visibility: visible; } }
+@keyframes section-fade-in { from { opacity: 0%; } to { opacity: 100%; } }
 @keyframes make-invisible { from { visibility: visible; } to { visibility: hidden; } }
 @keyframes collapse-rows  { from { grid-template-rows: 1fr; } to { grid-template-rows: 0fr; } }
 @keyframes expand-rows    { from { grid-template-rows: 0fr; } to { grid-template-rows: 1fr; } }
 @keyframes clip-overflow  { to { overflow: clip; } }
-@keyframes unset-overflow { to { overflow: visible; } }
 </style>

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -7,7 +7,6 @@ import {
     Heading,
     Subheading,
     Card,
-    Icon,
 } from '@ui';
 import FieldsProvider from './FieldsProvider.vue';
 import Fields from './Fields.vue';
@@ -15,8 +14,6 @@ import ShowField from '@/components/field-conditions/ShowField.js';
 import { injectContainerContext } from './Container.vue';
 import markdown from '@/util/markdown.js';
 import { computed } from 'vue';
-import { Primitive } from 'reka-ui';
-import { Motion } from 'motion-v';
 
 const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField } = injectContainerContext();
 const tab = injectTabContext();
@@ -43,6 +40,7 @@ function renderInstructions(instructions) {
 
 function toggleSection(section) {
     if (section.collapsible) {
+        section.collapsibleAnimated = true;
         section.collapsed = !section.collapsed;
     }
 }
@@ -75,7 +73,10 @@ function toggleSection(section) {
             </PanelHeader>
             <div
                 class="publish-section-collapsible grid"
-                :class="section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded'"
+                :class="[
+                    section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded',
+                    { 'publish-section-collapsible--animate': section.collapsibleAnimated },
+                ]"
             >
                 <div class="publish-section-collapsible__inner min-h-0">
                     <Card :class="{ 'p-0!': asConfig }">
@@ -92,7 +93,7 @@ function toggleSection(section) {
 </template>
 
 <style scoped>
-[class*="publish-section-collapsible"] {
+[class*='publish-section-collapsible'] {
     --speed: 250ms;
     --timing: ease;
 
@@ -101,23 +102,40 @@ function toggleSection(section) {
     }
 }
 
-.publish-section-collapsible--expanded {
-    /* We can animate collapse/expand using grid rows */
+.publish-section-collapsible--expanded:not(.publish-section-collapsible--animate) {
+    grid-template-rows: 1fr;
+}
+
+.publish-section-collapsible--collapsed:not(.publish-section-collapsible--animate) {
+    grid-template-rows: 0fr;
+}
+
+.publish-section-collapsible--expanded:not(.publish-section-collapsible--animate) .publish-section-collapsible__inner {
+    visibility: visible;
+    overflow: visible;
+}
+
+.publish-section-collapsible--collapsed:not(.publish-section-collapsible--animate) .publish-section-collapsible__inner {
+    visibility: hidden;
+    overflow: clip;
+}
+
+.publish-section-collapsible--animate.publish-section-collapsible--expanded {
     animation: expand-rows var(--speed) var(--timing) forwards;
 }
 
-.publish-section-collapsible--collapsed {
+.publish-section-collapsible--animate.publish-section-collapsible--collapsed {
     animation: collapse-rows var(--speed) var(--timing) forwards;
 }
 
-.publish-section-collapsible--expanded .publish-section-collapsible__inner {
+.publish-section-collapsible--animate.publish-section-collapsible--expanded .publish-section-collapsible__inner {
     animation:
         make-visible 0ms 0ms forwards,
         unset-overflow 0ms var(--speed) forwards;
     overflow: clip;
 }
 
-.publish-section-collapsible--collapsed .publish-section-collapsible__inner {
+.publish-section-collapsible--animate.publish-section-collapsible--collapsed .publish-section-collapsible__inner {
     animation:
         clip-overflow 0ms var(--speed) forwards,
         make-invisible 0ms var(--speed) forwards;


### PR DESCRIPTION
## Description of the Problem

As described in https://github.com/statamic/cms/issues/14488 collapse / expand sections can feel a bit off when animating.

This is basically because we're using overflow: clip; to hide the inside container, and this is not controlled with an animation.
Instead, it relies on a basic height transition on the container and clipped contents – which is why it feels like it "plops" on to the page when expanding.

## What this PR Does

- Adds some animation keyframes so we have better control of how the overclip and animation works.
- Takes into consideration motion preferences.
- I've opted into the animation when hovering over `data-ui-panel`, so things don't animate when the page loads
- Closes #14488 

### Before

https://github.com/user-attachments/assets/4239a429-eab9-430d-b064-cf33a503c462

### After

https://github.com/user-attachments/assets/e2defa36-f196-4b98-9e7a-e064fcfe5f4a

## How to Reproduce

1. Make a section collapsible and toggle its state