### PR TITLE
[6.x] Harden GitHub Actions workflows with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,5 @@ updates:
       github-actions:
         patterns:
           - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   lint-code-styling:
+    name: Lint code style
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Check PHP code style issues
         if: steps.changed-files.outputs.any_modified == 'true'
-        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # v2.6
+        uses: aglipanci/laravel-pint-action@36de00d5f5a8a4e12d443e01671daa12a18f4c79 # 2.6
         with:
           testMode: true
           verboseMode: true

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -3,6 +3,8 @@ name: Lint code style issues
 on:
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint-code-styling:
+  lint-code-styling: # zizmor: ignore[anonymous-definition]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -11,7 +11,6 @@ concurrency:
 
 jobs:
   lint-code-styling:
-    name: Lint code style
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -3,6 +3,10 @@ name: Lint code style issues
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-code-styling:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-style-lint.yml
+++ b/.github/workflows/code-style-lint.yml
@@ -6,6 +6,8 @@ on:
 jobs:
   lint-code-styling:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   pr-title:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate PR title matches target branch
         env:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,6 @@ concurrency:
 
 jobs:
   pr-title:
-    name: Validate PR title
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pr-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   pr-title:
+    name: Validate PR title
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-title:
+  pr-title: # zizmor: ignore[anonymous-definition]
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   uneditable:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -16,7 +16,6 @@ concurrency:
 
 jobs:
   uneditable:
-    name: Check maintainer edit access
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # post comment and close PRs that don't allow maintainer edits

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -4,7 +4,7 @@ name: Pull Requests
 #         https://github.com/laravel/.github/blob/main/.github/workflows/pull-requests.yml
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - opened
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -11,7 +11,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -8,8 +8,7 @@ on:
     types:
       - opened
 
-permissions:
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,6 +17,8 @@ concurrency:
 jobs:
   uneditable:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # post comment and close PRs that don't allow maintainer edits
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   uneditable:
+    name: Check maintainer edit access
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # post comment and close PRs that don't allow maintainer edits

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  uneditable:
+  uneditable: # zizmor: ignore[anonymous-definition]
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # post comment and close PRs that don't allow maintainer edits

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 20.19.0
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Use Node.js 20.19.0
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on: # zizmor: ignore[concurrency-limits]
 permissions: {}
 
 jobs:
-  build:
+  build: # zizmor: ignore[anonymous-definition]
     runs-on: ubuntu-latest
     permissions:
       contents: write # create GitHub release and upload assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,13 @@ on: # zizmor: ignore[concurrency-limits]
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # create GitHub release and upload assets
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,55 +35,18 @@ jobs:
           version: ${{ github.ref }}
 
       - name: Create release
-        id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.changelog.outputs.version }}
-          release_name: ${{ steps.changelog.outputs.version }}
+          name: ${{ steps.changelog.outputs.version }}
           body: ${{ steps.changelog.outputs.text }}
-          prerelease: false
-
-      - name: Upload dist zip to release
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./resources/dist.tar.gz
-          asset_name: dist.tar.gz
-          asset_content_type: application/tar+gz
-
-      - name: Upload dist-dev zip to release
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./resources/dist-dev.tar.gz
-          asset_name: dist-dev.tar.gz
-          asset_content_type: application/tar+gz
-
-      - name: Upload dist-frontend zip to release
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./resources/dist-frontend.tar.gz
-          asset_name: dist-frontend.tar.gz
-          asset_content_type: application/tar+gz
-
-      - name: Upload dist-package zip to release
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./resources/dist-package.tar.gz
-          asset_name: dist-package.tar.gz
-          asset_content_type: application/tar+gz
+          files: |
+            ./resources/dist.tar.gz
+            ./resources/dist-dev.tar.gz
+            ./resources/dist-frontend.tar.gz
+            ./resources/dist-package.tar.gz
 
       - name: Deploy Storybook to Forge
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ permissions: {}
 
 jobs:
   build:
+    name: Build and release
     runs-on: ubuntu-latest
     permissions:
       contents: write # create GitHub release and upload assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,7 @@ jobs:
 
       - name: Deploy Storybook to Forge
         continue-on-error: true
+        env:
+          FORGE_STORYBOOK_WEBHOOK: ${{ secrets.FORGE_STORYBOOK_WEBHOOK }}
         run: |
-          curl -X POST "${{ secrets.FORGE_STORYBOOK_WEBHOOK }}"
+          curl -X POST "$FORGE_STORYBOOK_WEBHOOK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,17 +35,17 @@ jobs:
           version: ${{ github.ref }}
 
       - name: Create release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ steps.changelog.outputs.version }}
-          name: ${{ steps.changelog.outputs.version }}
-          body: ${{ steps.changelog.outputs.text }}
-          files: |
-            ./resources/dist.tar.gz
-            ./resources/dist-dev.tar.gz
-            ./resources/dist-frontend.tar.gz
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ steps.changelog.outputs.version }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.text }}
+        run: |
+          gh release create "$RELEASE_VERSION" \
+            --title "$RELEASE_VERSION" \
+            --notes "$RELEASE_NOTES" \
+            ./resources/dist.tar.gz \
+            ./resources/dist-dev.tar.gz \
+            ./resources/dist-frontend.tar.gz \
             ./resources/dist-package.tar.gz
 
       - name: Deploy Storybook to Forge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ permissions: {}
 
 jobs:
   build:
