### PR TITLE
[6.x] Change Dictionary Item offsetGet to return from extra array

### DIFF
--- a/src/Dictionaries/Item.php
+++ b/src/Dictionaries/Item.php
@@ -28,7 +28,7 @@ class Item extends LabeledValue implements \ArrayAccess
 
     public function offsetGet(mixed $offset): mixed
     {
-        return $this->data()[$offset];
+        return $this->extra[$offset] ?? '';
     }
 
     public function offsetSet(mixed $offset, mixed $value): void


### PR DESCRIPTION
I had created a Dictionary (municipalities). This worked fine within the CMS, but when retrieving the data through GraphQL (using the fields available through introspection)  we received an error: `Undefined array key "label"` in `vendor/statamic/cms/src/Dictionaries/Item.php` line 31.

I noticed the `offsetGet()` method was using `$this->data()`, unlike the other `offset*` methods, which are directly using `$this->extra`.

When using the `$this->extra` property directly in `offsetGet()` the issue no longer occurs, and the value + label come through correctly.

While this seems to resolve the issue, I do think this issue is slightly more complex, since it seems the resolved fields in the GraphQL schema might not be correct. Currently the dictionary states the `value`, `label`, and `key` fields are available, however, the key field appears to never be filled.