### PR TITLE
[6.x] Always render Control Panel exceptions as JSON for XHR requests

### DIFF
--- a/src/Exceptions/ControlPanelExceptionHandler.php
+++ b/src/Exceptions/ControlPanelExceptionHandler.php
@@ -19,6 +19,15 @@ class ControlPanelExceptionHandler extends Handler
         return $this->renderException($request, $e);
     }
 
+    protected function shouldReturnJson($request, Throwable $e)
+    {
+        // The Control Panel relies on deterministic JSON (e.g. 422 validation)
+        // responses for its XHR requests. An app may register a custom
+        // shouldRenderJsonWhen() callback that Laravel applies to every handler,
+        // which would override this, so we always honor the request itself.
+        return $request->expectsJson();
+    }
+
     protected function convertValidationExceptionToResponse(ValidationException $e, $request)
     {
         $e = $this->newStatamicValidationException($e);

--- a/src/Exceptions/ControlPanelExceptionHandler.php
+++ b/src/Exceptions/ControlPanelExceptionHandler.php
@@ -21,10 +21,6 @@ class ControlPanelExceptionHandler extends Handler
 
     protected function shouldReturnJson($request, Throwable $e)
     {
-        // The Control Panel relies on deterministic JSON (e.g. 422 validation)
-        // responses for its XHR requests. An app may register a custom
-        // shouldRenderJsonWhen() callback that Laravel applies to every handler,
-        // which would override this, so we always honor the request itself.
         return $request->expectsJson();
     }
 

--- a/tests/Exceptions/ControlPanelExceptionHandlerTest.php
+++ b/tests/Exceptions/ControlPanelExceptionHandlerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Exceptions;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Exceptions\ControlPanelExceptionHandler;
+use Tests\TestCase;
+
+class ControlPanelExceptionHandlerTest extends TestCase
+{
+    #[Test]
+    public function it_renders_validation_errors_as_json_even_when_the_app_restricts_json_rendering()
+    {
+        $handler = app(ControlPanelExceptionHandler::class);
+
+        // Laravel applies an app's shouldRenderJsonWhen() callback (e.g. the one in the
+        // default bootstrap/app.php scaffold) to every exception handler. If the Control
+        // Panel honored it, an XHR save expecting JSON would get a redirect instead of a
+        // 422, sending axios into a redirect loop. The CP must ignore it.
+        $handler->shouldRenderJsonWhen(fn (Request $request) => $request->is('api/*'));
+
+        $request = Request::create('/cp/collections/pages/entries/123', 'PATCH');
+        $request->headers->set('Accept', 'application/json');
+        $request->headers->set('X-Requested-With', 'XMLHttpRequest');
+
+        $exception = ValidationException::withMessages(['title' => 'The title field is required.']);
+
+        $response = $handler->render($request, $exception);
+
+        $this->assertInstanceOf(JsonResponse::class, $response);
+        $this->assertEquals(422, $response->getStatusCode());
+        $this->assertArrayHasKey('title', $response->getData(true)['errors']);
+    }
+}

--- a/tests/Exceptions/ControlPanelExceptionHandlerTest.php
+++ b/tests/Exceptions/ControlPanelExceptionHandlerTest.php
@@ -16,10 +16,6 @@ class ControlPanelExceptionHandlerTest extends TestCase
     {
         $handler = app(ControlPanelExceptionHandler::class);
 
-        // Laravel applies an app's shouldRenderJsonWhen() callback (e.g. the one in the
-        // default bootstrap/app.php scaffold) to every exception handler. If the Control
-        // Panel honored it, an XHR save expecting JSON would get a redirect instead of a
-        // 422, sending axios into a redirect loop. The CP must ignore it.
         $handler->shouldRenderJsonWhen(fn (Request $request) => $request->is('api/*'));
 
         $request = Request::create('/cp/collections/pages/entries/123', 'PATCH');


### PR DESCRIPTION
## What

Make the Control Panel's exception handler decide between JSON and HTML responses based on the request's `Accept` header (`expectsJson()`), ignoring any app-level `shouldRenderJsonWhen()` callback.

## Why

Laravel applies an app's `shouldRenderJsonWhen()` callback (registered in `bootstrap/app.php`) to *every* exception handler instance — including the Control Panel's. The current default Laravel app skeleton ships:

```php
$exceptions->shouldRenderJsonWhen(fn (Request $request) => $request->is('api/*'));
```

Because `shouldRenderJsonWhen()` *replaces* the default `expectsJson()` decision rather than extending it, Control Panel routes (which don't match `api/*`) stop returning JSON for XHR requests — even when the request sends `Accept: application/json`. A validation error during an entry save then renders as a 302 redirect-back instead of a 422, and the CP's axios save pipeline follows the redirect repeatedly, resulting in `ERR_TOO_MANY_REDIRECTS`.

The Control Panel relies on deterministic JSON responses for its XHR requests, so it shouldn't be affected by an app's exception-rendering configuration.

[Laravel might revert it](https://github.com/laravel/laravel/pull/6837) - but it's worth us having this anyway. Anyone who installed Statamic/Laravel during this period, or someone who configures their app intentionally like this, would continue to have this problem.