### PR TITLE
[6.x] Avoid crop aspect ratios select being truncated

### DIFF
--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -478,6 +478,7 @@ function close() {
                         size="sm"
                         class="w-48"
                         :aria-label="__('Select aspect ratio')"
+                        :adaptive-width="true"
                         @update:modelValue="setAspectRatio"
                     />
                     <Button

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -478,7 +478,7 @@ function close() {
                         size="sm"
                         class="w-48"
                         :aria-label="__('Select aspect ratio')"
-                        :adaptive-width="true"
+                        adaptive-width
                         @update:modelValue="setAspectRatio"
                     />
                     <Button


### PR DESCRIPTION
This PR adds the `adaptive-width` prop to the aspect ratios select in the crop editor to account for long crop aspect ratio labels.

## Before

<img width="236" height="171" alt="CleanShot 2026-05-22 at 10 16 15" src="https://github.com/user-attachments/assets/fde5a3a7-570d-4d9d-92a3-b1f811e0912f" />


## After

<img width="440" height="171" alt="CleanShot 2026-05-22 at 10 15 58" src="https://github.com/user-attachments/assets/0a66b1bc-5dd2-4fee-b589-1433e10b3d5f" />


---

Closes #14703