### PR TITLE
[5.x] Fix order() error if structure contains null item

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -528,10 +528,13 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
             return $this->value('order');
         }
 
-        return $this->structure()->in($this->locale())
+        $order = $this->structure()->in($this->locale())
             ->flattenedPages()
             ->map->reference()
-            ->flip()->get($this->id) + 1;
+            ->filter()
+            ->flip()->get($this->id);
+
+        return $order !== null ? $order + 1 : null;
     }
 
     public function template($template = null)


### PR DESCRIPTION
When calling order() on an entry and the structure contains, for whatever reason, a `null` item, it would result in a fatal error from array_flip(). This commit makes the order() call more robust.

Fixes #14801