### PR TITLE
[6.x] Forms 2: Provide `pages` array to `{{ form:create }}` tag

### DIFF
--- a/src/Forms/JsDrivers/AbstractJsDriver.php
+++ b/src/Forms/JsDrivers/AbstractJsDriver.php
@@ -77,6 +77,18 @@ abstract class AbstractJsDriver implements JsDriver
     }
 
     /**
+     * Add to renderable page view data.
+     *
+     * @param  \Statamic\Fields\Tab  $page
+     * @param  array  $data
+     * @return array
+     */
+    public function addToRenderablePageData($page, $data)
+    {
+        return [];
+    }
+
+    /**
      * Render form html.
      *
      * @param  string  $html

--- a/src/Forms/JsDrivers/JsDriver.php
+++ b/src/Forms/JsDrivers/JsDriver.php
@@ -10,6 +10,8 @@ interface JsDriver
 
     public function addToRenderableFieldData($field, $data);
 
+    // public function addToRenderablePageData($page, array $data): array;
+
     public function addToRenderableFieldAttributes($field);
 
     public function render($html);

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -350,6 +350,10 @@ class Tags extends BaseTags
                     $page['previous_page_label'] = $contents['previous_page_label'] ?? null;
                 }
 
+                if ($jsDriver instanceof AbstractJsDriver) {
+                    $page = array_merge($page, $jsDriver->addToRenderablePageData($tab, $page));
+                }
+
                 return $page;
             })
             ->all();

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -11,6 +11,8 @@ use Statamic\Facades\Blink;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
 use Statamic\Facades\URL;
+use Statamic\Fields\Tab;
+use Statamic\Forms\JsDrivers\AbstractJsDriver;
 use Statamic\Forms\JsDrivers\JsDriver;
 use Statamic\Support\Arr;
 use Statamic\Support\Html;
@@ -75,6 +77,8 @@ class Tags extends BaseTags
         $data['form_config'] = ($configFields = Form::extraConfigFor($form->handle()))
             ? Blueprint::makeFromTabs($configFields)->fields()->addValues($form->data()->all())->augment()->values()->all()
             : [];
+
+        $data['pages'] = $this->getPages($this->sessionHandle(), $jsDriver);
 
         $data['sections'] = $this->getSections($this->sessionHandle(), $jsDriver);
 
@@ -283,7 +287,7 @@ class Tags extends BaseTags
     }
 
     /**
-     * Get sections of fields, using sections defined in blueprint.
+     * Get sections of fields across all pages, using sections defined in blueprint.
      *
      * @param  string  $sessionHandle
      * @param  JsDriver  $jsDriver
@@ -291,13 +295,62 @@ class Tags extends BaseTags
      */
     protected function getSections($sessionHandle, $jsDriver)
     {
-        return $this->form()->blueprint()->tabs()->first()->sections()
+        return $this->form()->blueprint()->tabs()
+            ->flatMap(fn ($tab) => $this->getSectionsForTab($tab, $sessionHandle, $jsDriver))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Get the sections of fields for a single page (blueprint tab).
+     *
+     * @param  \Statamic\Fields\Tab  $tab
+     * @param  string  $sessionHandle
+     * @param  JsDriver  $jsDriver
+     * @return \Illuminate\Support\Collection
+     */
+    private function getSectionsForTab($tab, $sessionHandle, $jsDriver)
+    {
+        return $tab->sections()
             ->map(function ($section) use ($sessionHandle, $jsDriver) {
                 return [
                     'display' => $section->display(),
                     'instructions' => $section->instructions(),
                     'fields' => $this->getFields($sessionHandle, $jsDriver, $section->fields()->all()),
                 ];
+            });
+    }
+
+    /**
+     * Get pages of sections, using the tabs defined in the blueprint.
+     *
+     * @param  string  $sessionHandle
+     * @param  JsDriver  $jsDriver
+     * @return array
+     */
+    protected function getPages($sessionHandle, $jsDriver)
+    {
+        $tabs = $this->form()->blueprint()->tabs()->values();
+
+        return $tabs
+            ->map(function (Tab $tab, $index) use ($tabs, $sessionHandle, $jsDriver) {
+                $contents = $tab->contents();
+                $isFirstPage = $index === 0;
+                $isLastPage = $index === $tabs->count() - 1;
+
+                $page = [
+                    'id' => $tab->handle(),
+                    'display' => $tab->display(),
+                    'instructions' => $tab->instructions(),
+                    'button_label' => $contents['button_label'] ?? ($isLastPage ? __('Submit') : __('Next')),
+                    'sections' => $this->getSectionsForTab($tab, $sessionHandle, $jsDriver)->all(),
+                ];
+
+                if (! $isFirstPage) {
+                    $page['previous_page_label'] = $contents['previous_page_label'] ?? null;
+                }
+
+                return $page;
             })
             ->all();
     }

--- a/src/Forms/Tags.php
+++ b/src/Forms/Tags.php
@@ -21,6 +21,8 @@ use Statamic\Tags\Concerns;
 use Statamic\Tags\Tags as BaseTags;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 
+use function Statamic\trans as __;
+
 class Tags extends BaseTags
 {
     use Concerns\GetsFormSession,

--- a/tests/Tags/Form/FormCreateTest.php
+++ b/tests/Tags/Form/FormCreateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags\Form;
 
+use Facades\Statamic\Console\Processes\Composer;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
@@ -723,6 +724,73 @@ EOT
         ], [
             'custom' => 'fall back to default partial',
         ]);
