### PR TITLE
[6.x] Add support for Collection in last modifier

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1536,6 +1536,10 @@ class CoreModifiers extends Modifier
             return Arr::last($value);
         }
 
+        if ($value instanceof Collection) {
+            return $value->last();
+        }
+
         return Stringy::last($value, Arr::get($params, 0));
     }
 

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1526,9 +1526,9 @@ class CoreModifiers extends Modifier
     }
 
     /**
-     * Returns the last $params[0] characters of a string, or the last element of an array.
+     * Returns the last $params[0] characters of a string, or the last element of an array or Collection.
      *
-     * @return string
+     * @return mixed
      */
     public function last($value, $params)
     {

--- a/tests/Modifiers/LastTest.php
+++ b/tests/Modifiers/LastTest.php
@@ -46,6 +46,27 @@ class LastTest extends TestCase
         ];
     }
 
+    #[Test]
+    #[DataProvider('collectionProvider')]
+    public function it_gets_the_last_value_of_a_collection($value, $expected)
+    {
+        $this->assertEquals($expected, $this->modify($value));
+    }
+
+    public static function collectionProvider()
+    {
+        return [
+            'list' => [
+                collect(['alfa', 'bravo', 'charlie']),
+                'charlie',
+            ],
+            'associative' => [
+                collect(['alfa' => 'bravo', 'charlie' => 'delta']),
+                'delta',
+            ],
+        ];
+    }
+
     private function modify($value, $arg = null)
     {
         return Modify::value($value)->last($arg)->fetch();


### PR DESCRIPTION
This PR replicates the `first` modifier functionality by adding support for `Collection` arrays. It will now get the last item of a `Collection` instead of returning nothing.
