### PR TITLE
[6.x] Change how the slot with the "customize columns" works. Instead of an…

### DIFF
--- a/resources/js/components/ui/Listing/CustomizeColumns.vue
+++ b/resources/js/components/ui/Listing/CustomizeColumns.vue
@@ -69,7 +69,7 @@ function reset() {
 </script>
 
 <template>
-    <div data-ui-column-customizer class="absolute right-0 mask-bg mask-bg--left">
+    <div data-ui-column-customizer>
         <Button icon="sliders-vertical" :disabled="reorderable" @click="open = true" :aria-label="__('Customize Columns')" v-tooltip="__('Customize Columns')" />
         <Modal :title="__('Customize Columns')" v-model:open="open">
             <div class="border rounded-lg dark:border-gray-700">

--- a/resources/js/components/ui/Listing/Filters.vue
+++ b/resources/js/components/ui/Listing/Filters.vue
@@ -131,9 +131,8 @@ function handleStackClosed() {
 </script>
 
 <template>
-    <div class="flex flex-1 items-center gap-2 sm:gap-3 overflow-x-auto py-3 rounded-r-4xl">
-
-        <div ref="filtersButtonWrapperRef" class="sticky left-0 ps-[1px] rounded-r-lg mask-bg mask-bg--left mask-bg--left-small">
+    <div class="flex flex-1 items-center gap-2 sm:gap-3 overflow-x-auto py-3 st-mask-horizontal-overflow">
+        <div ref="filtersButtonWrapperRef" class="sticky left-0 rounded-r-lg mask-bg mask-bg--left mask-bg--left-small">
             <Button icon="sliders-horizontal" class="[&_svg]:size-3.5" :disabled="reorderable" @click="open = true">
                 {{ __('Filters') }}
                 <Badge
@@ -198,7 +197,7 @@ function handleStackClosed() {
             variant="filled"
             v-for="({ filter, handle, badge }, index) in fieldFilterBadges"
             :key="`${filter}-${handle}`"
-            class="cursor-default ps-4 gap-1 text-gray-900 dark:text-gray-200 last:me-12 hover:bg-gray-950/5 dark:hover:bg-white/4"
+            class="cursor-default ps-4 gap-1 text-gray-900 dark:text-gray-200 hover:bg-gray-950/5 dark:hover:bg-white/4"
             :class="reorderable ? 'pe-4 text-gray-400 dark:text-gray-600' : 'pe-2'"
         >
             <span class="whitespace-nowrap" v-text="getFieldFilterBadgeLabel(handle, badge)" />
@@ -220,7 +219,7 @@ function handleStackClosed() {
             variant="filled"
             v-for="(badge, handle, index) in standardBadges"
             :key="handle"
-            class="cursor-default ps-4 gap-1 text-gray-900 dark:text-gray-200 last:me-12 hover:bg-gray-950/5 dark:hover:bg-white/4"
+            class="cursor-default ps-4 gap-1 text-gray-900 dark:text-gray-200 hover:bg-gray-950/5 dark:hover:bg-white/4"
             :class="reorderable ? 'pe-4 text-gray-400 dark:text-gray-600' : 'pe-2'"
         >
             <span class="whitespace-nowrap">{{ badge }}</span>

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -730,7 +730,7 @@ autoApplyState();
         <slot v-if="!initializing" :items="items" :is-column-visible="isColumnVisible" :loading="loading">
             <Presets v-if="showPresets" />
             <div v-if="allowSearch || hasFilters || allowCustomizingColumns" class="relative overflow-clip flex items-center gap-2 sm:gap-3 min-h-16 starting-style-transition st-overflow-clip-margin">
-                <div class="flex flex-1 items-center gap-2 sm:gap-3 w-full">
+                <div class="flex flex-1 items-center gap-2 sm:gap-3 overflow-x-auto">
                     <Search v-if="allowSearch" />
                     <Filters v-if="hasFilters" />
                 </div>


### PR DESCRIPTION
## Description of the Problem

Currently, the "Customize Columns" button is absolutely positioned to the right.
It's positioned absolutely in case there are many custom filters, which would otherwise push the "Customize Columns" button off screen, like in this example, where the numerous filters overflow underneath the control:

<img width="3420" height="2146" alt="2026-06-26 at 12 56 15@2x" src="https://github.com/user-attachments/assets/659dd19c-87a9-458c-8883-546f32a20c3f" />

This is OK, but it's a fragile solution when we want to pin more buttons in the same space as "Customize columns".
I found that extra buttons now clash with the filter overflow, like this:

<img width="3420" height="2146" alt="2026-06-26 at 12 59 24@2x" src="https://github.com/user-attachments/assets/985d786a-a3e6-427b-84a2-e7fc58302d55" />

## What this PR Does

Makes the layout less hacky by positioning the "Customize Columns" button within the parent flexbox layout

(After) you can see the filters now fade out as they overflow in the flexbox layout, rather than flowing _underneath_ the buttons to the right

<img width="3420" height="2146" alt="2026-06-26 at 13 01 33@2x" src="https://github.com/user-attachments/assets/9d1c356b-2255-40a3-b00a-6c91a81c2df1" />

If we inspect the DOM we can now see the right icons are part of the parent flex layout, including a gap

<img width="3420" height="2146" alt="2026-06-26 at 13 02 49@2x" src="https://github.com/user-attachments/assets/3568d834-8bc4-4cef-9930-62b5c9ad4ead" />

## How to Reproduce

1. Go to a collection page
2. Add a load of filters so they start to overflow below the Customize Columns button 