### PR TITLE
[6.x] Fix `current` augmentation handling in users fieldtype

### DIFF
--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -254,7 +254,11 @@ class Users extends Relationship
     {
         $single = $this->config('max_items') === 1;
 
-        $ids = Arr::wrap($values);
+        $ids = collect(Arr::wrap($values))
+            ->map(fn ($id) => $id === 'current' ? User::current()?->id() : $id)
+            ->filter()
+            ->values()
+            ->all();
 
         $query = (new OrderedQueryBuilder(User::query(), $ids))->whereIn('id', $ids);
 

--- a/tests/Fieldtypes/UsersTest.php
+++ b/tests/Fieldtypes/UsersTest.php
@@ -72,6 +72,25 @@ class UsersTest extends TestCase
     }
 
     #[Test]
+    public function it_augments_the_current_user_to_a_query_builder_when_value_is_the_current_string()
+    {
+        $this->actingAs(Facades\User::find('123'));
+
+        $augmented = $this->fieldtype()->augment('current');
+
+        $this->assertInstanceOf(Builder::class, $augmented);
+        $this->assertEquals(['123'], $augmented->get()->map->id()->all());
+    }
+
+    #[Test]
+    public function it_augments_to_null_when_value_is_the_current_string_and_no_user_is_authenticated()
+    {
+        $augmented = $this->fieldtype(['max_items' => 1])->augment('current');
+
+        $this->assertNull($augmented);
+    }
+
+    #[Test]
     public function it_shallow_augments_to_a_collection_of_users()
     {
         $augmented = $this->fieldtype()->shallowAugment(['123', 456]);

--- a/tests/Fieldtypes/UsersTest.php
+++ b/tests/Fieldtypes/UsersTest.php
@@ -61,6 +61,17 @@ class UsersTest extends TestCase
     }
 
     #[Test]
+    public function it_augments_the_current_user_when_value_is_the_current_string()
+    {
+        $this->actingAs(Facades\User::find('123'));
+
+        $augmented = $this->fieldtype(['max_items' => 1])->augment('current');
+
+        $this->assertInstanceOf(User::class, $augmented);
+        $this->assertEquals('123', $augmented->id());
+    }
+
+    #[Test]
     public function it_shallow_augments_to_a_collection_of_users()
     {
         $augmented = $this->fieldtype()->shallowAugment(['123', 456]);


### PR DESCRIPTION
Normalizes the `default: current` config in the `augment` method so it resolves to `User::current()?->id()` before actually hitting the query. Fixes a potential database error when using Eloquent users with Postgres and UUIDs.

Closes https://github.com/statamic/cms/issues/14723.