### PR TITLE
[5.x] Fix roles/groups select being empty for non-super users

### DIFF
--- a/src/Fieldtypes/UserGroups.php
+++ b/src/Fieldtypes/UserGroups.php
@@ -18,7 +18,7 @@ class UserGroups extends Relationship
 
     protected function authorizeItemData($id): bool
     {
-        return User::current()->can('edit user groups');
+        return User::current()->can('assign user groups');
     }
 
     protected function toItemArray($id, $site = null)
@@ -35,7 +35,7 @@ class UserGroups extends Relationship
 
     public function getIndexItems($request)
     {
-        if (! User::current()->can('edit user groups')) {
+        if (! User::current()->can('assign user groups')) {
             return collect();
         }
 

--- a/src/Fieldtypes/UserRoles.php
+++ b/src/Fieldtypes/UserRoles.php
@@ -18,7 +18,7 @@ class UserRoles extends Relationship
 
     protected function authorizeItemData($id): bool
     {
-        return User::current()->can('edit roles');
+        return User::current()->can('assign roles');
     }
 
     protected function toItemArray($id, $site = null)
@@ -47,7 +47,7 @@ class UserRoles extends Relationship
 
     public function getIndexItems($request)
     {
-        if (! User::current()->can('edit roles')) {
+        if (! User::current()->can('assign roles')) {
             return collect();
         }
 

--- a/tests/Fieldtypes/UserGroupsTest.php
+++ b/tests/Fieldtypes/UserGroupsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\UserGroups;
+use Tests\FakesRoles;
+use Tests\FakesUserGroups;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class UserGroupsTest extends TestCase
+{
+    use FakesRoles;
+    use FakesUserGroups;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_returns_empty_index_items_without_assign_user_groups_permission()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp']));
+
+        $items = $this->fieldtype()->getIndexItems(new Request);
+
+        $this->assertTrue($items->isEmpty());
+    }
+
+    #[Test]
+    public function it_returns_groups_in_index_items_with_assign_user_groups_permission()
+    {
+        $this->setTestUserGroups(['editors' => []]);
+        $this->actingAs($this->cpUserWithPermissions(['access cp', 'assign user groups']));
+
+        $items = $this->fieldtype()->getIndexItems(new Request);
+
+        $this->assertContains('editors', $items->pluck('id'));
+    }
+
+    private function fieldtype()
+    {
+        return (new UserGroups)->setField(new Field('test', ['type' => 'user_groups']));
+    }
+
+    private function cpUserWithPermissions(array $permissions)
+    {
+        $this->setTestRoles(['test' => $permissions]);
+
+        return tap(User::make()->id(uniqid())->assignRole('test'))->save();
+    }
+}

--- a/tests/Fieldtypes/UserRolesTest.php
+++ b/tests/Fieldtypes/UserRolesTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\UserRoles;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class UserRolesTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_returns_empty_index_items_without_assign_roles_permission()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp']));
+
+        $items = $this->fieldtype()->getIndexItems(new Request);
+
+        $this->assertTrue($items->isEmpty());
+    }
+
+    #[Test]
+    public function it_returns_roles_in_index_items_with_assign_roles_permission()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp', 'assign roles']));
+
+        $items = $this->fieldtype()->getIndexItems(new Request);
+
+        $this->assertContains('editor', $items->pluck('id'));
+    }
+
+    private function fieldtype()
+    {
+        return (new UserRoles)->setField(new Field('test', ['type' => 'user_roles']));
+    }
+
+    private function cpUserWithPermissions(array $permissions)
+    {
+        $this->setTestRoles(['test' => $permissions, 'editor' => []]);
+
+        return tap(User::make()->id(uniqid())->assignRole('test'))->save();
+    }
+}


### PR DESCRIPTION
The Roles (and User Groups) select on the user form comes back empty for a non-super user who has the **assign roles** / **assign user groups** permission — so they can't pick a role, even though that's exactly what the permission is for.

It's a regression from #14718. That PR scoped the relationship fieldtypes to the current user's permissions, but `UserRoles` and `UserGroups` got gated on `edit roles` / `edit user groups` — the permissions for editing the role/group *definitions* — instead of `assign roles` / `assign user groups`. Super users have everything, so it only bit non-super users.

These fieldtypes live on the user form, so they now authorize with `assign roles` / `assign user groups`, matching how the user form, `UsersController`, and the bulk assign actions already gate the same thing.

Fixes #14874.