### PR TITLE
[6.x] Remove `pt-4` as the default padding for a Group fieldtype

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -21,7 +21,7 @@
                             :field-path-prefix="fieldPathPrefix ? `${fieldPathPrefix}.${handle}` : handle"
                             :meta-path-prefix="metaPathPrefix ? `${metaPathPrefix}.${handle}` : handle"
                         >
-                            <Fields class="pt-4" :class="{ 'px-4 py-4': config.border }"/>
+                            <Fields :class="{ 'px-4 py-4': config.border, 'pt-4': !config.border && !config.hide_display }"/>
                         </FieldsProvider>
                     </div>
                 </section>


### PR DESCRIPTION
When a Group fieldtype has no border, there is a `pt-4` applied to the top.

With a border, it becomes `py-4`.

The space it creates is not aesthetically pleasing. 

This PR removes `pt-4` from a border-less Group fieldtype.

These examples are two Group fields, the top with the label hidden, and the bottom with the label visible. There are no field actions in this configuration, including disabling full screen.

Before:
<img width="265" height="465" alt="image" src="https://github.com/user-attachments/assets/3e6e9028-282f-4ffb-a725-f939171fda37" />

After:
<img width="267" height="439" alt="image" src="https://github.com/user-attachments/assets/224030c0-e7b5-45c5-9ee3-97a1ef747d78" />

There is still unnecessary space above the field, but will see https://github.com/statamic/cms/issues/14707 for this.