### PR TITLE
[6.x] Give precognitive form requests a separate rate limit bucket

### DIFF
--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -190,7 +190,9 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         RateLimiter::for('statamic.forms', function (Request $request) {
-            return Limit::perMinute(10)->by($request->ip());
+            return $request->isPrecognitive()
+                ? Limit::perMinute(30)->by('precognition:'.$request->ip())
+                : Limit::perMinute(10)->by('submission:'.$request->ip());
         });
 
         RateLimiter::for('two-factor', function (Request $request) {

--- a/tests/Feature/RateLimitingTest.php
+++ b/tests/Feature/RateLimitingTest.php
@@ -56,6 +56,24 @@ class RateLimitingTest extends TestCase
     }
 
     #[Test]
+    public function forms_precognitive_requests_have_a_higher_limit()
+    {
+        collect(range(1, 30))->each(fn () => $this->withPrecognition()->post('/!/forms/contact')->assertNotRateLimited());
+        $this->withPrecognition()->post('/!/forms/contact')->assertRateLimited();
+    }
+
+    #[Test]
+    public function forms_precognition_and_submission_buckets_are_independent()
+    {
+        // Exhaust the submission bucket...
+        collect(range(1, 10))->each(fn () => $this->post('/!/forms/contact')->assertNotRateLimited());
+        $this->post('/!/forms/contact')->assertRateLimited();
+
+        // ...precognitive validation should still be allowed.
+        $this->withPrecognition()->post('/!/forms/contact')->assertNotRateLimited();
+    }
+
+    #[Test]
     public function cp_login_endpoint_is_rate_limited()
     {
         collect(range(1, 4))->each(fn () => $this->post('/cp/auth/login')->assertNotRateLimited());


### PR DESCRIPTION
Fixes #14807.

Since #14475 (v6.15.0) the frontend form submission route is throttled via the `statamic.forms` limiter — a flat 10/min keyed on IP. That single bucket is shared between two very different kinds of traffic:

- **Precognitive validation pings** — the documented live-validation pattern fires one POST per field on `@change`.
- **The actual submission.**

Validation volume scales with field count and editing behaviour; submission volume doesn't. So a perfectly ordinary contact form can exhaust the 10/min budget on validation pings alone and get the real submission rejected with a 429.

This splits the limiter into two buckets with distinct keys:

- Precognitive validation → **30/min**, keyed `precognition:<ip>`
- Submissions → **10/min** (unchanged), keyed `submission:<ip>`

### On spoofing the `Precognition` header

A request only lands in the higher bucket if it sends `Precognition: true` — and the moment it does, `HandlePrecognitiveRequests` short-circuits with a 204 *before* `FormController::submit()` runs, so nothing is stored, no emails, no events. To actually submit (the thing worth attacking) a request must be non-precognitive, which puts it right back in the unchanged 10/min submission bucket.

So the header gates *less* capability, not more. The worst a spoofer gets is more runs of the validator — kept bounded by sizing the precognitive limit at 30/min rather than generously.

No upgrade step needed — it's a bug fix; the submission limit is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)