### PR TITLE
[6.x] More elegantly mask horizontal overflow for sets

### DIFF
--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -55,6 +55,26 @@
     }
 }
 
+/* =Jay. Mask the horizontal overflow of an element, e.g. in a long Bard Set header that overflows its container. Override the default mask by changing the --mask variable. */
+@utility st-mask-horizontal-overflow {
+    --mask: linear-gradient(to left, transparent 0%, black 1rem);
+    mask-image: var(--mask);
+    mask-repeat: no-repeat;
+    animation: mask-overflow-horizontal linear both;
+    animation-timeline: scroll(self inline);
+    animation-range: calc(100% - 1rem) 100%;
+}
+
+@keyframes mask-overflow-horizontal {
+    from {
+        mask-image: var(--mask);
+    }
+
+    to {
+        mask-image: unset;
+    }
+}
+
 /* UTILITIES / TEXT
 =================================================== */
 /* Avoid prefixing things with `st-text-` (st for Statamic) because `text-` is a Tailwind prefix */

--- a/resources/css/core/utilities.css
+++ b/resources/css/core/utilities.css
@@ -55,14 +55,15 @@
     }
 }
 
-/* =Jay. Mask the horizontal overflow of an element, e.g. in a long Bard Set header that overflows its container. Override the default mask by changing the --mask variable. */
+/* =Jay. Mask the horizontal overflow of an element, e.g. in a long Bard Set header that overflows its container. Override the default mask by changing the --mask-stop variable. */
 @utility st-mask-horizontal-overflow {
-    --mask: linear-gradient(to left, transparent 0%, black 1rem);
+    --mask-stop: 1rem;
+    --mask: linear-gradient(to left, transparent 0%, black var(--mask-stop));
     mask-image: var(--mask);
     mask-repeat: no-repeat;
     animation: mask-overflow-horizontal linear both;
     animation-timeline: scroll(self inline);
-    animation-range: calc(100% - 1rem) 100%;
+    animation-range: calc(100% - var(--mask-stop)) 100%;
 }
 
 @keyframes mask-overflow-horizontal {

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -26,7 +26,7 @@
                 <span v-if="!isReadOnly" data-drag-handle class="flex cursor-grab" @mousedown="enableDragging">
                     <Icon name="handles" class="size-4 text-gray-400" />
                 </span>
-                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-auto p-2 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
+                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-auto p-2 pe-4 focus:outline-none st-mask-horizontal-overflow" @click="toggleCollapsedState">
                     <Badge size="lg" :pill="true" color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -152,7 +152,7 @@ reveal.use(rootEl, () => emit('expanded'));
                     class="size-4 cursor-grab text-gray-400"
                     v-if="!readOnly"
                 />
-                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-auto p-2 py-1.75 pe-4 focus:outline-none [--mask:linear-gradient(to_left,transparent_0%,black_1rem)] [-webkit-mask:var(--mask)] [mask:var(--mask)]" @click="toggleCollapsedState">
+                <button type="button" class="show-focus-within_target flex flex-1 min-w-0 cursor-pointer items-center gap-4 overflow-x-auto p-2 py-1.75 pe-4 focus:outline-none st-mask-horizontal-overflow" @click="toggleCollapsedState">
                     <Badge size="lg" pill color="white" class="px-3">
                         <span v-if="isSetGroupVisible" class="flex items-center gap-2">
                             {{ __(setGroup.display) }}


### PR DESCRIPTION
## Description of the Problem

This is really a tiny indulgent "UI polish" PR, rather than a "problem to be solved".
https://github.com/statamic/cms/pull/14746 added an overflow mask for longer set header names, which works well.
However, the scroll bar was _also_ "masked" at the end, which is a bit like pulling back the curtain to see the Wizard of Oz pulling levers.

## What this PR Does

- Enhances the overflow with a tiny scroll-driven animation to remove the mask when we reach the end, so that the scrollbar does not get caught up in the mask
- Turns this into an editable utility in case we want to use it elsewhere

### Before

The scrollbar is also clipped by the mask

<img width="300" alt="2026-06-01 at 11 41 24@2x" src="https://github.com/user-attachments/assets/c890ba1f-f13f-410d-b873-e00470c5982b" />

### After

The mask is still in place, but doesn't affect the scrollbar

<img width="300" alt="2026-06-01 at 11 38 13@2x" src="https://github.com/user-attachments/assets/22affa8d-9306-4c7f-92ce-6fcabcec904d" />

## How to Reproduce

1. Add a set with a long name
2. Open Live Preview, or view the replicator handle in a small space