-    name: Build and release
     runs-on: ubuntu-latest
     permissions:
       contents: write # create GitHub release and upload assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Create Release
 
-on:
+on: # zizmor: ignore[concurrency-limits]
   push:
     tags:
       - 'v*'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,7 +7,7 @@ on: # zizmor: ignore[concurrency-limits]
 permissions: {}
 
 jobs:
-  stale:
+  stale: # zizmor: ignore[anonymous-definition]
     runs-on: ubuntu-latest
     permissions:
       issues: write # mark issues stale and close them

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   stale:
+    name: Close stale issues
     runs-on: ubuntu-latest
     permissions:
       issues: write # mark issues stale and close them

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,12 +4,14 @@ on: # zizmor: ignore[concurrency-limits]
   schedule:
   - cron: "30 1 * * *"
 
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
-      pull-requests: write
+      issues: write # mark issues stale and close them
+      pull-requests: write # mark pull requests stale and close them
     steps:
     - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,7 +8,6 @@ permissions: {}
 
 jobs:
   stale:
-    name: Close stale issues
     runs-on: ubuntu-latest
     permissions:
       issues: write # mark issues stale and close them

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
     - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
       with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,5 @@
 name: "Close stale issues"
-on:
+on: # zizmor: ignore[concurrency-limits]
   workflow_dispatch:
   schedule:
   - cron: "30 1 * * *"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,12 +160,15 @@ jobs:
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3
       - name: Send Slack notification
-        uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e # v3
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: env.WORKFLOW_CONCLUSION == 'failure' && github.event_name == 'schedule'
         with:
-          status: failure
-          fields: repo,message,commit,author,action,eventName,ref,workflow
-          author_name: ${{ github.actor }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":x: *${{ github.repository }}* tests failed"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":x: *${{ github.repository }}* tests failed\n*Ref:* ${{ github.ref }}\n*Author:* ${{ github.actor }}\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -159,7 +161,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [php-tests, js-tests]
     permissions:
-      actions: read
+      actions: read # required by workflow-conclusion-action to determine overall workflow status
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,16 +172,3 @@ jobs:
                 text:
                   type: mrkdwn
                   text: ":x: *${{ github.repository }}* tests failed\n*Ref:* ${{ github.ref }}\n*Author:* ${{ github.actor }}\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
-      - name: Send test Slack notification (temporary)
-        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
-        if: github.event_name == 'pull_request'
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-            text: ":white_check_mark: *statamic/cms* test notification"
-            blocks:
-              - type: section
-                text:
-                  type: mrkdwn
-                  text: ":white_check_mark: *statamic/cms* test notification\n*Ref:* refs/heads/zizmor\n*Author:* jasonvarga\n*Workflow:* <https://github.com/statamic/cms/actions/runs/123456789|Run Tests>"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,8 @@ jobs:
   php-tests:
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    permissions:
+      contents: read
 
     strategy:
       matrix:
@@ -96,6 +98,8 @@ jobs:
   js-tests:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    permissions:
+      contents: read
 
     name: JavaScript tests
 
@@ -146,6 +150,8 @@ jobs:
     name: Slack Notification
     runs-on: ubuntu-latest
     needs: [php-tests, js-tests]
+    permissions:
+      actions: read
     if: always()
     steps:
       - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,3 +172,16 @@ jobs:
                 text:
                   type: mrkdwn
                   text: ":x: *${{ github.repository }}* tests failed\n*Ref:* ${{ github.ref }}\n*Author:* ${{ github.actor }}\n*Workflow:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|${{ github.workflow }}>"
+      - name: Send test Slack notification (temporary)
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        if: github.event_name == 'pull_request'
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: ":white_check_mark: *statamic/cms* test notification"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: ":white_check_mark: *statamic/cms* test notification\n*Ref:* refs/heads/zizmor\n*Author:* jasonvarga\n*Workflow:* <https://github.com/statamic/cms/actions/runs/123456789|Run Tests>"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files
@@ -106,6 +108,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   php-tests:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,27 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+    branches:
+      - '**'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,6 +13,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
     name: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           advanced-security: false
           annotations: true
+          persona: pedantic

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -5,9 +5,11 @@ on:
     branches:
       - master
       - '*.x'
+    paths:
+      - '.github/**.yml'
   pull_request:
-    branches:
-      - '**'
+    paths:
+      - '.github/**.yml'
 
 permissions: {}
 
@@ -15,8 +17,7 @@ jobs:
   zizmor:
     name: zizmor
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
+    permissions: {}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -25,3 +26,6 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
Introduces zizmor, a static analyser for GitHub Actions, and applies its recommendations to existing workflows.

Changes include:

- Add Dependabot cooldown to mitigate supply chain attacks by delaying dependency update PRs, giving the community time to identify compromised releases
- Suppress a zizmor false positive for the `pull_request_target` trigger in the pull requests workflow (no fork code is checked out, so the pattern is safe)
- Scope all workflow job permissions to the minimum required rather than relying on overly broad defaults
- Disable auto-caching in the release workflow to prevent a poisoned cache from contaminating published release artifacts
- Set `persist-credentials: false` on all checkout steps to prevent the GitHub token from being exposed to subsequent steps
- Add a zizmor workflow that runs on every PR and push, uploading findings as SARIF to the Security tab