### PR TITLE
[6.x] Retain current tab hash in URL when switching localization

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -664,7 +664,7 @@ export default {
             }
 
             if (this.isBase) {
-                window.history.replaceState({}, '', localization.url);
+                window.history.replaceState({}, '', localization.url + window.location.hash);
             }
         },
 

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -289,7 +289,7 @@ export default {
             this.localizing = localization.handle;
 
             if (this.publishContainer === 'base') {
-                window.history.replaceState({}, '', localization.url);
+                window.history.replaceState({}, '', localization.url + window.location.hash);
             }
 
             this.$axios.get(localization.url).then((response) => {

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -423,7 +423,7 @@ export default {
             }
 
             if (this.publishContainer === 'base') {
-                window.history.replaceState({}, '', localization.url);
+                window.history.replaceState({}, '', localization.url + window.location.hash);
             }
         },
 


### PR DESCRIPTION
When you navigate between tabs in a publish form, the tab handle is used as a URL hash (eg. `/edit#seo`). This means you'll stay on the same tab if you refresh the page.

However, if you switch localization, the hash disappears and you end up with just the `site` query parameter. Refreshing the page will take you back to the first tab.

This PR ensures the hash is retained when switching localizations.