### PR TITLE
[6.x] Stop (excessive) logging of `ElevatedSessionAuthorizationException`

### DIFF
--- a/src/Exceptions/ElevatedSessionAuthorizationException.php
+++ b/src/Exceptions/ElevatedSessionAuthorizationException.php
@@ -2,13 +2,14 @@
 
 namespace Statamic\Exceptions;
 
+use Illuminate\Contracts\Debug\ShouldntReport;
 use Illuminate\Http\Request;
 use Statamic\Facades\URL;
 use Statamic\Statamic;
 
 use function Statamic\trans as __;
 
-class ElevatedSessionAuthorizationException extends \Exception
+class ElevatedSessionAuthorizationException extends \Exception implements ShouldntReport
 {
     public function __construct()
     {


### PR DESCRIPTION
The `ElevatedSessionAuthorizationException` is a flow control exception and thrown by the `RequireElevatedSession` middleware purely so it can redirect the user to the confirm-password page. It's not an actual error. Laravel does the same for `AuthorizationException` and `AuthenticationException`.

Alternatively, the exception could be added to the `dontReport` array in the app, see Laravel's docs: https://laravel.com/docs/13.x/errors#ignoring-exceptions-by-type

(Dropping the literal phrase "Elevated Sessions" in here so it gets picked up by search)