### PR TITLE
[6.x] Fix single-mode date fieldtype crashing when saving with a time

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -228,6 +228,17 @@ class Date extends Fieldtype
             return null;
         }
 
+        // If the value is an array, the CP has submitted the date and time separately.
+        // We'll combine them into a single string before parsing, since Carbon can't
+        // parse an array. A missing date means the field was left empty.
+        if (is_array($data)) {
+            if (! ($data['date'] ?? null)) {
+                return null;
+            }
+
+            $data = $data['date'].' '.(($data['time'] ?? null) ?: '00:00');
+        }
+
         return $this->processDateTime($data);
     }
 

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -244,6 +244,24 @@ class DateTest extends TestCase
                 ['start' => '2012-08-29', 'end' => '2013-09-27'],
                 ['start' => '2012-08-29', 'end' => '2013-09-27'],
             ],
+            'single with date and time array from cp' => [
+                'UTC',
+                [],
+                ['date' => '2012-08-29', 'time' => '13:43'],
+                '2012-08-29 13:43',
+            ],
+            'single with date array and no time' => [
+                'UTC',
+                [],
+                ['date' => '2012-08-29', 'time' => null],
+                '2012-08-29 00:00',
+            ],
+            'single with empty date array' => [
+                'UTC',
+                [],
+                ['date' => null, 'time' => null],
+                null,
+            ],
         ];
     }
 


### PR DESCRIPTION
Saving an entry with a single-mode `date` field whose format includes a time throws a `TypeError`. The CP submits the value as a `['date' => ..., 'time' => ...]` array, but `processSingle()` passed it straight to `Carbon::parse()`, which can't parse arrays. This hits the default date field, since the default save format (`Y-m-d H:i`) makes `formatHasTime()` true regardless of `time_enabled`.

This combines the date and time into a single string before parsing.

Fixes #14860
