### PR TITLE
[6.x] Handle linked field comboboxes when the text is long

### DIFF
--- a/resources/js/components/blueprints/LinkFields.vue
+++ b/resources/js/components/blueprints/LinkFields.vue
@@ -24,12 +24,12 @@
                             @update:modelValue="reference = $event"
                         >
                             <template #option="option">
-                                <div class="flex items-center">
+                                <div class="flex items-center text-start">
                                     <span
                                         v-text="option.fieldset"
-                                        class="text-2xs text-gray-500 dark:text-gray-300 ltr:mr-2 rtl:ml-2"
+                                        class="text-2xs line-clamp-2 text-gray-500 dark:text-gray-300 ltr:mr-2 rtl:ml-2"
                                     />
-                                    <span v-text="option.label" />
+                                    <span class="text-xs line-clamp-2" v-text="option.label" />
                                 </div>
                             </template>
                             <template #no-options>


### PR DESCRIPTION
## Description of the Problem

As noted in https://github.com/statamic/cms/issues/14862, when linking a field/fieldset, if the fieldset group or fieldset name is particularly long, it causes overlapping issues. Here is an extreme example:

<img width="3420" height="2146" alt="2026-06-23 at 08 34 00@2x" src="https://github.com/user-attachments/assets/2a00ab29-e088-4289-bbd6-3334252f5617" />

## What this PR Does

- Fixes https://github.com/statamic/cms/issues/14862
- left aligns the text inside the flexbox container—which is only noticeable when the text flows onto a second line
- Makes the field text slightly smaller so that we can see more information
- Clamps text to 2 lines, in case of excessive characters

<img width="3420" height="2146" alt="2026-06-23 at 08 33 44@2x" src="https://github.com/user-attachments/assets/28eebb01-c2d0-47e8-af42-724ee070ba33" />

## How to Reproduce

1. Go to blueprints
2. Add a fieldset with long names