### PR TITLE
[6.x] Remove margin from Label when label has no visible content

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -21,7 +21,7 @@
                             :field-path-prefix="fieldPathPrefix ? `${fieldPathPrefix}.${handle}` : handle"
                             :meta-path-prefix="metaPathPrefix ? `${metaPathPrefix}.${handle}` : handle"
                         >
-                            <Fields class="pt-4" :class="{ 'px-4 py-4': config.border }"/>
+                            <Fields :class="{ 'px-4 py-4': config.border, 'pt-4': !config.border && !config.hide_display }"/>
                         </FieldsProvider>
                     </div>
                 </section>

--- a/resources/js/components/ui/Label.vue
+++ b/resources/js/components/ui/Label.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { useSlots } from 'vue';
+import { computed, useSlots } from 'vue';
 import Badge from './Badge.vue';
 
 const slots = useSlots();
@@ -14,11 +14,16 @@ const props = defineProps({
     /** The label text to display */
     text: { type: [String, Number, Boolean, null], default: null },
 });
+
+const hasVisibleLabel = computed(() => {
+    return hasDefaultSlot.value || !!props.text?.trim() || props.required;
+});
 </script>
 
 <template>
     <label
-        class="flex justify-between mb-1.5 text-sm font-medium [&_button]:font-medium text-gray-925 select-none dark:text-gray-300 [&_button:has(svg)]:h-auto"
+        class="flex justify-between text-sm font-medium [&_button]:font-medium text-gray-925 select-none dark:text-gray-300 [&_button:has(svg)]:h-auto"
+        :class="{ 'mb-1.5': hasVisibleLabel }"
         data-ui-label
         :for="for"
     >


### PR DESCRIPTION
When a Field is configured to not show the Display Label, the `mb-1.5` is still applied.

This PR only applies the `mb-1.5` when the label has visible content. 

This is related to https://github.com/statamic/cms/issues/14707, and requires that be resolved to be notice.