### PR TITLE
[6.x] Crop images server-side

### DIFF
--- a/config/assets.php
+++ b/config/assets.php
@@ -72,6 +72,19 @@ return [
 
         /*
         |--------------------------------------------------------------------------
+        | Crop Quality
+        |--------------------------------------------------------------------------
+        |
+        | The quality used when saving images cropped in the control panel. The
+        | user may override this per crop. When null, the quality defined in
+        | the "defaults" above will be used, otherwise it falls back to 90.
+        |
+        */
+
+        'crop_quality' => null,
+
+        /*
+        |--------------------------------------------------------------------------
         | Image Manipulation Presets
         |--------------------------------------------------------------------------
         |

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -61,7 +61,7 @@ return [
     'collections_route_instructions' => 'The route controls the entries URL pattern. Learn more in the [documentation](https://statamic.dev/collections#routing).',
     'collections_sort_direction_instructions' => 'The default sort direction.',
     'collections_taxonomies_instructions' => 'Connect entries in this collection to taxonomies. Fields will be automatically added to publish forms.',
-    'crop_jpeg_background_help' => 'JPEG does not support transparency, so transparent areas will be filled with this colour.',
+    'crop_jpeg_background_help' => 'JPEG does not support transparency — transparent areas will be filled with this color.',
     'crop_replace_unavailable_format' => 'The original can only be replaced when keeping the same format.',
     'crop_save_as_copy_confirm' => 'Save the cropped image as a new copy?',
     'crop_save_copy_or_replace' => 'Would you like to save this as a new copy or replace the original image?',

--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -61,6 +61,8 @@ return [
     'collections_route_instructions' => 'The route controls the entries URL pattern. Learn more in the [documentation](https://statamic.dev/collections#routing).',
     'collections_sort_direction_instructions' => 'The default sort direction.',
     'collections_taxonomies_instructions' => 'Connect entries in this collection to taxonomies. Fields will be automatically added to publish forms.',
+    'crop_jpeg_background_help' => 'JPEG does not support transparency, so transparent areas will be filled with this colour.',
+    'crop_replace_unavailable_format' => 'The original can only be replaced when keeping the same format.',
     'crop_save_as_copy_confirm' => 'Save the cropped image as a new copy?',
     'crop_save_copy_or_replace' => 'Would you like to save this as a new copy or replace the original image?',
     'dictionaries_countries_emojis_instructions' => 'Include flag emojis in country labels.',

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -49,7 +49,7 @@ function normalizeFormat(format) {
 const sourceFormat = computed(() => normalizeFormat(props.asset.extension));
 
 // We only offer quality/conversion controls for these source types.
-const isConvertible = computed(() => ['jpg', 'png', 'webp'].includes(sourceFormat.value));
+const isConvertible = computed(() => ['jpg', 'png', 'webp', 'avif'].includes(sourceFormat.value));
 
 // PNG is lossless so its quality starts maxed out; lowering it implies the
 // user wants to convert to a lossy format.
@@ -61,27 +61,25 @@ const background = ref('white');
 
 const aspectRatios = ref(Statamic.$config.get('cropAspectRatios') || []);
 
+const formatLabels = { jpg: 'JPEG', png: 'PNG', webp: 'WebP', avif: 'AVIF' };
+
 const formatOptions = computed(() => {
-    const options = [
-        { value: 'jpg', label: 'JPEG' },
-        { value: 'webp', label: 'WebP' },
-    ];
-
-    // Only PNG sources can be kept (or reverted) as a lossless PNG.
-    if (sourceFormat.value === 'png') options.unshift({ value: 'png', label: 'PNG' });
-
-    return options;
+    // Lossy conversion targets, plus the source format so it can be kept as-is.
+    return [...new Set([sourceFormat.value, 'jpg', 'webp'])].map((value) => ({
+        value,
+        label: formatLabels[value] ?? value.toUpperCase(),
+    }));
 });
 
 // A quality setting only applies to lossy output formats.
-const outputUsesQuality = computed(() => ['jpg', 'webp'].includes(format.value));
+const outputUsesQuality = computed(() => ['jpg', 'webp', 'avif'].includes(format.value));
 
 const showQuality = computed(() => isConvertible.value);
 
 const showFormatSelector = computed(() => isConvertible.value);
 
 // JPEG has no alpha channel, so a potentially-transparent source needs a background colour.
-const showBackground = computed(() => format.value === 'jpg' && ['png', 'webp'].includes(sourceFormat.value));
+const showBackground = computed(() => format.value === 'jpg' && ['png', 'webp', 'avif'].includes(sourceFormat.value));
 
 // Changing the format writes a different extension, which can't overwrite the original.
 const canReplaceOutput = computed(() => props.canReplace && format.value === sourceFormat.value);

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -2,7 +2,7 @@
 import Cropper from 'cropperjs';
 import 'cropperjs/dist/cropper.css';
 import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
-import { Button, Heading, Icon, Modal, Radio, RadioGroup, Select, Slider, Stack } from '@ui';
+import { Button, Heading, Icon, Modal, Radio, RadioGroup, Select, Slider, Stack, Field, Subheading } from '@ui';
 import { keys, toast } from '@api';
 import wait from '@/util/wait';
 import axios from 'axios';
@@ -529,41 +529,49 @@ function close() {
 
                 <p>{{ canReplaceOutput ? __('messages.crop_save_copy_or_replace') : __('messages.crop_save_as_copy_confirm') }}</p>
 
-                <div v-if="showQuality" class="mt-4 space-y-4">
-                    <div>
-                        <div class="mb-2 flex items-center justify-between">
-                            <label class="text-sm font-medium" for="crop-quality">{{ __('Quality') }}</label>
-                            <span class="text-sm text-gray-500 tabular-nums">{{ outputUsesQuality ? quality : __('Lossless') }}</span>
-                        </div>
-                        <Slider id="crop-quality" v-model="quality" :min="1" :max="100" :aria-label="__('Quality')" />
-                    </div>
+                <div v-if="showQuality" class="mt-6 space-y-4">
+                    <div class="flex justify-between gap-4">
+                        <Field
+                            id="crop-quality"
+                            :label="__('Quality')"
+                            class="w-1/2 space-y-2"
+                        >
+                            <div class="flex items-center gap-2 bg-gray-50 dark:bg-gray-800 rounded-lg p-2 @lg:px-4 @lg:py-3 with-contrast:border with-contrast:border-gray-500">
+                                <Slider id="crop-quality" v-model="quality" :min="1" :max="100" :aria-label="__('Quality')" />
+                                <Subheading :text="`${quality}%`" class="w-14 justify-center" />
+                            </div>
+                        </Field>
 
-                    <div v-if="showFormatSelector" class="flex items-center justify-between gap-3">
-                        <label class="text-sm font-medium" for="crop-format">{{ __('Format') }}</label>
-                        <Select
+                        <Field
+                            v-if="showFormatSelector"
+                            class="w-1/2 space-y-2"
                             id="crop-format"
-                            v-model="format"
-                            :options="formatOptions"
-                            option-label="label"
-                            option-value="value"
-                            size="sm"
-                            class="w-40"
-                            :aria-label="__('Output format')"
-                        />
+                            :label="__('Format')"
+                        >
+                            <Select
+                                id="crop-format"
+                                v-model="format"
+                                :options="formatOptions"
+                                option-label="label"
+                                option-value="value"
+                                size="sm"
+                                :aria-label="__('Output format')"
+                            />
+                        </Field>
                     </div>
 
                     <div v-if="showBackground">
-                        <label class="mb-1 block text-sm font-medium">{{ __('Background') }}</label>
-                        <p class="mb-2 text-xs text-gray-500">{{ __('messages.crop_jpeg_background_help') }}</p>
-                        <RadioGroup v-model="background" appearance="inline" :aria-label="__('Background colour')">
-                            <Radio value="white" :label="__('White')" />
-                            <Radio value="black" :label="__('Black')" />
-                        </RadioGroup>
+                        <Field
+                            id="crop-background"
+                            :label="__('Background')"
+                            :instructions="__('messages.crop_jpeg_background_help')"
+                        >
+                            <RadioGroup v-model="background" appearance="inline" :aria-label="__('Background colour')">
+                                <Radio value="white" :label="__('White')" />
+                                <Radio value="black" :label="__('Black')" />
+                            </RadioGroup>
+                        </Field>
                     </div>
-
-                    <p v-if="canReplace && !canReplaceOutput" class="text-xs text-gray-500">
-                        {{ __('messages.crop_replace_unavailable_format') }}
-                    </p>
                 </div>
 
                 <template #footer>
@@ -575,7 +583,6 @@ function close() {
                             @click="dismissConfirmation"
                         />
                         <Button
-                            :variant="canReplaceOutput ? 'default' : 'primary'"
                             :disabled="uploading"
                             :text="__('Save as Copy')"
                             @click="upload(false)"
@@ -585,6 +592,7 @@ function close() {
                             variant="primary"
                             :disabled="uploading || !canReplaceOutput"
                             :text="__('Replace Original')"
+                            v-tooltip="canReplace && !canReplaceOutput ? __('messages.crop_replace_unavailable_format') : null"
                             @click="upload(true)"
                         />
                     </div>

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -91,8 +91,10 @@ watch(format, (value) => {
 });
 
 watch(quality, (value) => {
+    // Lowering a PNG's quality implies the user wants compression, so switch to
+    // WebP — it's lossy but, unlike JPEG, keeps the transparency.
     if (sourceFormat.value === 'png' && format.value === 'png' && value < 100) {
-        format.value = 'jpg';
+        format.value = 'webp';
     }
 });
 

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -2,7 +2,7 @@
 import Cropper from 'cropperjs';
 import 'cropperjs/dist/cropper.css';
 import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
-import { Button, Heading, Icon, Modal, Select, Stack } from '@ui';
+import { Button, Heading, Icon, Modal, Select, Slider, Stack } from '@ui';
 import { keys, toast } from '@api';
 import wait from '@/util/wait';
 import axios from 'axios';
@@ -36,11 +36,15 @@ const animationFrameId = ref(null);
 const imageRef = useTemplateRef('image');
 const showConfirmation = ref(false);
 const uploading = ref(false);
-const pendingBlob = ref(null);
-const pendingMimeType = ref(null);
+const pendingCrop = ref(null);
 const cropDimensions = ref(null);
+const defaultQuality = Statamic.$config.get('cropQuality') || 90;
+const quality = ref(defaultQuality);
 
 const aspectRatios = ref(Statamic.$config.get('cropAspectRatios') || []);
+
+// Only lossy formats use a quality setting; PNG/GIF ignore it.
+const supportsQuality = computed(() => ['image/jpeg', 'image/webp'].includes(props.asset.mimeType));
 
 watch(() => props.open, (newValue) => {
     if (newValue) {
@@ -66,9 +70,9 @@ function resetState() {
     initialCropBoxCenter.value = null;
     showConfirmation.value = false;
     uploading.value = false;
-    pendingBlob.value = null;
-    pendingMimeType.value = null;
+    pendingCrop.value = null;
     cropDimensions.value = null;
+    quality.value = defaultQuality;
 }
 
 function destroyCropper() {
@@ -277,41 +281,23 @@ function expandCropBoxToFill() {
 }
 
 function crop() {
-    const cropBoxData = cropper.value.getCropBoxData();
-    const imageData = cropper.value.getImageData();
+    // Crop box coordinates relative to the original image's natural dimensions.
+    // The actual cropping happens server-side from the original file.
+    const data = cropper.value.getData(true);
 
-    const scaleX = imageData.naturalWidth / imageData.width;
-    const scaleY = imageData.naturalHeight / imageData.height;
-
-    const canvas = cropper.value.getCroppedCanvas({
-        width: cropBoxData.width * scaleX,
-        height: cropBoxData.height * scaleY,
-    });
-
-    if (!canvas) {
+    if (!data || data.width < 1 || data.height < 1) {
         toast.error(__('Failed to crop image'));
         return;
     }
 
-    const outputMimeType = props.asset.mimeType;
-    const quality = outputMimeType === 'image/jpeg' || outputMimeType === 'image/webp' ? 0.95 : undefined;
+    pendingCrop.value = {
+        x: Math.max(0, data.x),
+        y: Math.max(0, data.y),
+        width: data.width,
+        height: data.height,
+    };
 
-    canvas.toBlob((blob) => {
-        if (!blob) {
-            toast.error(__('Failed to create cropped image'));
-            return;
-        }
-
-        const extensionMap = {
-            'image/jpeg': 'jpg',
-            'image/png': 'png',
-            'image/webp': 'webp',
-        };
-        const extension = extensionMap[outputMimeType] || 'png';
-        pendingBlob.value = new File([blob], `cropped-image.${extension}`, { type: outputMimeType });
-        pendingMimeType.value = outputMimeType;
-        showConfirmation.value = true;
-    }, outputMimeType, quality);
+    showConfirmation.value = true;
 }
 
 function reset() {
@@ -376,43 +362,20 @@ function unbindKeyboardShortcuts() {
 }
 
 async function upload(replaceOriginal) {
-    if (!pendingBlob.value) return;
+    if (!pendingCrop.value) return;
 
     uploading.value = true;
 
     try {
-        const [containerHandle, assetPath] = props.asset.id.split('::');
-        const pathParts = assetPath.split('/');
-        let filename = pathParts.pop();
-        const folder = pathParts.length > 0 ? pathParts.join('/') : '/';
-
-        if (!replaceOriginal && pendingMimeType.value && pendingMimeType.value !== props.asset.mimeType) {
-            const extensionMap = { 'image/jpeg': '.jpg', 'image/png': '.png', 'image/webp': '.webp' };
-            const newExtension = extensionMap[pendingMimeType.value];
-            if (newExtension) {
-                filename = filename.replace(/\.[^/.]+$/, '') + newExtension;
-            }
-        }
-
-        const formData = new FormData();
-        const fileToUpload = filename !== pendingBlob.value.name
-            ? new File([pendingBlob.value], filename, { type: pendingBlob.value.type })
-            : pendingBlob.value;
-        formData.append('file', fileToUpload);
-        formData.append('container', containerHandle);
-        formData.append('folder', folder);
-        formData.append('_token', Statamic.$config.get('csrfToken'));
-        formData.append('option', replaceOriginal ? 'overwrite' : 'timestamp');
-
-        const url = cp_url('assets');
-        const response = await axios.post(url, formData, {
-            headers: { 'Content-Type': 'multipart/form-data' },
+        const response = await axios.post(props.asset.cropUrl, {
+            ...pendingCrop.value,
+            quality: supportsQuality.value ? quality.value : null,
+            replace: replaceOriginal,
         });
 
         if (response.data?.data) {
             showConfirmation.value = false;
-            pendingBlob.value = null;
-            pendingMimeType.value = null;
+            pendingCrop.value = null;
             close();
             await wait(300); // wait for this cropper stack to close.
 
@@ -433,8 +396,7 @@ async function upload(replaceOriginal) {
 
 function dismissConfirmation() {
     showConfirmation.value = false;
-    pendingBlob.value = null;
-    pendingMimeType.value = null;
+    pendingCrop.value = null;
 }
 
 function close() {
@@ -512,6 +474,14 @@ function close() {
                 </div>
 
                 <p>{{ canReplace ? __('messages.crop_save_copy_or_replace') : __('messages.crop_save_as_copy_confirm') }}</p>
+
+                <div v-if="supportsQuality" class="mt-4">
+                    <div class="mb-2 flex items-center justify-between">
+                        <label class="text-sm font-medium" for="crop-quality">{{ __('Quality') }}</label>
+                        <span class="text-sm text-gray-500 tabular-nums">{{ quality }}</span>
+                    </div>
+                    <Slider id="crop-quality" v-model="quality" :min="1" :max="100" :aria-label="__('Quality')" />
+                </div>
 
                 <template #footer>
                     <div class="flex items-center justify-end space-x-3 pt-3 pb-1">

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -78,11 +78,7 @@ const outputUsesQuality = computed(() => ['jpg', 'webp'].includes(format.value))
 
 const showQuality = computed(() => isConvertible.value);
 
-// For PNG sources the format selector stays hidden until the user opts into a
-// lossy conversion (which happens when they lower the quality below 100).
-const showFormatSelector = computed(() =>
-    sourceFormat.value === 'png' ? format.value !== 'png' : isConvertible.value,
-);
+const showFormatSelector = computed(() => isConvertible.value);
 
 // JPEG has no alpha channel, so a potentially-transparent source needs a background colour.
 const showBackground = computed(() => format.value === 'jpg' && ['png', 'webp'].includes(sourceFormat.value));

--- a/resources/js/components/assets/Editor/CropEditor.vue
+++ b/resources/js/components/assets/Editor/CropEditor.vue
@@ -2,7 +2,7 @@
 import Cropper from 'cropperjs';
 import 'cropperjs/dist/cropper.css';
 import { computed, onBeforeUnmount, ref, useTemplateRef, watch } from 'vue';
-import { Button, Heading, Icon, Modal, Select, Slider, Stack } from '@ui';
+import { Button, Heading, Icon, Modal, Radio, RadioGroup, Select, Slider, Stack } from '@ui';
 import { keys, toast } from '@api';
 import wait from '@/util/wait';
 import axios from 'axios';
@@ -39,12 +39,66 @@ const uploading = ref(false);
 const pendingCrop = ref(null);
 const cropDimensions = ref(null);
 const defaultQuality = Statamic.$config.get('cropQuality') || 90;
-const quality = ref(defaultQuality);
+
+function normalizeFormat(format) {
+    format = (format || '').toLowerCase();
+    return format === 'jpeg' ? 'jpg' : format;
+}
+
+// The source image's format, normalized (e.g. jpeg -> jpg).
+const sourceFormat = computed(() => normalizeFormat(props.asset.extension));
+
+// We only offer quality/conversion controls for these source types.
+const isConvertible = computed(() => ['jpg', 'png', 'webp'].includes(sourceFormat.value));
+
+// PNG is lossless so its quality starts maxed out; lowering it implies the
+// user wants to convert to a lossy format.
+const initialQuality = () => (sourceFormat.value === 'png' ? 100 : defaultQuality);
+
+const format = ref(sourceFormat.value);
+const quality = ref(initialQuality());
+const background = ref('white');
 
 const aspectRatios = ref(Statamic.$config.get('cropAspectRatios') || []);
 
-// Only lossy formats use a quality setting; PNG/GIF ignore it.
-const supportsQuality = computed(() => ['image/jpeg', 'image/webp'].includes(props.asset.mimeType));
+const formatOptions = computed(() => {
+    const options = [
+        { value: 'jpg', label: 'JPEG' },
+        { value: 'webp', label: 'WebP' },
+    ];
+
+    // Only PNG sources can be kept (or reverted) as a lossless PNG.
+    if (sourceFormat.value === 'png') options.unshift({ value: 'png', label: 'PNG' });
+
+    return options;
+});
+
+// A quality setting only applies to lossy output formats.
+const outputUsesQuality = computed(() => ['jpg', 'webp'].includes(format.value));
+
+const showQuality = computed(() => isConvertible.value);
+
+// For PNG sources the format selector stays hidden until the user opts into a
+// lossy conversion (which happens when they lower the quality below 100).
+const showFormatSelector = computed(() =>
+    sourceFormat.value === 'png' ? format.value !== 'png' : isConvertible.value,
+);
+
+// JPEG has no alpha channel, so a potentially-transparent source needs a background colour.
+const showBackground = computed(() => format.value === 'jpg' && ['png', 'webp'].includes(sourceFormat.value));
+
+// Changing the format writes a different extension, which can't overwrite the original.
+const canReplaceOutput = computed(() => props.canReplace && format.value === sourceFormat.value);
+
+watch(format, (value) => {
+    if (value === 'png') quality.value = 100;
+});
+
+watch(quality, (value) => {
+    if (sourceFormat.value === 'png' && format.value === 'png' && value < 100) {
+        format.value = 'jpg';
+    }
+});
 
 watch(() => props.open, (newValue) => {
     if (newValue) {
@@ -72,7 +126,9 @@ function resetState() {
     uploading.value = false;
     pendingCrop.value = null;
     cropDimensions.value = null;
-    quality.value = defaultQuality;
+    quality.value = initialQuality();
+    format.value = sourceFormat.value;
+    background.value = 'white';
 }
 
 function destroyCropper() {
@@ -369,7 +425,9 @@ async function upload(replaceOriginal) {
     try {
         const response = await axios.post(props.asset.cropUrl, {
             ...pendingCrop.value,
-            quality: supportsQuality.value ? quality.value : null,
+            format: format.value,
+            quality: outputUsesQuality.value ? quality.value : null,
+            background: showBackground.value ? background.value : null,
             replace: replaceOriginal,
         });
 
@@ -473,14 +531,43 @@ function close() {
                     <Icon name="loading" />
                 </div>
 
-                <p>{{ canReplace ? __('messages.crop_save_copy_or_replace') : __('messages.crop_save_as_copy_confirm') }}</p>
+                <p>{{ canReplaceOutput ? __('messages.crop_save_copy_or_replace') : __('messages.crop_save_as_copy_confirm') }}</p>
 
-                <div v-if="supportsQuality" class="mt-4">
-                    <div class="mb-2 flex items-center justify-between">
-                        <label class="text-sm font-medium" for="crop-quality">{{ __('Quality') }}</label>
-                        <span class="text-sm text-gray-500 tabular-nums">{{ quality }}</span>
+                <div v-if="showQuality" class="mt-4 space-y-4">
+                    <div>
+                        <div class="mb-2 flex items-center justify-between">
+                            <label class="text-sm font-medium" for="crop-quality">{{ __('Quality') }}</label>
+                            <span class="text-sm text-gray-500 tabular-nums">{{ outputUsesQuality ? quality : __('Lossless') }}</span>
+                        </div>
+                        <Slider id="crop-quality" v-model="quality" :min="1" :max="100" :aria-label="__('Quality')" />
                     </div>
-                    <Slider id="crop-quality" v-model="quality" :min="1" :max="100" :aria-label="__('Quality')" />
+
+                    <div v-if="showFormatSelector" class="flex items-center justify-between gap-3">
+                        <label class="text-sm font-medium" for="crop-format">{{ __('Format') }}</label>
+                        <Select
+                            id="crop-format"
+                            v-model="format"
+                            :options="formatOptions"
+                            option-label="label"
+                            option-value="value"
+                            size="sm"
+                            class="w-40"
+                            :aria-label="__('Output format')"
+                        />
+                    </div>
+
+                    <div v-if="showBackground">
+                        <label class="mb-1 block text-sm font-medium">{{ __('Background') }}</label>
+                        <p class="mb-2 text-xs text-gray-500">{{ __('messages.crop_jpeg_background_help') }}</p>
+                        <RadioGroup v-model="background" appearance="inline" :aria-label="__('Background colour')">
+                            <Radio value="white" :label="__('White')" />
+                            <Radio value="black" :label="__('Black')" />
+                        </RadioGroup>
+                    </div>
+
+                    <p v-if="canReplace && !canReplaceOutput" class="text-xs text-gray-500">
+                        {{ __('messages.crop_replace_unavailable_format') }}
+                    </p>
                 </div>
 
                 <template #footer>
@@ -492,7 +579,7 @@ function close() {
                             @click="dismissConfirmation"
                         />
                         <Button
-                            :variant="canReplace ? 'default' : 'primary'"
+                            :variant="canReplaceOutput ? 'default' : 'primary'"
                             :disabled="uploading"
                             :text="__('Save as Copy')"
                             @click="upload(false)"
@@ -500,7 +587,7 @@ function close() {
                         <Button
                             v-if="canReplace"
                             variant="primary"
-                            :disabled="uploading"
+                            :disabled="uploading || !canReplaceOutput"
                             :text="__('Replace Original')"
                             @click="upload(true)"
                         />

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -256,6 +256,7 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
     Route::get('assets/browse/{asset_container}/{path?}', [BrowserController::class, 'show'])->where('path', '.*')->name('assets.browse.show');
     Route::post('assets-fieldtype', [FieldtypeController::class, 'index']);
     Route::resource('assets', AssetsController::class)->parameters(['assets' => 'encoded_asset'])->except('destroy');
+    Route::post('assets/{encoded_asset}/crop', [AssetsController::class, 'crop'])->name('assets.crop');
     Route::get('assets/{encoded_asset}/download', [AssetsController::class, 'download'])->name('assets.download');
     Route::get('thumbnails/{encoded_asset}/{size?}/{orientation?}', [ThumbnailController::class, 'show'])->name('assets.thumbnails.show');
     Route::get('svgs/{encoded_asset}', [SvgController::class, 'show'])->name('assets.svgs.show');

--- a/src/CP/Assets/CropProcessor.php
+++ b/src/CP/Assets/CropProcessor.php
@@ -1,10 +1,13 @@
 <?php
 
-namespace Statamic\Imaging;
+namespace Statamic\CP\Assets;
 
 use Intervention\Image\ImageManager;
 
-class Cropper
+/**
+ * @internal
+ */
+class CropProcessor
 {
     public function crop(string $contents, string $extension, int $x, int $y, int $width, int $height, ?int $quality = null, ?string $background = null): string
     {

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -177,7 +177,12 @@ class AssetsController extends CpController
             $request->input('background') === 'black' ? '000000' : 'ffffff',
         );
 
-        $basename = pathinfo($asset->basename(), PATHINFO_FILENAME).'.'.$extension;
+        // When replacing, reuse the original basename verbatim so the extension
+        // matches exactly (Asset::extension() isn't lowercased, and ".jpeg" stays
+        // ".jpeg"), otherwise reupload() throws a FileExtensionMismatch.
+        $basename = $replace
+            ? $asset->basename()
+            : pathinfo($asset->basename(), PATHINFO_FILENAME).'.'.$extension;
 
         $tempPath = tempnam(sys_get_temp_dir(), 'statamic-crop');
         file_put_contents($tempPath, $contents);

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -13,6 +13,7 @@ use Statamic\Assets\UploadedReplacementFile;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Assets\AssetContainer as AssetContainerContract;
 use Statamic\Contracts\Assets\AssetFolder;
+use Statamic\CP\Assets\CropProcessor;
 use Statamic\Exceptions\AuthorizationException;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\Asset;
@@ -20,7 +21,6 @@ use Statamic\Facades\AssetContainer;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Assets\Asset as AssetResource;
-use Statamic\Imaging\Cropper;
 use Statamic\Rules\AllowedFile;
 use Statamic\Rules\UploadableAssetPath;
 
@@ -169,7 +169,7 @@ class AssetsController extends CpController
             ? $this->authorize('reupload', $asset)
             : $this->authorize('store', [AssetContract::class, $asset->container()]);
 
-        $contents = app(Cropper::class)->crop(
+        $contents = app(CropProcessor::class)->crop(
             $asset->contents(),
             $extension,
             $request->integer('x'),

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -166,7 +166,7 @@ class AssetsController extends CpController
             ? $this->authorize('reupload', $asset)
             : $this->authorize('store', [AssetContract::class, $asset->container()]);
 
-        $contents = (new Cropper)->crop(
+        $contents = app(Cropper::class)->crop(
             $asset->contents(),
             $extension,
             $request->integer('x'),

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -148,10 +148,17 @@ class AssetsController extends CpController
             'width' => 'required|integer|min:1',
             'height' => 'required|integer|min:1',
             'quality' => 'nullable|integer|min:1|max:100',
+            'format' => 'nullable|in:jpg,jpeg,png,webp,gif',
+            'background' => 'nullable|in:black,white',
             'replace' => 'boolean',
         ]);
 
         $replace = $request->boolean('replace');
+        $extension = strtolower($request->input('format') ?: $asset->extension());
+
+        // Changing the format produces a different file extension, which can't
+        // overwrite the original. It can only be saved as a new copy.
+        abort_if($replace && $this->normalizeExtension($extension) !== $this->normalizeExtension($asset->extension()), 422, __('The format cannot be changed when replacing the original.'));
 
         $replace
             ? $this->authorize('reupload', $asset)
@@ -159,30 +166,56 @@ class AssetsController extends CpController
 
         $contents = (new Cropper)->crop(
             $asset->contents(),
-            $asset->extension(),
+            $extension,
             $request->integer('x'),
             $request->integer('y'),
             $request->integer('width'),
             $request->integer('height'),
             $request->filled('quality') ? $request->integer('quality') : null,
+            $request->input('background') === 'black' ? '000000' : 'ffffff',
         );
+
+        $basename = pathinfo($asset->basename(), PATHINFO_FILENAME).'.'.$extension;
 
         $tempPath = tempnam(sys_get_temp_dir(), 'statamic-crop');
         file_put_contents($tempPath, $contents);
 
-        $file = new UploadedFile($tempPath, $asset->basename(), $asset->mimeType(), test: true);
+        $file = new UploadedFile($tempPath, $basename, test: true);
 
-        if ($replace) {
-            $asset->reupload(new UploadedReplacementFile($file));
-        } else {
-            $folder = $asset->folder() === '.' ? '/' : $asset->folder();
-            $path = ltrim($folder.'/'.$asset->basename(), '/');
-            $asset = $asset->container()->makeAsset($path)->upload($file);
+        try {
+            $this->validateCroppedFile($file, $asset->container());
+
+            if ($replace) {
+                $asset->reupload(new UploadedReplacementFile($file));
+            } else {
+                $folder = $asset->folder() === '.' ? '/' : $asset->folder();
+                $path = ltrim($folder.'/'.$basename, '/');
+                $asset = $asset->container()->makeAsset($path)->upload($file);
+            }
+        } finally {
+            @unlink($tempPath);
         }
 
-        @unlink($tempPath);
-
         return new AssetResource($asset);
+    }
+
+    private function validateCroppedFile(UploadedFile $file, AssetContainerContract $container): void
+    {
+        $rules = collect($container->validationRules())
+            ->map(fn ($rule) => FieldValidator::parse($rule))
+            ->all();
+
+        Validator::make(
+            ['file' => $file],
+            ['file' => array_merge(['file', new AllowedFile], $rules)]
+        )->validate();
+    }
+
+    private function normalizeExtension($extension)
+    {
+        $extension = strtolower($extension);
+
+        return $extension === 'jpeg' ? 'jpg' : $extension;
     }
 
     public function download($asset)

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -4,6 +4,7 @@ namespace Statamic\Http\Controllers\CP\Assets;
 
 use Facades\Statamic\Fields\Validator as FieldValidator;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
@@ -19,6 +20,7 @@ use Statamic\Facades\AssetContainer;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Resources\CP\Assets\Asset as AssetResource;
+use Statamic\Imaging\Cropper;
 use Statamic\Rules\AllowedFile;
 use Statamic\Rules\UploadableAssetPath;
 
@@ -129,6 +131,56 @@ class AssetsController extends CpController
         $asset = $request->option === 'overwrite'
             ? $asset->reupload(new UploadedReplacementFile($file))
             : $asset->upload($file);
+
+        return new AssetResource($asset);
+    }
+
+    public function crop(Request $request, $encodedAsset)
+    {
+        $asset = Asset::find(base64_decode($encodedAsset));
+
+        abort_if(! $asset, 404);
+        abort_unless($asset->isImage(), 422, __('The asset is not an image.'));
+
+        $request->validate([
+            'x' => 'required|integer|min:0',
+            'y' => 'required|integer|min:0',
+            'width' => 'required|integer|min:1',
+            'height' => 'required|integer|min:1',
+            'quality' => 'nullable|integer|min:1|max:100',
+            'replace' => 'boolean',
+        ]);
+
+        $replace = $request->boolean('replace');
+
+        $replace
+            ? $this->authorize('reupload', $asset)
+            : $this->authorize('store', [AssetContract::class, $asset->container()]);
+
+        $contents = (new Cropper)->crop(
+            $asset->contents(),
+            $asset->extension(),
+            $request->integer('x'),
+            $request->integer('y'),
+            $request->integer('width'),
+            $request->integer('height'),
+            $request->filled('quality') ? $request->integer('quality') : null,
+        );
+
+        $tempPath = tempnam(sys_get_temp_dir(), 'statamic-crop');
+        file_put_contents($tempPath, $contents);
+
+        $file = new UploadedFile($tempPath, $asset->basename(), $asset->mimeType(), test: true);
+
+        if ($replace) {
+            $asset->reupload(new UploadedReplacementFile($file));
+        } else {
+            $folder = $asset->folder() === '.' ? '/' : $asset->folder();
+            $path = ltrim($folder.'/'.$asset->basename(), '/');
+            $asset = $asset->container()->makeAsset($path)->upload($file);
+        }
+
+        @unlink($tempPath);
 
         return new AssetResource($asset);
     }

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -142,6 +142,9 @@ class AssetsController extends CpController
         $asset = Asset::find(base64_decode($encodedAsset));
 
         abort_if(! $asset, 404);
+
+        $this->authorize('view', $asset);
+
         abort_unless($asset->isImage(), 422, __('The asset is not an image.'));
 
         $request->validate([

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -24,6 +24,8 @@ use Statamic\Imaging\Cropper;
 use Statamic\Rules\AllowedFile;
 use Statamic\Rules\UploadableAssetPath;
 
+use function Statamic\trans as __;
+
 class AssetsController extends CpController
 {
     use RedirectsToFirstAssetContainer;

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -158,7 +158,7 @@ class AssetsController extends CpController
 
         // Changing the format produces a different file extension, which can't
         // overwrite the original. It can only be saved as a new copy.
-        abort_if($replace && $this->normalizeExtension($extension) !== $this->normalizeExtension($asset->extension()), 422, __('The format cannot be changed when replacing the original.'));
+        abort_if($replace && $this->normalizeExtension($extension) !== $this->normalizeExtension($asset->extension()), 422, __('statamic::messages.crop_replace_unavailable_format'));
 
         $replace
             ? $this->authorize('reupload', $asset)

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -148,7 +148,7 @@ class AssetsController extends CpController
             'width' => 'required|integer|min:1',
             'height' => 'required|integer|min:1',
             'quality' => 'nullable|integer|min:1|max:100',
-            'format' => 'nullable|in:jpg,jpeg,png,webp,gif',
+            'format' => 'nullable|in:jpg,jpeg,png,webp,gif,avif',
             'background' => 'nullable|in:black,white',
             'replace' => 'boolean',
         ]);

--- a/src/Http/Controllers/CP/Assets/AssetsController.php
+++ b/src/Http/Controllers/CP/Assets/AssetsController.php
@@ -188,8 +188,7 @@ class AssetsController extends CpController
             if ($replace) {
                 $asset->reupload(new UploadedReplacementFile($file));
             } else {
-                $folder = $asset->folder() === '.' ? '/' : $asset->folder();
-                $path = ltrim($folder.'/'.$basename, '/');
+                $path = ltrim($asset->folder().'/'.$basename, '/');
                 $asset = $asset->container()->makeAsset($path)->upload($file);
             }
         } finally {

--- a/src/Http/Resources/CP/Assets/Asset.php
+++ b/src/Http/Resources/CP/Assets/Asset.php
@@ -24,6 +24,7 @@ class Asset extends JsonResource
             'permalink' => $this->absoluteUrl(),
             'extension' => $this->extension(),
             'downloadUrl' => $this->cpDownloadUrl(),
+            'cropUrl' => cp_route('assets.crop', ['encoded_asset' => base64_encode($this->id())]),
             'size' => Str::fileSizeForHumans($this->size()),
             'lastModified' => $this->lastModified()->toIso8601String(),
             'lastModifiedRelative' => $this->lastModified()->diffForHumans(),

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Statamic\Assets\CropAspectRatios;
 use Statamic\CommandPalette\Category;
+use Statamic\CP\Assets\CropProcessor;
 use Statamic\CP\Color;
 use Statamic\Facades\CommandPalette;
 use Statamic\Facades\CP\Toast;
@@ -16,7 +17,6 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Fieldtypes\Sets;
 use Statamic\Icons\IconSet;
-use Statamic\Imaging\Cropper;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 use voku\helper\ASCII;
@@ -67,7 +67,7 @@ class JavascriptComposer
             'googleDocsViewer' => config('statamic.assets.google_docs_viewer'),
             'focalPointEditorEnabled' => config('statamic.assets.focal_point_editor'),
             'cropAspectRatios' => CropAspectRatios::all(),
-            'cropQuality' => Cropper::defaultQuality(),
+            'cropQuality' => CropProcessor::defaultQuality(),
             'elevatedSessionsEnabled' => config('statamic.users.elevated_sessions_enabled'),
             'user' => $this->user($user),
             'defaultPreferences' => Preference::default()->all(),

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -16,6 +16,7 @@ use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Fieldtypes\Sets;
 use Statamic\Icons\IconSet;
+use Statamic\Imaging\Cropper;
 use Statamic\Statamic;
 use Statamic\Support\Str;
 use voku\helper\ASCII;
@@ -66,6 +67,7 @@ class JavascriptComposer
             'googleDocsViewer' => config('statamic.assets.google_docs_viewer'),
             'focalPointEditorEnabled' => config('statamic.assets.focal_point_editor'),
             'cropAspectRatios' => CropAspectRatios::all(),
+            'cropQuality' => Cropper::defaultQuality(),
             'elevatedSessionsEnabled' => config('statamic.users.elevated_sessions_enabled'),
             'user' => $this->user($user),
             'defaultPreferences' => Preference::default()->all(),

--- a/src/Imaging/Cropper.php
+++ b/src/Imaging/Cropper.php
@@ -6,7 +6,7 @@ use Intervention\Image\ImageManager;
 
 class Cropper
 {
-    public function crop(string $contents, string $extension, int $x, int $y, int $width, int $height, ?int $quality = null): string
+    public function crop(string $contents, string $extension, int $x, int $y, int $width, int $height, ?int $quality = null, ?string $background = null): string
     {
         // Bake in EXIF orientation so the crop coordinates, which come from the
         // auto-oriented image the user saw in the browser, line up with the source.
@@ -18,6 +18,12 @@ class Cropper
         $height = min($height, $image->height() - $y);
 
         $image->crop($width, $height, $x, $y);
+
+        // JPEG has no alpha channel, so flatten any transparency onto a
+        // background colour rather than letting it default to black.
+        if (in_array(strtolower($extension), ['jpg', 'jpeg'])) {
+            $image->blendTransparency($background ?? 'ffffff');
+        }
 
         return (string) $image->encodeByExtension($extension, quality: $quality ?? self::defaultQuality());
     }

--- a/src/Imaging/Cropper.php
+++ b/src/Imaging/Cropper.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Statamic\Imaging;
+
+use Intervention\Image\ImageManager;
+
+class Cropper
+{
+    public function crop(string $contents, string $extension, int $x, int $y, int $width, int $height, ?int $quality = null): string
+    {
+        // Bake in EXIF orientation so the crop coordinates, which come from the
+        // auto-oriented image the user saw in the browser, line up with the source.
+        $image = $this->manager()->read($contents)->orient();
+
+        $x = max(0, min($x, $image->width() - 1));
+        $y = max(0, min($y, $image->height() - 1));
+        $width = min($width, $image->width() - $x);
+        $height = min($height, $image->height() - $y);
+
+        $image->crop($width, $height, $x, $y);
+
+        return (string) $image->encodeByExtension($extension, quality: $quality ?? self::defaultQuality());
+    }
+
+    public static function defaultQuality(): int
+    {
+        return config('statamic.assets.image_manipulation.crop_quality')
+            ?? config('statamic.assets.image_manipulation.defaults.quality')
+            ?? 90;
+    }
+
+    protected function manager(): ImageManager
+    {
+        $driver = config('statamic.assets.image_manipulation.driver', 'gd');
+
+        return match ($driver) {
+            'gd' => ImageManager::gd(),
+            'imagick' => ImageManager::imagick(),
+            default => ImageManager::withDriver($driver),
+        };
+    }
+}

--- a/tests/Feature/Assets/CropAssetTest.php
+++ b/tests/Feature/Assets/CropAssetTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Feature\Assets;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Intervention\Image\ImageManager;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Assets\AssetContainer;
+use Statamic\Facades;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class CropAssetTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    private $container;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => __DIR__.'/tmp',
+        ]]);
+
+        $this->container = (new AssetContainer)
+            ->handle('test_container')
+            ->disk('test')
+            ->save();
+
+        Storage::fake('test');
+
+        Storage::disk('test')->put('path/to/test.jpg', $this->makeImage(200, 100));
+        $this->container->makeAsset('path/to/test.jpg')->set('alt', 'A test image')->save();
+    }
+
+    #[Test]
+    public function it_crops_and_saves_a_copy()
+    {
+        Carbon::setTestNow(Carbon::createFromTimestamp(1697379288, config('app.timezone')));
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->crop(['x' => 50, 'y' => 20, 'width' => 80, 'height' => 40])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'path/to/test-1697379288.jpg']]);
+
+        $this->assertCount(2, Storage::disk('test')->files('path/to'));
+        $this->assertImageDimensions('path/to/test.jpg', 200, 100, 'Original should be untouched.');
+        $this->assertImageDimensions('path/to/test-1697379288.jpg', 80, 40);
+    }
+
+    #[Test]
+    public function it_crops_and_replaces_the_original()
+    {
+        $this
+            ->actingAs($this->userWithReuploadPermission())
+            ->crop(['x' => 50, 'y' => 20, 'width' => 80, 'height' => 40, 'replace' => true])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'path/to/test.jpg']]);
+
+        $this->assertCount(1, Storage::disk('test')->files('path/to'));
+        $this->assertImageDimensions('path/to/test.jpg', 80, 40);
+        $this->assertEquals('A test image', $this->container->asset('path/to/test.jpg')->get('alt'), 'Metadata should be preserved.');
+    }
+
+    #[Test]
+    public function it_denies_saving_a_copy_without_permission()
+    {
+        $this
+            ->actingAs($this->userWithoutPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 80, 'height' => 40])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function it_denies_replacing_without_reupload_permission()
+    {
+        $this
+            ->actingAs($this->userWithPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 80, 'height' => 40, 'replace' => true])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function it_validates_the_crop_dimensions()
+    {
+        $this
+            ->actingAs($this->userWithPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 0])
+            ->assertStatus(422)
+            ->assertInvalid(['height', 'width']);
+    }
+
+    #[Test]
+    public function it_validates_the_quality()
+    {
+        $this
+            ->actingAs($this->userWithPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 80, 'height' => 40, 'quality' => 101])
+            ->assertStatus(422)
+            ->assertInvalid('quality');
+    }
+
+    #[Test]
+    public function the_quality_affects_the_resulting_file_size()
+    {
+        $noise = $this->makeNoiseImage(300, 300);
+        Storage::disk('test')->put('path/to/low.jpg', $noise);
+        Storage::disk('test')->put('path/to/high.jpg', $noise);
+        $this->container->makeAsset('path/to/low.jpg')->save();
+        $this->container->makeAsset('path/to/high.jpg')->save();
+
+        $user = $this->userWithReuploadPermission();
+
+        $this->actingAs($user)
+            ->postJson($this->cropRoute('path/to/low.jpg'), ['x' => 0, 'y' => 0, 'width' => 200, 'height' => 200, 'quality' => 10, 'replace' => true])
+            ->assertOk();
+
+        $this->actingAs($user)
+            ->postJson($this->cropRoute('path/to/high.jpg'), ['x' => 0, 'y' => 0, 'width' => 200, 'height' => 200, 'quality' => 95, 'replace' => true])
+            ->assertOk();
+
+        $this->assertLessThan(
+            strlen(Storage::disk('test')->get('path/to/high.jpg')),
+            strlen(Storage::disk('test')->get('path/to/low.jpg')),
+        );
+    }
+
+    #[Test]
+    public function it_cannot_crop_a_non_image()
+    {
+        Storage::disk('test')->put('path/to/doc.txt', 'not an image');
+        $this->container->makeAsset('path/to/doc.txt')->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->postJson($this->cropRoute('path/to/doc.txt'), ['x' => 0, 'y' => 0, 'width' => 10, 'height' => 10])
+            ->assertStatus(422);
+    }
+
+    private function crop($payload)
+    {
+        return $this->postJson($this->cropRoute('path/to/test.jpg'), $payload);
+    }
+
+    private function cropRoute($path)
+    {
+        return cp_route('assets.crop', ['encoded_asset' => base64_encode('test_container::'.$path)]);
+    }
+
+    private function makeImage($width, $height)
+    {
+        return (string) ImageManager::gd()->create($width, $height)->fill('ff0000')->encodeByExtension('jpg');
+    }
+
+    private function makeNoiseImage($width, $height)
+    {
+        mt_srand(1);
+        $gd = imagecreatetruecolor($width, $height);
+
+        for ($x = 0; $x < $width; $x++) {
+            for ($y = 0; $y < $height; $y++) {
+                imagesetpixel($gd, $x, $y, imagecolorallocate($gd, mt_rand(0, 255), mt_rand(0, 255), mt_rand(0, 255)));
+            }
+        }
+
+        ob_start();
+        imagejpeg($gd, null, 100);
+        $data = ob_get_clean();
+        imagedestroy($gd);
+
+        return $data;
+    }
+
+    private function assertImageDimensions($path, $width, $height, $message = '')
+    {
+        [$actualWidth, $actualHeight] = getimagesizefromstring(Storage::disk('test')->get($path));
+
+        $this->assertEquals([$width, $height], [$actualWidth, $actualHeight], $message);
+    }
+
+    private function userWithPermission()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'upload test_container assets']]);
+
+        return tap(Facades\User::make()->assignRole('test'))->save();
+    }
+
+    private function userWithReuploadPermission()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'upload test_container assets', 'edit test_container assets']]);
+
+        return tap(Facades\User::make()->assignRole('test'))->save();
+    }
+
+    private function userWithoutPermission()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+
+        return tap(Facades\User::make()->assignRole('test'))->save();
+    }
+}

