### PR TITLE
[6.x] Make the whole radio/checkbox item clickable

### DIFF
--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -79,7 +79,7 @@ const containerClasses = computed(() => {
         },
     })({ ...props });
 
-    const chipsClass = 'items-center gap-2 border border-gray-300 dark:border-gray-700 mb-0 p-2 py-2 pe-3 shadow-ui-xs rounded-xl [&_button]:mt-0';
+    const chipsClass = 'mb-0 items-center gap-1.5 rounded-xl border border-gray-300 bg-linear-to-b from-white to-white p-2 py-2 pe-4 shadow-ui-sm transition-[background] hover:bg-gray-50 hover:to-gray-50 with-contrast:border-gray-500 dark:border-gray-700/80 dark:from-gray-850 dark:to-gray-900 dark:shadow-ui-md dark:hover:bg-gray-900 dark:hover:to-gray-850 [&_button]:mt-0';
 
     return twMerge(classes, appearance.value === 'chips' ? chipsClass : null, attrs.class);
 });

--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -132,7 +132,7 @@ const conditionalProps = computed(() => {
             </span>
         </CheckboxRoot>
         <div class="flex flex-col" v-if="!solo">
-            <label class="text-sm font-normal antialiased dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
+            <label class="text-sm font-normal antialiased cursor-pointer dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
                 <slot>{{ label || value }}</slot>
             </label>
             <p v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500 dark:text-gray-200">{{ description }}</p>

--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -70,7 +70,7 @@ const checkboxClasses = computed(() => {
 
 const containerClasses = computed(() => {
     const classes = cva({
-        base: 'flex gap-2',
+        base: 'relative flex gap-2',
         variants: {
             align: {
                 start: 'items-start',
@@ -132,7 +132,7 @@ const conditionalProps = computed(() => {
             </span>
         </CheckboxRoot>
         <div class="flex flex-col" v-if="!solo">
-            <label class="text-sm font-normal antialiased dark:text-gray-200" :for="id">
+            <label class="text-sm font-normal antialiased dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
                 <slot>{{ label || value }}</slot>
             </label>
             <p v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500 dark:text-gray-200">{{ description }}</p>

--- a/resources/js/components/ui/Radio/Item.vue
+++ b/resources/js/components/ui/Radio/Item.vue
@@ -21,7 +21,7 @@ const id = useId();
 
 <template>
     <div
-        class="flex items-start gap-1.5"
+        class="relative flex items-start gap-1.5"
         :class="appearance === 'chips' ? 'border border-gray-300 dark:border-gray-700 mb-0 p-2 py-2 pe-4 shadow-ui-xs rounded-full' : null"
         data-ui-radio-item
     >
@@ -29,6 +29,7 @@ const id = useId();
             :id
             :value="value"
             :disabled="readOnly || disabled"
+            :aria-describedby="description ? `${id}-description` : undefined"
             class="
                 shadow-ui-xs mt-0.5 size-4 cursor-default rounded-full
                 focus:focus-outline border border-gray-400/75 bg-white with-contrast:border-gray-100
@@ -46,11 +47,11 @@ const id = useId();
                 "
             />
         </RadioGroupItem>
-        <label class="flex flex-col" :class="{ 'opacity-50': disabled }" :for="id">
-            <span class="text-sm font-normal antialiased dark:text-gray-200">
+        <div class="flex flex-col" :class="{ 'opacity-50': disabled }">
+            <label class="text-sm font-normal antialiased dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
                 <slot>{{ label || value }}</slot>
-            </span>
-            <span v-if="description" class="mt-0.5 block text-xs leading-snug text-gray-500">{{ description }}</span>
-        </label>
+            </label>
+            <span v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500">{{ description }}</span>
+        </div>
     </div>
 </template>

--- a/resources/js/components/ui/Radio/Item.vue
+++ b/resources/js/components/ui/Radio/Item.vue
@@ -48,7 +48,7 @@ const id = useId();
             />
         </RadioGroupItem>
         <div class="flex flex-col" :class="{ 'opacity-50': disabled }">
-            <label class="text-sm font-normal antialiased dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
+            <label class="text-sm font-normal antialiased cursor-pointer dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
                 <slot>{{ label || value }}</slot>
             </label>
             <span v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500">{{ description }}</span>

--- a/resources/js/components/ui/Radio/Item.vue
+++ b/resources/js/components/ui/Radio/Item.vue
@@ -22,7 +22,7 @@ const id = useId();
 <template>
     <div
         class="relative flex items-start gap-1.5"
-        :class="appearance === 'chips' ? 'border border-gray-300 dark:border-gray-700 mb-0 p-2 py-2 pe-4 shadow-ui-xs rounded-full' : null"
+        :class="appearance === 'chips' ? 'mb-0 rounded-full border border-gray-300 bg-linear-to-b from-white to-white p-2 py-2 pe-4 shadow-ui-sm transition-[background] hover:bg-gray-50 hover:to-gray-50 with-contrast:border-gray-500 dark:border-gray-700/80 dark:from-gray-850 dark:to-gray-900 dark:shadow-ui-md dark:hover:bg-gray-900 dark:hover:to-gray-850' : null"
         data-ui-radio-item
     >
         <RadioGroupItem


### PR DESCRIPTION
This pull request makes the entire radio and checkbox item — including the padding and empty space around the control and label — clickable, rather than only the control and label text.

Previously the clickable area was limited to the Reka control (`CheckboxRoot` / `RadioGroupItem`) and the `<label>` wrapping the label text. This meant clicking the surrounding padding of a chip (or the description) did nothing.

This PR fixes it by stretching the inner `<label>`'s hit-area across the whole item using an absolutely-positioned `before` pseudo-element (`before:absolute before:inset-0`), with the container made `relative` to anchor it. The label keeps its `for`/`id` association to the control, so clicks anywhere in the item forward a single activation to the checkbox/radio.

This PR also tidies up the radio item's accessibility by giving the description an `id` and wiring it to the control via `aria-describedby`, matching the checkbox component.