### PR TITLE
[6.x] Fix configure navs permission not working properly

### DIFF
--- a/src/Policies/NavTreePolicy.php
+++ b/src/Policies/NavTreePolicy.php
@@ -10,7 +10,9 @@ class NavTreePolicy extends NavPolicy
 
     public function before($user)
     {
-        if (User::fromUser($user)->isSuper()) {
+        $user = User::fromUser($user);
+
+        if ($user->isSuper() || $user->hasPermission('configure navs')) {
             return true;
         }
     }

--- a/tests/Policies/NavTreePolicyTest.php
+++ b/tests/Policies/NavTreePolicyTest.php
@@ -38,6 +38,17 @@ class NavTreePolicyTest extends PolicyTestCase
     }
 
     #[Test]
+    public function trees_are_viewable_and_editable_with_configure_permission()
+    {
+        $user = $this->userWithPermissions(['configure navs']);
+
+        $nav = Nav::make('test');
+
+        $this->assertTrue($user->can('view', $nav->makeTree('en')));
+        $this->assertTrue($user->can('edit', $nav->makeTree('en')));
+    }
+
+    #[Test]
     public function navs_are_editable_with_edit_permissions()
     {
         $user = $this->userWithPermissions(['edit alfa nav']);


### PR DESCRIPTION
When a user has the general `configure navs` permission but not the more granular per nav `view xy nav` permission, they can see the navigation listing view but clicking on a nav item results in a `You are not authorized to view navs`. That's not the intended behavior since `configure navs` states that it `Grants access to all navigation related permissions`.

This changes `NavTreePolicy::before()` to honor `configure navs` just like `NavPolicy::before()` does.

Closes #14774