### PR TITLE
[6.x] Fix clipboard pasting of validation rules

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -34,6 +34,7 @@
                 multiple
                 searchable
                 taggable
+                paste-delimiter="|"
                 close-on-select
                 :model-value="rules"
                 @selected="add($event)"

--- a/resources/js/components/fieldtypes/TagsFieldtype.vue
+++ b/resources/js/components/fieldtypes/TagsFieldtype.vue
@@ -6,6 +6,7 @@
         :multiple="true"
         :options="options"
         :placeholder="__(config.placeholder)"
+        :paste-delimiter="config.paste_delimiter || ','"
         :read-only="isReadOnly"
         :taggable="true"
         :should-open-dropdown="(open) => open && options.length > 0"

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -55,6 +55,8 @@ const props = defineProps({
 	options: { type: Array, default: () => [] },
 	/** Key of the option's value in the option's object. */
 	optionValue: { type: String, default: 'value' },
+	/** The delimiter used to split pasted text into multiple tags. Only used when `taggable` is `true`. */
+	pasteDelimiter: { type: String, default: ',' },
 	placeholder: { type: String, default: () => __('Select...') },
 	readOnly: { type: Boolean, default: false },
 	/** When `true`, the options will be searchable. */
@@ -315,7 +317,12 @@ function onPaste(e) {
 
     const pastedValue = e.clipboardData.getData('text');
 
-    updateModelValue([...(props.modelValue ?? []), ...pastedValue.split(',').map((v) => v.trim())]);
+    const tags = pastedValue
+        .split(props.pasteDelimiter)
+        .map((v) => v.trim())
+        .filter((v) => v !== '');
+
+    updateModelValue([...(props.modelValue ?? []), ...tags]);
 }
 
 function pushTaggableOption(e) {

--- a/src/Http/Controllers/CP/Assets/AssetContainersController.php
+++ b/src/Http/Controllers/CP/Assets/AssetContainersController.php
@@ -188,6 +188,7 @@ class AssetContainersController extends CpController
                         'type' => 'taggable',
                         'display' => __('Validation Rules'),
                         'instructions' => __('statamic::messages.asset_container_validation_rules_instructions'),
+                        'paste_delimiter' => '|',
                     ],
                 ],
             ],


### PR DESCRIPTION
Pasting a validation rule such as `mimes:jpg,jpeg,png,webp` into a validation rules field (general blueprint or asset container config) split it on every comma resulting in four separate and wrong rules instead of one. The reason is that `Combobox`'s paste handler always splits the pasted text on commas when `taggable` is true. Typing the rule by hand works fine.

Behavior now:
- Pasting `mimes:jpg,jpeg,png,webp` is one rule.
- Pasting `required|mimes:jpg,jpeg,png,webp` is two rules.
- Fixed in both places (general blueprints and the asset container config).
- Regular tags fields keep splitting on commas as before.

Closes https://github.com/statamic/cms/issues/14750.