### PR TITLE
[6.x] Make the ranking fieldtype orderable with just the keyboard

### DIFF
--- a/resources/js/components/fieldtypes/RankingFieldtype.vue
+++ b/resources/js/components/fieldtypes/RankingFieldtype.vue
@@ -66,6 +66,36 @@ watch(
     { deep: true },
 );
 
+function moveToRank(itemValue, newRank) {
+    if (isDisabled.value) {
+        return;
+    }
+
+    const fromIndex = rankedValues.value.indexOf(itemValue);
+
+    if (fromIndex === -1) {
+        return;
+    }
+
+    const parsed = Number(newRank);
+
+    if (! Number.isFinite(parsed)) {
+        return;
+    }
+
+    let toIndex = Math.round(parsed) - 1;
+    toIndex = Math.max(0, Math.min(rankedValues.value.length - 1, toIndex));
+
+    if (fromIndex === toIndex) {
+        return;
+    }
+
+    const next = [...rankedValues.value];
+    next.splice(fromIndex, 1);
+    next.splice(toIndex, 0, itemValue);
+    rankedValues.value = next;
+}
+
 </script>
 
 <template>
@@ -90,7 +120,19 @@ watch(
                     :class="sortableHandleClass"
                     class="cursor-grab [&_svg]:opacity-75 dark:[&_svg]:opacity-50"
                 />
+                <input
+                    v-if="!isDisabled"
+                    type="number"
+                    class="size-6 shrink-0 rounded-md border border-gray-300 bg-white px-0 text-center text-xs font-semibold text-gray-800 shadow-ui-xs focus:focus-outline dark:border-gray-700 dark:bg-gray-925 dark:text-gray-200 [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                    :min="1"
+                    :max="orderedRows.length"
+                    step="1"
+                    :value="row.index + 1"
+                    :aria-label="`${__('Rank')} ${__(row.label)}`"
+                    @change="moveToRank(row.value, $event.target.value)"
+                >
                 <span
+                    v-else
                     class="flex size-6 shrink-0 items-center justify-center rounded-md border border-gray-300 shadow-ui-xs bg-white text-xs font-semibold text-gray-800 dark:border-gray-700 dark:bg-gray-925 dark:text-gray-200"
                     aria-hidden="true"
                 >

--- a/resources/js/components/fieldtypes/RankingFieldtype.vue
+++ b/resources/js/components/fieldtypes/RankingFieldtype.vue
@@ -46,26 +46,6 @@ function buildRankedValues(value) {
     return ranked;
 }
 
-watch(
-    [() => props.value, options],
-    () => rankedValues.value = buildRankedValues(props.value),
-    { deep: true, immediate: true },
-);
-
-watch(
-    rankedValues,
-    (value) => {
-        const current = Array.isArray(props.value) ? props.value : [];
-
-        if (JSON.stringify(value) === JSON.stringify(current)) {
-            return;
-        }
-
-        update([...value]);
-    },
-    { deep: true },
-);
-
 function moveToRank(itemValue, event) {
     const fromIndex = rankedValues.value.indexOf(itemValue);
     const parsed = Number(event.target.value);
@@ -87,6 +67,25 @@ function moveToRank(itemValue, event) {
     event.target.value = rankedValues.value.indexOf(itemValue) + 1;
 }
 
+watch(
+    [() => props.value, options],
+    () => rankedValues.value = buildRankedValues(props.value),
+    { deep: true, immediate: true },
+);
+
+watch(
+    rankedValues,
+    (value) => {
+        const current = Array.isArray(props.value) ? props.value : [];
+
+        if (JSON.stringify(value) === JSON.stringify(current)) {
+            return;
+        }
+
+        update([...value]);
+    },
+    { deep: true },
+);
 </script>
 
 <template>

--- a/resources/js/components/fieldtypes/RankingFieldtype.vue
+++ b/resources/js/components/fieldtypes/RankingFieldtype.vue
@@ -66,34 +66,25 @@ watch(
     { deep: true },
 );
 
-function moveToRank(itemValue, newRank) {
-    if (isDisabled.value) {
-        return;
-    }
-
+function moveToRank(itemValue, event) {
     const fromIndex = rankedValues.value.indexOf(itemValue);
+    const parsed = Number(event.target.value);
 
-    if (fromIndex === -1) {
-        return;
+    if (! isDisabled.value && fromIndex !== -1 && Number.isFinite(parsed)) {
+        const toIndex = Math.max(0, Math.min(rankedValues.value.length - 1, Math.round(parsed) - 1));
+
+        if (toIndex !== fromIndex) {
+            const next = [...rankedValues.value];
+            next.splice(fromIndex, 1);
+            next.splice(toIndex, 0, itemValue);
+            rankedValues.value = next;
+        }
     }
 
-    const parsed = Number(newRank);
-
-    if (! Number.isFinite(parsed)) {
-        return;
-    }
-
-    let toIndex = Math.round(parsed) - 1;
-    toIndex = Math.max(0, Math.min(rankedValues.value.length - 1, toIndex));
-
-    if (fromIndex === toIndex) {
-        return;
-    }
-
-    const next = [...rankedValues.value];
-    next.splice(fromIndex, 1);
-    next.splice(toIndex, 0, itemValue);
-    rankedValues.value = next;
+    // Reset the input to the item's canonical rank. When the requested rank is
+    // clamped to the item's current position no reorder happens, so the binding
+    // wouldn't otherwise overwrite the invalid value left in the input.
+    event.target.value = rankedValues.value.indexOf(itemValue) + 1;
 }
 
 </script>
@@ -129,7 +120,7 @@ function moveToRank(itemValue, newRank) {
                     step="1"
                     :value="row.index + 1"
                     :aria-label="`${__('Rank')} ${__(row.label)}`"
-                    @change="moveToRank(row.value, $event.target.value)"
+                    @change="moveToRank(row.value, $event)"
                 >
                 <span
                     v-else

--- a/resources/js/components/fieldtypes/RankingFieldtype.vue
+++ b/resources/js/components/fieldtypes/RankingFieldtype.vue
@@ -146,3 +146,10 @@ function moveToRank(itemValue, newRank) {
         </ul>
     </SortableList>
 </template>
+
+<style scoped>
+.ranking-item.draggable-source--is-dragging {
+    /* Make the item slightly transparent than the default dragging opacity */
+    opacity: 0.65;
+}
+</style>

--- a/resources/js/components/fieldtypes/RankingFieldtype.vue
+++ b/resources/js/components/fieldtypes/RankingFieldtype.vue
@@ -62,7 +62,7 @@ function moveToRank(itemValue, event) {
     }
 
     // Reset the input to the item's canonical rank. When the requested rank is
-    // clamped to the item's current position no reorder happens, so the binding
+    // clamped to the item's current position, no reorder happens, so the binding
     // wouldn't otherwise overwrite the invalid value left in the input.
     event.target.value = rankedValues.value.indexOf(itemValue) + 1;
 }

--- a/resources/js/components/ui/DragHandle.vue
+++ b/resources/js/components/ui/DragHandle.vue
@@ -4,6 +4,7 @@ import DragDots from '@/../svg/drag-dots.svg';
 
 <template>
     <button
+        tabindex="-1"
         class="h-full cursor-grab flex items-center justify-center text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-gray-400"
         data-drag-handle
         :aria-label="__('Drag to reorder')"


### PR DESCRIPTION
## Description of the Problem

The ranking field type is not currently usable without a mouse

## What this PR Does

Allows you to interact with the field using your keyboard. In some ways this is even preferable to dragging tbh!

## How to Reproduce

1. Add the ranking field
2. Tab into it and change the numbers