### PR TITLE
[6.x] Date scrollbar fix

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -31,7 +31,7 @@
 }
 
 @utility st-custom-scrollbar {
-    --sb-size: 3px;
+    --sb-size: 5px;
     --sb-thumb-color: var(--color-gray-400);
     &:where(.dark, .dark *) {
         --sb-thumb-color: var(--color-gray-500);

--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -31,7 +31,7 @@
 }
 
 @utility st-custom-scrollbar {
-    --sb-size: 5px;
+    --sb-size: 4px;
     --sb-thumb-color: var(--color-gray-400);
     &:where(.dark, .dark *) {
         --sb-thumb-color: var(--color-gray-500);
@@ -42,6 +42,7 @@
 
     &::-webkit-scrollbar {
         width: var(--sb-size);
+        height: 2px;
     }
 
     &::-webkit-scrollbar-track {

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -159,7 +159,7 @@ const getInputLabel = (part) => {
                 <DatePickerAnchor as-child>
                     <div
                         :class="[
-                            'flex w-full items-center overflow-x-auto overflow-y-hidden bg-white uppercase dark:bg-gray-900',
+                            'st-custom-scrollbar flex w-full items-center overflow-x-auto overflow-y-hidden bg-white uppercase dark:bg-gray-900',
                             'border border-gray-300 dark:border-gray-700',
                             'text-gray-600 dark:text-gray-300',
                             'shadow-ui-sm not-prose h-10 rounded-lg px-2 disabled:shadow-none',

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -178,7 +178,7 @@ const getInputLabel = (part) => {
                         >
                             <Icon name="calendar" class="size-4" />
                         </DatePickerTrigger>
-                        <div class="flex flex-1 items-center @max-xs:text-sm">
+                        <div class="flex flex-1 items-center @max-xs:text-xs">
                             <template v-for="item in segments" :key="item.part">
                                 <div v-if="item.part === 'literal'">
                                     <DatePickerInput
@@ -210,7 +210,7 @@ const getInputLabel = (part) => {
                             :additional-timezones="additionalTimezones"
                             side="top"
                         >
-                            <Text class="text-gray-600! dark:text-gray-400! ms-2.5" size="xs" :text="timeZoneLabel" />
+                            <Text class="text-gray-600! dark:text-gray-400! ms-2" size="xs" :text="timeZoneLabel" />
                         </TimezoneHoverCard>
                         <Button
                             v-if="clearable && !readOnly"

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -117,6 +117,8 @@ const isInvalid = computed(() => {
     return props.modelValue === null && props.required;
 });
 
+const hasTime = computed(() => props.granularity != null && props.granularity !== 'day');
+
 const getInputLabel = (part) => {
     switch (part) {
         case 'day':
@@ -178,7 +180,7 @@ const getInputLabel = (part) => {
                         >
                             <Icon name="calendar" class="size-4" />
                         </DatePickerTrigger>
-                        <div class="flex flex-1 items-center @max-xs:text-xs">
+                        <div class="flex flex-1 items-center" :class="{ '@max-xs:text-xs': hasTime }">
                             <template v-for="item in segments" :key="item.part">
                                 <div v-if="item.part === 'literal'">
                                     <DatePickerInput

--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -178,7 +178,7 @@ const getInputLabel = (part) => {
                         >
                             <Icon name="calendar" class="size-4" />
                         </DatePickerTrigger>
-                        <div class="flex items-center flex-1">
+                        <div class="flex flex-1 items-center @max-xs:text-sm">
                             <template v-for="item in segments" :key="item.part">
                                 <div v-if="item.part === 'literal'">
                                     <DatePickerInput
@@ -210,7 +210,7 @@ const getInputLabel = (part) => {
                             :additional-timezones="additionalTimezones"
                             side="top"
                         >
-                            <Text class="text-gray-600! dark:text-gray-400! ms-2.5 me-1" size="xs" :text="timeZoneLabel" />
+                            <Text class="text-gray-600! dark:text-gray-400! ms-2.5" size="xs" :text="timeZoneLabel" />
                         </TimezoneHoverCard>
                         <Button
                             v-if="clearable && !readOnly"

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -140,7 +140,7 @@ const hoverCardDate = computed(() => {
                     :class="[
                         'st-custom-scrollbar flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
                         'border border-gray-300 dark:border-gray-700',
-                        'leading-[1.375rem] text-gray-600 dark:text-gray-300 @max-xs:text-sm',
+                        'leading-[1.375rem] text-gray-600 dark:text-gray-300 @max-xs:text-xs',
                         'shadow-ui-sm not-prose h-10 rounded-lg py-2 px-2.5 disabled:shadow-none',
                         'data-invalid:border-red-500',
                         'disabled:shadow-none disabled:opacity-50',
@@ -190,7 +190,7 @@ const hoverCardDate = computed(() => {
                         :additional-timezones="additionalTimezones"
                         side="top"
                     >
-                        <Text class="text-gray-600! dark:text-gray-400! ms-2.5" size="xs" :text="timeZoneLabel" />
+                        <Text class="text-gray-600! dark:text-gray-400! ms-2" size="xs" :text="timeZoneLabel" />
                     </TimezoneHoverCard>
                     <Button v-if="!readOnly" @click="emit('update:modelValue', null)" variant="subtle" size="sm" icon="x" class="-me-2" :disabled="disabled" />
                 </div>

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -140,7 +140,7 @@ const hoverCardDate = computed(() => {
                     :class="[
                         'flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
                         'border border-gray-300 dark:border-gray-700',
-                        'leading-[1.375rem] text-gray-600 dark:text-gray-300',
+                        'leading-[1.375rem] text-gray-600 dark:text-gray-300 @max-xs:text-sm',
                         'shadow-ui-sm not-prose h-10 rounded-lg py-2 px-2.5 disabled:shadow-none',
                         'data-invalid:border-red-500',
                         'disabled:shadow-none disabled:opacity-50',
@@ -190,7 +190,7 @@ const hoverCardDate = computed(() => {
                         :additional-timezones="additionalTimezones"
                         side="top"
                     >
-                        <Text class="text-gray-600! dark:text-gray-400! ms-2.5 me-1" size="xs" :text="timeZoneLabel" />
+                        <Text class="text-gray-600! dark:text-gray-400! ms-2.5" size="xs" :text="timeZoneLabel" />
                     </TimezoneHoverCard>
                     <Button v-if="!readOnly" @click="emit('update:modelValue', null)" variant="subtle" size="sm" icon="x" class="-me-2" :disabled="disabled" />
                 </div>

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -138,7 +138,7 @@ const hoverCardDate = computed(() => {
             <DateRangePickerField v-slot="{ segments }" class="w-full">
                 <div
                     :class="[
-                        'flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
+                        'st-custom-scrollbar flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
                         'border border-gray-300 dark:border-gray-700',
                         'leading-[1.375rem] text-gray-600 dark:text-gray-300 @max-xs:text-sm',
                         'shadow-ui-sm not-prose h-10 rounded-lg py-2 px-2.5 disabled:shadow-none',


### PR DESCRIPTION
## Description of the Problem

Date fields tend to have overflow when time is enabled, as per https://github.com/statamic/cms/issues/14702

<img width="684" height="254" alt="image" src="https://github.com/user-attachments/assets/7e3c0a77-9fbf-4beb-b99f-04d6eda1a209" />

This is a result of this fix, where the timezone badge overflow was made hidden https://github.com/statamic/cms/pull/14652
While this was the correct approach—and indeed there is too much info in the field, which creates overflow—this PR mitigates this, aesthetically.

## What this PR Does

- Uses a container query to shrink the text size when there is less space, i.e. when time is enabled, or we're using a date _range_
- Adds a custom scrollbar, so even when the text overflows it looks OK
- Fixes #14702

Here you can see a normal `Date Field` in the sidebar which has a standard text size, and then a `Date Range` with smaller text and a custom scrollbar.

<img width="3420" height="2146" alt="2026-05-26 at 16 51 00@2x" src="https://github.com/user-attachments/assets/93ad5e51-ac48-400b-8830-f48211ee5f87" />

## How to Reproduce

1. It's easiest to force scrollbars to appear. On macOS go to System Settings > Appearance > Scroll bar behavior > Show scroll bars > always
2. Add a date field with time enabled, or a date range, where you'll see the overscroll