### PR TITLE
[6.x] Render PDF viewer pages lazily

### DIFF
--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -215,34 +215,23 @@ function cleanup({ invalidateRender = true } = {}) {
 
     isRendering.value = false;
 
-    // Cancel all in-flight page renders.
     for (const state of pageStates) {
-        if (state.renderTask) {
-            state.renderTask.cancel();
-            state.renderTask = null;
-        }
+        state.renderTask?.cancel();
+        state.renderTask = null;
     }
 
-    if (observer) {
-        observer.disconnect();
-        observer = null;
-    }
+    observer?.disconnect();
+    observer = null;
 
-    if (loadingTask) {
-        loadingTask.destroy();
-        loadingTask = null;
-    }
+    loadingTask?.destroy();
+    loadingTask = null;
 
-    if (pdfDocument) {
-        pdfDocument.destroy();
-        pdfDocument = null;
-    }
+    pdfDocument?.destroy();
+    pdfDocument = null;
 
     pageStates = [];
 
-    if (pages.value) {
-        pages.value.replaceChildren();
-    }
+    pages.value?.replaceChildren();
 }
 </script>
 

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -17,7 +17,10 @@ const hasError = ref(false);
 let currentRenderId = 0;
 let loadingTask = null;
 let pdfDocument = null;
-let pageElements = [];
+let observer = null;
+let pageStates = [];
+
+const supportsOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
 
 onMounted(() => renderPdf());
 
