### PR TITLE
[6.x] Fix incorrect update badges in the Control Panel updater

### DIFF
--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -74,7 +74,8 @@ export default {
             gettingChangelog: true,
             changelog: [],
             currentVersion: null,
-            latestRelease: null,
+            onLatestVersion: false,
+            securityUpdateAvailable: false,
             showingUnlicensedReleases: false,
             page: 1,
             perPage: 10,
@@ -91,16 +92,6 @@ export default {
             return !this.gettingChangelog;
         },
 
-        onLatestVersion() {
-            return this.currentVersion && !this.changelog.some((release) => release.type === 'upgrade');
-        },
-
-        securityUpdateAvailable() {
-            return this.currentVersion && this.changelog
-                .filter((release) => release.type === 'upgrade')
-                .some((release) => release.security);
-        },
-
         licensedReleases() {
             return this.changelog.filter((release) => release.licensed);
         },
@@ -111,10 +102,6 @@ export default {
 
         hasUnlicensedReleases() {
             return this.unlicensedReleases.length > 0;
-        },
-
-        latestVersion() {
-            return this.latestRelease && this.latestRelease.version;
         },
 
         link() {
@@ -145,11 +132,9 @@ export default {
                     this.gettingChangelog = false;
                     this.changelog = response.data.changelog;
                     this.currentVersion = response.data.currentVersion;
+                    this.onLatestVersion = response.data.onLatestVersion;
+                    this.securityUpdateAvailable = response.data.securityUpdateAvailable;
                     this.meta = response.data.meta;
-
-                    if (this.page === 1 && response.data.changelog.length > 0) {
-                        this.latestRelease = response.data.changelog[0];
-                    }
                 });
         },
 

--- a/resources/js/components/updater/Updater.vue
+++ b/resources/js/components/updater/Updater.vue
@@ -92,7 +92,7 @@ export default {
         },
 
         onLatestVersion() {
-            return this.currentVersion && this.currentVersion == this.latestVersion;
+            return this.currentVersion && !this.changelog.some((release) => release.type === 'upgrade');
         },
 
         securityUpdateAvailable() {

--- a/src/Addons/Addon.php
+++ b/src/Addons/Addon.php
@@ -419,7 +419,7 @@ final class Addon
         $version = $versionParser->normalize($this->version);
         $latestVersion = $versionParser->normalize($this->latestVersion());
 
-        return version_compare($version, $latestVersion, '=');
+        return version_compare($version, $latestVersion, '>=');
     }
 
     public function license()

--- a/src/Http/Controllers/CP/Updater/UpdateProductController.php
+++ b/src/Http/Controllers/CP/Updater/UpdateProductController.php
@@ -85,6 +85,8 @@ class UpdateProductController extends CpController
         return [
             'changelog' => $paginated['data'],
             'currentVersion' => $changelog->currentVersion(),
+            'onLatestVersion' => $changelog->availableUpdatesCount() === 0,
+            'securityUpdateAvailable' => $changelog->hasSecurityUpdate(),
             'meta' => $paginated['meta'],
         ];
     }

--- a/tests/Addons/AddonTest.php
+++ b/tests/Addons/AddonTest.php
@@ -342,6 +342,11 @@ class AddonTest extends TestCase
             ['2.0.0', '2.0.0', true],
             ['1.0', '1.0.0', true],
             ['1.0', '1.0.1', false],
+
+            // Installed version is newer than the marketplace's indexed latest version
+            ['1.0.2', '1.0.1', true],
+            ['2.0.0', '1.0.0', true],
+            ['7.12.1', '7.12.0', true],
         ];
     }
 


### PR DESCRIPTION
Fixes two cases where the updater showed the wrong badge:

1. **Installed version newer than the marketplace** (e.g. installed `7.12.1`, marketplace still indexes `7.12.0`) showed a false "Update available". `Addon::isLatestVersion()` now treats equal-or-newer as up to date.

2. **Paginating the changelog** flipped the header badge ("Update available" → "Up to date", or "Security update available" → "Update available"), because it was derived from the current page. The badges are now computed server-side across all releases and returned from the changelog endpoint.

Related:
- #10277
- #6718 (fixed on the Marketplace directly, but this would prevent the CMS from flagging it in the future)
- statamic/ideas#1457