### PR TITLE
[6.x] Fix field filters returning all results when filtering by 0

### DIFF
--- a/src/Query/Scopes/Filters/Fields/Date.php
+++ b/src/Query/Scopes/Filters/Fields/Date.php
@@ -81,7 +81,7 @@ class Date extends FieldtypeFilter
 
     public function isComplete($values): bool
     {
-        $values = array_filter($values);
+        $values = Arr::removeNullValues($values);
 
         if (! $operator = Arr::get($values, 'operator')) {
             return false;

--- a/src/Query/Scopes/Filters/Fields/Dimensions.php
+++ b/src/Query/Scopes/Filters/Fields/Dimensions.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
-use Illuminate\Support\Arr;
+use Statamic\Support\Arr;
 
 use function Statamic\trans as __;
 
@@ -78,7 +78,7 @@ class Dimensions extends Integer
 
     public function isComplete($values): bool
     {
-        $values = array_filter($values);
+        $values = Arr::removeNullValues($values);
 
         return Arr::hasAll($values, ['dimension', 'operator', 'value']);
     }

--- a/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
@@ -84,6 +84,8 @@ class FieldtypeFilter
 
     public function isComplete($values): bool
     {
+        $values = Arr::removeNullValues($values);
+
         if (! $operator = Arr::get($values, 'operator')) {
             return false;
         }
@@ -92,8 +94,6 @@ class FieldtypeFilter
             return true;
         }
 
-        $value = Arr::get($values, 'value');
-
-        return $value !== null && $value !== '';
+        return Arr::has($values, 'value');
     }
 }

--- a/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
+++ b/src/Query/Scopes/Filters/Fields/FieldtypeFilter.php
@@ -84,8 +84,6 @@ class FieldtypeFilter
 
     public function isComplete($values): bool
     {
-        $values = array_filter($values);
-
         if (! $operator = Arr::get($values, 'operator')) {
             return false;
         }
@@ -94,6 +92,8 @@ class FieldtypeFilter
             return true;
         }
 
-        return Arr::has($values, 'value');
+        $value = Arr::get($values, 'value');
+
+        return $value !== null && $value !== '';
     }
 }

--- a/src/Query/Scopes/Filters/Fields/Terms.php
+++ b/src/Query/Scopes/Filters/Fields/Terms.php
@@ -70,7 +70,7 @@ class Terms extends FieldtypeFilter
 
     public function isComplete($values): bool
     {
-        $values = array_filter($values);
+        $values = Arr::removeNullValues($values);
 
         if (! $operator = Arr::get($values, 'operator')) {
             return false;

--- a/src/Query/Scopes/Filters/Fields/Toggle.php
+++ b/src/Query/Scopes/Filters/Fields/Toggle.php
@@ -2,7 +2,7 @@
 
 namespace Statamic\Query\Scopes\Filters\Fields;
 
-use Illuminate\Support\Arr;
+use Statamic\Support\Arr;
 
 use function Statamic\trans as __;
 
@@ -40,7 +40,7 @@ class Toggle extends FieldtypeFilter
 
     public function isComplete($values): bool
     {
-        $values = array_filter($values);
+        $values = Arr::removeNullValues($values);
 
         return Arr::has($values, 'value');
     }

--- a/tests/Query/FieldtypeFilterTest.php
+++ b/tests/Query/FieldtypeFilterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Query;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Text;
+use Tests\TestCase;
+
+class FieldtypeFilterTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('completenessProvider')]
+    public function it_determines_if_a_filter_is_complete($values, $expected)
+    {
+        $filter = (new Text)->setField(new Field('test', ['type' => 'text']))->filter();
+
+        $this->assertEquals($expected, $filter->isComplete($values));
+    }
+
+    public static function completenessProvider()
+    {
+        return [
+            'no operator' => [['value' => 'foo'], false],
+            'operator but no value' => [['operator' => '='], false],
+            'operator and value' => [['operator' => '=', 'value' => 'foo'], true],
+            'zero string value' => [['operator' => '=', 'value' => '0'], true],
+            'zero integer value' => [['operator' => '=', 'value' => 0], true],
+            'null value' => [['operator' => '=', 'value' => null], false],
+            'empty string value' => [['operator' => '=', 'value' => ''], false],
+            'null operator without value' => [['operator' => 'null'], true],
+            'not-null operator without value' => [['operator' => 'not-null'], true],
+        ];
+    }
+}

--- a/tests/Query/FieldtypeFilterTest.php
+++ b/tests/Query/FieldtypeFilterTest.php
@@ -5,7 +5,9 @@ namespace Tests\Query;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Integer as IntegerFieldtype;
 use Statamic\Fieldtypes\Text;
+use Statamic\Query\Scopes\Filters\Fields\Dimensions;
 use Tests\TestCase;
 
 class FieldtypeFilterTest extends TestCase
@@ -31,6 +33,28 @@ class FieldtypeFilterTest extends TestCase
             'empty string value' => [['operator' => '=', 'value' => ''], false],
             'null operator without value' => [['operator' => 'null'], true],
             'not-null operator without value' => [['operator' => 'not-null'], true],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('dimensionsCompletenessProvider')]
+    public function it_determines_if_a_dimensions_filter_is_complete($values, $expected)
+    {
+        $fieldtype = (new IntegerFieldtype)->setField(new Field('test', ['type' => 'integer']));
+        $filter = new Dimensions($fieldtype);
+
+        $this->assertEquals($expected, $filter->isComplete($values));
+    }
+
+    public static function dimensionsCompletenessProvider()
+    {
+        return [
+            'all fields present' => [['dimension' => 'width', 'operator' => '=', 'value' => '100'], true],
+            'zero value' => [['dimension' => 'width', 'operator' => '=', 'value' => 0], true],
+            'zero string value' => [['dimension' => 'width', 'operator' => '=', 'value' => '0'], true],
+            'null value' => [['dimension' => 'width', 'operator' => '=', 'value' => null], false],
+            'missing value' => [['dimension' => 'width', 'operator' => '='], false],
+            'missing dimension' => [['operator' => '=', 'value' => '100'], false],
         ];
     }
 }


### PR DESCRIPTION
On listing views filtering a field using `0` as the value returns items as no filter was being used instead of matching ones with an actual value of `0`.

Example: A text or integer field like `Levels` containing values like `0`, `1`, `2`, `3`, filtering for `0` ignores the filter entirely and returns all entries.

`Statamic\Query\Scopes\Filters\Fields\FieldtypeFilter::isComplete()` does `$values = array_filter($values)` where `array_filter()` with no callback removes every falsy element including both the string `'0'` and integer `0`. With the value stripped, `isComplete()` returns `false` and never applies the filter.

The fix is to replace `array_filter()` with explicit checks, so 0 and '0' are treated as actual values while actual empty filters (`null`, `''`) are skipped.

Related:

- #13785
- #13786