### PR TITLE
[6.x] Autopopulate email on password reset form

### DIFF
--- a/resources/js/pages/auth/passwords/Reset.vue
+++ b/resources/js/pages/auth/passwords/Reset.vue
@@ -7,7 +7,7 @@ import { computed, ref, watch } from 'vue';
 
 defineOptions({ layout: Outside });
 
-const props = defineProps(['errors', 'action', 'token', 'email', 'redirect', 'title', 'loginUrl']);
+const props = defineProps(['errors', 'action', 'token', 'email', 'emailReadonly', 'redirect', 'title', 'loginUrl']);
 
 const errors = ref(props.errors);
 watch(() => props.errors, (newErrors) => errors.value = newErrors);
@@ -47,7 +47,7 @@ const submit = () => {
             class="flex flex-col gap-6"
         >
             <Field :label="__('Email Address')" :error="errors?.email">
-                <Input v-model="email" autofocus type="email" />
+                <Input v-model="email" :read-only="emailReadonly" autofocus type="email" />
             </Field>
 
             <Field :label="__('Password')" :error="errors?.password">

--- a/resources/js/pages/auth/passwords/Reset.vue
+++ b/resources/js/pages/auth/passwords/Reset.vue
@@ -47,11 +47,11 @@ const submit = () => {
             class="flex flex-col gap-6"
         >
             <Field :label="__('Email Address')" :error="errors?.email">
-                <Input v-model="email" :read-only="emailReadonly" autofocus type="email" />
+                <Input v-model="email" :read-only="emailReadonly" :focus="! emailReadonly" type="email" />
             </Field>
 
             <Field :label="__('Password')" :error="errors?.password">
-                <Input v-model="password" type="password" />
+                <Input v-model="password" :focus="emailReadonly" type="password" />
             </Field>
 
             <Field :label="__('Confirm Password')" :error="errors?.password_confirmation">

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -126,7 +126,7 @@ Route::group(['prefix' => 'auth'], function () {
 
         Route::get('password/reset', [ForgotPasswordController::class, 'showLinkRequestForm'])->name('password.request');
         Route::post('password/email', [ForgotPasswordController::class, 'sendResetLinkEmail'])->middleware('throttle:statamic.cp.auth')->name('password.email');
-        Route::get('password/reset/{token}', [ResetPasswordController::class, 'showResetForm'])->name('password.reset');
+        Route::get('password/reset/{token}', [ResetPasswordController::class, 'showResetForm'])->middleware('throttle:statamic.cp.password-reset-form')->name('password.reset');
         Route::post('password/reset', [ResetPasswordController::class, 'reset'])->middleware('throttle:statamic.cp.auth')->name('password.reset.action');
 
         if (TwoFactor::enabled()) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -52,7 +52,7 @@ Route::name('statamic.')->group(function () {
             });
 
             Route::post('password/email', [ForgotPasswordController::class, 'sendResetLinkEmail'])->middleware('throttle:statamic.auth')->name('password.email');
-            Route::get('password/reset/{token}', [ResetPasswordController::class, 'showResetForm'])->name('password.reset');
+            Route::get('password/reset/{token}', [ResetPasswordController::class, 'showResetForm'])->middleware('throttle:statamic.password-reset-form')->name('password.reset');
             Route::post('password/reset', [ResetPasswordController::class, 'reset'])->middleware('throttle:statamic.auth')->name('password.reset.action');
 
             if (config('statamic.users.elevated_sessions_enabled')) {
@@ -94,7 +94,7 @@ Route::name('statamic.')->group(function () {
         });
 
         Route::group(['prefix' => 'auth', 'middleware' => [CPAuthGuard::class]], function () {
-            Route::get('activate/{token}', [ActivateAccountController::class, 'showResetForm'])->name('account.activate');
+            Route::get('activate/{token}', [ActivateAccountController::class, 'showResetForm'])->middleware('throttle:statamic.password-reset-form')->name('account.activate');
             Route::post('activate', [ActivateAccountController::class, 'reset'])->name('account.activate.action');
         });
 

--- a/src/Auth/Passwords/TokenRepository.php
+++ b/src/Auth/Passwords/TokenRepository.php
@@ -71,6 +71,21 @@ class TokenRepository extends DatabaseTokenRepository
             && $this->hasher->check($token, $record['token']);
     }
 
+    public function findEmailByToken(#[\SensitiveParameter] string $token): ?string
+    {
+        foreach ($this->getResets() as $email => $record) {
+            if ($this->tokenExpired(Carbon::createFromTimestamp($record['created_at'], config('app.timezone')))) {
+                continue;
+            }
+
+            if ($this->hasher->check($token, $record['token'])) {
+                return $email;
+            }
+        }
+
+        return null;
+    }
+
     public function recentlyCreatedToken(CanResetPasswordContract $user)
     {
         $record = $this->getResets()->get($user->email());

--- a/src/Http/Controllers/ResetPasswordController.php
+++ b/src/Http/Controllers/ResetPasswordController.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Password;
 use Inertia\Inertia;
 use Statamic\Auth\Passwords\PasswordReset;
+use Statamic\Auth\Passwords\TokenRepository;
 use Statamic\Auth\ResetsPasswords;
 use Statamic\Contracts\Auth\User;
 use Statamic\Facades\URL;
@@ -27,14 +28,33 @@ class ResetPasswordController extends Controller
 
     public function showResetForm(Request $request, $token = null)
     {
+        $emailFromRequest = $request->email;
+        $email = $emailFromRequest ?: $this->emailForToken($token);
+
         return Inertia::render('auth/passwords/Reset', [
             'loginUrl' => cp_route('login'),
             'token' => $token,
-            'email' => $request->email,
+            'email' => $email,
+            'emailReadonly' => $email && ! $emailFromRequest,
             'action' => $this->resetFormAction(),
             'redirect' => $request->redirect,
             'title' => $this->resetFormTitle(),
         ]);
+    }
+
+    protected function emailForToken(?string $token): ?string
+    {
+        if (! $token) {
+            return null;
+        }
+
+        $repository = $this->broker()->getRepository();
+
+        if (! $repository instanceof TokenRepository) {
+            return null;
+        }
+
+        return $repository->findEmailByToken($token);
     }
 
     protected function resetFormAction()

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -181,6 +181,14 @@ class AuthServiceProvider extends ServiceProvider
             return RateLimiter::limiter('statamic.auth')($request);
         });
 
+        RateLimiter::for('statamic.password-reset-form', function (Request $request) {
+            return Limit::perMinute(15)->by($request->ip());
+        });
+
+        RateLimiter::for('statamic.cp.password-reset-form', function (Request $request) {
+            return RateLimiter::limiter('statamic.password-reset-form')($request);
+        });
+
         RateLimiter::for('statamic.passkeys', function (Request $request) {
             return Limit::perMinute(30)->by($request->ip());
         });

--- a/tests/Auth/ResetPasswordTest.php
+++ b/tests/Auth/ResetPasswordTest.php
@@ -164,4 +164,64 @@ class ResetPasswordTest extends TestCase
         $this->assertGuest();
         $this->assertTrue(Hash::check('newpassword', $user->fresh()->password()));
     }
+
+    #[Test]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_prefills_email_on_the_reset_form_from_the_token($type)
+    {
+        $user = $this->createUser();
+        $token = $this->createToken($user, $type);
+
+        $url = match ($type) {
+            'cp' => cp_route('password.reset', $token),
+            'web' => route('statamic.password.reset', $token),
+        };
+
+        $this
+            ->get($url)
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('auth/passwords/Reset')
+                ->where('email', 'san@holo.com')
+                ->where('emailReadonly', true)
+            );
+    }
+
+    #[Test]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_allows_email_to_be_provided_in_the_query_string($type)
+    {
+        $user = $this->createUser();
+        $token = $this->createToken($user, $type);
+
+        $url = match ($type) {
+            'cp' => cp_route('password.reset', $token),
+            'web' => route('statamic.password.reset', $token),
+        };
+
+        $this
+            ->get($url.'?email=other@example.com')
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('auth/passwords/Reset')
+                ->where('email', 'other@example.com')
+                ->where('emailReadonly', false)
+            );
+    }
+
+    #[Test]
+    public function it_prefills_email_on_the_account_activation_form_from_the_token()
+    {
+        $user = tap(User::make()->email('san@holo.com'))->save();
+        $token = $user->generateActivateAccountToken();
+
+        $this
+            ->get(route('statamic.account.activate', $token))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('auth/passwords/Reset')
+                ->where('email', 'san@holo.com')
+                ->where('emailReadonly', true)
+            );
+    }
 }

