### PR TITLE
[6.x] Avoid version inertia prop

### DIFF
--- a/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleAuthenticatedInertiaRequests.php
@@ -47,6 +47,7 @@ class HandleAuthenticatedInertiaRequests
     private function alwaysProps()
     {
         return [
+            'version' => Statamic::version(),
             'isPro' => Statamic::pro(),
             'nav' => $this->nav(),
             'cmsName' => __(Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic'),

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -28,7 +28,6 @@ class HandleInertiaRequests extends Middleware
         return array_filter([
             ...parent::share($request),
             '_statamic' => [
-                'version' => Statamic::version(),
                 'cmsName' => __(Statamic::pro() ? config('statamic.cp.custom_cms_name', 'Statamic') : 'Statamic'),
                 'logos' => $this->logos(),
                 'isCpRoute' => Statamic::isCpRoute(),


### PR DESCRIPTION
The version is only used inside the control panel. It doesn't need to be on the outside views.
