### PR TITLE
[6.x] Fix nested Bard data loss when editing a set

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -442,6 +442,8 @@ export default {
         value(value, oldValue) {
             if (!this.editor) return;
 
+            if (document.activeElement?.closest('.bard-content')) return;
+
             const oldContent = this.editor.getJSON();
             const content = this.valueToContent(value);
 


### PR DESCRIPTION
When using Bard with nested Bard fields, typing in one set causes another set's content to get cleared. That might happen without you even noticing like when it's further down the page. Saving the entry then leads to actual data loss.

Right now before typing:
<img width="1081" height="469" alt="image" src="https://github.com/user-attachments/assets/9ef5f866-8f68-47df-a690-01bb350d62b9" />
After typing:
<img width="1024" height="584" alt="image" src="https://github.com/user-attachments/assets/8824f540-5c7e-46ee-b537-f11ac5c33362" />


Reason is that Bard shares a single value tree and editing one set re-emits the array up to the publish container, which changes the `value` reference of every sibling and nested Bard set. Each Bard's `value` watcher reacts to that by running a destructive `clearContent()`/`setContent()` to rebuild its editor from the value. For an unfocused set, this rebuild happens while the publish container for that set is empty. The set rebuilds from the empty state and emits empty content back, which gets persisted on save.

This skips the destructive reset while a Bard editor is focused anywhere in the tree (`document.activeElement` is inside a `.bard-content` region).

External resets coming from things like field actions should be unaffected.


Closes https://github.com/statamic/cms/issues/14759.