--- a/tests/Feature/Assets/CropAssetTest.php
+++ b/tests/Feature/Assets/CropAssetTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Feature\Assets;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 use Intervention\Image\ImageManager;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Assets\AssetContainer;
+use Statamic\Events\AssetUploaded;
 use Statamic\Facades;
+use Statamic\Imaging\Cropper;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -181,6 +184,32 @@ class CropAssetTest extends TestCase
             ->actingAs($this->userWithReuploadPermission())
             ->crop(['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100, 'format' => 'webp', 'replace' => true])
             ->assertStatus(422);
+    }
+
+    #[Test]
+    public function it_can_crop_an_avif_image()
+    {
+        // The crop is mocked because encoding AVIF requires GD/Imagick to be
+        // built with libavif, which isn't guaranteed. This asserts the request
+        // is accepted and saved as a copy rather than rejected for its format.
+        $this->mock(Cropper::class)->shouldReceive('crop')->once()->andReturn('cropped');
+
+        // Prevent the post-upload thumbnail generation, which would try to read
+        // the mocked (non-image) output and has the same AVIF codec dependency.
+        Event::fake([AssetUploaded::class]);
+
+        Storage::disk('test')->put('path/to/photo.avif', 'source');
+        $this->container->makeAsset('path/to/photo.avif')->save();
+
+        Carbon::setTestNow(Carbon::createFromTimestamp(1697379288, config('app.timezone')));
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->postJson($this->cropRoute('path/to/photo.avif'), ['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'path/to/photo-1697379288.avif']]);
+
+        $this->assertEquals('cropped', Storage::disk('test')->get('path/to/photo-1697379288.avif'));
     }
 
     #[Test]

--- a/tests/Feature/Assets/CropAssetTest.php
+++ b/tests/Feature/Assets/CropAssetTest.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Facades\Storage;
 use Intervention\Image\ImageManager;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Assets\AssetContainer;
+use Statamic\CP\Assets\CropProcessor;
 use Statamic\Events\AssetUploaded;
 use Statamic\Facades;
-use Statamic\Imaging\Cropper;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -232,7 +232,7 @@ class CropAssetTest extends TestCase
         // The crop is mocked because encoding AVIF requires GD/Imagick to be
         // built with libavif, which isn't guaranteed. This asserts the request
         // is accepted and saved as a copy rather than rejected for its format.
-        $this->mock(Cropper::class)->shouldReceive('crop')->once()->andReturn('cropped');
+        $this->mock(CropProcessor::class)->shouldReceive('crop')->once()->andReturn('cropped');
 
         // Prevent the post-upload thumbnail generation, which would try to read
         // the mocked (non-image) output and has the same AVIF codec dependency.

--- a/tests/Feature/Assets/CropAssetTest.php
+++ b/tests/Feature/Assets/CropAssetTest.php
@@ -130,6 +130,15 @@ class CropAssetTest extends TestCase
     }
 
     #[Test]
+    public function it_denies_cropping_an_asset_the_user_cannot_view()
+    {
+        $this
+            ->actingAs($this->userWithoutViewPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 80, 'height' => 40])
+            ->assertStatus(403);
+    }
+
+    #[Test]
     public function it_denies_replacing_without_reupload_permission()
     {
         $this
@@ -342,14 +351,21 @@ class CropAssetTest extends TestCase
 
     private function userWithPermission()
     {
-        $this->setTestRoles(['test' => ['access cp', 'upload test_container assets']]);
+        $this->setTestRoles(['test' => ['access cp', 'view test_container assets', 'upload test_container assets']]);
 
         return tap(Facades\User::make()->assignRole('test'))->save();
     }
 
     private function userWithReuploadPermission()
     {
-        $this->setTestRoles(['test' => ['access cp', 'upload test_container assets', 'edit test_container assets']]);
+        $this->setTestRoles(['test' => ['access cp', 'view test_container assets', 'upload test_container assets', 'edit test_container assets']]);
+
+        return tap(Facades\User::make()->assignRole('test'))->save();
+    }
+
+    private function userWithoutViewPermission()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'upload test_container assets']]);
 
         return tap(Facades\User::make()->assignRole('test'))->save();
     }

