### PR TITLE
[6.x] Fix icon fieldtype error when stored icon is missing

### DIFF
--- a/src/Icons/IconSet.php
+++ b/src/Icons/IconSet.php
@@ -38,9 +38,13 @@ class IconSet
         return $this->files()->map->getContents()->all();
     }
 
-    public function get(string $name): string
+    public function get(string $name): ?string
     {
-        return $this->filesystem->get($this->directory.'/'.$name.'.svg');
+        $path = $this->directory.'/'.$name.'.svg';
+
+        return $this->filesystem->exists($path)
+            ? $this->filesystem->get($path)
+            : null;
     }
 
     private function files(): Collection

--- a/tests/Fieldtypes/IconTest.php
+++ b/tests/Fieldtypes/IconTest.php
@@ -27,6 +27,12 @@ class IconTest extends TestCase
         $this->assertStringContainsString('<svg class="w-4 h-4"', $result);
     }
 
+    #[Test]
+    public function it_augments_a_missing_icon_to_null()
+    {
+        $this->assertNull($this->fieldtype()->augment('this-icon-does-not-exist'));
+    }
+
     private function fieldtype($config = [])
     {
         return (new Icon)->setField(new Field('test', array_merge(['type' => 'icon'], $config)));


### PR DESCRIPTION
A stored icon value that no longer exists in the configured set throws a `FileNotFoundException` and 500s the page during augmentation. This bites after the v5 → v6 icon redesign, where icons like `swap` were removed, so existing content that references them now crashes on the front end.

`IconSet::get()` now checks the file exists and returns `null` when it doesn't, matching the `svg` tag's behaviour. `Icon::augment()` already short-circuits on a null, so it's a no-op for callers.

Fixes #14669
