### PR TITLE
[6.x] Add horizontal padding around PDF viewer pages

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -110,7 +110,9 @@
                             <img v-else-if="asset.preview" :src="asset.preview" class="asset-thumb shadow-ui-xl max-w-full max-h-full object-contain" />
                         </div>
 
-                        <pdf-viewer v-else-if="asset.isPdf" :src="asset.pdfUrl" />
+                        <div v-else-if="asset.isPdf" class="flex flex-1 flex-col justify-center items-center px-8 h-full min-h-0">
+                            <pdf-viewer :src="asset.pdfUrl" />
+                        </div>
 
                         <div class="h-full" v-else-if="asset.isPreviewable && canUseGoogleDocsViewer">
                             <iframe


### PR DESCRIPTION
Add some horizontal padding around PDF viewer pages. Mostly applies on smaller screen sizes, largers screens would naturally limit the width to the canvas' intrinsic size.

### Before

<img width="2210" height="1434" alt="statamic-v6 test_cp_assets_browse_assets_die-leiden-des-jungen-werther pdf_edit (2)" src="https://github.com/user-attachments/assets/67f0e681-6ae2-40d1-b5cc-69de1760d31f" />

### After

<img width="2210" height="1434" alt="statamic-v6 test_cp_assets_browse_assets_die-leiden-des-jungen-werther pdf_edit (1)" src="https://github.com/user-attachments/assets/a0b8e84d-9cef-4027-9c35-8ba42995a2ff" />
