### PR TITLE
[6.x] Add explicit `package` param to `installed` tag

### DIFF
--- a/src/Tags/Installed.php
+++ b/src/Tags/Installed.php
@@ -7,12 +7,27 @@ use Facades\Statamic\Console\Processes\Composer;
 class Installed extends Tags
 {
     /**
+     * Check if composer package is installed via {{ installed package="*" }}.
+     *
+     * @return string|void
+     */
+    public function index()
+    {
+        return $this->installed($this->params->get('package'));
+    }
+
+    /**
      * Check if composer package is installed via {{ installed:* }}.
      *
      * @param  string  $package
      * @return string|void
      */
     public function wildcard($package)
+    {
+        return $this->installed($package);
+    }
+
+    protected function installed($package)
     {
         $installed = Composer::isInstalled($package);
 

--- a/src/Tags/Installed.php
+++ b/src/Tags/Installed.php
@@ -7,7 +7,7 @@ use Facades\Statamic\Console\Processes\Composer;
 class Installed extends Tags
 {
     /**
-     * Check if composer package is installed via {{ installed package="*" }}.
+     * Check if composer package is installed via {{ installed package="vendor/package" }}.
      *
      * @return string|void
      */

--- a/src/Tags/Installed.php
+++ b/src/Tags/Installed.php
@@ -13,7 +13,11 @@ class Installed extends Tags
      */
     public function index()
     {
-        return $this->installed($this->params->get('package'));
+        if (! $package = $this->params->get('package')) {
+            return;
+        }
+
+        return $this->installed($package);
     }
 
     /**

--- a/tests/Tags/InstalledTest.php
+++ b/tests/Tags/InstalledTest.php
@@ -34,4 +34,11 @@ class InstalledTest extends TestCase
         $this->assertEquals('yes', $this->tag('{{ installed:hasselhoff/baywatch-embeds }}yes{{ /installed:hasselhoff/baywatch-embeds }}'));
         $this->assertEquals('', $this->tag('{{ installed:hasselhoff/lotr-embeds }}yes{{ /installed:hasselhoff/lotr-embeds }}'));
     }
+
+    #[Test]
+    public function it_can_check_if_package_is_installed_using_param()
+    {
+        $this->assertEquals('yes', $this->tag('{{ installed package="hasselhoff/baywatch-embeds" }}yes{{ /installed }}'));
+        $this->assertEquals('', $this->tag('{{ installed package="hasselhoff/lotr-embeds" }}yes{{ /installed }}'));
+    }
 }

--- a/tests/Tags/InstalledTest.php
+++ b/tests/Tags/InstalledTest.php
@@ -41,4 +41,11 @@ class InstalledTest extends TestCase
         $this->assertEquals('yes', $this->tag('{{ installed package="hasselhoff/baywatch-embeds" }}yes{{ /installed }}'));
         $this->assertEquals('', $this->tag('{{ installed package="hasselhoff/lotr-embeds" }}yes{{ /installed }}'));
     }
+
+    #[Test]
+    public function it_outputs_empty_when_passing_nothing()
+    {
+        $this->assertEquals('', $this->tag('{{ installed package="" }}yes{{ /installed }}'));
+        $this->assertEquals('', $this->tag('{{ installed :package="null" }}yes{{ /installed }}'));
+    }
 }


### PR DESCRIPTION
Allow using the `installed` tag with a param. Currently, only wildcard usage is supported.

```antlers
{{ package_name = "scope/package" }}

{{ installed :package="package_name" }}yes{{ /installed }}
```
