### PR TITLE
[6.x] Fix TypeError when elevated_session_duration is a string

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -357,7 +357,7 @@ class AppServiceProvider extends ServiceProvider
             }
 
             return Carbon::createFromTimestamp($lastElevated)
-                ->addMinutes((int) config('statamic.users.elevated_session_duration', 15))
+                ->addMinutes((float) config('statamic.users.elevated_session_duration', 15))
                 ->timestamp;
         });
 

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -357,7 +357,7 @@ class AppServiceProvider extends ServiceProvider
             }
 
             return Carbon::createFromTimestamp($lastElevated)
-                ->addMinutes(config('statamic.users.elevated_session_duration', 15))
+                ->addMinutes((int) config('statamic.users.elevated_session_duration', 15))
                 ->timestamp;
         });
 

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -76,12 +76,12 @@ class ElevatedSessionTest extends TestCase
             ]);
     }
 
+    /**
+     * @see https://github.com/statamic/cms/pull/14771
+     **/
     #[Test]
     public function it_handles_string_config_value_for_elevated_session_duration()
     {
-        // This tests GitHub issue #14769 - when env() returns a string value
-        // for STATAMIC_ELEVATED_SESSION_DURATION, Carbon's addMinutes() should
-        // handle it gracefully without throwing a type error.
         config(['statamic.users.elevated_session_duration' => '15']);
 
         $this

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -82,7 +82,7 @@ class ElevatedSessionTest extends TestCase
     #[Test]
     public function it_handles_string_config_value_for_elevated_session_duration()
     {
-        config(['statamic.users.elevated_session_duration' => '15']);
+        config(['statamic.users.elevated_session_duration' => '15.5']);
 
         $this
             ->withElevatedSession(now()->subMinutes(5))

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -77,6 +77,26 @@ class ElevatedSessionTest extends TestCase
     }
 
     #[Test]
+    public function it_handles_string_config_value_for_elevated_session_duration()
+    {
+        // This tests GitHub issue #14769 - when env() returns a string value
+        // for STATAMIC_ELEVATED_SESSION_DURATION, Carbon's addMinutes() should
+        // handle it gracefully without throwing a type error.
+        config(['statamic.users.elevated_session_duration' => '15']);
+
+        $this
+            ->withElevatedSession(now()->subMinutes(5))
+            ->actingAs($this->user)
+            ->get('/cp/elevated-session')
+            ->assertOk()
+            ->assertJson([
+                'elevated' => true,
+                'expiry' => now()->addMinutes(10)->timestamp,
+                'method' => 'password_confirmation',
+            ]);
+    }
+
+    #[Test]
     public function it_can_get_status_of_elevated_session_when_session_key_does_not_exist()
     {
         $this

--- a/tests/Auth/ElevatedSessionTest.php
+++ b/tests/Auth/ElevatedSessionTest.php
@@ -91,7 +91,7 @@ class ElevatedSessionTest extends TestCase
             ->assertOk()
             ->assertJson([
                 'elevated' => true,
-                'expiry' => now()->addMinutes(10)->timestamp,
+                'expiry' => now()->addMinutes(10.5)->timestamp,
                 'method' => 'password_confirmation',
             ]);
     }


### PR DESCRIPTION
This pull request fixes an issue where setting `STATAMIC_ELEVATED_SESSION_DURATION` via `env()` causes a TypeError.

This was happening because `env()` returns string values, and Carbon's `addMinutes()` method requires `int|float`. When a user publishes the config and modifies it to use `env('STATAMIC_ELEVATED_SESSION_DURATION', 15)`, the string value like `'15'` would cause:

```
Carbon\Carbon::rawAddUnit(): Argument #3 ($value) must be of type int|float, string given
```

This PR fixes it by casting the config value to `float` before passing it to `addMinutes()`.

Fixes #14769