+    }
+
+    #[Test]
+    public function it_dynamically_renders_pages_array()
+    {
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(true);
+
+        $this->createForm([
+            'pages' => [
+                [
+                    'id' => 'page_one',
+                    'display' => 'Page One',
+                    'instructions' => 'Page One Instructions',
+                    'sections' => [
+                        ['display' => 'Section A', 'fields' => [['handle' => 'name', 'field' => ['type' => 'text']]]],
+                    ],
+                ],
+                [
+                    'id' => 'page_two',
+                    'display' => 'Page Two',
+                    'previous_page_label' => 'Back',
+                    'sections' => [
+                        ['display' => 'Section B', 'fields' => [['handle' => 'email', 'field' => ['type' => 'text']]]],
+                    ],
+                ],
+            ],
+        ], 'survey');
+
+        $output = $this->normalizeHtml($this->tag(<<<'EOT'
+{{ form:survey }}
+    {{ pages }}
+        <div class="page">{{ id }} - {{ display }}{{ if instructions }} ({{ instructions }}){{ /if }}{{ if previous_page_label }} - back:{{ previous_page_label }}{{ /if }} - button:{{ button_label }} - {{ sections }}[{{ display }}:{{ fields }}{{ handle }},{{ /fields }}]{{ /sections }}</div>
+    {{ /pages }}
+{{ /form:survey }}
+EOT
+        ));
+
+        // button_label should default to "Next", then "Submit" on the last page.
+        // The back button is only output when a previous_page_label is set.
+        $this->assertStringContainsString('<div class="page">page_one - Page One (Page One Instructions) - button:Next - [Section A:name,]</div>', $output);
+        $this->assertStringContainsString('<div class="page">page_two - Page Two - back:Back - button:Submit - [Section B:email,]</div>', $output);
+    }
+
+    #[Test]
+    public function it_dynamically_renders_simplified_pages_array_when_forms_pro_is_not_installed()
+    {
+        // When forms-pro isn't installed, sections will be collapsed under a single page.
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(false);
+
+        $this->createForm([
+            'sections' => [
+                ['display' => 'Section A', 'fields' => [['handle' => 'name', 'field' => ['type' => 'text']]]],
+                ['display' => 'Section B', 'fields' => [['handle' => 'email', 'field' => ['type' => 'text']]]],
+            ],
+        ], 'survey');
+
+        $output = $this->normalizeHtml($this->tag(<<<'EOT'
+{{ form:survey }}
+    {{ pages }}
+        <div class="page">{{ id }}{{ if previous_page_label }} - back:{{ previous_page_label }}{{ /if }} - button:{{ button_label }} - {{ sections }}[{{ display }}:{{ fields }}{{ handle }},{{ /fields }}]{{ /sections }}</div>
+    {{ /pages }}
+    <div class="all-sections">{{ sections }}{{ display }},{{ /sections }}</div>
+{{ /form:survey }}
+EOT
+        ));
+
+        $this->assertStringContainsString('<div class="page">main - button:Submit - [Section A:name,][Section B:email,]</div>', $output);
     }
 
     #[Test]

--- a/tests/Tags/Form/FormTestCase.php
+++ b/tests/Tags/Form/FormTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags\Form;
 
+use Facades\Statamic\Console\Processes\Composer;
 use Illuminate\Support\Facades\Blade;
 use Statamic\Facades\Form;
 use Statamic\Facades\Parse;
@@ -48,6 +49,8 @@ abstract class FormTestCase extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(false)->byDefault();
 
         $this->createForm();
         $this->clearSubmissions();


### PR DESCRIPTION
This pull request provides a `pages` array to the `{{ form:create }}` tag, allowing developers to loop through a form's pages on the frontend.

Forms always have at least one page internally. To add more pages, you'll need to install the first-party Forms Pro addon.

## Usage

```antlers
{{ form:contact }}
    {{ pages }}
         <h2>{{ display }}</h2>

        {{ sections }}
            <h3>{{ display }}</h3>

            {{ form:fields }}
                {{ field }}
            {{ /form:fields }}
        {{ /sections }}

        <button>{{ button_label }}</button>

        {{ if not first }}
            <button type="button">{{ previous_page_label }}</button>
        {{ /if }}
    {{ /pages }}
{{ /form:contact }}
```

The following variables can be used when looping through pages:

| Variable | Description |
| --- | --- |
| `id` | The page's handle. |
| `display` | The page's label. |
| `instructions` | The page's help text, if any. |
| `button_label` | Defaults to `Next` for every page but the last, and `Submit` for the last page. |
| `previous_page_label` | The "previous page" button label. Absent on the first page. |
| `sections` | The page's sections, with nested fields. The same variables are available as in the normal `{{ sections }}` loop.  |

JS Drivers can provide additional data (eg. an Alpine expression) by implementing `addToRenderablePageData()`:

```php
public function addToRenderablePageData($page, $data)
{
    return [
        'show_page' => "...",
    ];
}
```

This mirrors the existing `addToRenderableFieldData()` hook. To avoid introducing breaking changes, this method is currently commented out in the `JsDriver` interface and can be un-commented in v7.
