### PR TITLE
[6.x] Translate untranslated CP page titles

### DIFF
--- a/resources/js/pages/assets/Browse.vue
+++ b/resources/js/pages/assets/Browse.vue
@@ -17,6 +17,16 @@ export default {
         };
     },
 
+    computed: {
+        headTitle() {
+            const title = __(this.container.title);
+            const section = __('Assets');
+
+            // Avoid duplicating when the container is named "Assets".
+            return title === section ? section : [title, section];
+        },
+    },
+
     mounted() {
         this.bindBrowserNavigation();
     },
@@ -91,7 +101,7 @@ export default {
 
 <template>
     <div class="h-full" v-cloak>
-        <Head :title="container.title" />
+        <Head :title="headTitle" />
 
         <asset-browser
             ref="browser"

--- a/resources/js/pages/forms/Show.vue
+++ b/resources/js/pages/forms/Show.vue
@@ -59,9 +59,9 @@ function exportSubmissions() {
 
 <template>
     <div class="max-w-5xl 3xl:max-w-6xl mx-auto" data-max-width-wrapper>
-        <Head :title="[form.title, __('Forms')]" />
+        <Head :title="[__(form.title), __('Forms')]" />
 
-        <Header :title="form.title" icon="forms">
+        <Header :title="__(form.title)" icon="forms">
             <Dropdown v-if="form.canEdit || form.canDelete" placement="left-start" class="me-2">
                 <DropdownMenu>
                     <DropdownItem v-if="form.canEdit" :text="__('Configure Form')" icon="cog" :href="form.editUrl" />

--- a/resources/js/pages/forms/Submission.vue
+++ b/resources/js/pages/forms/Submission.vue
@@ -21,7 +21,7 @@ provide('isFormSubmission', true);
 
 <template>
     <div class="max-w-5xl 3xl:max-w-6xl mx-auto" data-max-width-wrapper>
-        <Head :title="[title, formTitle, __('Forms')]" />
+        <Head :title="[title, __(formTitle), __('Forms')]" />
 
         <PublishForm
             icon="forms"

--- a/resources/js/pages/layout/Head.vue
+++ b/resources/js/pages/layout/Head.vue
@@ -10,11 +10,11 @@ const props = defineProps<{
 const { cmsName } = useStatamicPageProps();
 
 const title = computed(() => {
-    let title = props.title;
-    if (typeof title === 'string') title = [title];
-    title.push(cmsName);
+    let parts = props.title;
+    if (typeof parts === 'string') parts = [parts];
+    parts = [...parts, cmsName];
     const divider = Statamic.$config.get('direction') === 'ltr' ? '‹' : '›';
-    return title.join(` ${divider} `);
+    return parts.join(` ${divider} `);
 });
 </script>
 

--- a/resources/js/pages/navigation/Show.vue
+++ b/resources/js/pages/navigation/Show.vue
@@ -359,9 +359,9 @@ export default {
 
 <template>
     <div class="max-w-5xl 3xl:max-w-6xl mx-auto" data-max-width-wrapper>
-        <Head :title="title" />
+        <Head :title="[__(title), __('Navigation')]" />
 
-        <Header v-if="mounted" :title="title" icon="navigation">
+        <Header v-if="mounted" :title="__(title)" icon="navigation">
             <ItemActions
                 v-if="hasItemActions"
                 :url="itemActionUrl"

--- a/resources/js/pages/taxonomies/Empty.vue
+++ b/resources/js/pages/taxonomies/Empty.vue
@@ -17,7 +17,7 @@ defineProps([
 </script>
 
 <template>
-    <Head :title="taxonomyTitle" />
+    <Head :title="[__(taxonomyTitle), __('Taxonomies')]" />
 
     <header class="py-8 pt-16 text-center">
         <h1 class="text-[25px] font-medium antialiased flex justify-center items-center gap-2">

--- a/resources/js/pages/taxonomies/Show.vue
+++ b/resources/js/pages/taxonomies/Show.vue
@@ -91,7 +91,7 @@ export default {
 
 <template>
     <div>
-        <Head :title="taxonomyTitle" />
+        <Head :title="[__(taxonomyTitle), __('Taxonomies')]" />
 
         <Header :title="__(taxonomyTitle)">
             <Dropdown>

--- a/resources/js/pages/user-groups/Edit.vue
+++ b/resources/js/pages/user-groups/Edit.vue
@@ -36,7 +36,7 @@ const props = defineProps({
 
 <template>
     <div>
-        <Head :title="`${__('Edit')} ${title}`" />
+        <Head :title="`${__('Edit')} ${__(title)}`" />
 
         <PublishForm
             publish-container="base"

--- a/resources/js/pages/user-groups/Show.vue
+++ b/resources/js/pages/user-groups/Show.vue
@@ -29,9 +29,9 @@ function handleDelete() {
 
 <template>
     <div class="max-w-5xl 3xl:max-w-6xl mx-auto" data-max-width-wrapper>
-        <Head :title="group.title" />
+        <Head :title="__(group.title)" />
 
-        <Header :title="group.title" icon="groups">
+        <Header :title="__(group.title)" icon="groups">
             <template #actions>
                 <Dropdown v-if="group.canEdit || group.canDelete">
                     <template #trigger>

--- a/resources/js/pages/utilities/Show.vue
+++ b/resources/js/pages/utilities/Show.vue
@@ -6,7 +6,7 @@ defineProps(['title', 'html']);
 </script>
 
 <template>
-    <Head :title="[title, __('Utilities')]" />
+    <Head :title="[__(title), __('Utilities')]" />
 
     <DynamicHtmlRenderer :html="html" />
 </template>


### PR DESCRIPTION
Fixes #14837

Some Control Panel browser tab titles (Assets, Taxonomies, Navigation) weren't being translated. This wraps them in `__()` like the other sections.