### PR TITLE
[6.x] Truncate full measure static cache files before writing

### DIFF
--- a/src/StaticCaching/Cachers/Writer.php
+++ b/src/StaticCaching/Cachers/Writer.php
@@ -43,6 +43,11 @@ class Writer
             return false;
         }
 
+        // Truncate the file before writing. Since the "c" mode doesn't truncate and leaves
+        // the pointer at the start, writing content shorter than what's already on disk
+        // would otherwise leave stale bytes behind, producing an invalid document.
+        ftruncate($handle, 0);
+
         fwrite($handle, $content);
         chmod($path, $this->permissions['file']);
 

--- a/src/StaticCaching/Cachers/Writer.php
+++ b/src/StaticCaching/Cachers/Writer.php
@@ -46,7 +46,11 @@ class Writer
         // Truncate the file before writing. Since the "c" mode doesn't truncate and leaves
         // the pointer at the start, writing content shorter than what's already on disk
         // would otherwise leave stale bytes behind, producing an invalid document.
-        ftruncate($handle, 0);
+        if (! ftruncate($handle, 0)) {
+            fclose($handle);
+
+            return false;
+        }
 
         fwrite($handle, $content);
         chmod($path, $this->permissions['file']);

--- a/tests/StaticCaching/WriterTest.php
+++ b/tests/StaticCaching/WriterTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\StaticCaching;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\StaticCaching\Cachers\Writer;
+use Tests\TestCase;
+
+class WriterTest extends TestCase
+{
+    private string $path;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->path = storage_path('framework/testing/static-cache-writer/page.html');
+
+        @unlink($this->path);
+    }
+
+    public function tearDown(): void
+    {
+        @unlink($this->path);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_writes_the_content_to_disk()
+    {
+        $written = (new Writer)->write($this->path, '<html>hello</html>');
+
+        $this->assertTrue($written);
+        $this->assertSame('<html>hello</html>', file_get_contents($this->path));
+    }
+
+    #[Test]
+    public function it_truncates_stale_bytes_when_overwriting_with_shorter_content()
+    {
+        $writer = new Writer;
+
+        $writer->write($this->path, '<html>this is a much longer page</html>');
+        $writer->write($this->path, '<html>short</html>');
+
+        $this->assertSame('<html>short</html>', file_get_contents($this->path));
+    }
+}

--- a/tests/StaticCaching/WriterTest.php
+++ b/tests/StaticCaching/WriterTest.php
@@ -22,6 +22,7 @@ class WriterTest extends TestCase
     public function tearDown(): void
     {
         @unlink($this->path);
+        @rmdir(dirname($this->path));
 
         parent::tearDown();
     }


### PR DESCRIPTION
Right now, full measure static cache operations open cache files with `fopen($path, 'c')` and then `fwrite`s the content. Mode `c` positions the pointer at the _start_ of the file but does _not_ truncate it. When a page is recached with content shorter than the version already on disk, the leftover bytes past the new content are still there producing a valid document followed by leftovers after the `</html>`.

Having `background_recache` enabled, saving an entry overwrites the file in place rather than deleting it, so any edit that shrinks a page leaves bits behind.

This fixes it by calling `ftruncate($handle, 0)` after acquiring the lock and before writing. Mode `c` keeps the pointer at byte 0 after truncation.

Closes #14742.