### PR TITLE
[6.x] Prevent rare case of the container scrolling when focusing on the con…

### DIFF
--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -54,7 +54,7 @@ function focusMain() {
 
                 // Otherwise, focus the content card
                 if (!autofocusInput) {
-                    document.querySelector('#content-card')?.focus();
+                    document.querySelector('#content-card')?.focus({ preventScroll: true });
                 }
             }, 100);
         });


### PR DESCRIPTION
## Description of the Problem

We try to focus on an input or the content card when the content loads but on rare occasions this can cause a small scroll movement. This is outlined in great detail here https://github.com/statamic/cms/issues/14838

Scroll movement is never desirable, and this small PR prevents it.

## What this PR Does

- Prevents_ scroll when focusing on the content card (which is at the top of the page anyway).
- Closes #14838 

## How to Reproduce

1. See https://github.com/statamic/cms/issues/14838