### PR TITLE
[6.x] Fix form box-shadows being clipped by expanding/collapsing sections

### DIFF
--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -117,6 +117,7 @@ function toggleSection(section) {
 .publish-section-collapsible--expanded .publish-section-collapsible__inner {
     animation: calc(var(--speed) * 2) var(--timing) section-fade-in both;
     overflow: clip;
+    overflow-clip-margin: 4px;
 }
 
 .publish-section-collapsible--collapsed .publish-section-collapsible__inner {


### PR DESCRIPTION
## Description of the Problem

Shadows were inadvertently clipped following the recent section collapse overhaul

## What this PR Does

Pulls the clip out a little to let the shadows breathe when the form is expanded

### Before

Notice the shadows are clipped

<img width="1990" height="300" alt="2026-05-27 at 16 34 11@2x" src="https://github.com/user-attachments/assets/c4967634-3163-4004-bbe8-d0cb708551ba" />

### After

The shadows are back!

<img width="1990" height="300" alt="2026-05-27 at 16 29 32@2x" src="https://github.com/user-attachments/assets/c164cc02-e13c-4dea-8a0b-175413c9d705" />

## How to Reproduce

1. Make the section collapsible in the blueprint