### PR TITLE
[6.x] Change `shouldBootRootItems` visibility in `AddonServiceProvider`

### DIFF
--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -882,7 +882,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $autoloadable;
     }
 
-    private function shouldBootRootItems()
+    protected function shouldBootRootItems()
     {
         $addon = $this->getAddon();
 


### PR DESCRIPTION
This PR changes `shouldBootRootItems` visibility from private to protected, so inheriting classes can use it.

For example, I want to overwrite the logic of how my addon config is published and still prevent multiple boots by calling this from within the overwritten `bootConfig()` method:
```php
protected function bootConfig()
{
    if (! $this->shouldBootRootItems()) {
        return $this;
    }
```