### PR TITLE
[6.x] Forms 2: Compressed view

### DIFF
--- a/resources/css/components/forms.css
+++ b/resources/css/components/forms.css
@@ -125,8 +125,10 @@
     display: none;
 }
 
-/* Collapsed state */
+/* GROUP MAIN COLUMN / COLLAPSIBLE FIELDS / COLLAPSED STATE
+=================================================== */
 [data-fields-collapsed="true"] {
+    /* Hide the inputs */
     [data-ui-input-group] {
         [data-ui-description],
         > :not(:first-child, :has([data-logic-attached])) {
@@ -137,28 +139,27 @@
             margin-bottom: 0;
         }
     }
+
     [data-editing-item] {
-        /* Tweak things optically, since the field is no longer here */
-        > *:first-child {
-            top: -0.175rem;
+        /* Tweak the actions position since the surrounding space is different */
+        [data-editing-field-actions] {
+            top: 50%;
+            transform: translateY(calc(-50% - 0.5px));
+            @apply pe-3;
         }
+
+        &[data-first-row]::before,
+        &[data-last-row]::before,
         &::before {
-            inset-block: -0.75rem;
-        }
-        &[data-first-row]::before {
-            inset-block-start: -1.25rem;
-        }
-        &[data-last-row]::before {
-            inset-block-end: -1.25rem;
+            inset: calc(0% - 1px);
         }
     }
+
     /* Field Icons */
     [data-collapsed-field-icon] {
         display: inline-flex;
     }
 
-
-    gap: 0.5rem!important;
     /* Wrapper/white background */
     [data-section-drop-zone]:has(&) {
         background: unset;
@@ -172,8 +173,12 @@
         border-radius: 0.75rem;
         @apply shadow-ui-md;
     }
-    + [id*="actions"] {
+
+    ~ [data-pagination] {
         margin-block-start: 1rem;
+        button:first-of-type {
+            border-end-start-radius: 10px;
+        }
     }
 }
 

--- a/resources/css/components/forms.css
+++ b/resources/css/components/forms.css
@@ -156,6 +156,25 @@
     [data-collapsed-field-icon] {
         display: inline-flex;
     }
+
+
+    gap: 0.5rem!important;
+    /* Wrapper/white background */
+    [data-section-drop-zone]:has(&) {
+        background: unset;
+        box-shadow: unset;
+        padding: 0;
+    }
+
+    [data-field-item] {
+        @apply px-4 py-2.75;
+        background: white;
+        border-radius: 0.75rem;
+        @apply shadow-ui-md;
+    }
+    + [id*="actions"] {
+        margin-block-start: 1rem;
+    }
 }
 
 

--- a/resources/css/components/forms.css
+++ b/resources/css/components/forms.css
@@ -168,16 +168,14 @@
     }
 
     [data-field-item] {
-        @apply px-4 py-2.75;
-        background: white;
-        border-radius: 0.75rem;
-        @apply shadow-ui-md;
+        @apply px-3 sm:px-5 py-2.75 bg-white dark:bg-gray-850 rounded-xl ring ring-gray-200 dark:ring-gray-700/80 shadow-ui-md;
     }
 
     ~ [data-pagination] {
-        margin-block-start: 1rem;
-        button:first-of-type {
-            border-end-start-radius: 10px;
+        @apply mt-4;
+        /* Editing a button like "Next page" and "Submit" */
+        :has(> button)::before {
+            inset: calc(0% - 1px);
         }
     }
 }

--- a/resources/css/components/publish.css
+++ b/resources/css/components/publish.css
@@ -9,7 +9,7 @@
 
     &[data-fields-collapsed="true"] {
         /* Collapse the grid further on Forms > Someform > Edit, when we're in the collapsed view */
-        @apply gap-5;
+        @apply gap-2;
     }
 
     aside & {

--- a/resources/js/components/forms/builder/Page.vue
+++ b/resources/js/components/forms/builder/Page.vue
@@ -110,7 +110,7 @@ onMounted(() => {
                 @deleted="sectionDeleted"
             >
                 <template v-if="section.fields.length && sectionIndex === (sections.length - 1)" #footer>
-                    <div :id="`actions-${page._id}`" class="mt-8">
+                    <div :id="`actions-${page._id}`" data-pagination class="mt-8">
                         <div class="cursor-pointer flex gap-2.5" @click.prevent="inspectAction">
                             <Button
                                 v-if="page.previous_page_label"


### PR DESCRIPTION
## Description of the Problem

The "compressed view" for forms is sort of the same idea really as the regular blueprint editing view.
I think it's better to bridge this gap and make it feel very similar for a few reasons: 

- Consistency across the CP / adhering to known affordances
- If we roll out the three column paradigm later on to regular blueprints then things slot together more nicely 

## What this PR Does

Makes the "compressed" view closer to that of the v6 regular blueprint
Adds a helper data attribute

### Before

<img width="3420" height="2146" alt="2026-06-19 at 22 43 14@2x" src="https://github.com/user-attachments/assets/05f6698c-2856-4e64-8374-94fb28b7c0cb" />

### After

<img width="3420" height="2146" alt="2026-06-19 at 22 42 40@2x" src="https://github.com/user-attachments/assets/c146f14b-a9c6-4f54-924d-ee50beb04d79" />

FYI I think this looks better when things get messier:

Before

<img width="3420" height="2146" alt="2026-06-19 at 22 44 45@2x" src="https://github.com/user-attachments/assets/4270e4dd-d881-4913-84f8-bc9a493d5cc8" />

After

<img width="3420" height="2146" alt="2026-06-19 at 22 45 24@2x" src="https://github.com/user-attachments/assets/aa19f863-6fe4-4f61-b01e-6c40cbd40076" />

## How to Reproduce

1. Click the "compressed view" button when editing a form