### PR TITLE
[5.x] Drop support for Laravel 10/11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Get Changelog
         id: changelog
-        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1
+        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1.0.2
         with:
           version: ${{ github.ref }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
         run: sudo apt-get install language-pack-fr
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
@@ -159,7 +159,7 @@ jobs:
       actions: read # required by workflow-conclusion-action to determine overall workflow status
     if: always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
       - name: Send Slack notification
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: env.WORKFLOW_CONCLUSION == 'failure' && github.event_name == 'schedule'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,30 +24,15 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
             php: 8.3
-            laravel: 10.*
-            stability: prefer-stable
-          - os: windows-latest
-            php: 8.3
-            laravel: 11.*
-            stability: prefer-stable
-        exclude:
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
             laravel: 12.*
-          - php: 8.4
-            laravel: 10.*
-          - php: 8.5
-            laravel: 10.*
-          - php: 8.5
-            laravel: 11.*
+            stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            php: 8.3
+            php: 8.5
             laravel: 12.*
             stability: prefer-stable
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer/semver": "^3.4",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",
-        "laravel/framework": "^10.48.29 || ^11.44.1 || ^12.40.0",
+        "laravel/framework": "^12.40.0",
         "laravel/prompts": "^0.1.16 || ^0.2.0 || ^0.3.0",
         "league/commonmark": "^2.2",
         "league/csv": "^9.1",
@@ -44,7 +44,7 @@
         "google/cloud-translate": "^1.6",
         "laravel/pint": "1.16.0",
         "mockery/mockery": "^1.6.10",
-        "orchestra/testbench": "^8.36 || ^9.15 || ^10.8",
+        "orchestra/testbench": "^10.8",
         "phpunit/phpunit": "^10.5.35 || ^11.5.3",
         "sebastian/recursion-context": "^5.0.1 || ^6.0.3",
         "spatie/laravel-ray": "^1.42"

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -20,7 +20,7 @@ use Statamic\Support\TextDirection;
 use Statamic\Tags\FluentTag;
 use Stringy\StaticStringy;
 
-class Statamic //
+class Statamic
 {
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -20,7 +20,7 @@ use Statamic\Support\TextDirection;
 use Statamic\Tags\FluentTag;
 use Stringy\StaticStringy;
 
-class Statamic
+class Statamic //
 {
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';


### PR DESCRIPTION
Laravel 10 and 11 are both past their security-support EOL, so they no longer receive security fixes from Laravel itself. On top of that, Composer 2.10's advisory protections now refuse to install their dependency trees because of known CVEs in those (and transitive) packages — our CI suite literally couldn't install Laravel 10 anymore without explicitly bypassing Composer's security checks.

The only way to continue to use Laravel 10/11 yourself is to explicitly opt into using vulnerable packages. Or use an older version of Composer which doesn't have that protection.

Our commitment to supporting Statamic 5 with security fixes until December is for Statamic itself.

---

This PR also fixes some small workflow issues to get zizmor's CI checks to pass.