### PR TITLE
[6.x] Style the list of blueprints as badges instead, improving legibility

### DIFF
--- a/resources/js/pages/collections/Empty.vue
+++ b/resources/js/pages/collections/Empty.vue
@@ -45,12 +45,18 @@ const props = defineProps([
                 :heading="createLabel"
                 :description="__('statamic::messages.collection_next_steps_create_entry_description')"
             >
-                <a
-                    v-for="blueprint in blueprints"
-                    :href="blueprint.createEntryUrl"
-                    class="text-blue-600 text-sm rtl:ml-2 ltr:mr-2"
-                    v-text="blueprint.title"
-                />
+                <div class="flex flex-wrap gap-2 mt-2">
+                    <ui-badge
+                        v-for="blueprint in blueprints"
+                        :key="blueprint.createEntryUrl"
+                        :href="blueprint.createEntryUrl"
+                        :text="blueprint.title"
+                        color="blue"
+                        size="sm"
+                        pill
+                        class="dark:bg-gray-925"
+                    />
+                </div>
             </ui-empty-state-item>
 
             <ui-empty-state-item


### PR DESCRIPTION
## Description of the Problem

- As per #14877, when you have a list of possible blueprints for a collection's "empty" state, it fails WCAG AA for dark mode
- I think overall the "list" of blueprints could be improved by styling them as badges

## What this PR Does

- Fixes #14877
- Styles blueprint options as badges rather than raw links
- I think this makes it easier to distinguish the different blueprints (see below examples)

### Before

It's difficult to tell where one blueprint ends and another begins here:

<img width="3420" height="2146" alt="2026-06-25 at 15 31 00@2x" src="https://github.com/user-attachments/assets/47c35360-6bb6-4268-bc30-af93fe3cb486" />

<img width="3420" height="2146" alt="2026-06-25 at 15 30 52@2x" src="https://github.com/user-attachments/assets/a05284a8-eb7f-4170-8ef3-6974db5faf0f" />

### After

<img width="3420" height="2146" alt="2026-06-25 at 15 30 19@2x" src="https://github.com/user-attachments/assets/57dca7be-3299-4e95-b13c-9d2f629f9689" />

(Hits AA)

<img width="3420" height="2146" alt="2026-06-25 at 15 30 29@2x" src="https://github.com/user-attachments/assets/1974f5f5-3676-44e8-b184-221274fc7d38" />

## How to Reproduce

1. Assign multiple blueprints to a collection
2. Make sure the collection doesn't have any entries so that you see the "empty" state