### PR TITLE
[5.x] Fix permission for Live Preview

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -448,7 +448,7 @@ export default {
         },
 
         showLivePreviewButton() {
-            return !this.isCreating && this.isBase && this.livePreviewUrl;
+            return !this.readOnly && !this.isCreating && this.isBase && this.livePreviewUrl;
         },
 
         showVisitUrlButton() {

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -323,7 +323,7 @@ export default {
         },
 
         showLivePreviewButton() {
-            return !this.isCreating && this.isBase && this.livePreviewUrl && this.showVisitUrlButton;
+            return !this.readOnly && !this.isCreating && this.isBase && this.livePreviewUrl && this.showVisitUrlButton;
         },
 
         showVisitUrlButton() {

--- a/src/Http/Controllers/CP/PreviewController.php
+++ b/src/Http/Controllers/CP/PreviewController.php
@@ -17,7 +17,7 @@ class PreviewController extends CpController
 
     public function edit(Request $request, $_, $data)
     {
-        $this->authorize('view', $data);
+        $this->authorize('update', $data);
 
         $fields = $data->blueprint()
             ->fields()

--- a/tests/Feature/Entries/PreviewEntryTest.php
+++ b/tests/Feature/Entries/PreviewEntryTest.php
@@ -181,6 +181,33 @@ class PreviewEntryTest extends TestCase
         );
     }
 
+    #[Test]
+    public function it_doesnt_create_a_token_without_edit_permission()
+    {
+        Collection::make('blog')->routes('/blog/{slug}')->save();
+
+        EntryFactory::id('the-entry')
+            ->collection('blog')
+            ->slug('the-existing-entry')
+            ->data(['title' => 'The Existing Entry'])
+            ->create();
+
+        LivePreview::shouldReceive('tokenize')->never();
+
+        $this->setTestRoles(['viewer' => ['access cp', 'view blog entries']]);
+        $user = User::make()->assignRole('viewer')->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson('/cp/collections/blog/entries/the-entry/preview', [
+                'preview' => [
+                    'title' => 'Edited title',
+                    'slug' => 'edited-slug',
+                ],
+            ])
+            ->assertForbidden();
+    }
+
     private function user()
     {
         $this->setTestRoles(['test' => ['access cp', 'create blog entries', 'edit blog entries']]);


### PR DESCRIPTION
Live preview was gated by a view permission, but the point of it is to show content based on what's submitted. Only users with permission to edit should be able to do that. The button is hidden when read only too.
