### PR TITLE
[6.x] Define emits in `PublishActions` component

### DIFF
--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -56,6 +56,8 @@ export default {
         canManagePublishState: Boolean,
     },
 
+    emits: ['closed', 'saving', 'saved', 'failed'],
+
     data() {
         return {
             action: this.canManagePublishState ? 'publish' : 'revision',

--- a/resources/js/components/entries/PublishActions.vue
+++ b/resources/js/components/entries/PublishActions.vue
@@ -47,6 +47,8 @@ import { Heading, Button, Select, DatePicker, Textarea, Icon, Subheading, Stack 
 export default {
     components: { Heading, Button, Select, DatePicker, Textarea, Icon, Subheading, Stack },
 
+    emits: ['closed', 'saving', 'saved', 'failed'],
+
     props: {
         actions: Object,
         published: Boolean,
@@ -55,8 +57,6 @@ export default {
         publishContainer: String,
         canManagePublishState: Boolean,
     },
-
-    emits: ['closed', 'saving', 'saved', 'failed'],
 
     data() {
         return {


### PR DESCRIPTION
This pull request defines emits in the `entries/PublishActions` component to avoid console warnings when publishing a revision:

<img width="1896" height="809" alt="CleanShot 2026-06-24 at 12 55 32" src="https://github.com/user-attachments/assets/e7787a4a-3b12-419b-adff-9d11599f8aec" />
