### PR TITLE
[6.x] Fix share_errors breaking nocache regions on successful responses

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -106,13 +106,15 @@ class Cache
 
     private function copyError($request, $response)
     {
-        $status = $response->getStatusCode();
+        if ($response->isSuccessful()) {
+            return;
+        }
 
         if (! config('statamic.static_caching.share_errors')) {
             return;
         }
 
-        $request = Request::createFrom($request)->fakeStaticCacheStatus($status);
+        $request = Request::createFrom($request)->fakeStaticCacheStatus($response->getStatusCode());
 
         if (! $this->cacher->hasCachedPage($request)) {
             $this->cacher->cachePage($request, $response);

--- a/tests/StaticCaching/HalfMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/HalfMeasureStaticCachingTest.php
@@ -126,6 +126,48 @@ class HalfMeasureStaticCachingTest extends TestCase
             ->assertSee('1 3', false);
     }
 
+    public function shareErrorsEnabled($app)
+    {
+        $app['config']->set('statamic.static_caching.share_errors', true);
+    }
+
+    #[Test]
+    #[DefineEnvironment('shareErrorsEnabled')]
+    public function nocache_session_is_written_under_the_real_url_when_share_errors_is_enabled()
+    {
+        \Illuminate\Support\Facades\Cache::flush();
+
+        // Regression: when share_errors is enabled, the middleware's copyError()
+        // step used to call Request::fakeStaticCacheStatus() on every cacheable
+        // response, including 200s. That mutated the singleton nocache Session
+        // URL to /__shared-errors/200, causing Session::write() to persist the
+        // regions list under the wrong cache key. On subsequent hits in a
+        // fresh PHP process, the cached page was found but its nocache regions
+        // could not be restored, a RegionNotFound was caught, and the request
+        // fell through to a full dynamic re-render — defeating half-measure
+        // caching. See discussion: nocache regions silently failing under
+        // share_errors on 200 responses.
+
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('default', '{{ title }} {{ nocache }}{{ title }}{{ /nocache }}');
+
+        $this->createPage('about', ['with' => ['title' => 'Hello']]);
+
+        $this->get('/about')->assertOk();
+
+        // The session metadata must be persisted under the real request URL,
+        // not under the fake /__shared-errors/200 URL.
+        $store = \Statamic\Facades\StaticCache::cacheStore();
+        $this->assertNotNull(
+            $store->get('nocache::session.'.md5('http://localhost/about')),
+            'Expected nocache session to be stored under the real request URL.'
+        );
+        $this->assertNull(
+            $store->get('nocache::session.'.md5('/__shared-errors/200')),
+            'nocache session must not be stored under the shared-errors URL for 200 responses.'
+        );
+    }
+
     #[Test]
     public function it_can_keep_parts_dynamic_using_nocache_tags_in_loops()
     {

--- a/tests/StaticCaching/HalfMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/HalfMeasureStaticCachingTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\StaticCaching;
 
-use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
@@ -140,7 +139,7 @@ class HalfMeasureStaticCachingTest extends TestCase
         // Regression: when share_errors is enabled, the middleware's copyError()
         // step used to call Request::fakeStaticCacheStatus() on every cacheable
         // response, including 200s. That mutated the singleton nocache Session
-        // URL to /__shared-errors/200, causing Session::write() to persist the
+        // URL to /__shared-errors/sitename/200, causing Session::write() to persist the
         // regions list under the wrong cache key. On subsequent hits in a
         // fresh PHP process, the cached page was found but its nocache regions
         // could not be restored, a RegionNotFound was caught, and the request
@@ -156,14 +155,14 @@ class HalfMeasureStaticCachingTest extends TestCase
         $this->get('/about')->assertOk();
 
         // The session metadata must be persisted under the real request URL,
-        // not under the fake /__shared-errors/200 URL.
+        // not under the fake /__shared-errors/default/200 URL.
         $store = \Statamic\Facades\StaticCache::cacheStore();
         $this->assertNotNull(
             $store->get('nocache::session.'.md5('http://localhost/about')),
             'Expected nocache session to be stored under the real request URL.'
         );
         $this->assertNull(
-            $store->get('nocache::session.'.md5('/__shared-errors/200')),
+            $store->get('nocache::session.'.md5('/__shared-errors/default/200')),
             'nocache session must not be stored under the shared-errors URL for 200 responses.'
         );
     }


### PR DESCRIPTION
Fixes a bug where enabling `static_caching.share_errors` silently breaks `{{ nocache }}` regions on regular 200 responses when using half measure static caching.
Affected pages log `Static cache region [...] not found on [URL]. Serving uncached response.` on every request after the first, fall through to a full dynamic render, and lose the benefit of static caching. Funny thing is that the Control Panel still reports them as cached.

The fix is an early return from `copyError()` when `$response->isSuccessful()`. The shared error cache is only ever consumed by `RendersHttpExceptions` for actual 4xx/5xx exceptions, so successful responses have no reason to go through the shared error caching path.
The shared error behavior for genuine error responses is unchanged.

Closes https://github.com/statamic/cms/issues/11700.

Related:

- #10340
- #12216