### PR TITLE
[6.x] Bump league/csv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "laravel/framework": "^12.40.0 || ^13.0",
         "laravel/prompts": "^0.3.0",
         "league/commonmark": "^2.2",
-        "league/csv": "^9.0",
+        "league/csv": "^9.1",
         "league/glide": "^3.0",
         "maennchen/zipstream-php": "^3.1",
         "michelf/php-smartypants": "^1.8.1",


### PR DESCRIPTION
In the 5.x->6.x merge (1566276e8) that included #14760, I unintentionally missed the composer.json bump. This PR re-adds it.
