### PR TITLE
[6.x] Improve term/entry stache warming performance

### DIFF
--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -58,6 +58,13 @@ abstract class Index
         $this->items[] = $value;
     }
 
+    public function setItems(array $items): static
+    {
+        $this->items = $items;
+
+        return $this;
+    }
+
     public function load()
     {
         if ($this->loaded) {

--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -58,6 +58,10 @@ abstract class Index
         $this->items[] = $value;
     }
 
+    /**
+     * Bulk-sets the index items without going through getItems(). Used by
+     * Store::warmValueIndexes() to write pre-accumulated values in one shot.
+     */
     public function setItems(array $items): static
     {
         $this->items = $items;

--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Stache\Indexes\Terms;
 
+use Statamic\Facades\Stache;
 use Statamic\Facades\Taxonomy;
 use Statamic\Stache\Indexes\Index;
 use Statamic\Support\Str;
@@ -13,6 +14,35 @@ class Associations extends Index
         return Taxonomy::findByHandle($handle = $this->store->childKey())
             ->collections()
             ->flatMap(function ($collection) use ($handle) {
+                $entriesStore = Stache::store('entries')->store($collection->handle());
+                $collectionHandle = $collection->handle();
+
+                // Fast path: warmValueIndexes() already built entries' category index in Redis.
+                $storeKey = $entriesStore->key();
+                $cacheKey = "stache::indexes::{$storeKey}::{$handle}";
+                $taxData = Stache::cacheStore()->get($cacheKey);
+
+                if ($taxData !== null) {
+                    $taxValues = collect($taxData)->filter(fn ($v) => ! empty($v));
+                    $siteData = Stache::cacheStore()->get("stache::indexes::{$storeKey}::site");
+                    $sites = $siteData !== null ? collect($siteData) : null;
+
+                    return $taxValues->flatMap(function ($value, $entryId) use ($collectionHandle, $entriesStore, $sites) {
+                        $site = $sites !== null
+                            ? $sites->get($entryId)
+                            : $entriesStore->getItem($entryId)?->locale();
+
+                        return collect((array) $value)->map(fn ($v) => [
+                            'value'      => $v,
+                            'slug'       => Str::slug($v),
+                            'entry'      => $entryId,
+                            'collection' => $collectionHandle,
+                            'site'       => $site,
+                        ]);
+                    });
+                }
+
+                // Cold path fallback (fires outside of a 2-pass warm, e.g. in tests or direct calls).
                 return $collection->queryEntries()
                     ->where($handle, '<>', null)
                     ->get()
@@ -20,11 +50,11 @@ class Associations extends Index
                         return collect($entry->value($handle))
                             ->map(function ($value) use ($entry) {
                                 return [
-                                    'value' => $value,
-                                    'slug' => Str::slug($value),
-                                    'entry' => $entry->id(),
+                                    'value'      => $value,
+                                    'slug'       => Str::slug($value),
+                                    'entry'      => $entry->id(),
                                     'collection' => $entry->collectionHandle(),
-                                    'site' => $entry->locale(),
+                                    'site'       => $entry->locale(),
                                 ];
                             });
                     })->all();

--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -9,6 +9,20 @@ use Statamic\Support\Str;
 
 class Associations extends Index
 {
+    /**
+     * Builds the term→entry association map for a taxonomy.
+     *
+     * This index is the reason warm() runs in two passes. Associations needs to know
+     * which entries reference each term, but the only way to find that (without loading
+     * every Entry from disk) is to read the entries' already-warmed taxonomy index from
+     * Redis. The 2-pass warm guarantees that index exists before this method is called.
+     *
+     * Fast path (used during stache:warm): reads the flat `[entryId => termValue]` and
+     * `[entryId => site]` arrays directly from Redis — no Entry objects are constructed.
+     *
+     * Cold path (used outside of stache:warm, e.g. on-demand index builds): queries
+     * entries via Eloquent as before. Slower but always correct.
+     */
     public function getItems()
     {
         return Taxonomy::findByHandle($handle = $this->store->childKey())
@@ -17,12 +31,11 @@ class Associations extends Index
                 $entriesStore = Stache::store('entries')->store($collection->handle());
                 $collectionHandle = $collection->handle();
 
-                // Fast path: warmValueIndexes() already built entries' category index in Redis.
                 $storeKey = $entriesStore->key();
-                $cacheKey = "stache::indexes::{$storeKey}::{$handle}";
-                $taxData = Stache::cacheStore()->get($cacheKey);
+                $taxData = Stache::cacheStore()->get("stache::indexes::{$storeKey}::{$handle}");
 
                 if ($taxData !== null) {
+                    // Fast path: entries' value indexes are already in Redis (Pass 1 ran first).
                     $taxValues = collect($taxData)->filter(fn ($v) => ! empty($v));
                     $siteData = Stache::cacheStore()->get("stache::indexes::{$storeKey}::site");
                     $sites = $siteData !== null ? collect($siteData) : null;
@@ -42,7 +55,7 @@ class Associations extends Index
                     });
                 }
 
-                // Cold path fallback (fires outside of a 2-pass warm, e.g. in tests or direct calls).
+                // Cold path: Redis miss — fall back to querying entries directly.
                 return $collection->queryEntries()
                     ->where($handle, '<>', null)
                     ->get()

--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -5,74 +5,37 @@ namespace Statamic\Stache\Indexes\Terms;
 use Statamic\Facades\Stache;
 use Statamic\Facades\Taxonomy;
 use Statamic\Stache\Indexes\Index;
+use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
 class Associations extends Index
 {
     /**
-     * Builds the term→entry association map for a taxonomy.
+     * Builds the term→entry association map for a taxonomy from the entries
+     * stores' value indexes rather than by loading every Entry from disk.
      *
-     * This index is the reason warm() runs in two passes. Associations needs to know
-     * which entries reference each term, but the only way to find that (without loading
-     * every Entry from disk) is to read the entries' already-warmed taxonomy index from
-     * the cache. The 2-pass warm guarantees that index exists before this method is called.
-     *
-     * Fast path (used during stache:warm): reads the flat `[entryId => termValue]` and
-     * `[entryId => site]` arrays directly from the cache — no Entry objects are constructed.
-     *
-     * Cold path (used outside of stache:warm, e.g. on-demand index builds): queries
-     * entries via Eloquent as before. Slower but always correct.
+     * During stache:warm those indexes are already cached (Pass 1 runs before
+     * this index is built in Pass 2). Outside of warming they'll be built on
+     * demand, which costs the same as the old query-based approach did.
      */
     public function getItems()
     {
         return Taxonomy::findByHandle($handle = $this->store->childKey())
             ->collections()
             ->flatMap(function ($collection) use ($handle) {
-                $entriesStore = Stache::store('entries')->store($collection->handle());
-                $collectionHandle = $collection->handle();
+                $entries = Stache::store('entries')->store($collection->handle());
+                $ids = $entries->index('id');
+                $sites = $entries->index('site');
 
-                $storeKey = $entriesStore->key();
-
-                // array of [entry_id => [term]]
-                $taxonomyData = collect(Stache::cacheStore()->get("stache::indexes::{$storeKey}::{$handle}"));
-
-                if ($taxonomyData->isNotEmpty()) {
-                    // Fast path: entries' value indexes are already in the cache (Pass 1 ran first).
-                    $sites = collect(Stache::cacheStore()->get("stache::indexes::{$storeKey}::site"));
-
-                    return $taxonomyData
-                        ->filter(fn (?array $entryTerms): bool => ! empty($entryTerms))
-                        ->flatMap(function (array $terms, string|int $entryId) use ($collectionHandle, $entriesStore, $sites) {
-                            $site = $sites->isNotEmpty()
-                                ? $sites->get($entryId)
-                                : $entriesStore->getItem($entryId)?->locale();
-
-                            return collect($terms)->map(fn (string $term) => [
-                                'value' => $term,
-                                'slug' => Str::slug($term),
-                                'entry' => $entryId,
-                                'collection' => $collectionHandle,
-                                'site' => $site,
-                            ]);
-                        });
-                }
-
-                // Cold path: Redis miss — fall back to querying entries directly.
-                return $collection->queryEntries()
-                    ->where($handle, '<>', null)
-                    ->get()
-                    ->flatMap(function ($entry) use ($handle) {
-                        return collect($entry->value($handle))
-                            ->map(function ($value) use ($entry) {
-                                return [
-                                    'value' => $value,
-                                    'slug' => Str::slug($value),
-                                    'entry' => $entry->id(),
-                                    'collection' => $entry->collectionHandle(),
-                                    'site' => $entry->locale(),
-                                ];
-                            });
-                    })->all();
+                return $entries->index($handle)->items()
+                    ->filter()
+                    ->flatMap(fn ($terms, $key) => collect(Arr::wrap($terms))->map(fn ($term) => [
+                        'value' => $term,
+                        'slug' => Str::slug($term),
+                        'entry' => $ids->get($key),
+                        'collection' => $collection->handle(),
+                        'site' => $sites->get($key),
+                    ]));
             })->all();
     }
 

--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -36,20 +36,20 @@ class Associations extends Index
                 // array of [entry_id => [term]]
                 $taxonomyData = collect(Stache::cacheStore()->get("stache::indexes::{$storeKey}::{$handle}"));
 
-                if (! is_null($taxonomyData)) {
+                if ($taxonomyData->isNotEmpty()) {
                     // Fast path: entries' value indexes are already in the cache (Pass 1 ran first).
                     $sites = collect(Stache::cacheStore()->get("stache::indexes::{$storeKey}::site"));
 
                     return $taxonomyData
-                        ->filter(fn (?array $entryTerms) => ! empty($entryTerms))
-                        ->flatMap(function ($value, $entryId) use ($collectionHandle, $entriesStore, $sites) {
+                        ->filter(fn (?array $entryTerms): bool => ! empty($entryTerms))
+                        ->flatMap(function (array $terms, string|int $entryId) use ($collectionHandle, $entriesStore, $sites) {
                             $site = $sites->isNotEmpty()
                                 ? $sites->get($entryId)
                                 : $entriesStore->getItem($entryId)?->locale();
 
-                            return collect((array) $value)->map(fn ($v) => [
-                                'value' => $v,
-                                'slug' => Str::slug($v),
+                            return collect($terms)->map(fn (string $term) => [
+                                'value' => $term,
+                                'slug' => Str::slug($term),
                                 'entry' => $entryId,
                                 'collection' => $collectionHandle,
                                 'site' => $site,

--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -15,10 +15,10 @@ class Associations extends Index
      * This index is the reason warm() runs in two passes. Associations needs to know
      * which entries reference each term, but the only way to find that (without loading
      * every Entry from disk) is to read the entries' already-warmed taxonomy index from
-     * Redis. The 2-pass warm guarantees that index exists before this method is called.
+     * the cache. The 2-pass warm guarantees that index exists before this method is called.
      *
      * Fast path (used during stache:warm): reads the flat `[entryId => termValue]` and
-     * `[entryId => site]` arrays directly from Redis — no Entry objects are constructed.
+     * `[entryId => site]` arrays directly from the cache — no Entry objects are constructed.
      *
      * Cold path (used outside of stache:warm, e.g. on-demand index builds): queries
      * entries via Eloquent as before. Slower but always correct.
@@ -32,27 +32,29 @@ class Associations extends Index
                 $collectionHandle = $collection->handle();
 
                 $storeKey = $entriesStore->key();
-                $taxData = Stache::cacheStore()->get("stache::indexes::{$storeKey}::{$handle}");
 
-                if ($taxData !== null) {
-                    // Fast path: entries' value indexes are already in Redis (Pass 1 ran first).
-                    $taxValues = collect($taxData)->filter(fn ($v) => ! empty($v));
-                    $siteData = Stache::cacheStore()->get("stache::indexes::{$storeKey}::site");
-                    $sites = $siteData !== null ? collect($siteData) : null;
+                // array of [entry_id => [term]]
+                $taxonomyData = collect(Stache::cacheStore()->get("stache::indexes::{$storeKey}::{$handle}"));
 
-                    return $taxValues->flatMap(function ($value, $entryId) use ($collectionHandle, $entriesStore, $sites) {
-                        $site = $sites !== null
-                            ? $sites->get($entryId)
-                            : $entriesStore->getItem($entryId)?->locale();
+                if (! is_null($taxonomyData)) {
+                    // Fast path: entries' value indexes are already in the cache (Pass 1 ran first).
+                    $sites = collect(Stache::cacheStore()->get("stache::indexes::{$storeKey}::site"));
 
-                        return collect((array) $value)->map(fn ($v) => [
-                            'value' => $v,
-                            'slug' => Str::slug($v),
-                            'entry' => $entryId,
-                            'collection' => $collectionHandle,
-                            'site' => $site,
-                        ]);
-                    });
+                    return $taxonomyData
+                        ->filter(fn (?array $entryTerms) => ! empty($entryTerms))
+                        ->flatMap(function ($value, $entryId) use ($collectionHandle, $entriesStore, $sites) {
+                            $site = $sites->isNotEmpty()
+                                ? $sites->get($entryId)
+                                : $entriesStore->getItem($entryId)?->locale();
+
+                            return collect((array) $value)->map(fn ($v) => [
+                                'value' => $v,
+                                'slug' => Str::slug($v),
+                                'entry' => $entryId,
+                                'collection' => $collectionHandle,
+                                'site' => $site,
+                            ]);
+                        });
                 }
 
                 // Cold path: Redis miss — fall back to querying entries directly.

--- a/src/Stache/Indexes/Terms/Associations.php
+++ b/src/Stache/Indexes/Terms/Associations.php
@@ -46,11 +46,11 @@ class Associations extends Index
                             : $entriesStore->getItem($entryId)?->locale();
 
                         return collect((array) $value)->map(fn ($v) => [
-                            'value'      => $v,
-                            'slug'       => Str::slug($v),
-                            'entry'      => $entryId,
+                            'value' => $v,
+                            'slug' => Str::slug($v),
+                            'entry' => $entryId,
                             'collection' => $collectionHandle,
-                            'site'       => $site,
+                            'site' => $site,
                         ]);
                     });
                 }
@@ -63,11 +63,11 @@ class Associations extends Index
                         return collect($entry->value($handle))
                             ->map(function ($value) use ($entry) {
                                 return [
-                                    'value'      => $value,
-                                    'slug'       => Str::slug($value),
-                                    'entry'      => $entry->id(),
+                                    'value' => $value,
+                                    'slug' => Str::slug($value),
+                                    'entry' => $entry->id(),
                                     'collection' => $entry->collectionHandle(),
-                                    'site'       => $entry->locale(),
+                                    'site' => $entry->locale(),
                                 ];
                             });
                     })->all();

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -137,6 +137,10 @@ class Stache
         if ($this->shouldUseParallelWarming($stores)) {
             $this->warmInParallel($stores);
         } else {
+            // Two-pass warm: Pass 1 writes all Value indexes (including entries' taxonomy
+            // indexes) to Redis across every store before Pass 2 runs. This lets
+            // Terms\Associations read from Redis in Pass 2 instead of loading all Entry
+            // objects from disk, which was the main source of slow warm times.
             $stores->each->warmValueIndexes();
             $stores->each->warmOtherIndexes();
         }

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -137,7 +137,8 @@ class Stache
         if ($this->shouldUseParallelWarming($stores)) {
             $this->warmInParallel($stores);
         } else {
-            $stores->each->warm();
+            $stores->each->warmValueIndexes();
+            $stores->each->warmOtherIndexes();
         }
 
         $this->stopTimer();

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -137,10 +137,10 @@ class Stache
         if ($this->shouldUseParallelWarming($stores)) {
             $this->warmInParallel($stores);
         } else {
-            // Two-pass warm: Pass 1 writes all Value indexes (including entries' taxonomy
-            // indexes) to Redis across every store before Pass 2 runs. This lets
-            // Terms\Associations read from Redis in Pass 2 instead of loading all Entry
-            // objects from disk, which was the main source of slow warm times.
+            // Two-pass warm: Pass 1 caches all per-item value indexes (including entries'
+            // taxonomy indexes) across every store before Pass 2 runs. This lets
+            // Terms\Associations read from the cache in Pass 2 instead of loading all
+            // Entry objects from disk, which was the main source of slow warm times.
             $stores->each->warmValueIndexes();
             $stores->each->warmOtherIndexes();
         }

--- a/src/Stache/Stores/AggregateStore.php
+++ b/src/Stache/Stores/AggregateStore.php
@@ -94,6 +94,16 @@ abstract class AggregateStore extends Store
         $this->stores->each->resetMemoizedState();
     }
 
+    public function warmValueIndexes()
+    {
+        $this->discoverStores()->each->warmValueIndexes();
+    }
+
+    public function warmOtherIndexes()
+    {
+        $this->discoverStores()->each->warmOtherIndexes();
+    }
+
     public function paths()
     {
         return $this->discoverStores()->flatMap(function ($store) {

--- a/src/Stache/Stores/AggregateStore.php
+++ b/src/Stache/Stores/AggregateStore.php
@@ -94,11 +94,13 @@ abstract class AggregateStore extends Store
         $this->stores->each->resetMemoizedState();
     }
 
+    /** @see Store::warmValueIndexes() */
     public function warmValueIndexes()
     {
         $this->discoverStores()->each->warmValueIndexes();
     }
 
+    /** @see Store::warmOtherIndexes() */
     public function warmOtherIndexes()
     {
         $this->discoverStores()->each->warmOtherIndexes();

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -414,6 +414,12 @@ abstract class Store
         $this->warmOtherIndexes();
     }
 
+    /**
+     * Pass 1 of the 2-pass warm. Loads every file once and accumulates values for
+     * all Value-based indexes in a single loop, then writes each index to Redis in
+     * one shot. This ensures entries' taxonomy indexes (e.g. `categories`) are in
+     * Redis before Pass 2 runs, so Terms\Associations can use the fast path.
+     */
     public function warmValueIndexes()
     {
         $valueIndexes = $this->resolveIndexes()->filter(
@@ -435,6 +441,11 @@ abstract class Store
         });
     }
 
+    /**
+     * Pass 2 of the 2-pass warm. Runs after all stores have completed Pass 1, so
+     * non-Value indexes (e.g. Terms\Associations) can read from Redis instead of
+     * loading Entry objects from disk.
+     */
     public function warmOtherIndexes()
     {
         $this->resolveIndexes()

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -416,24 +416,14 @@ abstract class Store
 
     /**
      * Pass 1 of the 2-pass warm. Loads every file once and accumulates values for
-     * all Value-based indexes in a single loop, then writes each index to Redis in
-     * one shot. This ensures entries' taxonomy indexes (e.g. `categories`) are in
-     * Redis before Pass 2 runs, so Terms\Associations can use the fast path.
+     * all per-item value indexes in a single loop, then writes each index to the
+     * cache in one shot. This ensures entries' taxonomy indexes (e.g. `categories`)
+     * are cached before Pass 2 runs, so Terms\Associations can build from them.
      */
     public function warmValueIndexes()
     {
-        $valueIndexes = $this
-            ->resolveIndexes()
-            ->filter(
-                fn ($index) => method_exists($index, 'getItemValue')
-            );
+        $valueIndexes = $this->resolveIndexes()->filter(fn ($index) => $this->isPerItemValueIndex($index));
 
-        /*
-            This sets up a structure like ['fieldName' => [], 'anotherField' => []] before the loop below
-            it iterates over every item in the store. Each inner array then gets populated with $key => $value
-            pairs as items are processed, so all items are batched by index rather than writing to cache one at a time.
-            It's a performance optimization — collect everything first, then flush each index to cache in one shot on line 449.
-        */
         $accumulated = $valueIndexes->map(fn () => [])->all();
 
         foreach ($this->paths()->keys() as $key) {
@@ -451,14 +441,19 @@ abstract class Store
 
     /**
      * Pass 2 of the 2-pass warm. Runs after all stores have completed Pass 1, so
-     * non-Value indexes (e.g. Terms\Associations) can read from Redis instead of
-     * loading Entry objects from disk.
+     * indexes that depend on other indexes (e.g. Terms\Associations) can read
+     * them from the cache instead of loading Entry objects from disk.
      */
     public function warmOtherIndexes()
     {
+        $this->shouldCacheFileItems = true;
+
         $this->resolveIndexes()
-            ->filter(fn ($index) => ! method_exists($index, 'getItemValue'))
+            ->reject(fn ($index) => $this->isPerItemValueIndex($index))
             ->each->update();
+
+        $this->shouldCacheFileItems = false;
+        $this->fileItems = null;
     }
 
     public function keys()
@@ -468,5 +463,16 @@ abstract class Store
         }
 
         return $this->keys = (new Keys($this))->load();
+    }
+
+    /**
+     * Whether an index can be built purely by mapping getItemValue() over each item.
+     * Subclasses of Value that override getItems() (e.g. Terms\Value, which merges in
+     * on-the-fly terms) need their own build logic and belong in Pass 2.
+     */
+    private function isPerItemValueIndex(Index $index): bool
+    {
+        return $index instanceof Indexes\Value
+            && (new \ReflectionMethod($index, 'getItems'))->getDeclaringClass()->getName() === Indexes\Value::class;
     }
 }

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -422,10 +422,18 @@ abstract class Store
      */
     public function warmValueIndexes()
     {
-        $valueIndexes = $this->resolveIndexes()->filter(
-            fn ($index) => method_exists($index, 'getItemValue')
-        );
+        $valueIndexes = $this
+            ->resolveIndexes()
+            ->filter(
+                fn ($index) => method_exists($index, 'getItemValue')
+            );
 
+        /*
+            This sets up a structure like ['fieldName' => [], 'anotherField' => []] before the loop below
+            it iterates over every item in the store. Each inner array then gets populated with $key => $value
+            pairs as items are processed, so all items are batched by index rather than writing to cache one at a time.
+            It's a performance optimization — collect everything first, then flush each index to cache in one shot on line 449.
+        */
         $accumulated = $valueIndexes->map(fn () => [])->all();
 
         foreach ($this->paths()->keys() as $key) {

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -410,12 +410,36 @@ abstract class Store
 
     public function warm()
     {
-        $this->shouldCacheFileItems = true;
+        $this->warmValueIndexes();
+        $this->warmOtherIndexes();
+    }
 
-        $this->resolveIndexes()->each->update();
+    public function warmValueIndexes()
+    {
+        $valueIndexes = $this->resolveIndexes()->filter(
+            fn ($index) => method_exists($index, 'getItemValue')
+        );
 
-        $this->shouldCacheFileItems = false;
-        $this->fileItems = null;
+        $accumulated = $valueIndexes->map(fn () => [])->all();
+
+        foreach ($this->paths()->keys() as $key) {
+            $item = $this->getItem($key);
+
+            foreach ($valueIndexes as $name => $index) {
+                $accumulated[$name][$key] = $index->getItemValue($item);
+            }
+        }
+
+        $valueIndexes->each(function ($index, $name) use ($accumulated) {
+            $index->setItems($accumulated[$name])->cache();
+        });
+    }
+
+    public function warmOtherIndexes()
+    {
+        $this->resolveIndexes()
+            ->filter(fn ($index) => ! method_exists($index, 'getItemValue'))
+            ->each->update();
     }
 
     public function keys()

--- a/tests/Stache/StacheTest.php
+++ b/tests/Stache/StacheTest.php
@@ -226,4 +226,26 @@ class StacheTest extends TestCase
             ['value' => 'bravo', 'slug' => 'bravo', 'entry' => '2', 'collection' => 'blog', 'site' => 'en'],
         ], StacheFacade::store('terms')->store('tags')->index('associations')->items()->all());
     }
+
+    #[Test]
+    public function warming_includes_on_the_fly_terms_in_term_value_indexes()
+    {
+        Taxonomy::make('tags')->save();
+        CollectionFacade::make('blog')->taxonomies(['tags'])->save();
+        Term::make('alfa')->taxonomy('tags')->data(['title' => 'Alfa'])->save();
+        EntryFactory::collection('blog')->id('1')->slug('one')->data(['tags' => ['alfa', 'bravo']])->create();
+
+        StacheFacade::clear();
+        StacheFacade::warm();
+
+        $store = StacheFacade::store('terms')->store('tags');
+
+        $this->assertEquals([
+            ['value' => 'alfa', 'slug' => 'alfa', 'entry' => '1', 'collection' => 'blog', 'site' => 'en'],
+            ['value' => 'bravo', 'slug' => 'bravo', 'entry' => '1', 'collection' => 'blog', 'site' => 'en'],
+        ], $store->index('associations')->items()->all());
+
+        $this->assertEquals(['en::alfa' => 'alfa', 'en::bravo' => 'bravo'], $store->index('slug')->items()->all());
+        $this->assertEquals(['en::alfa' => 'en', 'en::bravo' => 'en'], $store->index('site')->items()->all());
+    }
 }

--- a/tests/Stache/StacheTest.php
+++ b/tests/Stache/StacheTest.php
@@ -2,21 +2,30 @@
 
 namespace Tests\Stache;
 
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Blink;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Collection as CollectionFacade;
+use Statamic\Facades\Stache as StacheFacade;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
 use Statamic\Stache\NullLockStore;
 use Statamic\Stache\Stache;
 use Statamic\Stache\Stores\ChildStore;
 use Statamic\Stache\Stores\CollectionsStore;
 use Statamic\Stache\Stores\EntriesStore;
 use Symfony\Component\Lock\LockFactory;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class StacheTest extends TestCase
 {
+    use PreventSavingStacheItemsToDisk;
+
     protected $stache;
 
     public function setUp(): void
@@ -194,5 +203,27 @@ class StacheTest extends TestCase
             ['local', 'config' => null, 'expected' => false],
             ['production', 'config' => null, 'expected' => false],
         ];
+    }
+
+    #[Test]
+    public function warming_builds_term_associations_for_single_item_taxonomy_fields()
+    {
+        Taxonomy::make('tags')->save();
+        CollectionFacade::make('blog')->taxonomies(['tags'])->save();
+        Blueprint::make('blog')->setNamespace('collections.blog')->setContents(['fields' => [
+            ['handle' => 'tags', 'field' => ['type' => 'terms', 'taxonomies' => ['tags'], 'max_items' => 1]],
+        ]])->save();
+        Term::make('alfa')->taxonomy('tags')->data(['title' => 'Alfa'])->save();
+        EntryFactory::collection('blog')->id('1')->slug('one')->data(['tags' => 'alfa'])->create();
+        EntryFactory::collection('blog')->id('2')->slug('two')->data(['tags' => 'bravo'])->create();
+        EntryFactory::collection('blog')->id('3')->slug('three')->data([])->create();
+
+        StacheFacade::clear();
+        StacheFacade::warm();
+
+        $this->assertEquals([
+            ['value' => 'alfa', 'slug' => 'alfa', 'entry' => '1', 'collection' => 'blog', 'site' => 'en'],
+            ['value' => 'bravo', 'slug' => 'bravo', 'entry' => '2', 'collection' => 'blog', 'site' => 'en'],
+        ], StacheFacade::store('terms')->store('tags')->index('associations')->items()->all());
     }
 }


### PR DESCRIPTION
On our largest site, stache refreshing took 7-8 mins, which is too close to Forge's 10 mins deployment limit.

I proposed a 2 pass approach to Claude to see if it was feasible and this code results in over a 2 min decrease on my machine, from ~7:30 to ~5:15.