### PR TITLE
[6.x] Fix entry revision localizations to filter unauthorized sites

### DIFF
--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -83,7 +83,7 @@ class EntryRevisionsController extends CpController
             'readOnly' => true,
             'published' => $entry->published(),
             'locale' => $entry->locale(),
-            'localizations' => $entry->collection()->sites()->map(function ($handle) use ($entry) {
+            'localizations' => $this->getAuthorizedSitesForCollection($entry->collection())->map(function ($handle) use ($entry) {
                 $localized = $entry->in($handle);
                 $exists = $localized !== null;
 
@@ -119,5 +119,12 @@ class EntryRevisionsController extends CpController
             'title' => $collection->title(),
             'url' => cp_route('collections.show', $collection->handle()),
         ];
+    }
+
+    private function getAuthorizedSitesForCollection($collection)
+    {
+        return $collection
+            ->sites()
+            ->filter(fn ($handle) => User::current()->can('view', Site::get($handle)));
     }
 }

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -699,6 +699,57 @@ class EntryRevisionsTest extends TestCase
         );
     }
 
+    #[Test]
+    public function revision_localizations_only_includes_authorized_sites()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+            'de' => ['url' => 'http://localhost/de/', 'locale' => 'de'],
+        ]);
+
+        $this->setTestBlueprint('test', ['foo' => ['type' => 'text']]);
+        $this->setTestRoles(['test' => [
+            'access cp',
+            'view blog entries',
+            'access en site',
+            'access fr site',
+            // Note: no 'access de site' permission
+        ]]);
+        $user = User::make()->id('user-1')->assignRole('test')->save();
+
+        $this->collection->sites(['en', 'fr', 'de'])->save();
+
+        $entry = EntryFactory::id('1')
+            ->slug('test')
+            ->collection('blog')
+            ->locale('en')
+            ->published(true)
+            ->date('2010-12-25')
+            ->data([
+                'blueprint' => 'test',
+                'title' => 'Original title',
+                'foo' => 'bar',
+            ])->create();
+
+        $revision = tap($entry->makeRevision(), function ($copy) {
+            $copy->message('Revision one');
+            $copy->date(Carbon::parse('2017-02-01'));
+        });
+        $revision->save();
+
+        $response = $this
+            ->actingAs($user)
+            ->getJson($entry->revisionsUrl().'/'.$revision->date()->timestamp)
+            ->assertOk();
+
+        $localizations = $response->json('localizations');
+
+        // User should only see en and fr sites, not de
+        $this->assertCount(2, $localizations);
+        $this->assertEquals(['en', 'fr'], array_column($localizations, 'handle'));
+    }
+
     private function setTestBlueprint($handle, $fields)
     {
         $blueprint = Blueprint::makeFromFields($fields)->setHandle($handle);


### PR DESCRIPTION
This pull request fixes an issue where the entry revision preview endpoint exposed all collection sites in the localizations array, regardless of user permissions. This allowed users with restricted site access to view site details they shouldn't have access to.

This was happening because `EntryRevisionsController::show()` was building the localizations list directly from `$entry->collection()->sites()` without applying authorization checks.

This PR fixes it by adding the `getAuthorizedSitesForCollection()` method (matching the pattern already used in `EntriesController`) to filter sites based on whether the current user can view each site.

Fixes #14697