### PR TITLE
[6.x] Don't show selection checkboxes when bulk actions are disabled

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -180,7 +180,7 @@ const columns = ref(initializeColumns());
 const sortColumn = ref(props.sortColumn || (columns.value.length ? columns.value[0].field : null));
 const sortDirection = ref(props.sortDirection || getDefaultSortDirectionForColumn(sortColumn.value));
 const selections = ref(props.selections || []);
-const allowsSelections = computed(() => (props.selections || hasActions.value) && !props.reorderable);
+const allowsSelections = computed(() => (props.selections || (props.allowBulkActions && hasActions.value)) && !props.reorderable);
 const allowsMultipleSelections = computed(() => props.maxSelections > 1);
 const hasReachedSelectionLimit = computed(() => selections.value.length === props.maxSelections);
 const hasActions = computed(() => !!props.actionUrl);


### PR DESCRIPTION
Fixes #14849.

Setting `allowBulkActions` to `false` on a `Listing` hid the bulk actions toolbar but still rendered the selection checkboxes whenever an `actionUrl` was present.

The checkbox column is gated by `allowsSelections`, which only considered `hasActions`, ignoring the `allowBulkActions` prop. This gates the actions-driven branch behind `allowBulkActions` so the checkboxes disappear when bulk actions are turned off.

Controlled selection (a bound `:selections` array, e.g. the asset browser used as a field picker) is unaffected, since that branch of the condition is untouched.