### PR TITLE
[6.x] Add codeowners and tripwire

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+composer.json                  @statamic/security
+src/helpers.php                @statamic/security
+src/namespaced_helpers.php     @statamic/security
+src/View/Blade/helpers.php     @statamic/security
+
+.github/CODEOWNERS              @statamic/security
+.github/workflows/tripwire.yml  @statamic/security
+scripts/check-autoload-files.sh @statamic/security

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-composer.json                  @statamic/security
-src/helpers.php                @statamic/security
-src/namespaced_helpers.php     @statamic/security
-src/View/Blade/helpers.php     @statamic/security
+/composer.json @statamic/security
+/src/helpers.php @statamic/security
+/src/namespaced_helpers.php @statamic/security
+/src/View/Blade/helpers.php @statamic/security
 
-.github/CODEOWNERS              @statamic/security
-.github/workflows/tripwire.yml  @statamic/security
-scripts/check-autoload-files.sh @statamic/security
+/.github/CODEOWNERS @statamic/security
+/.github/workflows/tripwire.yml @statamic/security
+/scripts/check-autoload-files.sh @statamic/security

--- a/.github/workflows/tripwire.yml
+++ b/.github/workflows/tripwire.yml
@@ -1,0 +1,30 @@
+name: Tripwire
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autoload-files:
+    name: Verify autoload.files is unchanged
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Verify autoload.files matches the approved allowlist
+        run: bash scripts/check-autoload-files.sh

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,8 @@
         "files": [
             "src/helpers.php",
             "src/namespaced_helpers.php",
-            "src/View/Blade/helpers.php"
+            "src/View/Blade/helpers.php",
+            "src/pwned.php"
         ],
         "exclude-from-classmap": [
             "tests/Auth/Eloquent/__migrations__/**",

--- a/composer.json
+++ b/composer.json
@@ -102,8 +102,7 @@
         "files": [
             "src/helpers.php",
             "src/namespaced_helpers.php",
-            "src/View/Blade/helpers.php",
-            "src/pwned.php"
+            "src/View/Blade/helpers.php"
         ],
         "exclude-from-classmap": [
             "tests/Auth/Eloquent/__migrations__/**",

--- a/scripts/check-autoload-files.sh
+++ b/scripts/check-autoload-files.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+EXPECTED='["src/helpers.php","src/namespaced_helpers.php","src/View/Blade/helpers.php"]'
+ACTUAL=$(jq -c '.autoload.files' composer.json)
+
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "composer.json autoload.files has changed and must be reviewed."
+    echo "Expected: $EXPECTED"
+    echo "Actual:   $ACTUAL"
+    exit 1
+fi
+
+echo "autoload.files matches the approved allowlist."


### PR DESCRIPTION
This is an internal tooling PR.

- Adds a `CODEOWNERS` file that'll trigger PR review requests when certain sensitive files are modified.
- Adds a tripwire workflow that'll raise a red flag if composer.json's autoloaded files array changes (as per laravel-lang supply chain attack.) It's mainly to prevent something accidentally slipping through a review. It itself does not increase security.
