### PR TITLE
[5.x] Fix OAuth 

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -9,6 +9,7 @@ use Laravel\Socialite\Two\InvalidStateException;
 use Statamic\Exceptions\NotFoundHttpException;
 use Statamic\Facades\OAuth;
 use Statamic\Facades\URL;
+use Statamic\Facades\User;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -50,7 +51,7 @@ class OAuthController
             if (config('statamic.oauth.merge_user_data', true)) {
                 $user = $oauth->mergeUser($user, $providerUser);
             }
-        } elseif (config('statamic.oauth.create_user', true)) {
+        } elseif (config('statamic.oauth.create_user', true) && ! User::findByEmail($providerUser->getEmail())) {
             $user = $oauth->createUser($providerUser);
         }
 

--- a/src/OAuth/Provider.php
+++ b/src/OAuth/Provider.php
@@ -62,14 +62,22 @@ class Provider
      */
     public function findUser($socialite): ?StatamicUser
     {
-        if (
-            ($user = User::findByOAuthId($this, $socialite->getId())) ||
-            ($user = User::findByEmail($socialite->getEmail()))
-        ) {
+        if ($user = User::findByOAuthId($this, $socialite->getId())) {
+            return $user;
+        }
+
+        if ($this->trustsEmails() && $user = User::findByEmail($socialite->getEmail())) {
             return $user;
         }
 
         return null;
+    }
+
+    private function trustsEmails(): bool
+    {
+        return in_array($this->name, config('statamic.oauth.trusted_providers', [
+            'google', 'github', 'apple', 'bitbucket', 'slack', 'slack-openid', 'twitter-oauth-2',
+        ]));
     }
 
     /**

--- a/tests/OAuth/OAuthCallbackTest.php
+++ b/tests/OAuth/OAuthCallbackTest.php
@@ -61,6 +61,26 @@ class OAuthCallbackTest extends TestCase
     }
 
     #[Test]
+    public function an_untrusted_provider_creates_and_logs_in_a_new_user_when_the_email_is_free()
+    {
+        config(['statamic.oauth.trusted_providers' => ['google']]); // 'evil' is untrusted
+        config(['statamic.oauth.create_user' => true]);
+
+        // No existing account owns the email, so there's nothing to overwrite — the
+        // untrusted provider should still onboard a brand new user.
+        $this->assertCount(0, UserFacade::all());
+
+        $this->fakeProvider('evil');
+
+        $this->get('/oauth/evil/callback');
+
+        $this->assertCount(1, UserFacade::all());
+        $user = UserFacade::all()->first();
+        $this->assertEquals('admin@target.tld', $user->email());
+        $this->assertAuthenticatedAs($user->fresh());
+    }
+
+    #[Test]
     public function a_trusted_provider_logs_into_the_existing_account()
     {
         config(['statamic.oauth.trusted_providers' => ['google']]);

--- a/tests/OAuth/OAuthCallbackTest.php
+++ b/tests/OAuth/OAuthCallbackTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Tests\OAuth;
+
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\OAuth;
+use Statamic\Facades\User as UserFacade;
+use Statamic\OAuth\Provider;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class OAuthCallbackTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    protected function defineEnvironment($app)
+    {
+        $app['config']->set('statamic.oauth.enabled', true);
+        $app['config']->set('statamic.oauth.providers', ['evil', 'google']);
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory(storage_path('statamic/oauth'));
+
+        parent::tearDown();
+    }
+
+    private function fakeProvider(string $name)
+    {
+        $socialiteUser = new FakeSocialiteUser();
+
+        $provider = Mockery::mock(Provider::class.'[getSocialiteUser]', [$name, []]);
+        $provider->shouldReceive('getSocialiteUser')->andReturn($socialiteUser);
+
+        OAuth::partialMock()->shouldReceive('provider')->with($name)->andReturn($provider);
+    }
+
+    #[Test]
+    public function an_untrusted_provider_does_not_overwrite_or_log_into_an_existing_account()
+    {
+        config(['statamic.oauth.trusted_providers' => ['google']]); // 'evil' is untrusted
+        config(['statamic.oauth.create_user' => true]);
+
+        $admin = UserFacade::make()->email('admin@target.tld')->data(['name' => 'Admin'])->makeSuper()->save();
+
+        $this->fakeProvider('evil');
+
+        $response = $this->get('/oauth/evil/callback');
+
+        // No login happened, and they were sent to the unauthorized redirect.
+        $this->assertGuest();
+        $response->assertRedirect();
+
+        // The existing super admin is untouched and no duplicate was created.
+        $this->assertCount(1, UserFacade::all());
+        $admin = $admin->fresh();
+        $this->assertTrue($admin->isSuper());
+        $this->assertEquals('Admin', $admin->name());
+    }
+
+    #[Test]
+    public function a_trusted_provider_logs_into_the_existing_account()
+    {
+        config(['statamic.oauth.trusted_providers' => ['google']]);
+
+        $admin = UserFacade::make()->email('admin@target.tld')->data(['name' => 'Admin'])->makeSuper()->save();
+
+        $this->fakeProvider('google');
+
+        $this->get('/oauth/google/callback');
+
+        $this->assertAuthenticatedAs($admin->fresh());
+        $this->assertCount(1, UserFacade::all());
+    }
+}
+
+class FakeSocialiteUser
+{
+    public function getId()
+    {
+        return 'attacker-1';
+    }
+
+    public function getName()
+    {
+        return 'Mallory';
+    }
+
+    public function getEmail()
+    {
+        return 'admin@target.tld';
+    }
+}

--- a/tests/OAuth/ProviderTest.php
+++ b/tests/OAuth/ProviderTest.php
@@ -22,6 +22,8 @@ class ProviderTest extends TestCase
             'driver' => 'local',
             'root' => $this->tempDir = __DIR__.'/tmp',
         ]]);
+
+        config(['statamic.oauth.trusted_providers' => ['test']]);
     }
 
     public function tearDown(): void
@@ -153,6 +155,35 @@ class ProviderTest extends TestCase
         $this->assertCount(0, UserFacade::all());
         $user = UserFacade::all()->get(0);
         $this->assertNull($user);
+    }
+
+    #[Test]
+    public function it_does_not_find_an_existing_user_by_email_for_an_untrusted_provider()
+    {
+        config(['statamic.oauth.trusted_providers' => ['google']]);
+
+        $this->user()->save();
+
+        $foundUser = (new Provider('test'))->findUser($this->socialite());
+
+        $this->assertNull($foundUser);
+    }
+
+    #[Test]
+    public function it_still_finds_an_existing_user_by_oauth_id_for_an_untrusted_provider()
+    {
+        config(['statamic.oauth.trusted_providers' => ['google']]);
+
+        $provider = new Provider('test');
+        $savedUser = $this->user()->save();
+
+        // Link the account to the provider, then ensure a subsequent lookup matches
+        // on the stored OAuth id even though email matching is not trusted.
+        $provider->mergeUser($savedUser, $this->socialite());
+
+        $foundUser = $provider->findUser($this->socialite());
+
+        $this->assertEquals($savedUser, $foundUser);
     }
 
     #[Test]


### PR DESCRIPTION
This prevents trusting providers that do not guarantee that the email is verified.

This only applies to using oauth for the first time to link to an existing account.

Using oauth from any provider will still work to create completely fresh accounts.