### PR TITLE
[6.x] Scope shared static cache errors to sites

### DIFF
--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 use Illuminate\Support\Str;
 use Statamic\Facades\Cascade;
+use Statamic\Facades\Site;
 use Statamic\StaticCaching\NoCache\DatabaseSession;
 use Statamic\StaticCaching\NoCache\Session;
 
@@ -97,7 +98,10 @@ class ServiceProvider extends LaravelServiceProvider
         });
 
         Request::macro('fakeStaticCacheStatus', function (int $status) {
-            $url = '/__shared-errors/'.$status;
+            // Namespace the shared error by the current site so that multisite
+            // installs serve a correctly localized error page per site, rather
+            // than whichever site happened to render the error first.
+            $url = '/__shared-errors/'.Site::current()->handle().'/'.$status;
             $this->pathInfo = $url;
             $this->requestUri = $url;
             app(Session::class)->setUrl($url);

--- a/tests/StaticCaching/SharedErrorsStaticCachingTest.php
+++ b/tests/StaticCaching/SharedErrorsStaticCachingTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\StaticCaching;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Events\ResponsePrepared;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Site;
+use Statamic\StaticCaching\Cachers\ApplicationCacher;
+use Tests\TestCase;
+
+class SharedErrorsStaticCachingTest extends TestCase
+{
+    private ApplicationCacher $cacher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->cacher = new ApplicationCacher($this->app['cache']->store('array'), []);
+    }
+
+    #[Test]
+    public function the_shared_error_is_scoped_to_the_current_site()
+    {
+        $this->setSites([
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'french' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+
+        // Render and share the english 404 first.
+        Site::setCurrent('english');
+        $this->shareError(404, 'English not found');
+
+        // The french site must not be considered to already have a shared error.
+        // Before scoping by site, the english error would leak here and break the
+        // localization (e.g. the language picker) for every other site.
+        Site::setCurrent('french');
+        $this->assertFalse($this->cacher->hasCachedPage($this->sharedErrorRequest(404)));
+
+        $this->shareError(404, 'French not found');
+
+        // Each site now serves its own localized shared error.
+        Site::setCurrent('english');
+        $this->assertTrue($this->cacher->hasCachedPage($this->sharedErrorRequest(404)));
+        $this->assertEquals('English not found', $this->cacher->getCachedPage($this->sharedErrorRequest(404))->content);
+
+        Site::setCurrent('french');
+        $this->assertTrue($this->cacher->hasCachedPage($this->sharedErrorRequest(404)));
+        $this->assertEquals('French not found', $this->cacher->getCachedPage($this->sharedErrorRequest(404))->content);
+    }
+
+    /**
+     * Replicates the request that's built when a shared error is written
+     * (the Cache middleware's copyError) and read (RendersHttpExceptions's
+     * getCachedError) for the current site.
+     */
+    private function sharedErrorRequest(int $status): Request
+    {
+        return Request::createFrom(Request::create('http://localhost/'))->fakeStaticCacheStatus($status);
+    }
+
+    /**
+     * Cache a shared error for the current site, mirroring how the cacher
+     * persists pages once the response has been prepared.
+     */
+    private function shareError(int $status, string $content): void
+    {
+        $request = $this->sharedErrorRequest($status);
+        $response = response($content, $status);
+
+        $this->cacher->cachePage($request, $response);
+
+        // The cacher writes to the store on the ResponsePrepared event, which
+        // the framework fires during the real response lifecycle.
+        event(new ResponsePrepared($request, $response));
+    }
+}


### PR DESCRIPTION
https://github.com/statamic/cms/pull/10294 introduced statically caching 404s when using half measure static caching. Additionally, it introduced a config setting that lets you  `share_errors` which results in a _single_ 404 page being served to _all_ requests that result in a 404. The cache key generated in the `fakeStaticCacheStatus` request is not scoped to any site though but to `/__shared-errors/{status}`. When using multi-site this leads to whichever site/locale renders an error first "wins". Every site is then served that one site's 404 even when it's the wrong language, for example.

The fix is to namespace the cache key for each error page to the respective site.

Single-site installs are unaffected because the handle is just `default` so the behavior is unchanged.

The added test caches a shared error for one site and asserts a second site neither sees it nor has it overwritten as well as checking that each site retrieves its own error page.