### PR TITLE
[6.x] Merge 5.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Get Changelog
         id: changelog
-        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1
+        uses: statamic/changelog-action@5d112d0d790cdeeb5adca3e584e37edc474ab51b # v1.0.2
         with:
           version: ${{ github.ref }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,30 +24,15 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4, 8.5]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.2, 8.3, 8.4, 8.5]
+        laravel: [12.*]
         stability: [prefer-lowest, prefer-stable]
         os: [ubuntu-latest]
         include:
           - os: windows-latest
-            php: 8.3
-            laravel: 10.*
-            stability: prefer-stable
-          - os: windows-latest
-            php: 8.3
-            laravel: 11.*
-            stability: prefer-stable
-        exclude:
-          - php: 8.1
-            laravel: 11.*
-          - php: 8.1
+            php: 8.5
             laravel: 12.*
-          - php: 8.4
-            laravel: 10.*
-          - php: 8.5
-            laravel: 10.*
-          - php: 8.5
-            laravel: 11.*
+            stability: prefer-stable
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -92,7 +77,7 @@ jobs:
         run: sudo apt-get install language-pack-fr
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         if: steps.should-run-tests.outputs.result == 'true'
         with:
           php-version: ${{ matrix.php }}
@@ -174,7 +159,7 @@ jobs:
       actions: read # required by workflow-conclusion-action to determine overall workflow status
     if: always()
     steps:
-      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3
+      - uses: technote-space/workflow-conclusion-action@45ce8e0eb155657ab8ccf346ade734257fd196a5 # v3.0.3
       - name: Send Slack notification
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         if: env.WORKFLOW_CONCLUSION == 'failure' && github.event_name == 'schedule'

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "composer/semver": "^3.4",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "james-heinrich/getid3": "^1.9.21",
-        "laravel/framework": "^10.48.29 || ^11.44.1 || ^12.40.0",
+        "laravel/framework": "^12.40.0",
         "laravel/prompts": "^0.1.16 || ^0.2.0 || ^0.3.0",
         "league/commonmark": "^2.2",
         "league/csv": "^9.1",
@@ -44,7 +44,7 @@
         "google/cloud-translate": "^1.6",
         "laravel/pint": "1.16.0",
         "mockery/mockery": "^1.6.10",
-        "orchestra/testbench": "^8.36 || ^9.15 || ^10.8",
+        "orchestra/testbench": "^10.8",
         "phpunit/phpunit": "^10.5.35 || ^11.5.3",
         "sebastian/recursion-context": "^5.0.1 || ^6.0.3",
         "spatie/laravel-ray": "^1.42"

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -448,7 +448,7 @@ export default {
         },
 
         showLivePreviewButton() {
-            return !this.isCreating && this.isBase && this.livePreviewUrl;
+            return !this.readOnly && !this.isCreating && this.isBase && this.livePreviewUrl;
         },
 
         showVisitUrlButton() {

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -323,7 +323,7 @@ export default {
         },
 
         showLivePreviewButton() {
-            return !this.isCreating && this.isBase && this.livePreviewUrl && this.showVisitUrlButton;
+            return !this.readOnly && !this.isCreating && this.isBase && this.livePreviewUrl && this.showVisitUrlButton;
         },
 
         showVisitUrlButton() {

--- a/src/Http/Controllers/CP/PreviewController.php
+++ b/src/Http/Controllers/CP/PreviewController.php
@@ -17,7 +17,7 @@ class PreviewController extends CpController
 
     public function edit(Request $request, $_, $data)
     {
-        $this->authorize('view', $data);
+        $this->authorize('update', $data);
 
         $fields = $data->blueprint()
             ->fields()

--- a/tests/Feature/Entries/PreviewEntryTest.php
+++ b/tests/Feature/Entries/PreviewEntryTest.php
@@ -181,6 +181,33 @@ class PreviewEntryTest extends TestCase
         );
     }
 
+    #[Test]
+    public function it_doesnt_create_a_token_without_edit_permission()
+    {
+        Collection::make('blog')->routes('/blog/{slug}')->save();
+
+        EntryFactory::id('the-entry')
+            ->collection('blog')
+            ->slug('the-existing-entry')
+            ->data(['title' => 'The Existing Entry'])
+            ->create();
+
+        LivePreview::shouldReceive('tokenize')->never();
+
+        $this->setTestRoles(['viewer' => ['access cp', 'view blog entries']]);
+        $user = User::make()->assignRole('viewer')->save();
+
+        $this
+            ->actingAs($user)
+            ->postJson('/cp/collections/blog/entries/the-entry/preview', [
+                'preview' => [
+                    'title' => 'Edited title',
+                    'slug' => 'edited-slug',
+                ],
+            ])
+            ->assertForbidden();
+    }
+
     private function user()
     {
         $this->setTestRoles(['test' => ['access cp', 'create blog entries', 'edit blog entries']]);


### PR DESCRIPTION
Going forward we're adding a rule that commits that land on 6.x must have already had all status checks pass.

This means that `5.x → 6.x` merges need to exist in a PR first so tests can run.

This PR merges the following two PRs:

- #14793
- #14791
