### PR TITLE
[6.x] Trigger the grid table mode a bit earlier because it's more useful

### DIFF
--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -55,7 +55,7 @@
                 @apply outline-hidden;
 
                 > td {
-                    @apply border-b px-2 py-3 align-top dark:border-gray-900;
+                    @apply border-b px-1 @2xl:px-2 py-3 align-top dark:border-gray-900;
         
                     &:first-child.grid-cell {
                         @apply ltr:pl-3 rtl:pr-3;

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -86,7 +86,7 @@ export default {
 
     computed: {
         component() {
-            const isNarrow = this.fields.length > 1 && this.containerWidth < 600;
+            const isNarrow = this.fields.length > 1 && this.containerWidth < 550;
 
             return this.config.mode === 'stacked' || isNarrow ? 'GridStacked' : 'GridTable';
         },


### PR DESCRIPTION
## Description of the Problem

As mentioned in https://github.com/statamic/cms/issues/14734 v5 triggered the grid table mode at a lower viewport width. Users seem to find this more of a useful view so I've triggered it at a lower breakpoint.

## What this PR Does

- Trigger the grid table mode at a lower container query
- Use a container query to alter padding so that the grid table view is more readable

## How to Reproduce

1. Add a Grid fieldtype
2. Pull in the window. In v5, it would trigger around a viewport width of 1270px. In v6 it the grid doesn't use a viewport media query—it measures the field's container width via element-container and switches to stacked mode when that width drops below a threshold. I've changed the threshold so it should be more often in grid _table_ mode