### PR TITLE
[6.x] Prevent browser re-sort of dictionary options with integer keys

### DIFF
--- a/src/Http/Controllers/CP/Fieldtypes/DictionaryFieldtypeController.php
+++ b/src/Http/Controllers/CP/Fieldtypes/DictionaryFieldtypeController.php
@@ -11,10 +11,16 @@ class DictionaryFieldtypeController extends CpController
 {
     public function __invoke(Request $request, string $dictionary)
     {
-        $fieldtype = $this->fieldtype($request);
+        $options = $this->fieldtype($request)->dictionary()->options($request->search);
 
+        // Return an ordered list of key/value pairs rather than a value-keyed object.
+        // When the values are integers, the browser would re-sort the object's keys ascending,
+        // discarding the dictionary's own order.
         return [
-            'data' => $fieldtype->dictionary()->options($request->search),
+            'data' => collect($options)
+                ->map(fn ($label, $key) => ['key' => (string) $key, 'value' => $label])
+                ->values()
+                ->all(),
         ];
     }
 


### PR DESCRIPTION
The Dictionary fieldtype loads options over XHR and the controller returns them as a value-keyed object:

https://github.com/statamic/cms/blob/9f08e491ba2ec45918ab5711078b161e961cc4a6/src/Http/Controllers/CP/Fieldtypes/DictionaryFieldtypeController.php#L16-L18
This will output e.g.  `{"123": "...", "1": "...", "7": "..."}`

When a dictionary's option values are integers as in the example above, the browser re-sorts the object's integer keys into ascending numeric order at `JSON.parse`. So the CP receives them ascending by ID, and the dropdown ignores the order the dictionary returned (which can be important, for example for search relevance).

The suggested fix for this would be to return an ordered list instead of a keyed object. The {key, value} format is already supported and arrays preserve order through `JSON.parse`.

Fixes https://github.com/statamic/cms/issues/14873