### PR TITLE
[6.x] Fix date picker inconsistencies

### DIFF
--- a/resources/js/components/ui/DatePicker/DatePicker.vue
+++ b/resources/js/components/ui/DatePicker/DatePicker.vue
@@ -163,7 +163,7 @@ const getInputLabel = (part) => {
                         :class="[
                             'flex w-full items-center overflow-x-auto overflow-y-hidden bg-white uppercase dark:bg-gray-900',
                             'border border-gray-300 dark:border-gray-700',
-                            'text-gray-600 dark:text-gray-300',
+                            'leading-[1.375rem] text-gray-600 dark:text-gray-300',
                             'shadow-ui-sm not-prose h-10 rounded-lg px-2 disabled:shadow-none',
                             'data-invalid:border-red-500',
                             'disabled:shadow-none disabled:opacity-50',
@@ -185,7 +185,8 @@ const getInputLabel = (part) => {
                                 <div v-if="item.part === 'literal'">
                                     <DatePickerInput
                                         :part="item.part"
-                                        :class="{ 'text-sm text-gray-600 dark:text-gray-400 antialiased': !item.contenteditable }"
+                                        class="whitespace-pre"
+                                        :class="{ 'text-gray-600 dark:text-gray-400': !item.contenteditable }"
                                         v-on="inputEvents"
                                     >
                                         {{ item.value }}
@@ -194,9 +195,9 @@ const getInputLabel = (part) => {
                                 <div v-else>
                                     <DatePickerInput
                                         :part="item.part"
-                                        class="rounded-sm px-0.25 py-0.5 focus:bg-blue-100 focus:outline-hidden data-placeholder:text-gray-600 dark:focus:bg-blue-900 dark:data-placeholder:text-gray-400"
+                                        class="rounded-sm py-0.5 focus:bg-blue-100 focus:outline-hidden data-placeholder:text-gray-600 dark:focus:bg-blue-900 dark:data-placeholder:text-gray-400"
                                         :class="{
-                                            'px-0.5!': item.part === 'month' || item.part === 'year' || item.part === 'day',
+                                            'px-0.25!': item.part === 'month' || item.part === 'year' || item.part === 'day',
                                         }"
                                         :aria-label="getInputLabel(item.part)"
                                         v-on="inputEvents"

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -147,8 +147,12 @@ const hoverCardDate = computed(() => {
                         readOnly ? 'border-dashed' : '',
                     ]"
                 >
-                    <DateRangePickerTrigger v-if="!inline">
-                        <Button as="div" variant="ghost" size="sm" icon="calendar" class="-ms-2" />
+                    <DateRangePickerTrigger
+                        v-if="!inline"
+                        class="flex size-8 shrink-0 items-center justify-center rounded-lg -ms-2 text-gray-500 dark:text-gray-400 outline-hidden hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-900 dark:focus:bg-gray-900"
+                        :aria-label="__('Open calendar')"
+                    >
+                        <Icon name="calendar" class="size-3.5!" />
                     </DateRangePickerTrigger>
                     <template v-for="item in segments.start" :key="item.part">
                         <DateRangePickerInput v-if="item.part === 'literal'" :part="item.part" type="start">

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -143,7 +143,7 @@ const hoverCardDate = computed(() => {
                         'flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
                         'border border-gray-300 dark:border-gray-700',
                         'leading-[1.375rem] text-gray-600 dark:text-gray-300 @max-xs:text-xs',
-                        'shadow-ui-sm not-prose h-10 rounded-lg py-2 px-2.5 disabled:shadow-none',
+                        'shadow-ui-sm not-prose h-10 rounded-lg px-2 disabled:shadow-none',
                         'data-invalid:border-red-500',
                         'disabled:shadow-none disabled:opacity-50',
                         readOnly ? 'border-dashed' : '',
@@ -151,13 +151,13 @@ const hoverCardDate = computed(() => {
                 >
                     <DateRangePickerTrigger
                         v-if="!inline"
-                        class="flex size-8 shrink-0 items-center justify-center rounded-lg -ms-2 text-gray-500 dark:text-gray-400 outline-hidden hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-900 dark:focus:bg-gray-900"
+                        class="flex shrink-0 items-center justify-center rounded-lg p-2 -ms-1 text-gray-500 dark:text-gray-400 outline-hidden hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-900 dark:focus:bg-gray-900"
                         :aria-label="__('Open calendar')"
                     >
                         <Icon name="calendar" class="size-4" />
                     </DateRangePickerTrigger>
                     <template v-for="item in segments.start" :key="item.part">
-                        <DateRangePickerInput v-if="item.part === 'literal'" :part="item.part" type="start">
+                        <DateRangePickerInput v-if="item.part === 'literal'" :part="item.part" type="start" class="whitespace-pre">
                             {{ item.value }}
                         </DateRangePickerInput>
                         <DateRangePickerInput
@@ -174,7 +174,7 @@ const hoverCardDate = computed(() => {
                     </template>
                     <span class="mx-0.75 text-gray-400 dark:text-gray-600">&ndash;</span>
                     <template v-for="item in segments.end" :key="item.part">
-                        <DateRangePickerInput v-if="item.part === 'literal'" :part="item.part" type="end">
+                        <DateRangePickerInput v-if="item.part === 'literal'" :part="item.part" type="end" class="whitespace-pre">
                             {{ item.value }}
                         </DateRangePickerInput>
                         <DateRangePickerInput

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -154,7 +154,7 @@ const hoverCardDate = computed(() => {
                         class="flex size-8 shrink-0 items-center justify-center rounded-lg -ms-2 text-gray-500 dark:text-gray-400 outline-hidden hover:bg-gray-100 focus:bg-gray-100 dark:hover:bg-gray-900 dark:focus:bg-gray-900"
                         :aria-label="__('Open calendar')"
                     >
-                        <Icon name="calendar" class="size-3.5!" />
+                        <Icon name="calendar" class="size-4" />
                     </DateRangePickerTrigger>
                     <template v-for="item in segments.start" :key="item.part">
                         <DateRangePickerInput v-if="item.part === 'literal'" :part="item.part" type="start">

--- a/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
+++ b/resources/js/components/ui/DateRangePicker/DateRangePicker.vue
@@ -15,6 +15,7 @@ import {
     DateRangePickerHeading,
     DateRangePickerNext,
     DateRangePickerPrev,
+    DateRangePickerAnchor,
     DateRangePickerContent,
     DateRangePickerField,
     DateRangePickerInput,
@@ -136,6 +137,7 @@ const hoverCardDate = computed(() => {
             close-on-select
         >
             <DateRangePickerField v-slot="{ segments }" class="w-full">
+                <DateRangePickerAnchor as-child>
                 <div
                     :class="[
                         'flex items-center w-full overflow-x-auto overflow-y-hidden bg-white dark:bg-gray-900',
@@ -198,13 +200,13 @@ const hoverCardDate = computed(() => {
                     </TimezoneHoverCard>
                     <Button v-if="!readOnly" @click="emit('update:modelValue', null)" variant="subtle" size="sm" icon="x" class="-me-2" :disabled="disabled" />
                 </div>
+                </DateRangePickerAnchor>
             </DateRangePickerField>
 
             <DateRangePickerContent
                 v-if="!inline"
                 align="start"
-                :align-offset="-12"
-                :side-offset="14"
+                :side-offset="4"
                 class="data-[state=open]:data-[side=top]:animate-slideDownAndFade data-[state=open]:data-[side=right]:animate-slideLeftAndFade data-[state=open]:data-[side=bottom]:animate-slideUpAndFade data-[state=open]:data-[side=left]:animate-slideRightAndFade will-change-[transform,opacity]"
             >
                 <Card class="w-[20rem]">


### PR DESCRIPTION
Edit by Jason:
The scope crept a little. I noticed some more inconsistencies between the single and range fields, so thought made sense to resolve them here. Things like padding, leading, spacing, etc.

---

## Description of the Problem

Tiny thing, but the date _range_ picker button is slightly different from the date picker button.
This is noticeable when escaping the date field

## Escaping the **date** field

(desirable focus experience) – see the sidebar date field calendar icon, which just receives a gray background

<img width="3420" height="2146" alt="2026-05-26 at 17 47 25@2x" src="https://github.com/user-attachments/assets/7839a65f-d779-4bb7-8f1a-65f98a5e196b" />

## Escaping the **date range** field

(undesirable focus experience) – see the sidebar date field calendar icon, which receives a wonky blue ring

<img width="3420" height="2146" alt="2026-05-26 at 17 49 25@2x" src="https://github.com/user-attachments/assets/767677e8-fae3-4826-bc04-a2cf5b1b4a10" />

## What this PR Does

Fixes the date range calendar icon to use the same styling as the date field calendar icon, like this

(wonky blue focus line no longer visible)

<img width="3420" height="2146" alt="2026-05-26 at 17 53 54@2x" src="https://github.com/user-attachments/assets/57e6c67e-fc29-4016-89c2-592cc06a9f20" />

## How to Reproduce

1. Add a date range field type
2. Click the picker calendar icon
3. Press escape without picking anything
4. Observe the wonky focus ring