--- a/tests/Auth/ResetPasswordTest.php
+++ b/tests/Auth/ResetPasswordTest.php
@@ -224,4 +224,23 @@ class ResetPasswordTest extends TestCase
                 ->where('emailReadonly', true)
             );
     }
+
+    #[Test]
+    #[DataProvider('resetPasswordProvider')]
+    public function it_throttles_requests_to_the_reset_form($type)
+    {
+        $user = $this->createUser();
+        $token = $this->createToken($user, $type);
+
+        $url = match ($type) {
+            'cp' => cp_route('password.reset', $token),
+            'web' => route('statamic.password.reset', $token),
+        };
+
+        foreach (range(1, 15) as $i) {
+            $this->get($url)->assertOk();
+        }
+
+        $this->get($url)->assertStatus(429);
+    }
 }

--- a/tests/Auth/TokenRepositoryTest.php
+++ b/tests/Auth/TokenRepositoryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Auth;
+
+use Illuminate\Support\Facades\Password;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Auth\Passwords\PasswordReset;
+use Statamic\Auth\Passwords\TokenRepository;
+use Statamic\Facades\User;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class TokenRepositoryTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    private function repository(string $broker): TokenRepository
+    {
+        $broker = config('statamic.users.passwords.'.$broker);
+
+        if (is_array($broker)) {
+            $broker = $broker['cp'];
+        }
+
+        return Password::broker($broker)->getRepository();
+    }
+
+    #[Test]
+    public function it_finds_email_by_token()
+    {
+        $user = tap(User::make()->email('san@holo.com')->password('secret'))->save();
+
+        $token = Password::broker(config('statamic.users.passwords.'.PasswordReset::BROKER_RESETS))->createToken($user);
+
+        $this->assertSame('san@holo.com', $this->repository(PasswordReset::BROKER_RESETS)->findEmailByToken($token));
+    }
+
+    #[Test]
+    public function it_returns_null_for_invalid_token()
+    {
+        $this->assertNull($this->repository(PasswordReset::BROKER_RESETS)->findEmailByToken('invalid-token'));
+    }
+
+    #[Test]
+    public function it_returns_null_for_expired_token()
+    {
+        $user = tap(User::make()->email('san@holo.com')->password('secret'))->save();
+
+        $repository = $this->repository(PasswordReset::BROKER_RESETS);
+        $token = Password::broker(config('statamic.users.passwords.'.PasswordReset::BROKER_RESETS))->createToken($user);
+
+        $this->travel(2)->hours();
+
+        $this->assertNull($repository->findEmailByToken($token));
+    }
+}


### PR DESCRIPTION
Checks the email attached to the token and autopopulates the field. Went with this method instead of a GET param so the email address doesn't get passed around in URLs/logs etc.