### PR TITLE
[6.x] Support for namespaced tags

### DIFF
--- a/src/Extend/RegistersItself.php
+++ b/src/Extend/RegistersItself.php
@@ -4,17 +4,18 @@ namespace Statamic\Extend;
 
 trait RegistersItself
 {
-    public static function register()
+    public static function register(?string $namespace = null)
     {
         $key = self::class;
+        $prefix = $namespace ? $namespace.'::' : '';
         $extensions = app('statamic.extensions');
 
-        $extensions[$key] = with($extensions[$key] ?? collect(), function ($bindings) {
-            $bindings[static::handle()] = static::class;
+        $extensions[$key] = with($extensions[$key] ?? collect(), function ($bindings) use ($prefix) {
+            $bindings[$prefix.static::handle()] = static::class;
 
             if (method_exists(static::class, 'aliases')) {
                 foreach (static::aliases() as $alias) {
-                    $bindings[$alias] = static::class;
+                    $bindings[$prefix.$alias] = static::class;
                 }
             }
 

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -165,19 +165,12 @@ abstract class AddonServiceProvider extends ServiceProvider
      */
     protected $fieldsetNamespace;
 
+    protected ?string $tagNamespace;
+
     /**
      * @var string
      */
     protected $viewNamespace;
-
-    /**
-     * When set, the addon's tags (and their aliases) are registered under
-     * this namespace instead of their bare handles, e.g. `{{ my-namespace::my_tag }}`.
-     * Must be a simple slug without colons.
-     *
-     * @var string|null
-     */
-    protected $tagNamespace;
 
     /**
      * @var bool

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -171,6 +171,15 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $viewNamespace;
 
     /**
+     * When set, the addon's tags (and their aliases) are additionally
+     * registered under this namespace, e.g. `{{ my-namespace::my_tag }}`.
+     * Must be a simple slug without colons.
+     *
+     * @var string|null
+     */
+    protected $tagNamespace;
+
+    /**
      * @var bool
      */
     protected $publishAfterInstall = true;
@@ -304,7 +313,28 @@ abstract class AddonServiceProvider extends ServiceProvider
             $class::register();
         }
 
+        if ($this->tagNamespace) {
+            $this->registerNamespacedTags($tags);
+        }
+
         return $this;
+    }
+
+    private function registerNamespacedTags($tags)
+    {
+        $extensions = app('statamic.extensions');
+
+        $extensions[Tags::class] = with($extensions[Tags::class] ?? collect(), function ($bindings) use ($tags) {
+            foreach ($tags as $class) {
+                $bindings[$this->tagNamespace.'::'.$class::handle()] = $class;
+
+                foreach ($class::aliases() as $alias) {
+                    $bindings[$this->tagNamespace.'::'.$alias] = $class;
+                }
+            }
+
+            return $bindings;
+        });
     }
 
     protected function bootScopes()

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -309,32 +309,9 @@ abstract class AddonServiceProvider extends ServiceProvider
             ->merge($this->autoloadFilesFromFolder('Tags', Tags::class))
             ->unique();
 
-        if ($this->tagNamespace) {
-            return $this->registerNamespacedTags($tags);
-        }
-
         foreach ($tags as $class) {
-            $class::register();
+            $class::register($this->tagNamespace);
         }
-
-        return $this;
-    }
-
-    private function registerNamespacedTags($tags)
-    {
-        $extensions = app('statamic.extensions');
-
-        $extensions[Tags::class] = with($extensions[Tags::class] ?? collect(), function ($bindings) use ($tags) {
-            foreach ($tags as $class) {
-                $bindings[$this->tagNamespace.'::'.$class::handle()] = $class;
-
-                foreach ($class::aliases() as $alias) {
-                    $bindings[$this->tagNamespace.'::'.$alias] = $class;
-                }
-            }
-
-            return $bindings;
-        });
 
         return $this;
     }

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -171,8 +171,8 @@ abstract class AddonServiceProvider extends ServiceProvider
     protected $viewNamespace;
 
     /**
-     * When set, the addon's tags (and their aliases) are additionally
-     * registered under this namespace, e.g. `{{ my-namespace::my_tag }}`.
+     * When set, the addon's tags (and their aliases) are registered under
+     * this namespace instead of their bare handles, e.g. `{{ my-namespace::my_tag }}`.
      * Must be a simple slug without colons.
      *
      * @var string|null
@@ -309,12 +309,12 @@ abstract class AddonServiceProvider extends ServiceProvider
             ->merge($this->autoloadFilesFromFolder('Tags', Tags::class))
             ->unique();
 
-        foreach ($tags as $class) {
-            $class::register();
+        if ($this->tagNamespace) {
+            return $this->registerNamespacedTags($tags);
         }
 
-        if ($this->tagNamespace) {
-            $this->registerNamespacedTags($tags);
+        foreach ($tags as $class) {
+            $class::register();
         }
 
         return $this;
@@ -335,6 +335,8 @@ abstract class AddonServiceProvider extends ServiceProvider
 
             return $bindings;
         });
+
+        return $this;
     }
 
     protected function bootScopes()

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -4,6 +4,7 @@ namespace Statamic\Tags;
 
 use ArrayIterator;
 use Statamic\Support\Str;
+use Statamic\View\Antlers\Language\Analyzers\TagIdentifierAnalyzer;
 use Traversable;
 
 class FluentTag implements \ArrayAccess, \IteratorAggregate
@@ -109,12 +110,11 @@ class FluentTag implements \ArrayAccess, \IteratorAggregate
             return $this->fetched;
         }
 
-        $name = $this->name;
+        [$name, $methodPart] = TagIdentifierAnalyzer::splitNameAndMethodPart($this->name);
 
-        if ($pos = strpos($name, ':')) {
-            $originalMethod = substr($name, $pos + 1);
+        if ($methodPart !== null && $methodPart !== '') {
+            $originalMethod = $methodPart;
             $method = Str::camel($originalMethod);
-            $name = substr($name, 0, $pos);
         } else {
             $method = $originalMethod = 'index';
         }

--- a/src/Tags/FluentTag.php
+++ b/src/Tags/FluentTag.php
@@ -112,12 +112,8 @@ class FluentTag implements \ArrayAccess, \IteratorAggregate
 
         [$name, $methodPart] = TagIdentifierAnalyzer::splitNameAndMethodPart($this->name);
 
-        if ($methodPart !== null && $methodPart !== '') {
-            $originalMethod = $methodPart;
-            $method = Str::camel($originalMethod);
-        } else {
-            $method = $originalMethod = 'index';
-        }
+        $originalMethod = $methodPart ?: 'index';
+        $method = Str::camel($originalMethod);
 
         $tagName = $name.':'.$originalMethod;
         $profileTagName = 'tag_'.$tagName.microtime();

--- a/src/View/Antlers/Language/Analyzers/TagIdentifierAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/TagIdentifierAnalyzer.php
@@ -49,12 +49,9 @@ class TagIdentifierAnalyzer
     /**
      * Splits the input into the tag name and method part at the first
      * single colon. Double colons act as a namespace separator and
-     * remain part of the name (e.g. `ns::tag:method`).
-     *
-     * @param  string  $input  The content to split.
-     * @return array
+     * remain part of the name (e.g. `namespace::tag:method`).
      */
-    public static function splitNameAndMethodPart($input)
+    public static function splitNameAndMethodPart(string $input): array
     {
         // Mask double colons so the namespace separator
         // is not mistaken for the name/method boundary.

--- a/src/View/Antlers/Language/Analyzers/TagIdentifierAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/TagIdentifierAnalyzer.php
@@ -26,22 +26,16 @@ class TagIdentifierAnalyzer
         $identifier = new TagIdentifier();
         $identifier->content = trim($input);
 
-        $parts = explode(':', $input);
+        [$name, $methodPart] = self::splitNameAndMethodPart($input);
 
-        if (count($parts) == 1) {
-            $identifier->name = trim($parts[0]);
+        if ($methodPart === null) {
+            $identifier->name = trim($name);
             $identifier->methodPart = null;
             $identifier->compound = $identifier->name;
-        } elseif (count($parts) > 1) {
-            $name = array_shift($parts);
-            $methodPart = implode(':', $parts);
-
+        } else {
             $identifier->name = trim($name);
             $identifier->methodPart = trim($methodPart);
             $identifier->compound = $identifier->name.':'.$identifier->methodPart;
-        } else {
-            $identifier->name = trim($input);
-            $identifier->methodPart = '';
         }
 
         if (Str::startsWith($identifier->name, '/')) {
@@ -50,5 +44,32 @@ class TagIdentifierAnalyzer
         }
 
         return $identifier;
+    }
+
+    /**
+     * Splits the input into the tag name and method part at the first
+     * single colon. Double colons act as a namespace separator and
+     * remain part of the name (e.g. `ns::tag:method`).
+     *
+     * @param  string  $input  The content to split.
+     * @return array
+     */
+    public static function splitNameAndMethodPart($input)
+    {
+        $len = strlen($input);
+
+        for ($i = 0; $i < $len; $i++) {
+            if ($input[$i] === ':') {
+                if ($i + 1 < $len && $input[$i + 1] === ':') {
+                    $i++;
+
+                    continue;
+                }
+
+                return [substr($input, 0, $i), substr($input, $i + 1)];
+            }
+        }
+
+        return [$input, null];
     }
 }

--- a/src/View/Antlers/Language/Analyzers/TagIdentifierAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/TagIdentifierAnalyzer.php
@@ -28,12 +28,12 @@ class TagIdentifierAnalyzer
 
         [$name, $methodPart] = self::splitNameAndMethodPart($input);
 
+        $identifier->name = trim($name);
+
         if ($methodPart === null) {
-            $identifier->name = trim($name);
             $identifier->methodPart = null;
             $identifier->compound = $identifier->name;
         } else {
-            $identifier->name = trim($name);
             $identifier->methodPart = trim($methodPart);
             $identifier->compound = $identifier->name.':'.$identifier->methodPart;
         }
@@ -56,20 +56,12 @@ class TagIdentifierAnalyzer
      */
     public static function splitNameAndMethodPart($input)
     {
-        $len = strlen($input);
-
-        for ($i = 0; $i < $len; $i++) {
-            if ($input[$i] === ':') {
-                if ($i + 1 < $len && $input[$i + 1] === ':') {
-                    $i++;
-
-                    continue;
-                }
-
-                return [substr($input, 0, $i), substr($input, $i + 1)];
-            }
+        // Mask double colons so the namespace separator
+        // is not mistaken for the name/method boundary.
+        if (($pos = strpos(strtr($input, ['::' => '__']), ':')) === false) {
+            return [$input, null];
         }
 
-        return [$input, null];
+        return [substr($input, 0, $pos), substr($input, $pos + 1)];
     }
 }

--- a/src/View/Blade/StatamicTagCompiler.php
+++ b/src/View/Blade/StatamicTagCompiler.php
@@ -3,6 +3,7 @@
 namespace Statamic\View\Blade;
 
 use Illuminate\Support\Str;
+use Statamic\View\Antlers\Language\Analyzers\TagIdentifierAnalyzer;
 use Statamic\View\Blade\Concerns\CompilesComponents;
 use Statamic\View\Blade\Concerns\CompilesNavs;
 use Statamic\View\Blade\Concerns\CompilesNocache;
@@ -125,15 +126,10 @@ class StatamicTagCompiler
 
     protected function extractMethodNames(ComponentNode $component): array
     {
-        $name = $component->tagName;
+        [$name, $methodPart] = TagIdentifierAnalyzer::splitNameAndMethodPart($component->tagName);
 
-        if ($pos = strpos($name, ':')) {
-            $originalMethod = substr($name, $pos + 1);
-            $method = Str::camel($originalMethod);
-            $name = substr($name, 0, $pos);
-        } else {
-            $method = $originalMethod = 'index';
-        }
+        $originalMethod = $methodPart ?: 'index';
+        $method = Str::camel($originalMethod);
 
         return [$name, $method, $originalMethod];
     }

--- a/tests/Addons/NamespacedTagsTest.php
+++ b/tests/Addons/NamespacedTagsTest.php
@@ -35,8 +35,8 @@ class NamespacedTagsTest extends TestCase
 
         $tags = $this->app['statamic.tags'];
 
-        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test'));
-        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test_alias'));
+        $this->assertNull($tags->get('namespaced_test'));
+        $this->assertNull($tags->get('namespaced_test_alias'));
         $this->assertSame(NamespacedTestTag::class, $tags->get('acme::namespaced_test'));
         $this->assertSame(NamespacedTestTag::class, $tags->get('acme::namespaced_test_alias'));
     }

--- a/tests/Addons/NamespacedTagsTest.php
+++ b/tests/Addons/NamespacedTagsTest.php
@@ -14,24 +14,7 @@ class NamespacedTagsTest extends TestCase
     #[Test]
     public function it_registers_namespaced_tags_when_a_tag_namespace_is_set()
     {
-        $provider = new class($this->app) extends AddonServiceProvider
-        {
-            protected $tags = [NamespacedTestTag::class];
-
-            protected $tagNamespace = 'acme';
-
-            protected function autoloadFilesFromFolder($folder, $requiredClass = null)
-            {
-                return [];
-            }
-
-            public function callBootTags()
-            {
-                return $this->bootTags();
-            }
-        };
-
-        $provider->callBootTags();
+        $this->makeProvider('acme')->callBootTags();
 
         $tags = $this->app['statamic.tags'];
 
@@ -44,11 +27,30 @@ class NamespacedTagsTest extends TestCase
     #[Test]
     public function it_does_not_register_namespaced_tags_without_a_tag_namespace()
     {
-        $provider = new class($this->app) extends AddonServiceProvider
+        $this->makeProvider(null)->callBootTags();
+
+        $tags = $this->app['statamic.tags'];
+
+        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test'));
+        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test_alias'));
+        $this->assertNull($tags->get('acme::namespaced_test'));
+        $this->assertNull($tags->get('acme::namespaced_test_alias'));
+    }
+
+    private function makeProvider(?string $tagNamespace): AddonServiceProvider
+    {
+        return new class($this->app, $tagNamespace) extends AddonServiceProvider
         {
             protected $tags = [NamespacedTestTag::class];
 
-            protected function autoloadFilesFromFolder($folder, $requiredClass = null)
+            public function __construct($app, $tagNamespace)
+            {
+                parent::__construct($app);
+
+                $this->tagNamespace = $tagNamespace;
+            }
+
+            protected function autoloadFilesFromFolder($folder, $requiredClass = null): array
             {
                 return [];
             }
@@ -58,15 +60,6 @@ class NamespacedTagsTest extends TestCase
                 return $this->bootTags();
             }
         };
-
-        $provider->callBootTags();
-
-        $tags = $this->app['statamic.tags'];
-
-        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test'));
-        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test_alias'));
-        $this->assertNull($tags->get('acme::namespaced_test'));
-        $this->assertNull($tags->get('acme::namespaced_test_alias'));
     }
 }
 
@@ -76,7 +69,7 @@ class NamespacedTestTag extends Tags
 
     protected static $aliases = ['namespaced_test_alias'];
 
-    public function index()
+    public function index(): string
     {
         return 'hello';
     }

--- a/tests/Addons/NamespacedTagsTest.php
+++ b/tests/Addons/NamespacedTagsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Addons;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Providers\AddonServiceProvider;
+use Statamic\Tags\Tags;
+use Tests\TestCase;
+
+#[Group('addons')]
+class NamespacedTagsTest extends TestCase
+{
+    #[Test]
+    public function it_registers_namespaced_tags_when_a_tag_namespace_is_set()
+    {
+        $provider = new class($this->app) extends AddonServiceProvider
+        {
+            protected $tags = [NamespacedTestTag::class];
+
+            protected $tagNamespace = 'acme';
+
+            protected function autoloadFilesFromFolder($folder, $requiredClass = null)
+            {
+                return [];
+            }
+
+            public function callBootTags()
+            {
+                return $this->bootTags();
+            }
+        };
+
+        $provider->callBootTags();
+
+        $tags = $this->app['statamic.tags'];
+
+        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test'));
+        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test_alias'));
+        $this->assertSame(NamespacedTestTag::class, $tags->get('acme::namespaced_test'));
+        $this->assertSame(NamespacedTestTag::class, $tags->get('acme::namespaced_test_alias'));
+    }
+
+    #[Test]
+    public function it_does_not_register_namespaced_tags_without_a_tag_namespace()
+    {
+        $provider = new class($this->app) extends AddonServiceProvider
+        {
+            protected $tags = [NamespacedTestTag::class];
+
+            protected function autoloadFilesFromFolder($folder, $requiredClass = null)
+            {
+                return [];
+            }
+
+            public function callBootTags()
+            {
+                return $this->bootTags();
+            }
+        };
+
+        $provider->callBootTags();
+
+        $tags = $this->app['statamic.tags'];
+
+        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test'));
+        $this->assertSame(NamespacedTestTag::class, $tags->get('namespaced_test_alias'));
+        $this->assertNull($tags->get('acme::namespaced_test'));
+        $this->assertNull($tags->get('acme::namespaced_test_alias'));
+    }
+}
+
+class NamespacedTestTag extends Tags
+{
+    protected static $handle = 'namespaced_test';
+
+    protected static $aliases = ['namespaced_test_alias'];
+
+    public function index()
+    {
+        return 'hello';
+    }
+}

--- a/tests/Antlers/Runtime/NamespacedTagsTest.php
+++ b/tests/Antlers/Runtime/NamespacedTagsTest.php
@@ -52,11 +52,9 @@ class NamespacedTagsTest extends ParserTestCase
 
     private function registerNamespacedTag(string $namespace, $tag): void
     {
-        $tag::register();
-
         $extensions = app('statamic.extensions');
 
-        $extensions[Tags::class] = with($extensions[Tags::class], function ($bindings) use ($namespace, $tag) {
+        $extensions[Tags::class] = with($extensions[Tags::class] ?? collect(), function ($bindings) use ($namespace, $tag) {
             $bindings[$namespace.'::'.$tag::handle()] = get_class($tag);
 
             foreach ($tag::aliases() as $alias) {
@@ -92,10 +90,10 @@ class NamespacedTagsTest extends ParserTestCase
         $this->assertSame('hi', $this->renderString('{{ acme::ns_hi:hello }}', [], true));
     }
 
-    public function test_bare_handle_still_works_alongside_namespace()
+    public function test_bare_handle_is_not_registered_for_namespaced_tags()
     {
-        $this->assertSame('hi', $this->renderString('{{ ns_greet:hello }}', [], true));
-        $this->assertSame('hi', $this->renderString('{{ ns_hi:hello }}', [], true));
+        $this->assertSame('', $this->renderString('{{ ns_greet:hello }}', [], true));
+        $this->assertSame('', $this->renderString('{{ ns_hi:hello }}', [], true));
     }
 
     public function test_double_colons_in_method_part_route_to_wildcard()

--- a/tests/Antlers/Runtime/NamespacedTagsTest.php
+++ b/tests/Antlers/Runtime/NamespacedTagsTest.php
@@ -8,63 +8,6 @@ use Tests\Antlers\ParserTestCase;
 
 class NamespacedTagsTest extends ParserTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->registerNamespacedTag('acme', new class extends Tags
-        {
-            public static $handle = 'ns_greet';
-
-            protected static $aliases = ['ns_hi'];
-
-            public function index()
-            {
-                return 'greetings';
-            }
-
-            public function hello()
-            {
-                return 'hi';
-            }
-
-            public function details()
-            {
-                return $this->tag.'|'.$this->method;
-            }
-
-            public function wildcard($method)
-            {
-                return 'wildcard: '.$method;
-            }
-        });
-
-        $this->registerNamespacedTag('acme', new class extends Tags
-        {
-            public static $handle = 'ns_items';
-
-            public function index()
-            {
-                return [['value' => 'a'], ['value' => 'b']];
-            }
-        });
-    }
-
-    private function registerNamespacedTag(string $namespace, $tag): void
-    {
-        $extensions = app('statamic.extensions');
-
-        $extensions[Tags::class] = with($extensions[Tags::class] ?? collect(), function ($bindings) use ($namespace, $tag) {
-            $bindings[$namespace.'::'.$tag::handle()] = get_class($tag);
-
-            foreach ($tag::aliases() as $alias) {
-                $bindings[$namespace.'::'.$alias] = get_class($tag);
-            }
-
-            return $bindings;
-        });
-    }
-
     public function test_namespaced_tag_with_method_can_be_rendered()
     {
         $this->assertSame('hi', $this->renderString('{{ acme::ns_greet:hello }}', [], true));
@@ -119,5 +62,47 @@ class NamespacedTagsTest extends ParserTestCase
     public function test_namespaced_tag_can_be_resolved_fluently()
     {
         $this->assertSame('hi', (string) Statamic::tag('acme::ns_greet:hello'));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        (new class extends Tags
+        {
+            public static $handle = 'ns_greet';
+
+            protected static $aliases = ['ns_hi'];
+
+            public function index()
+            {
+                return 'greetings';
+            }
+
+            public function hello()
+            {
+                return 'hi';
+            }
+
+            public function details()
+            {
+                return $this->tag.'|'.$this->method;
+            }
+
+            public function wildcard($method)
+            {
+                return 'wildcard: '.$method;
+            }
+        })::register('acme');
+
+        (new class extends Tags
+        {
+            public static $handle = 'ns_items';
+
+            public function index()
+            {
+                return [['value' => 'a'], ['value' => 'b']];
+            }
+        })::register('acme');
     }
 }

--- a/tests/Antlers/Runtime/NamespacedTagsTest.php
+++ b/tests/Antlers/Runtime/NamespacedTagsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Tests\Antlers\Runtime;
+
+use Statamic\Statamic;
+use Statamic\Tags\Tags;
+use Tests\Antlers\ParserTestCase;
+
+class NamespacedTagsTest extends ParserTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerNamespacedTag('acme', new class extends Tags
+        {
+            public static $handle = 'ns_greet';
+
+            protected static $aliases = ['ns_hi'];
+
+            public function index()
+            {
+                return 'greetings';
+            }
+
+            public function hello()
+            {
+                return 'hi';
+            }
+
+            public function details()
+            {
+                return $this->tag.'|'.$this->method;
+            }
+
+            public function wildcard($method)
+            {
+                return 'wildcard: '.$method;
+            }
+        });
+
+        $this->registerNamespacedTag('acme', new class extends Tags
+        {
+            public static $handle = 'ns_items';
+
+            public function index()
+            {
+                return [['value' => 'a'], ['value' => 'b']];
+            }
+        });
+    }
+
+    private function registerNamespacedTag(string $namespace, $tag): void
+    {
+        $tag::register();
+
+        $extensions = app('statamic.extensions');
+
+        $extensions[Tags::class] = with($extensions[Tags::class], function ($bindings) use ($namespace, $tag) {
+            $bindings[$namespace.'::'.$tag::handle()] = get_class($tag);
+
+            foreach ($tag::aliases() as $alias) {
+                $bindings[$namespace.'::'.$alias] = get_class($tag);
+            }
+
+            return $bindings;
+        });
+    }
+
+    public function test_namespaced_tag_with_method_can_be_rendered()
+    {
+        $this->assertSame('hi', $this->renderString('{{ acme::ns_greet:hello }}', [], true));
+    }
+
+    public function test_namespaced_tag_without_method_calls_index()
+    {
+        $this->assertSame('greetings', $this->renderString('{{ acme::ns_greet }}', [], true));
+    }
+
+    public function test_namespaced_tag_can_be_paired()
+    {
+        $this->assertSame('ab', $this->renderString('{{ acme::ns_items }}{{ value }}{{ /acme::ns_items }}', [], true));
+    }
+
+    public function test_namespaced_tag_can_be_self_closing()
+    {
+        $this->assertSame('greetings', $this->renderString('{{ acme::ns_greet /}}', [], true));
+    }
+
+    public function test_namespaced_alias_can_be_rendered()
+    {
+        $this->assertSame('hi', $this->renderString('{{ acme::ns_hi:hello }}', [], true));
+    }
+
+    public function test_bare_handle_still_works_alongside_namespace()
+    {
+        $this->assertSame('hi', $this->renderString('{{ ns_greet:hello }}', [], true));
+        $this->assertSame('hi', $this->renderString('{{ ns_hi:hello }}', [], true));
+    }
+
+    public function test_double_colons_in_method_part_route_to_wildcard()
+    {
+        $this->assertSame('wildcard: foo::bar', $this->renderString('{{ acme::ns_greet:foo::bar }}', [], true));
+    }
+
+    public function test_namespaced_tag_can_be_used_in_conditions()
+    {
+        $this->assertSame('yes', $this->renderString('{{ if {acme::ns_greet:hello} == "hi" }}yes{{ /if }}', [], true));
+    }
+
+    public function test_unregistered_namespace_falls_back_to_variable()
+    {
+        $this->assertSame('', $this->renderString('{{ unknown::ns_greet }}', [], true));
+    }
+
+    public function test_namespaced_tag_receives_namespaced_tag_and_method_properties()
+    {
+        $this->assertSame('acme::ns_greet:details|details', $this->renderString('{{ acme::ns_greet:details }}', [], true));
+    }
+
+    public function test_namespaced_tag_can_be_resolved_fluently()
+    {
+        $this->assertSame('hi', (string) Statamic::tag('acme::ns_greet:hello'));
+    }
+}

--- a/tests/View/Blade/AntlersComponents/NamespacedTagsTest.php
+++ b/tests/View/Blade/AntlersComponents/NamespacedTagsTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\View\Blade\AntlersComponents;
+
+use Illuminate\Support\Facades\Blade;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Tags\Tags;
+use Tests\TestCase;
+
+#[Group('blade-compiler')]
+class NamespacedTagsTest extends TestCase
+{
+    #[Test]
+    public function it_renders_namespaced_tags_with_a_method()
+    {
+        $this->assertSame('hi', Blade::render('<s:acme::ns_greet:hello />'));
+    }
+
+    #[Test]
+    public function it_renders_namespaced_tags_without_a_method()
+    {
+        $this->assertSame('greetings', Blade::render('<s:acme::ns_greet />'));
+    }
+
+    #[Test]
+    public function it_renders_paired_namespaced_tags()
+    {
+        $template = <<<'BLADE'
+<s:acme::ns_items>{{ $value }}</s:acme::ns_items>
+BLADE;
+
+        $this->assertSame('ab', Blade::render($template));
+    }
+
+    #[Test]
+    public function it_renders_namespaced_tag_aliases()
+    {
+        $this->assertSame('hi', Blade::render('<s:acme::ns_hi:hello />'));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('view:clear');
+
+        (new class extends Tags
+        {
+            public static $handle = 'ns_greet';
+
+            protected static $aliases = ['ns_hi'];
+
+            public function index()
+            {
+                return 'greetings';
+            }
+
+            public function hello()
+            {
+                return 'hi';
+            }
+        })::register('acme');
+
+        (new class extends Tags
+        {
+            public static $handle = 'ns_items';
+
+            public function index()
+            {
+                return [['value' => 'a'], ['value' => 'b']];
+            }
+        })::register('acme');
+    }
+}


### PR DESCRIPTION
This PR adds opt-in namespace support for tags, analogous to how views are namespaced (`vendor::view`):

```antlers
{{ juicebox::my_tag:method }}
```

## Why

Tag handles are currently global. Two addons registering a tag with the same handle silently collide (last one wins), and there's no way to explicitly address a specific addon's tag.

## Usage

Addons opt in by setting a property on their service provider:

```php
class ServiceProvider extends AddonServiceProvider {
    protected $tagNamespace = 'juicebox';
}
```

When set, the addon's tags (and their aliases) are registered only under the namespace — `{{ juicebox::my_tag }}` — and no longer under their bare handles. Since the property defaults to null, existing addons are unaffected.

The underlying mechanism is generic: `RegistersItself::register()` now accepts an optional namespace, so any tag class can be registered namespaced manually:

```php
MyTag::register('juicebox');
```

Namespaced tags work across all three surfaces:
- Antlers: `{{ juicebox::my_tag:method }}`, including paired tags, self-closing tags, and interpolations in conditions
- Blade components: `<s:juicebox::my_tag:method />`
- Fluent: `Statamic::tag('juicebox::my_tag:method')`

## Notes

- Non-breaking: behavior only changes when an addon explicitly sets `$tagNamespace`.