@@ -46,14 +49,22 @@ async function renderPdf() {
         if (renderId !== currentRenderId) return;
 
         pdfDocument = pdf;
-        const { linkService, AnnotationLayerBuilder } = await initViewer(pdf);
+        const viewerContext = await initViewer(pdf);
 
+        if (renderId !== currentRenderId) return;
+
+        const scale = window.devicePixelRatio || 2;
+
+        // Phase 1: Create all page placeholders with correctly-sized empty canvases.
+        // This gives the user the full scrollable document structure immediately,
+        // while the actual rendering happens lazily via IntersectionObserver.
         for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
             const page = await pdf.getPage(pageNumber);
 
             if (renderId !== currentRenderId) return;
 
-            const viewport = page.getViewport({ scale: 2 });
+            const viewport = page.getViewport({ scale });
+
             const pageContainer = document.createElement('div');
             pageContainer.className = 'pdf-page';
             pageContainer.dataset.pageNumber = String(pageNumber);
@@ -65,29 +76,46 @@ async function renderPdf() {
             pageContainer.appendChild(canvas);
 
             pages.value?.appendChild(pageContainer);
-            pageElements.push(pageContainer);
 
-            const canvasContext = canvas.getContext('2d');
-            if (!canvasContext) continue;
-
-            await page.render({
-                canvasContext,
+            pageStates.push({
+                pageNumber,
+                page,
                 viewport,
-            }).promise;
-
-            const annotationLayerBuilder = new AnnotationLayerBuilder({
-                pdfPage: page,
-                linkService,
-                renderForms: true,
-                onAppend: (div) => pageContainer.appendChild(div),
+                canvas,
+                container: pageContainer,
+                rendered: false,
+                rendering: false,
+                renderTask: null,
             });
-
-            await annotationLayerBuilder.render({ viewport });
-
-            if (pageNumber === 1 && renderId === currentRenderId) {
-                isLoading.value = false;
-            }
         }
+
+        // Phase 2: Observe pages for viewport proximity and render on demand.
+        // rootMargin pre-renders pages 200px before they scroll into view
+        // to avoid blank flashes during normal scrolling.
+        observer = new IntersectionObserver(
+            (entries) => {
+                for (const entry of entries) {
+                    if (!entry.isIntersecting) continue;
+
+                    const pageNumber = parseInt(entry.target.dataset.pageNumber, 10);
+                    const state = pageStates[pageNumber - 1];
+
+                    if (state && !state.rendered && !state.rendering) {
+                        renderPage(state, renderId, viewerContext);
+                    }
+                }
+            },
+            {
+                root: pages.value,
+                rootMargin: '200px 0px',
+            },
+        );
+
+        for (const state of pageStates) {
+            observer.observe(state.container);
+        }
+
+        isLoading.value = false;
     } catch (error) {
         if (renderId === currentRenderId) {
             hasError.value = true;
@@ -95,9 +123,74 @@ async function renderPdf() {
         }
     } finally {
         if (renderId === currentRenderId) {
-            isLoading.value = false;
             isRendering.value = false;
         }
+    }
+}
+
+async function renderPage(state, renderId, viewerContext) {
+    if (renderId !== currentRenderId) return;
+
+    state.rendering = true;
+
+    try {
+        const { canvas, page, viewport, container } = state;
+        const { linkService, AnnotationLayerBuilder } = viewerContext;
+
+        if (supportsOffscreenCanvas) {
+            const offscreen = new OffscreenCanvas(canvas.width, canvas.height);
+            const offCtx = offscreen.getContext('2d');
+
+            const task = page.render({ canvasContext: offCtx, viewport });
+            state.renderTask = task;
+            await task.promise;
+
+            if (renderId !== currentRenderId) return;
+
+            // Transfer rendered pixels to the visible canvas.
+            const visibleCtx = canvas.getContext('2d');
+            visibleCtx.drawImage(offscreen, 0, 0);
+        } else {
+            const canvasContext = canvas.getContext('2d');
+            if (!canvasContext) return;
+
+            const task = page.render({ canvasContext, viewport });
+            state.renderTask = task;
+            await task.promise;
+        }
+
+        if (renderId !== currentRenderId) return;
+
+        const annotationLayerBuilder = new AnnotationLayerBuilder({
+            pdfPage: page,
+            linkService,
+            renderForms: true,
+            onAppend: (div) => container.appendChild(div),
+        });
+
+        await annotationLayerBuilder.render({ viewport });
+
+        state.rendered = true;
+
+        // Release parsed operator lists and font data.
+        // The canvas retains its rendered pixels.
+        page.cleanup();
+    } catch (error) {
+        if (renderId !== currentRenderId) return;
+
+        // Cancelled renders are expected during cleanup — not an error.
+        if (error?.name === 'RenderingCancelledException') return;
+
+        // Per-page error: show an indicator but keep the rest of the viewer alive.
+        console.warn(`Failed to render PDF page ${state.pageNumber}:`, error);
+
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'pdf-page-error';
+        errorDiv.textContent = `Page ${state.pageNumber} failed to render`;
+        state.container.appendChild(errorDiv);
+    } finally {
+        state.rendering = false;
+        state.renderTask = null;
     }
 }
 
@@ -130,10 +223,10 @@ async function initViewer(pdf) {
         isInPresentationMode: false,
         pageLabelToPageNumber: () => null,
         scrollPageIntoView: ({ pageNumber }) => {
-            const pageElement = pageElements[pageNumber - 1];
+            const state = pageStates[pageNumber - 1];
 
-            if (pageElement) {
-                pageElement.scrollIntoView({
+            if (state?.container) {
+                state.container.scrollIntoView({
                     behavior: 'smooth',
                     block: 'start',
                 });
@@ -152,6 +245,19 @@ function cleanup({ invalidateRender = true } = {}) {
 
     isRendering.value = false;
 
+    // Cancel all in-flight page renders.
+    for (const state of pageStates) {
+        if (state.renderTask) {
+            state.renderTask.cancel();
+            state.renderTask = null;
+        }
+    }
+
+    if (observer) {
+        observer.disconnect();
+        observer = null;
+    }
+
     if (loadingTask) {
         loadingTask.destroy();
         loadingTask = null;
@@ -162,7 +268,7 @@ function cleanup({ invalidateRender = true } = {}) {
         pdfDocument = null;
     }
 
-    pageElements = [];
+    pageStates = [];
 
     if (pages.value) {
         pages.value.replaceChildren();
@@ -184,7 +290,18 @@ function cleanup({ invalidateRender = true } = {}) {
 }
 
 .pdf-page .annotationLayer {
+    position: absolute;
     inset: 0;
+}
+
+.pdf-page-error {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #9ca3af;
+    font-size: 0.875rem;
 }
 </style>
 

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -107,6 +107,12 @@ async function renderPdf() {
             observer.observe(state.container);
         }
 
+        if (pageStates.length > 0) {
+            await renderPage(pageStates[0], renderId, viewerContext);
+        }
+
+        if (renderId !== currentRenderId) return;
+
         isLoading.value = false;
     } catch (error) {
         if (renderId === currentRenderId) {

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -300,8 +300,7 @@ function cleanup({ invalidateRender = true } = {}) {
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #9ca3af;
-    font-size: 0.875rem;
+    @apply text-sm text-gray-400;
 }
 </style>
 

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -17,8 +17,8 @@ const hasError = ref(false);
 let currentRenderId = 0;
 let loadingTask = null;
 let pdfDocument = null;
-let observer = null;
 let pageStates = [];
+let observer = null;
 
 const scale = Math.min(2, window.devicePixelRatio || 2);
 
@@ -50,8 +50,6 @@ async function renderPdf() {
 
         pdfDocument = pdf;
         const viewerContext = await initViewer(pdf);
-
-        if (renderId !== currentRenderId) return;
 
         // Phase 1: Create all page placeholders with correctly-sized empty canvases.
         // This gives the user the full scrollable document structure immediately,

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -20,7 +20,6 @@ let pdfDocument = null;
 let observer = null;
 let pageStates = [];
 
-const supportsOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
 const scale = Math.min(2, window.devicePixelRatio || 2);
 
 onMounted(() => renderPdf());
@@ -136,27 +135,12 @@ async function renderPage(state, renderId, viewerContext) {
         const { canvas, page, viewport, container } = state;
         const { linkService, AnnotationLayerBuilder } = viewerContext;
 
-        if (supportsOffscreenCanvas) {
-            const offscreen = new OffscreenCanvas(canvas.width, canvas.height);
-            const offCtx = offscreen.getContext('2d');
+        const canvasContext = canvas.getContext('2d');
+        if (!canvasContext) return;
 
-            const task = page.render({ canvasContext: offCtx, viewport });
-            state.renderTask = task;
-            await task.promise;
-
-            if (renderId !== currentRenderId) return;
-
-            // Transfer rendered pixels to the visible canvas.
-            const visibleCtx = canvas.getContext('2d');
-            visibleCtx.drawImage(offscreen, 0, 0);
-        } else {
-            const canvasContext = canvas.getContext('2d');
-            if (!canvasContext) return;
-
-            const task = page.render({ canvasContext, viewport });
-            state.renderTask = task;
-            await task.promise;
-        }
+        const task = page.render({ canvasContext, viewport });
+        state.renderTask = task;
+        await task.promise;
 
         if (renderId !== currentRenderId) return;
 

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -146,8 +146,6 @@ async function renderPage(state, renderId, viewerContext) {
         }).render({ viewport });
 
         state.rendered = true;
-
-        page.cleanup();
     } catch (error) {
         if (renderId !== currentRenderId) return;
         if (error?.name === 'RenderingCancelledException') return;
@@ -159,6 +157,7 @@ async function renderPage(state, renderId, viewerContext) {
 
         console.warn(`Failed to render PDF page ${state.pageNumber}`, error);
     } finally {
+        state.page.cleanup();
         state.rendering = false;
         state.renderTask = null;
     }

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -138,33 +138,26 @@ async function renderPage(state, renderId, viewerContext) {
 
         if (renderId !== currentRenderId) return;
 
-        const annotationLayerBuilder = new AnnotationLayerBuilder({
+        await new AnnotationLayerBuilder({
             pdfPage: page,
             linkService,
             renderForms: true,
             onAppend: (div) => container.appendChild(div),
-        });
-
-        await annotationLayerBuilder.render({ viewport });
+        }).render({ viewport });
 
         state.rendered = true;
 
-        // Release parsed operator lists and font data.
-        // The canvas retains its rendered pixels.
         page.cleanup();
     } catch (error) {
         if (renderId !== currentRenderId) return;
-
-        // Cancelled renders are expected during cleanup — not an error.
         if (error?.name === 'RenderingCancelledException') return;
-
-        // Per-page error: show an indicator but keep the rest of the viewer alive.
-        console.warn(`Failed to render PDF page ${state.pageNumber}:`, error);
 
         const errorDiv = document.createElement('div');
         errorDiv.className = 'pdf-page-error';
-        errorDiv.textContent = `Page ${state.pageNumber} failed to render`;
+        errorDiv.textContent = __('Something went wrong');
         state.container.appendChild(errorDiv);
+
+        console.warn(`Failed to render PDF page ${state.pageNumber}`, error);
     } finally {
         state.rendering = false;
         state.renderTask = null;

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -259,7 +259,6 @@ function cleanup({ invalidateRender = true } = {}) {
     display: flex;
     align-items: center;
     justify-content: center;
-    @apply text-sm text-gray-400;
 }
 </style>
 
@@ -270,6 +269,6 @@ function cleanup({ invalidateRender = true } = {}) {
             <div v-if="hasError" class="text-gray-500 flex gap-2" v-text="__('Something went wrong')" />
         </div>
 
-        <div ref="pages" class="pdf-pages h-full min-h-0 overflow-auto"></div>
+        <div ref="pages" class="pdf-pages h-full min-h-0 overflow-auto text-gray-500"></div>
     </div>
 </template>

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -21,6 +21,7 @@ let observer = null;
 let pageStates = [];
 
 const supportsOffscreenCanvas = typeof OffscreenCanvas !== 'undefined';
+const scale = Math.min(2, window.devicePixelRatio || 2);
 
 onMounted(() => renderPdf());
 
@@ -52,8 +53,6 @@ async function renderPdf() {
         const viewerContext = await initViewer(pdf);
 
         if (renderId !== currentRenderId) return;
-
-        const scale = window.devicePixelRatio || 2;
 
         // Phase 1: Create all page placeholders with correctly-sized empty canvases.
         // This gives the user the full scrollable document structure immediately,

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -51,9 +51,7 @@ async function renderPdf() {
         pdfDocument = pdf;
         const viewerContext = await initViewer(pdf);
 
-        // Phase 1: Create all page placeholders with correctly-sized empty canvases.
-        // This gives the user the full scrollable document structure immediately,
-        // while the actual rendering happens lazily via IntersectionObserver.
+        // Create page placeholders with sized canvases for scrollable layout
         for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
             const page = await pdf.getPage(pageNumber);
 
@@ -85,9 +83,7 @@ async function renderPdf() {
             });
         }
 
-        // Phase 2: Observe pages for viewport proximity and render on demand.
-        // rootMargin pre-renders pages 200px before they scroll into view
-        // to avoid blank flashes during normal scrolling.
+        // Observe pages for viewport proximity and render on demand
         observer = new IntersectionObserver(
             (entries) => {
                 for (const entry of entries) {

--- a/resources/js/components/assets/Editor/PdfViewer.vue
+++ b/resources/js/components/assets/Editor/PdfViewer.vue
@@ -249,7 +249,6 @@ function cleanup({ invalidateRender = true } = {}) {
 }
 
 .pdf-page .annotationLayer {
-    position: absolute;
     inset: 0;
 }
 


### PR DESCRIPTION
The PDF viewer currently renders all pages eagerly, freezing the asset editor ui for PDFs with 100+ pages.

This PR makes it so pages render lazily when they enter the viewport ± 200px. It also dynamically checks viewport scale to allow cheaper rendering on 1x where appropriate.

### Before

<img width="1106" height="385" alt="Screenshot 2026-06-02 at 17 49 26" src="https://github.com/user-attachments/assets/a02eaafc-9939-4704-a2fb-2f68c5027fee" />

### After

<img width="1316" height="386" alt="Screenshot 2026-06-02 at 18 51 06" src="https://github.com/user-attachments/assets/d4b775dc-fa4d-4c31-a037-26988ee3f944" />
