### PR TITLE
[6.x] Remove custom scrollbar from date fields

### DIFF
--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -161,7 +161,7 @@ const getInputLabel = (part) => {
                 <DatePickerAnchor as-child>
                     <div
                         :class="[
-                            'st-custom-scrollbar flex w-full items-center overflow-x-auto overflow-y-hidden bg-white uppercase dark:bg-gray-900',
+                            'flex w-full items-center overflow-x-auto overflow-y-hidden bg-white uppercase dark:bg-gray-900',
                             'border border-gray-300 dark:border-gray-700',
                             'text-gray-600 dark:text-gray-300',
                             'shadow-ui-sm not-prose h-10 rounded-lg px-2 disabled:shadow-none',

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -138,7 +138,7 @@ const hoverCardDate = computed(() => {
             <DateRangePickerField v-slot="{ segments }" class="w-full">
                 <div
                     :class="[
-                        'st-custom-scrollbar flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
+                        'flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
                         'border border-gray-300 dark:border-gray-700',
                         'leading-[1.375rem] text-gray-600 dark:text-gray-300 @max-xs:text-xs',
                         'shadow-ui-sm not-prose h-10 rounded-lg py-2 px-2.5 disabled:shadow-none',


### PR DESCRIPTION
Hot off the back of https://github.com/statamic/cms/pull/14730 I realised that the custom scroll bar appears at all times for overflow, even when "Show scroll bars > When scrolling" is set.

This is is a bit annoying if you don't want to see scroll bars unless interacting with them, so we'll just let the default OS scrollbar take over here

## Before

(scrollbar on the date range at all times)

<img width="3420" height="2146" alt="2026-05-26 at 17 18 29@2x" src="https://github.com/user-attachments/assets/5e615392-dd83-42a3-98b4-9c989c75ee9e" />

## After

(no scrollbar on the date range unless you interact with it)

<img width="3420" height="2146" alt="2026-05-26 at 17 17 49@2x" src="https://github.com/user-attachments/assets/3408fbd0-8713-4c47-9df6-3e63fb17851c" />
