### PR TITLE
[6.x] Prevent the link field group from exceeding 50% of the container so t…

### DIFF
--- a/resources/js/components/blueprints/LinkFields.vue
+++ b/resources/js/components/blueprints/LinkFields.vue
@@ -24,10 +24,10 @@
                             @update:modelValue="reference = $event"
                         >
                             <template #option="option">
-                                <div class="flex items-center text-start">
+                                <div class="flex items-center text-start w-full">
                                     <span
                                         v-text="option.fieldset"
-                                        class="text-2xs line-clamp-2 text-gray-500 dark:text-gray-300 ltr:mr-2 rtl:ml-2"
+                                        class="text-2xs line-clamp-2 text-gray-500 dark:text-gray-300 ltr:mr-2 rtl:ml-2 max-w-[50%]"
                                     />
                                     <span class="text-xs line-clamp-2" v-text="option.label" />
                                 </div>


### PR DESCRIPTION
## Description of the Problem

Related to https://github.com/statamic/cms/issues/14862, I noticed that even with the https://github.com/statamic/cms/pull/14863 fix, if you have many groups with long names the dropdown can look lopsided

## What this PR Does

### Before

You can see here the second column can appear lopsided, even though the fieldset group names are the same

<img width="3420" height="2146" alt="2026-06-23 at 08 48 09@2x" src="https://github.com/user-attachments/assets/23cc538d-351f-4dc7-8877-fdf61f5feda3" />

### After

More harmonious

<img width="3420" height="2146" alt="2026-06-23 at 08 48 00@2x" src="https://github.com/user-attachments/assets/cc4c816f-7abc-416d-b11f-527980678ef1" />

## How to Reproduce

1. Go to blueprints
2. Add a fieldset with long names