### PR TITLE
[5.x] Fix asset fieldtype icon

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -18,7 +18,7 @@
                     :alt="asset.basename"
                     v-if="isImage"
                 />
-                <file-icon :extension="asset.extension" v-else class="w-7 h-7" />
+                <file-icon :extension="asset.extension ?? 'generic'" v-else class="w-7 h-7" />
             </button>
             <button
                 v-if="showFilename"

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -33,7 +33,7 @@
                         <img v-if="canShowSvg" :src="asset.url" :title="label" class="p-4" />
                         <file-icon
                             v-else
-                            :extension="asset.extension"
+                            :extension="asset.extension ?? 'generic'"
                             class="p-4 h-full w-full"
                         />
                     </template>


### PR DESCRIPTION
In #14719 I noticed #14718 left the icons for asset fieldtypes broken.
#14719 fixes it for v6. This fixes it for v5.