### PR TITLE
[6.x] Pass active query scope handles to relationship index scopes

### DIFF
--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -366,7 +366,12 @@ abstract class Relationship extends Fieldtype
 
     protected function applyIndexQueryScopes($query, $params)
     {
-        collect(Arr::wrap($this->config('query_scopes')))
+        $handles = Arr::wrap($this->config('query_scopes'));
+
+        // Pass the active handles along (like the asset browser) so an aliased scope knows which is in effect.
+        $params = array_merge($params, ['queryScopes' => $handles]);
+
+        collect($handles)
             ->map(fn ($handle) => Scope::find($handle))
             ->filter()
             ->each(fn ($scope) => $scope->apply($query, $params));

--- a/src/Fieldtypes/Relationship.php
+++ b/src/Fieldtypes/Relationship.php
@@ -368,7 +368,7 @@ abstract class Relationship extends Fieldtype
     {
         $handles = Arr::wrap($this->config('query_scopes'));
 
-        // Pass the active handles along (like the asset browser) so an aliased scope knows which is in effect.
+        // Pass the active handles along so an aliased scope knows which is in effect.
         $params = array_merge($params, ['queryScopes' => $handles]);
 
         collect($handles)

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -31,6 +31,10 @@ class RelationshipFieldtypeTest extends TestCase
         $this->collection = Collection::make('test')->save();
 
         app('statamic.scopes')[StartsWithC::handle()] = StartsWithC::class;
+
+        // Register one scope class under an alias that differs from its handle, so the
+        // test can prove the configured alias is what reaches the scope.
+        app('statamic.scopes')['fruit_filter'] = AliasedScope::class;
     }
 
     #[Test]
@@ -62,6 +66,34 @@ class RelationshipFieldtypeTest extends TestCase
         $this->assertContains('Cherry', $titles);
         $this->assertNotContains('Apple', $titles);
         $this->assertNotContains('Banana', $titles);
+    }
+
+    #[Test]
+    public function it_passes_the_active_scope_handles_to_aliased_scopes()
+    {
+        Entry::make()->collection('test')->slug('apple')->data(['title' => 'Apple'])->save();
+        Entry::make()->collection('test')->slug('carrot')->data(['title' => 'Carrot'])->save();
+        Entry::make()->collection('test')->slug('cherry')->data(['title' => 'Cherry'])->save();
+        Entry::make()->collection('test')->slug('banana')->data(['title' => 'Banana'])->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view test entries']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'entries',
+            'collections' => ['test'],
+            'query_scopes' => ['fruit_filter'],
+        ]));
+
+        $response = $this
+            ->actingAs($user)
+            ->get("/cp/fieldtypes/relationship?config={$config}")
+            ->assertOk();
+
+        $titles = collect($response->json('data'))->pluck('title')->all();
+
+        // The scope only filters when its alias is present in the queryScopes param.
+        $this->assertEqualsCanonicalizing(['Carrot', 'Cherry'], $titles);
     }
 
     #[Test]
@@ -714,5 +746,15 @@ class StartsWithC extends Scope
     public function apply($query, $params)
     {
         $query->where('title', 'like', 'C%');
+    }
+}
+
+class AliasedScope extends Scope
+{
+    public function apply($query, $params)
+    {
+        if (in_array('fruit_filter', $params['queryScopes'] ?? [])) {
+            $query->where('title', 'like', 'C%');
+        }
     }
 }


### PR DESCRIPTION
An entries/relationship field with `query_scopes` applies each scope with `$request->all()` during the CP index (the entry picker), but that never includes the list of active scope handles. A scope registered under multiple aliases — one class backing several handles — can't tell which one is in effect, so it can't apply the right filter.

`Relationship::applyIndexQueryScopes()` now merges the field's configured handles into the params as `queryScopes`, the same way the asset browser passes them.

Fixes #14204
