### PR TITLE
[6.x] Improve modal text formatting and dark mode background

### DIFF
--- a/resources/js/components/ui/Modal/ConfirmationModal.vue
+++ b/resources/js/components/ui/Modal/ConfirmationModal.vue
@@ -93,9 +93,13 @@ const shouldCloseOnSubmit = computed(() => {
             <Icon name="loading" />
         </div>
 
-        <p v-if="bodyText" v-text="bodyText" />
+        <p
+            v-if="bodyText"
+            class="text-gray-700 dark:text-gray-200 antialiased"
+            v-text="bodyText"
+        />
         <slot v-else>
-            <p>{{ __('Are you sure?') }}</p>
+            <p class="text-gray-700 dark:text-gray-200 antialiased">{{ __('Are you sure?') }}</p>
         </slot>
 
         <template v-if="cancellable || submittable" #footer>

--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -33,7 +33,7 @@ const props = defineProps({
 });
 
 const overlayClasses = cva({
-    base: 'fixed inset-0 z-(--z-index-portal) bg-gray-800/20 dark:bg-gray-800/50',
+    base: 'fixed inset-0 z-(--z-index-portal) bg-gray-800/20 dark:bg-gray-950/60',
     variants: {
         blur: {
             true: 'backdrop-blur-[2px]',
@@ -189,7 +189,7 @@ provide('closeModal', close);
                     <div class="relative space-y-3 rounded-xl overflow-auto max-h-[60vh] border border-gray-400/60 bg-white p-4 shadow-[0_1px_16px_-2px_rgba(63,63,71,0.2)] dark:border-none dark:bg-gray-800 dark:shadow-[0_1px_16px_-2px_rgba(0,0,0,.5)] dark:inset-shadow-2xs dark:inset-shadow-white/10">
                         <div v-if="!hasModalTitleComponent && (title || icon)" data-ui-modal-title class="flex items-center gap-2">
                             <Icon :name="icon" v-if="icon" class="size-4" />
-                            <Heading :text="title" size="lg" class="font-medium" />
+                            <Heading :text="title" size="lg" class="font-semibold text-gray-950 dark:text-gray-100" />
                         </div>
                         <slot />
                     </div>


### PR DESCRIPTION
## Description of the Problem

Confirmation modal headings feel like they're not differentiated from the text

## What this PR Does

- Improve the heading weight
- Lighten the text slightly to improve contrast between the heading and the message
- Improve contrast between modal and background on dark mode

## Before

(light heading weight, dark text on the page confirmation body, not much contrast between modal and background for dark mode)

<img width="3420" height="2146" alt="2026-05-28 at 10 55 59@2x" src="https://github.com/user-attachments/assets/6a5322a5-13c3-420e-9fee-a28f129bdb12" />
<img width="3420" height="2146" alt="2026-05-28 at 10 58 20@2x" src="https://github.com/user-attachments/assets/4a6ac6ed-4d20-4df3-bd36-cf66a490b98b" />
<img width="3420" height="2146" alt="2026-05-28 at 10 58 23@2x" src="https://github.com/user-attachments/assets/a8ca6ad1-981c-4eee-afbe-290a3831e36a" />

## After

(stronger heading weight, lighter text on the page confirmation body, stronger dark mode contrast)

<img width="3420" height="2146" alt="2026-05-28 at 10 55 30@2x" src="https://github.com/user-attachments/assets/ea217469-2819-44c8-8925-a9b7b93ef78f" />
<img width="3420" height="2146" alt="2026-05-28 at 10 57 32@2x" src="https://github.com/user-attachments/assets/f5c40a67-4dc4-49e0-a613-d3c20bc7af21" />
<img width="3420" height="2146" alt="2026-05-28 at 10 57 28@2x" src="https://github.com/user-attachments/assets/9f7ee238-16d1-447d-bf33-b6d325ee5891" />
