### PR TITLE
[6.x] Reusable GitHub workflows

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,5 +12,5 @@ concurrency:
 
 jobs:
   pr-title:
-    uses: statamic/.github/.github/workflows/global/pr-title.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
+    uses: statamic/.github/.github/workflows/pr-title.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions: {}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -11,60 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  pr-title: # zizmor: ignore[anonymous-definition]
-    runs-on: ubuntu-latest
+  pr-title:
+    uses: statamic/.github/.github/workflows/global/pr-title.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions: {}
-    steps:
-      - name: Validate PR title matches target branch
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-        run: |
-          # Validates PR title against target branch
-          # Returns error message if invalid, empty string if valid
-          validate_pr_title() {
-            local target_branch="$1"
-            local pr_title="$2"
-            local default_branch="$3"
-
-            # Check if target branch is a version branch (e.g., 5.x, 4.x)
-            if [[ $target_branch =~ ^([0-9]+)\.x$ ]]; then
-              local version="${BASH_REMATCH[1]}"
-              if [[ ! $pr_title =~ ^\[$version\.x\][[:space:]] ]]; then
-                echo "PR targeting '$target_branch' must have title starting with '[$version.x] '"
-                return
-              fi
-
-            # Check if target branch is master (next major version)
-            elif [[ $target_branch == "master" ]]; then
-              local current_version="${default_branch//\.x/}"
-              local next_version=$((current_version + 1))
-              if [[ ! $pr_title =~ ^\[$next_version\.x\][[:space:]] ]]; then
-                echo "PR targeting 'master' must have title starting with '[$next_version.x] '"
-                return
-              fi
-
-            # For other branches, just enforce that there's a version prefix
-            else
-              if [[ ! $pr_title =~ ^\[[0-9]+\.x\][[:space:]] ]]; then
-                echo "PR title must start with a version prefix like '[5.x] '"
-                return
-              fi
-            fi
-
-            echo ""
-          }
-
-          echo "PR Title: $PR_TITLE"
-          echo "Base Branch: $BASE_BRANCH"
-          echo "Default Branch: $DEFAULT_BRANCH"
-
-          ERROR=$(validate_pr_title "$BASE_BRANCH" "$PR_TITLE" "$DEFAULT_BRANCH")
-
-          if [[ -n $ERROR ]]; then
-            echo $ERROR
-            exit 1
-          fi
-
-          echo "PR title validation passed"

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,8 +1,5 @@
 name: Pull Requests
 
-# Credit: https://github.com/github/docs/blob/main/.github/workflows/notify-when-maintainers-cannot-edit.yaml
-#         https://github.com/laravel/.github/blob/main/.github/workflows/pull-requests.yml
-
 on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -15,66 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  uneditable: # zizmor: ignore[anonymous-definition]
-    runs-on: ubuntu-latest
+  uneditable:
+    uses: statamic/.github/.github/workflows/global/pull-requests.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions:
       pull-requests: write # post comment and close PRs that don't allow maintainer edits
-    steps:
-      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const repo = context.repo.repo;
-
-            const query = `
-              query($number: Int!) {
-                repository(owner: "statamic", name: "${repo}") {
-                  pullRequest(number: $number) {
-                    headRepositoryOwner {
-                      login
-                    }
-                    maintainerCanModify
-                    state
-                  }
-                }
-              }
-            `;
-
-            const pullNumber = context.issue.number;
-            const variables = { number: pullNumber };
-
-            try {
-              console.log(`Check for maintainer edit access ...`);
-              const result = await github.graphql(query, variables);
-              console.log(JSON.stringify(result, null, 2));
-              const pullRequest = result.repository.pullRequest;
-
-              if (pullRequest.headRepositoryOwner.login === 'statamic') {
-                console.log('PR owned by statamic');
-                return;
-              }
-
-              if (pullRequest.state !== 'OPEN') {
-                 console.log('PR has already been closed or merged');
-                 return;
-              }
-
-              if (!pullRequest.maintainerCanModify) {
-                console.log('PR not owned by statamic and does not have maintainer edits enabled');
-
-                await github.rest.issues.createComment({
-                  issue_number: pullNumber,
-                  owner: 'statamic',
-                  repo,
-                  body: "Thanks for submitting a PR!\n\nIn order to review and merge PRs most efficiently, we require that all PRs grant maintainer edit access before we review them. For information on how to do this, [see the relevant GitHub documentation](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork). Additionally, GitHub doesn't allow maintainer permissions from organization accounts. Please resubmit this PR from a personal GitHub account with maintainer permissions enabled."
-                });
-
-                await github.rest.pulls.update({
-                  pull_number: pullNumber,
-                  owner: 'statamic',
-                  repo,
-                  state: 'closed'
-                });
-              }
-            } catch(e) {
-              console.log(e);
-            }

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -16,6 +16,6 @@ concurrency:
 
 jobs:
   uneditable:
-    uses: statamic/.github/.github/workflows/global/pull-requests.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
+    uses: statamic/.github/.github/workflows/pull-requests.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions:
       pull-requests: write # post comment and close PRs that don't allow maintainer edits

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,4 +11,3 @@ jobs:
     uses: statamic/.github/.github/workflows/stale.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions:
       issues: write # mark issues stale and close them
-      pull-requests: write # mark pull requests stale and close them

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,7 @@ permissions: {}
 
 jobs:
   stale:
-    uses: statamic/.github/.github/workflows/global/stale.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
+    uses: statamic/.github/.github/workflows/stale.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions:
       issues: write # mark issues stale and close them
+      pull-requests: write # mark pull requests stale and close them

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,21 +7,7 @@ on: # zizmor: ignore[concurrency-limits]
 permissions: {}
 
 jobs:
-  stale: # zizmor: ignore[anonymous-definition]
-    runs-on: ubuntu-latest
+  stale:
+    uses: statamic/.github/.github/workflows/global/stale.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions:
       issues: write # mark issues stale and close them
-      pull-requests: write # mark pull requests stale and close them
-    steps:
-    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 60
-        days-before-close: 7
-        ascending: true
-        only-labels: 'needs more info'
-        stale-issue-label: stale
-        stale-issue-message: >
-          This issue has not had recent activity and has been marked as stale — by me, a robot.
-          Simply reply to keep it open and send me away. If you do nothing, I will close it in
-          a week. I have no feelings, so whatever you do is fine by me.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,18 +19,5 @@ concurrency:
 
 jobs:
   zizmor:
-    name: zizmor
-    runs-on: ubuntu-latest
+    uses: statamic/.github/.github/workflows/global/zizmor.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions: {}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run zizmor
-        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
-        with:
-          advanced-security: false
-          annotations: true
-          persona: pedantic

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   zizmor:
-    uses: statamic/.github/.github/workflows/global/zizmor.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
+    uses: statamic/.github/.github/workflows/zizmor.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
     permissions: {}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -19,5 +19,5 @@ concurrency:
 
 jobs:
   zizmor:
-    uses: statamic/.github/.github/workflows/zizmor.yml@bebe92309b4276e45ebc0d0c65854fb2ecf786ba
+    uses: statamic/.github/.github/workflows/zizmor.yml@7e941c239074d66da6cad3322bec3b1005c80cf7
     permissions: {}


### PR DESCRIPTION
Some of our workflows have been moved into the statamic org repo so they can be reused across repos. This PR adjusts the workflows to use those.

https://github.com/statamic/.github/pull/2