### PR TITLE
[5.x] Avoid eager loading asset move folders

### DIFF
--- a/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
+++ b/resources/js/components/fieldtypes/AssetFolderFieldtype.vue
@@ -5,7 +5,7 @@
             :handle="handle"
             :value="value"
             :meta="relationshipMeta"
-            :config="{ type: 'asset_folder', max_items: this.config.max_items }"
+            :config="relationshipConfig"
             @input="update"
         />
     </div>
@@ -16,12 +16,40 @@ export default {
 
     mixins: [Fieldtype],
 
-    inject: ['storeName'],
+    inject: {
+        storeName: {
+            default: null
+        }
+    },
 
     computed: {
 
         container() {
-            return data_get(this.$store.state.publish[this.storeName].values.container, '0', this.config.container);
+            let container = this.config.container;
+
+            if (container) {
+                return Array.isArray(container) ? container[0] : container;
+            }
+
+            if (! this.storeName) return null;
+
+            const state = this.$store?.state?.publish?.[this.storeName];
+            if (! state) return null;
+
+            container = state.values.container;
+
+            if (Array.isArray(container)) {
+                return container[0] || null;
+            }
+
+            return container || null;
+        },
+
+        relationshipConfig() {
+            return {
+                ...this.config,
+                type: 'asset_folder',
+            };
         },
 
         relationshipMeta() {

--- a/src/Actions/MoveAsset.php
+++ b/src/Actions/MoveAsset.php
@@ -3,8 +3,6 @@
 namespace Statamic\Actions;
 
 use Statamic\Contracts\Assets\Asset;
-use Statamic\Facades\AssetContainer;
-use Statamic\Facades\Blink;
 
 class MoveAsset extends Action
 {
@@ -46,21 +44,13 @@ class MoveAsset extends Action
 
     protected function fieldItems()
     {
-        $options = Blink::once('action-move-asset-folders', function () {
-            return AssetContainer::find($this->context['container'])
-                ->assetFolders()
-                ->mapWithKeys(function ($folder) {
-                    return [$folder->path() => $folder->path()];
-                })
-                ->prepend('/', '/')
-                ->all();
-        });
-
         return [
             'folder' => [
                 'display' => __('Folder'),
-                'type' => 'select',
-                'options' => $options,
+                'type' => 'asset_folder',
+                'container' => $this->context['container'],
+                'mode' => 'select',
+                'max_items' => 1,
                 'validate' => 'required',
             ],
         ];

--- a/src/Actions/MoveAssetFolder.php
+++ b/src/Actions/MoveAssetFolder.php
@@ -3,8 +3,6 @@
 namespace Statamic\Actions;
 
 use Statamic\Contracts\Assets\AssetFolder;
-use Statamic\Facades\AssetContainer;
-use Statamic\Facades\Blink;
 
 class MoveAssetFolder extends Action
 {
@@ -42,21 +40,13 @@ class MoveAssetFolder extends Action
 
     protected function fieldItems()
     {
-        $options = Blink::once('action-move-asset-folders', function () {
-            return AssetContainer::find($this->context['container'])
-                ->assetFolders()
-                ->mapWithKeys(function ($folder) {
-                    return [$folder->path() => $folder->path()];
-                })
-                ->prepend('/', '/')
-                ->all();
-        });
-
         return [
             'folder' => [
                 'display' => __('Folder'),
-                'type' => 'select',
-                'options' => $options,
+                'type' => 'asset_folder',
+                'container' => $this->context['container'],
+                'mode' => 'select',
+                'max_items' => 1,
                 'validate' => 'required',
             ],
         ];

--- a/tests/Actions/MoveAssetTest.php
+++ b/tests/Actions/MoveAssetTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Actions;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Actions\MoveAsset;
+use Statamic\Actions\MoveAssetFolder;
+use Statamic\Assets\AssetContainer;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class MoveAssetTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    private $container;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Storage::fake('test');
+
+        $this->container = tap(
+            (new AssetContainer)->handle('test_container')->disk('test')
+        )->save();
+    }
+
+    #[Test]
+    #[DataProvider('moveActionsProvider')]
+    public function move_action_folder_field_lists_all_destination_folders($action)
+    {
+        $this->container
+            ->makeAsset('source/one.txt')
+            ->upload(UploadedFile::fake()->create('one.txt'));
+        $this->container
+            ->makeAsset('destination/two.txt')
+            ->upload(UploadedFile::fake()->create('two.txt'));
+
+        $field = (new $action)
+            ->context(['container' => 'test_container'])
+            ->toArray()['fields'][0];
+
+        $folders = $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->getJson(cp_route('relationship.index').'?'.http_build_query([
+                'config' => base64_encode(json_encode($field)),
+                'container' => 'test_container',
+            ]))
+            ->assertOk()
+            ->collect('data')
+            ->pluck('id')
+            ->all();
+
+        $this->assertEqualsCanonicalizing(['/', 'destination', 'source'], $folders);
+    }
+
+    public static function moveActionsProvider()
+    {
+        return [
+            'asset' => [MoveAsset::class],
+            'asset folder' => [MoveAssetFolder::class],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Fix asset browser move actions so destination folders are no longer serialized into every asset/folder action payload.

Previously, `MoveAsset` and `MoveAssetFolder` built a plain `select` field with every folder in the container as inline `options`. In large containers, the browser payload scaled with:

```
visible assets/folders × total folders in container
```

This PR reuses Statamic's existing `asset_folder` relationship field instead. The move actions now return a small field config:

- `type: asset_folder`
- `container: <current container>`
- `mode: select`
- `max_items: 1`

The initial asset browser payload stays small, and destination folders are loaded only when the Move modal opens.

## Why reuse `asset_folder`?

Statamic already has a fieldtype for selecting folders from an asset container. It is relationship-backed and already loads selectable items through the relationship endpoint.

Reusing it avoids a new action-specific endpoint or custom UI while keeping the old dropdown-style UX. `max_items: 1` also preserves the existing action value shape because the relationship field processes the selection back to a single folder path string.

## Implementation notes

`MoveAsset` and `MoveAssetFolder` no longer call:

```php
AssetContainer::find($this->context['container'])->assetFolders()
```

inside `fieldItems()`.

`AssetFolderFieldtype.vue` now passes action config like `container` and `mode` through to the underlying relationship field. It also supports action modal usage where there is no publish `storeName`, by reading the container directly from field config.

## Performance impact

Before:

- every visible move action included every destination folder option
- `Blink::once()` avoided repeated PHP computation, but not repeated JSON serialization

After:

- browser response contains only lightweight field config
- opening a Move modal performs one relationship request to load folder destinations
