### PR TITLE
[5.x] Harden `DataCollection` sort value resolution

### DIFF
--- a/src/Data/DataCollection.php
+++ b/src/Data/DataCollection.php
@@ -7,9 +7,9 @@ use Closure;
 use Illuminate\Support\Collection as IlluminateCollection;
 use Statamic\Exceptions\MethodNotFoundException;
 use Statamic\Facades\Compare;
+use Statamic\Query\ResolveValue;
 use Statamic\Search\PlainResult;
 use Statamic\Search\Result;
-use Statamic\Support\Str;
 
 /**
  * An abstract collection of data types.
@@ -100,15 +100,7 @@ class DataCollection extends IlluminateCollection
             $item = $item->getSearchable() ?? $item;
         }
 
-        if (method_exists($item, $method = Str::camel($sort))) {
-            return $this->normalizeSortableValue(call_user_func([$item, $method]));
-        }
-
-        if (method_exists($item, 'value')) {
-            return $this->normalizeSortableValue($item->value($sort));
-        }
-
-        return $this->normalizeSortableValue($item->get($sort));
+        return $this->normalizeSortableValue((new ResolveValue)($item, $sort));
     }
 
     /**

--- a/tests/Data/DataCollectionTest.php
+++ b/tests/Data/DataCollectionTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Data;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Search\Searchable;
 use Statamic\Data\DataCollection;
+use Statamic\Search\Result;
 use Tests\TestCase;
 
 class DataCollectionTest extends TestCase
@@ -45,9 +47,26 @@ class DataCollectionTest extends TestCase
         $this->assertFalse($a->deleted);
         $this->assertFalse($b->deleted);
     }
+
+    #[Test]
+    public function sorting_search_results_by_unsafe_method_does_not_invoke_it()
+    {
+        $a = new DataCollectionTestObject('alfa');
+        $b = new DataCollectionTestObject('bravo');
+
+        $collection = new DataCollection([
+            new Result($a, 'test'),
+            new Result($b, 'test'),
+        ]);
+
+        $collection->multisort('delete');
+
+        $this->assertFalse($a->deleted);
+        $this->assertFalse($b->deleted);
+    }
 }
 
-class DataCollectionTestObject
+class DataCollectionTestObject implements Searchable
 {
     public bool $deleted = false;
 
@@ -63,5 +82,20 @@ class DataCollectionTestObject
     public function get($key)
     {
         return $this->{$key} ?? null;
+    }
+
+    public function getSearchValue(string $field)
+    {
+        return $this->{$field} ?? null;
+    }
+
+    public function getSearchReference(): string
+    {
+        return 'test::'.$this->title;
+    }
+
+    public function toSearchResult(): Result
+    {
+        return new Result($this, 'test');
     }
 }

--- a/tests/Data/DataCollectionTest.php
+++ b/tests/Data/DataCollectionTest.php
@@ -51,7 +51,9 @@ class DataCollectionTestObject
 {
     public bool $deleted = false;
 
-    public function __construct(public string $title) {}
+    public function __construct(public string $title)
+    {
+    }
 
     public function delete()
     {

--- a/tests/Data/DataCollectionTest.php
+++ b/tests/Data/DataCollectionTest.php
@@ -31,4 +31,35 @@ class DataCollectionTest extends TestCase
 
         $this->assertEquals([1, 3, 2], $collection->multisort('foos')->pluck('id')->all());
     }
+
+    #[Test]
+    public function sorting_by_unsafe_method_does_not_invoke_it()
+    {
+        $a = new DataCollectionTestObject('alfa');
+        $b = new DataCollectionTestObject('bravo');
+
+        $collection = new DataCollection([$a, $b]);
+
+        $collection->multisort('delete');
+
+        $this->assertFalse($a->deleted);
+        $this->assertFalse($b->deleted);
+    }
+}
+
+class DataCollectionTestObject
+{
+    public bool $deleted = false;
+
+    public function __construct(public string $title) {}
+
+    public function delete()
+    {
+        $this->deleted = true;
+    }
+
+    public function get($key)
+    {
+        return $this->{$key} ?? null;
+    }
 }


### PR DESCRIPTION
This PR updates `DataCollection::getSortableValue()` to delegate value resolution to `ResolveValue`, replacing the previously open ended `method_exists()` check.