### PR TITLE
[6.x] Fix share_errors breaking nocache regions on error responses

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -79,6 +79,12 @@ class Cache
             return $response;
         }
 
+        // Capture the real nocache session URL before rendering. While handling an
+        // error, the shared-error flow (RendersHttpExceptions::getCachedError and
+        // copyError) repoints the singleton session at /__shared-errors/... so its
+        // regions can be restored when the same error is served for other URLs.
+        $nocacheUrl = $this->nocache->url();
+
         $response = $next($request);
 
         if ($this->shouldBeCached($request, $response)) {
@@ -87,6 +93,14 @@ class Cache
             $this->makeReplacementsAndCacheResponse($request, $response);
 
             $this->nocache->write();
+
+            // The page is also cached under its real URL, and a repeat request to
+            // that same URL restores the session by its real URL. If the shared-error
+            // flow repointed the session, persist it under the real URL too so that
+            // repeat request doesn't fall through to an uncached render.
+            if ($this->nocache->url() !== $nocacheUrl) {
+                $this->nocache->setUrl($nocacheUrl)->write();
+            }
 
             if ($paginator = Blink::get('tag-paginator')) {
                 if ($paginator->hasMorePages()) {

--- a/tests/StaticCaching/HalfMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/HalfMeasureStaticCachingTest.php
@@ -168,6 +168,44 @@ class HalfMeasureStaticCachingTest extends TestCase
     }
 
     #[Test]
+    #[DefineEnvironment('shareErrorsEnabled')]
+    public function nocache_session_is_written_under_the_real_url_for_shared_errors()
+    {
+        \Illuminate\Support\Facades\Cache::flush();
+
+        // Regression: when share_errors is enabled, rendering an error repoints the
+        // singleton nocache Session URL at /__shared-errors/<site>/<status> (via
+        // RendersHttpExceptions::getCachedError and the middleware's copyError).
+        // Session::write() then persisted the regions list only under that shared
+        // URL. But half-measure caching also stores the error page under its real
+        // URL, so a repeat request to that same URL restored the session by its
+        // real URL, found nothing, caught a RegionNotFound, and fell through to a
+        // full dynamic re-render. The session must be persisted under both URLs.
+
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('errors.layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('errors.404', '404 {{ nocache }}dynamic{{ /nocache }}');
+
+        $this->get('/this-does-not-exist')->assertNotFound();
+
+        $store = \Statamic\Facades\StaticCache::cacheStore();
+
+        // Stored under the real request URL so repeat requests (served from the
+        // per-URL cache) can restore their nocache regions.
+        $this->assertNotNull(
+            $store->get('nocache::session.'.md5('http://localhost/this-does-not-exist')),
+            'Expected nocache session to be stored under the real request URL.'
+        );
+
+        // Still stored under the shared-errors URL so the same error served for
+        // other erroring URLs can restore its nocache regions.
+        $this->assertNotNull(
+            $store->get('nocache::session.'.md5('/__shared-errors/en/404')),
+            'Expected nocache session to be stored under the shared-errors URL.'
+        );
+    }
+
+    #[Test]
     public function it_can_keep_parts_dynamic_using_nocache_tags_in_loops()
     {
         // Use a tag that outputs something dynamic but consistent.


### PR DESCRIPTION
Follow-up to #14729 which fixed `{{ nocache }}` regions breaking on _successful_ responses. The same bug still exists for cached _error_ responses like 404s when using half measure caching.

So when clearing the static cache and requesting a non-existent URL every subsequent request logs:

`Static cache region [...] not found on [URL]. Serving uncached response.`

The page renders but half measure caching is bypassed and the request actually does a full render which is not idea of having this config setting enabled.

This fixes it so it works for cached errors as well.