### PR TITLE
[6.x] Apply regenerate handle pattern for replicator sections

### DIFF
--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -53,6 +53,7 @@
                             type="text"
                             class="font-mono text-sm"
                             v-model="editingSection.handle"
+                            @input="handleSyncedWithDisplay = false"
                         >
                             <template #append>
                                 <ui-button
@@ -166,6 +167,7 @@ export default {
         return {
             editingSection: false,
             editingField: null,
+            handleSyncedWithDisplay: false,
             saveKeyBinding: null,
         };
     },
@@ -199,6 +201,12 @@ export default {
             handler(section) {
                 this.$emit('updated', section);
             },
+        },
+
+        'editingSection.display': function (display) {
+            if (this.editingSection && this.handleSyncedWithDisplay) {
+                this.editingSection.handle = snake_case(display);
+            }
         },
 
         editingSection: {
@@ -253,6 +261,7 @@ export default {
         },
 
         edit() {
+            this.handleSyncedWithDisplay = !this.section.handle || ['new_section', 'new_set'].includes(this.section.handle);
             this.editingSection = {
                 display: this.section.display,
                 handle: this.section.handle,
@@ -266,6 +275,10 @@ export default {
         },
 
         editConfirmed() {
+            if (!this.editingSection.handle) {
+                this.editingSection.handle = snake_case(this.editingSection.display);
+            }
+
             this.$emit('updated', { ...this.section, ...this.editingSection });
             this.editingSection = false;
         },

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -59,6 +59,7 @@
                                     icon="sync"
                                     size="sm"
                                     variant="ghost"
+                                    :aria-label="__('Regenerate from: :field', { field: __('Display') })"
                                     @click="regenerateHandle"
                                     v-tooltip="__('Regenerate from: :field', { field: __('Display') })"
                                 />

--- a/resources/js/components/blueprints/Section.vue
+++ b/resources/js/components/blueprints/Section.vue
@@ -53,8 +53,17 @@
                             type="text"
                             class="font-mono text-sm"
                             v-model="editingSection.handle"
-                            @input="handleSyncedWithDisplay = false"
-                        />
+                        >
+                            <template #append>
+                                <ui-button
+                                    icon="sync"
+                                    size="sm"
+                                    variant="ghost"
+                                    @click="regenerateHandle"
+                                    v-tooltip="__('Regenerate from: :field', { field: __('Display') })"
+                                />
+                            </template>
+                        </ui-input>
                     </ui-field>
                     <ui-field :label="__('Instructions')">
                         <ui-input type="text" v-model="editingSection.instructions" />
@@ -156,7 +165,6 @@ export default {
         return {
             editingSection: false,
             editingField: null,
-            handleSyncedWithDisplay: false,
             saveKeyBinding: null,
         };
     },
@@ -192,12 +200,6 @@ export default {
             },
         },
 
-        'editingSection.display': function (display) {
-            if (this.editingSection && this.handleSyncedWithDisplay) {
-                this.editingSection.handle = snake_case(display);
-            }
-        },
-
         editingSection: {
             handler(isEditing) {
                 if (isEditing) {
@@ -219,15 +221,15 @@ export default {
         },
     },
 
-    created() {
-        // This logic isn't ideal, but it was better than passing along a 'isNew' boolean and having
-        // to deal with stripping it out and making it not new, etc. Good enough for a quick win.
-        if (!this.section.handle || this.section.handle == 'new_section' || this.section.handle == 'new_set') {
-            this.handleSyncedWithDisplay = true;
-        }
-    },
-
     methods: {
+        regenerateHandle() {
+            if (!this.editingSection) {
+                return;
+            }
+
+            this.editingSection.handle = snake_case(this.editingSection.display);
+        },
+
         fieldLinked(field) {
             this.section.fields.push(field);
             this.$toast.success(__('Field added'));
@@ -263,10 +265,6 @@ export default {
         },
 
         editConfirmed() {
-            if (!this.editingSection.handle) {
-                this.editingSection.handle = snake_case(this.editingSection.display);
-            }
-
             this.$emit('updated', { ...this.section, ...this.editingSection });
             this.editingSection = false;
         },

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -32,7 +32,17 @@
                         <Input ref="title" :model-value="display" @update:model-value="fieldUpdated('display', $event)" />
                     </Field>
                     <Field :label="__('Handle')" class="form-group field-w-100">
-                        <Input class="font-mono" :model-value="handle" @update:model-value="fieldUpdated('handle', $event)" />
+                        <Input class="font-mono" :model-value="handle" @update:model-value="fieldUpdated('handle', $event)">
+                            <template #append>
+                                <Button
+                                    icon="sync"
+                                    size="sm"
+                                    variant="ghost"
+                                    @click="regenerateHandle"
+                                    v-tooltip="__('Regenerate from: :field', { field: __('Title') })"
+                                />
+                            </template>
+                        </Input>
                     </Field>
                     <Field v-if="showInstructions" :label="__('Instructions')" class="form-group field-w-100">
                         <Input :model-value="instructions" @update:model-value="fieldUpdated('instructions', $event)" />
@@ -98,17 +108,8 @@ export default {
             instructions: this.tab.instructions,
             icon: this.tab.icon,
             editing: false,
-            handleSyncedWithDisplay: false,
             saveKeyBinding: null,
         };
-    },
-
-    created() {
-        // This logic isn't ideal, but it was better than passing along a 'isNew' boolean and having
-        // to deal with stripping it out and making it not new, etc. Good enough for a quick win.
-        if (!this.handle || this.handle == 'new_tab' || this.handle == 'new_set_group') {
-            this.handleSyncedWithDisplay = true;
-        }
     },
 
     computed: {
@@ -149,15 +150,19 @@ export default {
     },
 
     methods: {
+        regenerateHandle() {
+            this.handle = snake_case(this.display);
+        },
+
         edit() {
+            this.display = this.tab.display;
+            this.handle = this.tab.handle;
+            this.instructions = this.tab.instructions;
+            this.icon = this.tab.icon;
             this.editing = true;
         },
 
         editConfirmed() {
-            if (!this.handle) {
-                this.handle = snake_case(this.display);
-            }
-
             this.$emit('updated', {
                 ...this.tab,
                 handle: this.handle,
@@ -194,14 +199,6 @@ export default {
         },
 
         fieldUpdated(handle, value) {
-            if (handle === 'display' && this.handleSyncedWithDisplay) {
-                this.handle = snake_case(value);
-            }
-
-            if (handle === 'handle') {
-                this.handleSyncedWithDisplay = false;
-            }
-
             this[handle] = value;
         },
 

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -109,6 +109,7 @@ export default {
             instructions: this.tab.instructions,
             icon: this.tab.icon,
             editing: false,
+            handleSyncedWithDisplay: false,
             saveKeyBinding: null,
         };
     },
@@ -160,10 +161,15 @@ export default {
             this.handle = this.tab.handle;
             this.instructions = this.tab.instructions;
             this.icon = this.tab.icon;
+            this.handleSyncedWithDisplay = !this.tab.handle || ['new_tab', 'new_set_group'].includes(this.tab.handle);
             this.editing = true;
         },
 
         editConfirmed() {
+            if (!this.handle) {
+                this.handle = snake_case(this.display);
+            }
+
             this.$emit('updated', {
                 ...this.tab,
                 handle: this.handle,
@@ -200,6 +206,14 @@ export default {
         },
 
         fieldUpdated(handle, value) {
+            if (handle === 'display' && this.handleSyncedWithDisplay) {
+                this.handle = snake_case(value);
+            }
+
+            if (handle === 'handle') {
+                this.handleSyncedWithDisplay = false;
+            }
+
             this[handle] = value;
         },
 

--- a/resources/js/components/blueprints/Tab.vue
+++ b/resources/js/components/blueprints/Tab.vue
@@ -38,6 +38,7 @@
                                     icon="sync"
                                     size="sm"
                                     variant="ghost"
+                                    :aria-label="__('Regenerate from: :field', { field: __('Title') })"
                                     @click="regenerateHandle"
                                     v-tooltip="__('Regenerate from: :field', { field: __('Title') })"
                                 />


### PR DESCRIPTION
## Description of the Problem

I noticed that while changing some set names – I inadvertently "deleted" the content too because it changed the handle at the same time. Changing the display name should not also change the handle name, and we should use the same "regenerate handle" pattern we use elsewhere.

## What this PR Does

- Applies the regenerate handle pattern to replicator set names and tab names

### Before

<img width="3420" height="2146" alt="2026-05-29 at 11 02 30@2x" src="https://github.com/user-attachments/assets/adaa0466-cccd-4f2e-8fb7-9a15d2f5c9d4" />

### After

<img width="3420" height="2146" alt="2026-05-29 at 11 01 11@2x" src="https://github.com/user-attachments/assets/aec17886-6b3d-45dd-bae2-013b2c578ef0" />

## How to Reproduce

1. Add a replicator field and some dummy sets
2. Save
3. Go back in to edit the replicator sets
4. Change the `Display` name
5. Observe how the handle also changes as you change the `Display` name