### PR TITLE
[6.x] Render asset editor video player with dimensions

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -104,7 +104,7 @@
                             </div>
 
                             <!-- Video -->
-                            <video :src="asset.url" class="max-w-full max-h-full object-contain" controls v-else-if="asset.isVideo" />
+                            <video :src="asset.url" :width="asset.width" :height="asset.height" class="max-w-full max-h-full object-contain" controls v-else-if="asset.isVideo" />
 
                             <!-- Other thumbnail -->
                             <img v-else-if="asset.preview" :src="asset.preview" class="asset-thumb shadow-ui-xl max-w-full max-h-full object-contain" />


### PR DESCRIPTION
Render videos with `width` and `height` params to avoid the player resizing once the video is loaded. This isn't necessary for images since these don't have any chrome and render transparent until loaded.

### Before

<img width="1200" height="959" alt="Screen Recording 2026-06-12 at 17 48 43" src="https://github.com/user-attachments/assets/5dc5b044-1f85-4940-a339-4d6f1f4b7c91" />

### After

<img width="1200" height="959" alt="Screen Recording 2026-06-12 at 17 50 53" src="https://github.com/user-attachments/assets/c32b78b0-c954-4c5d-a1fd-bc269fad7827" />
