### PR TITLE
[6.x] Handle external links in empty-state component

### DIFF
--- a/resources/js/components/ui/EmptyState/Item.vue
+++ b/resources/js/components/ui/EmptyState/Item.vue
@@ -1,13 +1,18 @@
 <script setup>
 import { Link } from '@inertiajs/vue3';
 import Icon from '../Icon/Icon.vue';
-import { useSlots } from 'vue';
+import { computed, useSlots } from 'vue';
 
 const props = defineProps({
     /** Optional link */
     href: {
         type: String,
         default: null,
+    },
+    /** Optionally open link in new tab */
+    openNewTab: {
+        type: Boolean,
+        default: false
     },
     /** Icon name. [Browse available icons](/?path=/story/components-icon--all-icons) */
     icon: {
@@ -28,13 +33,32 @@ const props = defineProps({
 
 const slots = useSlots();
 const hasSlot = !!slots.default;
+
+const cpBaseUrl = Statamic.$config.get('cpUrl');
+
+function isUrlWithinControlPanel(url) {
+    return url && (url === cpBaseUrl || url.startsWith(cpBaseUrl + '/'));
+}
+
+const linkComponent = computed(() => {
+    if (hasSlot) {
+        return 'div';
+    } else if (isUrlWithinControlPanel(props.href)) {
+        return Link;
+    } else if (props.href) {
+        return 'a';
+    } else {
+        return 'button';
+    }
+});
 </script>
 
 <template>
     <li class="w-full">
         <component
-            :is="hasSlot ? 'div' : (href ? Link : 'button')"
+            :is="linkComponent"
             :href="href"
+            :target="openNewTab ? '_blank' : null"
             class="w-full flex gap-2 px-3 pt-4 pb-5.5 items-start hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md group cursor-pointer"
         >
             <Icon :name="icon" class="size-6 me-4 mt-1 text-gray-400" />

--- a/resources/js/components/ui/EmptyState/Item.vue
+++ b/resources/js/components/ui/EmptyState/Item.vue
@@ -9,10 +9,10 @@ const props = defineProps({
         type: String,
         default: null,
     },
-    /** Optionally open link in new tab */
-    openNewTab: {
-        type: Boolean,
-        default: false
+    /** When `href` is provided, this prop controls the link's `target` attribute */
+    target: {
+        type: String,
+        default: null,
     },
     /** Icon name. [Browse available icons](/?path=/story/components-icon--all-icons) */
     icon: {
@@ -43,6 +43,8 @@ function isUrlWithinControlPanel(url) {
 const linkComponent = computed(() => {
     if (hasSlot) {
         return 'div';
+    } else if (props.target === '_blank') {
+        return 'a';
     } else if (isUrlWithinControlPanel(props.href)) {
         return Link;
     } else if (props.href) {
@@ -58,7 +60,7 @@ const linkComponent = computed(() => {
         <component
             :is="linkComponent"
             :href="href"
-            :target="openNewTab ? '_blank' : null"
+            :target="target"
             class="w-full flex gap-2 px-3 pt-4 pb-5.5 items-start hover:bg-gray-100 dark:hover:bg-gray-800 rounded-md group cursor-pointer"
         >
             <Icon :name="icon" class="size-6 me-4 mt-1 text-gray-400" />


### PR DESCRIPTION
The [Empty State components](https://ui.statamic.dev/?path=/docs/layout-emptystate--docs) are great for custom addons :) Passing in an external link as `href` leads to an exception since Inertia is blocking the navigation. This PR makes the component check for and handle external links and optionally opens links in a new tab.