### PR TITLE
[6.x] Avoid widget table overflow

### DIFF
--- a/resources/js/components/entries/CollectionWidget.vue
+++ b/resources/js/components/entries/CollectionWidget.vue
@@ -65,7 +65,7 @@ function formatDate(value) {
                 <ui-description v-if="!items.length" class="flex-1 flex items-center justify-center">
                     {{ __('There are no entries in this collection') }}
                 </ui-description>
-                <div class="px-4 py-3">
+                <div class="px-4 py-3 overflow-x-auto">
                     <table class="w-full widget-table" :class="{ 'opacity-50': loading }">
                         <TableHead :sr-only="!props.showTableHeader" />
                         <TableBody>

--- a/resources/js/components/forms/FormWidget.vue
+++ b/resources/js/components/forms/FormWidget.vue
@@ -61,7 +61,7 @@ function formatDate(value) {
                 <ui-description v-if="!items.length" class="flex-1 flex items-center justify-center">
                     {{ __('This form is awaiting responses') }}
                 </ui-description>
-                <div class="px-4 py-3">
+                <div class="px-4 py-3 overflow-x-auto">
                     <table class="w-full widget-table">
                         <TableHead :sr-only="!props.showTableHeader" />
                         <TableBody>


### PR DESCRIPTION
Super-long entry titles make the collection widget table extend beyond the widget container. This should prevent it.

### Before

<img width="748" height="554" alt="Screenshot 2026-06-19 at 21 09 21" src="https://github.com/user-attachments/assets/686796db-da42-4765-ab66-cd4c3cdb3e0c" />

### After

<img width="766" height="560" alt="Screenshot 2026-06-19 at 21 10 56" src="https://github.com/user-attachments/assets/19cb45f0-46db-425a-8f9a-7bea074e9c92" />