--- a/tests/Feature/Assets/CropAssetTest.php
+++ b/tests/Feature/Assets/CropAssetTest.php
@@ -90,6 +90,37 @@ class CropAssetTest extends TestCase
     }
 
     #[Test]
+    public function it_can_replace_a_jpeg_original()
+    {
+        Storage::disk('test')->put('path/to/photo.jpeg', $this->makeImage(200, 100));
+        $this->container->makeAsset('path/to/photo.jpeg')->save();
+
+        $this
+            ->actingAs($this->userWithReuploadPermission())
+            // The UI normalizes the source's "jpeg" to "jpg" and sends it as the format.
+            ->postJson($this->cropRoute('path/to/photo.jpeg'), ['x' => 50, 'y' => 20, 'width' => 80, 'height' => 40, 'format' => 'jpg', 'replace' => true])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'path/to/photo.jpeg']]);
+
+        $this->assertImageDimensions('path/to/photo.jpeg', 80, 40);
+    }
+
+    #[Test]
+    public function it_can_replace_an_original_with_an_uppercase_extension()
+    {
+        Storage::disk('test')->put('path/to/PHOTO.JPG', $this->makeImage(200, 100));
+        $this->container->makeAsset('path/to/PHOTO.JPG')->save();
+
+        $this
+            ->actingAs($this->userWithReuploadPermission())
+            ->postJson($this->cropRoute('path/to/PHOTO.JPG'), ['x' => 50, 'y' => 20, 'width' => 80, 'height' => 40, 'format' => 'jpg', 'replace' => true])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'path/to/PHOTO.JPG']]);
+
+        $this->assertImageDimensions('path/to/PHOTO.JPG', 80, 40);
+    }
+
+    #[Test]
     public function it_denies_saving_a_copy_without_permission()
     {
         $this

--- a/tests/Feature/Assets/CropAssetTest.php
+++ b/tests/Feature/Assets/CropAssetTest.php
@@ -56,6 +56,23 @@ class CropAssetTest extends TestCase
     }
 
     #[Test]
