### PR TITLE
[6.x] Hash URL in static caching lock key

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -241,7 +241,7 @@ class Cache
             $store = AppCache::store('null');
         } else {
             $store = StaticCache::cacheStore();
-            $key .= '-'.$this->cacher->getUrl($request);
+            $key .= '-'.md5($this->cacher->getUrl($request));
         }
 
         return $store->lock($key, $this->lockFor);


### PR DESCRIPTION
This pull request hashes the URL in the static caching lock key to avoid hitting column length limits when using the `database` cache driver.

Fixes #14684