### PR TITLE
[6.x] Adjust listing skeleton to match configured features

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -717,12 +717,12 @@ autoApplyState();
     <div>
         <slot name="initializing" v-if="shouldShowSkeleton">
             <div class="flex flex-col gap-4 justify-between mt-3 starting-style-transition starting-style-transition--delay">
-                <ui-skeleton class="h-5 w-48" />
+                <ui-skeleton v-if="showPresets" class="h-5 w-48" />
                 <div class="flex gap-2 sm:gap-3">
-                    <ui-skeleton class="h-9 w-96" />
-                    <ui-skeleton class="h-9 w-24" />
+                    <ui-skeleton v-if="allowSearch" class="h-9 w-96" />
+                    <ui-skeleton v-if="hasFilters" class="h-9 w-24" />
                     <div class="flex-1" />
-                    <ui-skeleton class="size-10" />
+                    <ui-skeleton v-if="allowCustomizingColumns" class="size-10" />
                 </div>
                 <ui-skeleton class="h-48 w-full" />
             </div>

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -718,7 +718,7 @@ autoApplyState();
         <slot name="initializing" v-if="shouldShowSkeleton">
             <div class="flex flex-col gap-4 justify-between mt-3 starting-style-transition starting-style-transition--delay">
                 <ui-skeleton v-if="showPresets" class="h-5 w-48" />
-                <div class="flex gap-2 sm:gap-3">
+                <div v-if="allowSearch || hasFilters || allowCustomizingColumns" class="flex gap-2 sm:gap-3">
                     <ui-skeleton v-if="allowSearch" class="h-9 w-96" />
                     <ui-skeleton v-if="hasFilters" class="h-9 w-24" />
                     <div class="flex-1" />


### PR DESCRIPTION
This makes the skeleton UI of listings check for configured features. The search bar skeleton is only shown when search is enabled; the column customization button skeleton is only shown if columns can be customized; etc.

## Example

Using the Listing component with no filters and presets and columns disabled.

```vue
<Listing
  ref="listing"
  :url="endpoint"
  :columns="columns"
  :allow-presets="false"
  :allow-customizing-columns="false"
>
```

### Before

<img width="1405" height="306" alt="Screenshot 2026-06-10 at 00 50 11" src="https://github.com/user-attachments/assets/ffe709fd-39b5-4156-b559-4c59e97232d3" />

### After

<img width="1427" height="295" alt="Screenshot 2026-06-10 at 00 50 05" src="https://github.com/user-attachments/assets/0181d145-7fcb-4f20-b38d-8977415f7178" />