+    public function it_saves_a_copy_of_a_root_folder_asset()
+    {
+        Storage::disk('test')->put('root.jpg', $this->makeImage(200, 100));
+        $this->container->makeAsset('root.jpg')->save();
+
+        Carbon::setTestNow(Carbon::createFromTimestamp(1697379288, config('app.timezone')));
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->postJson($this->cropRoute('root.jpg'), ['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'root-1697379288.jpg']]);
+
+        Storage::disk('test')->assertExists('root-1697379288.jpg');
+    }
+
+    #[Test]
     public function it_crops_and_replaces_the_original()
     {
         $this

--- a/tests/Feature/Assets/CropAssetTest.php
+++ b/tests/Feature/Assets/CropAssetTest.php
@@ -144,6 +144,72 @@ class CropAssetTest extends TestCase
             ->assertStatus(422);
     }
 
+    #[Test]
+    public function it_converts_to_a_different_format_when_saving_a_copy()
+    {
+        $this
+            ->actingAs($this->userWithPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100, 'format' => 'webp'])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'path/to/test.webp']]);
+
+        Storage::disk('test')->assertExists('path/to/test.webp');
+        $this->assertImageDimensions('path/to/test.jpg', 200, 100, 'Original should be untouched.');
+    }
+
+    #[Test]
+    public function it_cannot_change_the_format_when_replacing_the_original()
+    {
+        $this
+            ->actingAs($this->userWithReuploadPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100, 'format' => 'webp', 'replace' => true])
+            ->assertStatus(422);
+    }
+
+    #[Test]
+    public function it_validates_the_format()
+    {
+        $this
+            ->actingAs($this->userWithPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 80, 'height' => 40, 'format' => 'tiff'])
+            ->assertStatus(422)
+            ->assertInvalid('format');
+    }
+
+    #[Test]
+    public function it_validates_the_output_against_the_containers_allowed_file_types()
+    {
+        $this->container->validationRules(['extensions:jpg'])->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->crop(['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100, 'format' => 'webp'])
+            ->assertStatus(422);
+    }
+
+    #[Test]
+    public function it_flattens_transparency_onto_the_chosen_background_when_converting_to_jpeg()
+    {
+        Storage::disk('test')->put('path/to/black.png', $this->makeTransparentImage(200, 100));
+        Storage::disk('test')->put('path/to/white.png', $this->makeTransparentImage(200, 100));
+        $this->container->makeAsset('path/to/black.png')->save();
+        $this->container->makeAsset('path/to/white.png')->save();
+
+        $user = $this->userWithPermission();
+
+        $this->actingAs($user)
+            ->postJson($this->cropRoute('path/to/black.png'), ['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100, 'format' => 'jpg', 'background' => 'black'])
+            ->assertOk()
+            ->assertJson(['data' => ['path' => 'path/to/black.jpg']]);
+
+        $this->actingAs($user)
+            ->postJson($this->cropRoute('path/to/white.png'), ['x' => 0, 'y' => 0, 'width' => 100, 'height' => 100, 'format' => 'jpg', 'background' => 'white'])
+            ->assertOk();
+
+        $this->assertLessThan(40, $this->redChannel('path/to/black.jpg'));
+        $this->assertGreaterThan(215, $this->redChannel('path/to/white.jpg'));
+    }
+
     private function crop($payload)
     {
         return $this->postJson($this->cropRoute('path/to/test.jpg'), $payload);
@@ -157,6 +223,18 @@ class CropAssetTest extends TestCase
     private function makeImage($width, $height)
     {
         return (string) ImageManager::gd()->create($width, $height)->fill('ff0000')->encodeByExtension('jpg');
+    }
+
+    private function makeTransparentImage($width, $height)
+    {
+        return (string) ImageManager::gd()->create($width, $height)->encodeByExtension('png');
+    }
+
+    private function redChannel($path)
+    {
+        $hex = ImageManager::gd()->read(Storage::disk('test')->get($path))->pickColor(5, 5)->toHex();
+
+        return hexdec(substr($hex, 0, 2));
     }
 
     private function makeNoiseImage($width, $height)


### PR DESCRIPTION
The image cropper previously cropped on a canvas in the browser and re-encoded the result before uploading it. Re-encoding an already-compressed image could actually *inflate* the file size (e.g. cropping an 11MB JPEG produced a 13MB file), since the browser re-encoded at a fixed high quality regardless of the source.

This crops the original server-side instead. The browser now sends the crop coordinates, and the original is cropped once with Intervention, so there's a single encode straight from the source.

While here, it adds a few related controls to the save dialog:

- **Quality** — a per-crop quality slider for lossy formats, defaulting to a new `image_manipulation.crop_quality` config option (which falls back to the existing `defaults.quality`, then 90).
- **Format** — the crop can be saved in a different format. This gives PNGs an effective quality control by converting them to a lossy format. Lowering a PNG's quality converts it to WebP, which keeps transparency. Converting to JPEG offers a black/white background choice for flattening transparency.

Format changes are saved as a new copy (the extension can't change on a replace) and are validated against the container's allowed file types.

<img width="860" height="457" alt="CleanShot 2026-06-18 at 13 18 22" src="https://github.com/user-attachments/assets/4b9540ab-c279-45c3-8181-24a7319a9fe2" />
