### PR TITLE
[6.x] Fix tests

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -20,7 +20,7 @@ use Statamic\Support\Svg;
 use Statamic\Support\TextDirection;
 use Statamic\Tags\FluentTag;
 
-class Statamic
+class Statamic //
 {
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -20,7 +20,7 @@ use Statamic\Support\Svg;
 use Statamic\Support\TextDirection;
 use Statamic\Tags\FluentTag;
 
-class Statamic //
+class Statamic
 {
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';

--- a/tests/Assets/AssetRepositoryTest.php
+++ b/tests/Assets/AssetRepositoryTest.php
@@ -36,7 +36,7 @@ class AssetRepositoryTest extends TestCase
 
         $disk->assertExists($path = 'foo/.meta/image.jpg.yaml');
         $contents = <<<EOT
-data: {  }
+data: {}
 size: 723
 last_modified: $timestamp
 width: 30
@@ -45,7 +45,7 @@ mime_type: image/jpeg
 duration: null
 
 EOT;
-        $this->assertEquals($contents, $disk->get($path));
+        $this->assertEquals($contents, $this->normalizeYaml($disk->get($path)));
     }
 
     #[Test]

--- a/tests/Data/Globals/VariablesTest.php
+++ b/tests/Data/Globals/VariablesTest.php
@@ -96,10 +96,10 @@ array:
   - 'second one'
 string: 'The string'
 'null': null
-empty: {  }
+empty: {}
 
 EOT;
-        $this->assertEquals($expected, $b->fileContents());
+        $this->assertEquals($expected, $this->normalizeYaml($b->fileContents()));
 
         $expected = <<<'EOT'
 array:

--- a/tests/Stache/Stores/CollectionTreeStoreTest.php
+++ b/tests/Stache/Stores/CollectionTreeStoreTest.php
@@ -160,12 +160,11 @@ YAML;
 
         $expected = <<<'EOT'
 tree:
-  -
-    entry: test
+  - entry: test
 
 EOT;
 
-        $this->assertStringEqualsFile($this->tempDir.'/pages.yaml', $expected);
+        $this->assertEquals($expected, $this->normalizeYaml(file_get_contents($this->tempDir.'/pages.yaml')));
     }
 
     private function assertTree($array, $item)

--- a/tests/Stache/Stores/NavTreeStoreTest.php
+++ b/tests/Stache/Stores/NavTreeStoreTest.php
@@ -123,13 +123,12 @@ YAML;
 
         $expected = <<<'EOT'
 tree:
-  -
-    title: Test
+  - title: Test
     url: /test
 
 EOT;
 
-        $this->assertStringEqualsFile($this->tempDir.'/links.yaml', $expected);
+        $this->assertEquals($expected, $this->normalizeYaml(file_get_contents($this->tempDir.'/links.yaml')));
     }
 
     private function assertTree($array, $item)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -200,6 +200,15 @@ YAML);
         $this->assertEquals(count($items), $matches, 'Failed asserting that every item is an instance of '.$class);
     }
 
+    protected function normalizeYaml(string $yaml): string
+    {
+        // Normalize formatting changes introduced in symfony/yaml 8.1
+        $yaml = str_replace('{  }', '{}', $yaml);
+        $yaml = preg_replace('/^( *)-\n\1  (\S)/m', '$1- $2', $yaml);
+
+        return $yaml;
+    }
+
     protected function assertContainsHtml($string)
     {
         preg_match('/<[^<]+>/', $string, $matches);

--- a/tests/Yaml/YamlTest.php
+++ b/tests/Yaml/YamlTest.php
@@ -68,11 +68,11 @@ EOT;
     {
         $expected = <<<'EOT'
 foo: bar
-content: {  }
+content: {}
 
 EOT;
 
-        $this->assertEquals($expected, YAML::dump(['foo' => 'bar'], []));
+        $this->assertEquals($expected, $this->normalizeYaml(YAML::dump(['foo' => 'bar'], [])));
     }
 
     #[Test]
@@ -134,12 +134,12 @@ EOT;
         $expected = <<<'EOT'
 ---
 foo: bar
-content: {  }
+content: {}
 ---
 
 EOT;
 
-        $this->assertStringEqualsStringIgnoringLineEndings($expected, YAML::dumpFrontMatter(['foo' => 'bar'], []));
+        $this->assertStringEqualsStringIgnoringLineEndings($expected, $this->normalizeYaml(YAML::dumpFrontMatter(['foo' => 'bar'], [])));
     }
 
     #[Test]


### PR DESCRIPTION
Looks like symfony's releases today have caused some failures. This PR resolves them.

symfony/yaml 8.1 changes the format of a couple of things.  Since we still support symfony/yaml 7, I've added a helper to normalize to 8.1's format. Once we drop support for 7, the helper can be removed and call-sites unwrapped.
