### PR TITLE
[6.x] Handle replicator handle overflow

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -26,7 +26,7 @@
                 <span v-if="!isReadOnly" data-drag-handle class="flex cursor-grab" @mousedown="enableDragging">
                     <Icon name="handles" class="size-4 text-gray-400" />
                 </span>
-                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-scroll p-2 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
+                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-auto p-2 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
                     <Badge size="lg" :pill="true" color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -26,7 +26,7 @@
                 <span v-if="!isReadOnly" data-drag-handle class="flex cursor-grab" @mousedown="enableDragging">
                     <Icon name="handles" class="size-4 text-gray-400" />
                 </span>
-                <button type="button" class="show-focus-within_target flex flex-1 items-center gap-4 p-2 min-w-0 focus:outline-none cursor-pointer" @click="toggleCollapsedState">
+                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-scroll p-2 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
                     <Badge size="lg" :pill="true" color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -152,7 +152,7 @@ reveal.use(rootEl, () => emit('expanded'));
                     class="size-4 cursor-grab text-gray-400"
                     v-if="!readOnly"
                 />
-                <button type="button" class="show-focus-within_target flex flex-1 items-center gap-4 p-2 py-1.75 min-w-0 focus:outline-none cursor-pointer" @click="toggleCollapsedState">
+                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-scroll p-2 py-1.75 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
                     <Badge size="lg" pill color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -152,7 +152,7 @@ reveal.use(rootEl, () => emit('expanded'));
                     class="size-4 cursor-grab text-gray-400"
                     v-if="!readOnly"
                 />
-                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-scroll p-2 py-1.75 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
+                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-auto p-2 py-1.75 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
                     <Badge size="lg" pill color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}


### PR DESCRIPTION
## Description of the Problem

When you have long set names, it can cause overflow in smaller spaces, such as Live Preview, as described in #14735 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ee2a0ace-c571-4488-90cd-e8efe91d4bfa" />

## What this PR Does

- Forces an overflow scroll if it's too long
- Uses a mask so the overflow gets cut off nicely
- Closes #14735 

### Before

<img width="3420" height="2146" alt="2026-05-29 at 12 02 26@2x" src="https://github.com/user-attachments/assets/30015f8d-7897-43db-9ec8-39904a2ecce9" />

### After

<img width="3420" height="2146" alt="2026-05-29 at 12 02 10@2x" src="https://github.com/user-attachments/assets/06c8d87b-001b-4a68-b164-a048065a17b2" />

## How to Reproduce

1. Add a set with a long name
2. Open Live Preview, or view the replicator handle in a small space