### PR TITLE
[6.x] Include `is_pdf` in augmented asset data

### DIFF
--- a/src/Assets/AugmentedAsset.php
+++ b/src/Assets/AugmentedAsset.php
@@ -31,6 +31,7 @@ class AugmentedAsset extends AbstractAugmented
                 'is_image',
                 'is_svg',
                 'is_video',
+                'is_pdf',
                 'blueprint',
                 'edit_url',
                 'container',


### PR DESCRIPTION
This PR adds `is_pdf` to augmented asset data.