### PR TITLE
[6.x] Speed up Stache warming for large structured collections

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -561,10 +561,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             return $this->value('order');
         }
 
-        return $this->structure()->in($this->locale())
-            ->flattenedPages()
-            ->map->reference()
-            ->flip()->get($this->id) + 1;
+        return $this->structure()->in($this->locale())->entryOrder($this->id) + 1;
     }
 
     public function template($template = null)

--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -27,22 +27,13 @@ class CollectionStructure extends Structure
         });
     }
 
-    private function flattenedPages($entry)
-    {
-        return Blink::once('collection-structure-flattened-pages-collection'.$this->handle().'-'.$entry->locale(), function () use ($entry) {
-            return $this->in($entry->locale())->flattenedPages();
-        });
-    }
-
     public function entryUri($entry)
     {
         if (! $this->route($entry->locale())) {
             return null;
         }
 
-        $page = $this->flattenedPages($entry)
-            ->keyBy->reference()
-            ->get($entry->id());
+        $page = $this->in($entry->locale())->findByEntry($entry->id());
 
         $page?->setEntry($entry);
 

--- a/src/Structures/Pages.php
+++ b/src/Structures/Pages.php
@@ -92,7 +92,10 @@ class Pages
 
         foreach ($this->all() as $page) {
             $flattened->push($page);
-            $flattened = $flattened->merge($page->flattenedPages());
+
+            foreach ($page->flattenedPages() as $descendant) {
+                $flattened->push($descendant);
+            }
         }
 
         return $flattened;

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -22,6 +22,9 @@ abstract class Tree implements ContainsQueryableValues, Contract, Localization
     protected $locale;
     protected $tree = [];
     protected $cachedFlattenedPages;
+    protected $cachedFlattenedPagesById;
+    protected $cachedFlattenedPagesByReference;
+    protected $cachedFlattenedPageOrder;
     protected $withEntries = false;
     protected $uriCacheEnabled = true;
 
@@ -143,17 +146,17 @@ abstract class Tree implements ContainsQueryableValues, Contract, Localization
 
     public function find($id): ?Page
     {
-        return $this->flattenedPages()
-            ->keyBy->id()
-            ->get($id);
+        return ($this->cachedFlattenedPagesById ??= $this->flattenedPages()->keyBy->id())->get($id);
     }
 
     public function findByEntry($id)
     {
-        return $this->flattenedPages()
-            ->filter->reference()
-            ->keyBy->reference()
-            ->get($id);
+        return ($this->cachedFlattenedPagesByReference ??= $this->flattenedPages()->filter->reference()->keyBy->reference())->get($id);
+    }
+
+    public function entryOrder($reference)
+    {
+        return ($this->cachedFlattenedPageOrder ??= $this->flattenedPages()->map->reference()->flip())->get($reference);
     }
 
     public function save()
@@ -163,8 +166,10 @@ abstract class Tree implements ContainsQueryableValues, Contract, Localization
         }
 
         $this->cachedFlattenedPages = null;
+        $this->cachedFlattenedPagesById = null;
+        $this->cachedFlattenedPagesByReference = null;
+        $this->cachedFlattenedPageOrder = null;
 
-        Blink::forget('collection-structure-flattened-pages-collection*');
         Blink::forget('collection-structure-tree*');
 
         $this->repository()->save($this);

--- a/tests/Data/Structures/CollectionStructureTest.php
+++ b/tests/Data/Structures/CollectionStructureTest.php
@@ -174,14 +174,13 @@ class CollectionStructureTest extends StructureTestCase
         $this->collection->shouldReceive('route')->with('en')->once()->andReturn('{slug}');
 
         $page = $this->mock(Page::class);
-        $page->shouldReceive('reference')->andReturn('the-entry-id');
         $page->shouldReceive('setEntry')->once()->andReturnSelf();
         $page->shouldReceive('uri')->andReturn('/the-uri-from-the-page');
 
         $tree = $this->mock(Tree::class);
         $tree->shouldReceive('structure')->andReturn($structure);
         $tree->shouldReceive('locale')->andReturn('en');
-        $tree->shouldReceive('flattenedPages')->andReturn(collect([$page]));
+        $tree->shouldReceive('findByEntry')->with('the-entry-id')->andReturn($page);
 
         CollectionTreeRepository::shouldReceive('find')->with('test', 'en')->andReturn($tree);
 


### PR DESCRIPTION
Warming a structured collection got slower and slower as entries piled up. Each entry resolved its order, URI and parent from the structure tree and every one of those lookups rebuilt a full keyed map over all pages from scratch. The flattened page list was cached but the derived maps weren't. In this commit they are now memorized and built once per tree.

Most sites will never hit this issue. It only adds up when:
- The collection is structured / orderable: true
- It has _many_ entries. The cost is quadratic. So it is only painful in the thousands.
- The stache is cold.

10000 entry structured collection:
`stache:warm`: **~117s => ~59s**. 🚤💨