### PR TITLE
[6.x] Avoid loading the revisions store when finding a working copy

### DIFF
--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -5,6 +5,7 @@ namespace Statamic\Revisions;
 use Statamic\Contracts\Revisions\Revision as RevisionContract;
 use Statamic\Contracts\Revisions\RevisionQueryBuilder;
 use Statamic\Contracts\Revisions\RevisionRepository as Contract;
+use Statamic\Facades\File;
 use Statamic\Stache\Stache;
 use Statamic\Support\Str;
 
@@ -40,11 +41,13 @@ class RevisionRepository implements Contract
 
     public function findWorkingCopyByKey($key)
     {
-        return $this
-            ->query()
-            ->where('key', $key)
-            ->where('action', 'working')
-            ->first();
+        $path = $this->directory().'/'.$key.'/working.yaml';
+
+        if (! File::exists($path)) {
+            return null;
+        }
+
+        return $this->store->makeItemFromFile($path, File::get($path));
     }
 
     public function save(RevisionContract $revision)

--- a/tests/Revisions/RepositoryTest.php
+++ b/tests/Revisions/RepositoryTest.php
@@ -83,4 +83,36 @@ class RepositoryTest extends TestCase
         $this->assertInstanceOf(Collection::class, $revisions);
         $this->assertCount(0, $revisions);
     }
+
+    #[Test]
+    public function it_finds_a_working_copy_by_key()
+    {
+        $revision = $this->repo->findWorkingCopyByKey('123');
+
+        $this->assertInstanceOf(Revision::class, $revision);
+        $this->assertEquals('123', $revision->key());
+        $this->assertEquals('working', $revision->action());
+    }
+
+    #[Test]
+    public function it_returns_null_when_there_is_no_working_copy()
+    {
+        $this->assertNull($this->repo->findWorkingCopyByKey('does-not-exist'));
+    }
+
+    #[Test]
+    public function it_finds_the_working_copy_without_using_the_query_builder()
+    {
+        // Resolving a single working copy reads its file directly. It must not go
+        // through the query builder, which would force the entire revisions store
+        // to be loaded - the cause of slow Stache warming when many entries are
+        // checked for working copies.
+        $repo = \Mockery::mock(RevisionRepository::class, [$this->stache])->makePartial();
+        $repo->shouldNotReceive('query');
+
+        $revision = $repo->findWorkingCopyByKey('123');
+
+        $this->assertInstanceOf(Revision::class, $revision);
+        $this->assertEquals('working', $revision->action());
+    }
 }


### PR DESCRIPTION
## Summary

Resolving a single working copy via `Revisions::findWorkingCopyByKey()` ran a query against the revisions Stache store:

```php
return $this->query()
    ->where('key', $key)
    ->where('action', 'working')
    ->first();
```

The first such call forces the revisions store's indexes to build, which loads **every** revision and working-copy file on the site into memory. A working copy is a single file at a deterministic path, so this reads it directly instead:

```php
$path = $this->directory().'/'.$key.'/working.yaml';

if (! File::exists($path)) {
    return null;
}

return $this->store->makeItemFromFile($path, File::get($path));
```

This restores the pre-#10437 behaviour for this lookup while keeping the query builder for actual revision queries (`whereKey()`, CP revision history, etc.).

## Why

`Entry::workingCopy()` / `hasWorkingCopy()` are called per-entry during Stache warming — e.g. via computed fields, or any `values()` call during URI index building. Before #10437 each call was a cheap `file_exists()`; afterwards each call could trigger a full warm of the revisions store.

On a real site (~3,600 entries in one collection, revisions enabled) this was the dominant cost of `stache:warm`. Isolated cold-load of that collection:

| `findWorkingCopyByKey` | time | peak memory |
|---|---|---|
| query builder (current) | 144s | 2,224 MB |
| direct file read (this PR) | 15s | 728 MB |

Fixes #14842.

## Testing

Added coverage to `tests/Revisions/RepositoryTest.php`:
- finds a working copy by key
- returns `null` when there's no working copy
- does **not** use the query builder (regression guard against re-loading the whole store)