### PR TITLE
[6.x] Bard fields use language for fields, browser direction for labels/instructions

### DIFF
--- a/packages/cms/src/index.js
+++ b/packages/cms/src/index.js
@@ -22,4 +22,5 @@ export const {
     debounce,
     deepClone,
     resetValuesFromResponse,
+    useUiDirection,
 } = __STATAMIC__.core;

--- a/resources/js/bootstrap/cms/core.js
+++ b/resources/js/bootstrap/cms/core.js
@@ -19,3 +19,4 @@ export { default as resetValuesFromResponse } from '../../util/resetValuesFromRe
 export { requireElevatedSession, requireElevatedSessionIf } from '../../components/elevated-sessions';
 export { default as clone, deepClone } from '../../util/clone.js';
 export { default as debounce } from '../../util/debounce.js';
+export { useUiDirection } from '../../composables/ui-direction.js';

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -98,7 +98,7 @@
                                 @added="addSet"
                             >
                                 <template #trigger>
-                                    <div :dir="uiDirection" class="absolute flex items-center gap-2 top-[-6px] z-1 -start-7 @lg/bard:-start-4.5 group" :style="{ transform: `translateY(${y}px)` }">
+                                    <div :dir="direction" class="absolute flex items-center gap-2 top-[-6px] z-1 -start-7 @lg/bard:-start-4.5 group" :style="{ transform: `translateY(${y}px)` }">
                                         <ui-button
                                             icon="plus"
                                             size="sm"

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -177,6 +177,7 @@ import 'highlight.js/styles/github.css';
 import importTiptap from '@/util/tiptap.js';
 import { computed } from 'vue';
 import { data_get } from "@/bootstrap/globals.js";
+import { useUiDirection } from '@/composables/ui-direction.js';
 
 const lowlight = createLowlight(common);
 let tiptap = null;
@@ -184,6 +185,10 @@ let commandPaletteCallbackRegistered = false;
 
 export default {
     mixins: [Fieldtype, ManagesSetMeta],
+
+    setup() {
+        return useUiDirection();
+    },
 
     components: {
         BubbleMenu,
@@ -227,10 +232,6 @@ export default {
     },
 
     computed: {
-        uiDirection() {
-            return document.documentElement.dir || 'ltr';
-        },
-
         setFieldPathPrefix() {
             return this.fieldPathPrefix ? `${this.fieldPathPrefix}.${this.handle}` : this.handle;
         },

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -98,7 +98,7 @@
                                 @added="addSet"
                             >
                                 <template #trigger>
-                                    <div class="absolute flex items-center gap-2 top-[-6px] z-1 -start-7 @lg/bard:-start-4.5 group" :style="{ transform: `translateY(${y}px)` }">
+                                    <div :dir="uiDirection" class="absolute flex items-center gap-2 top-[-6px] z-1 -start-7 @lg/bard:-start-4.5 group" :style="{ transform: `translateY(${y}px)` }">
                                         <ui-button
                                             icon="plus"
                                             size="sm"
@@ -227,6 +227,10 @@ export default {
     },
 
     computed: {
+        uiDirection() {
+            return document.documentElement.dir || 'ltr';
+        },
+
         setFieldPathPrefix() {
             return this.fieldPathPrefix ? `${this.fieldPathPrefix}.${this.handle}` : this.handle;
         },

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -18,7 +18,7 @@
         >
             <div ref="content" hidden />
             <header
-                :dir="uiDirection"
+                :dir="direction"
                 class="group/header animate-border-color show-focus-within flex items-center rounded-[calc(var(--radius-lg)-1px)] px-1.5 antialiased duration-200 bg-gray-100/50 dark:bg-gray-925 hover:bg-gray-100 dark:hover:bg-gray-950/45 border-gray-300 dark:shadow-md"
                 :class="{
                     'bg-gray-200/50 dark:bg-gray-950/35 rounded-b-none': !collapsed && hasFields

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -18,6 +18,7 @@
         >
             <div ref="content" hidden />
             <header
+                :dir="uiDirection"
                 class="group/header animate-border-color show-focus-within flex items-center rounded-[calc(var(--radius-lg)-1px)] px-1.5 antialiased duration-200 bg-gray-100/50 dark:bg-gray-925 hover:bg-gray-100 dark:hover:bg-gray-950/45 border-gray-300 dark:shadow-md"
                 :class="{
                     'bg-gray-200/50 dark:bg-gray-950/35 rounded-b-none': !collapsed && hasFields
@@ -145,6 +146,10 @@ export default {
     },
 
     computed: {
+        uiDirection() {
+            return document.documentElement.dir || 'ltr';
+        },
+
         fields() {
             return this.config.fields;
         },

--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -118,9 +118,14 @@ import {
 import { containerContextKey } from '@/components/ui/Publish/Container.vue';
 import { watch } from 'vue';
 import { reveal } from '@api';
+import { useUiDirection } from '@/composables/ui-direction.js';
 
 export default {
     props: nodeViewProps,
+
+    setup() {
+        return useUiDirection();
+    },
 
     components: {
         Button,
@@ -146,10 +151,6 @@ export default {
     },
 
     computed: {
-        uiDirection() {
-            return document.documentElement.dir || 'ltr';
-        },
-
         fields() {
             return this.config.fields;
         },

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -121,7 +121,7 @@ function destroy() {
     emit('removed');
 }
 
-const { uiDirection } = useUiDirection();
+const { direction } = useUiDirection();
 
 const rootEl = ref();
 reveal.use(rootEl, () => emit('expanded'));
@@ -144,7 +144,7 @@ reveal.use(rootEl, () => emit('expanded'));
             :data-type="config.handle"
         >
             <header
-                :dir="uiDirection"
+                :dir="direction"
                 class="group/header animate-border-color flex items-center show-focus-within rounded-[calc(var(--radius-lg)-1px)] px-1.5 antialiased duration-200 bg-gray-100/50 dark:bg-gray-925 hover:bg-gray-100 dark:hover:bg-gray-950/45 border-gray-300 dark:shadow-md"
                 :class="{
                     'bg-gray-200/50 dark:bg-gray-950/35 rounded-b-none': !collapsed && hasFields

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, inject, ref } from 'vue';
+import { useUiDirection } from '@/composables/ui-direction.js';
 import {
     Icon,
     Switch,
@@ -120,7 +121,7 @@ function destroy() {
     emit('removed');
 }
 
-const uiDirection = computed(() => document.documentElement.dir || 'ltr');
+const { uiDirection } = useUiDirection();
 
 const rootEl = ref();
 reveal.use(rootEl, () => emit('expanded'));

--- a/resources/js/components/fieldtypes/replicator/Set.vue
+++ b/resources/js/components/fieldtypes/replicator/Set.vue
@@ -120,6 +120,8 @@ function destroy() {
     emit('removed');
 }
 
+const uiDirection = computed(() => document.documentElement.dir || 'ltr');
+
 const rootEl = ref();
 reveal.use(rootEl, () => emit('expanded'));
 </script>
@@ -141,6 +143,7 @@ reveal.use(rootEl, () => emit('expanded'));
             :data-type="config.handle"
         >
             <header
+                :dir="uiDirection"
                 class="group/header animate-border-color flex items-center show-focus-within rounded-[calc(var(--radius-lg)-1px)] px-1.5 antialiased duration-200 bg-gray-100/50 dark:bg-gray-925 hover:bg-gray-100 dark:hover:bg-gray-950/45 border-gray-300 dark:shadow-md"
                 :class="{
                     'bg-gray-200/50 dark:bg-gray-950/35 rounded-b-none': !collapsed && hasFields

--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -12,7 +12,7 @@ defineOptions({
     inheritAttrs: false,
 });
 
-const { uiDirection } = useUiDirection();
+const { direction } = useUiDirection();
 
 const props = defineProps({
     /** When `true`, the field is styled as a configuration field with a two-column grid layout. */
@@ -85,7 +85,7 @@ const hasErrors = computed(() => {
 <template>
     <div :class="[rootClasses, $attrs.class]" data-ui-input-group :data-ui-field-has-errors="hasErrors ? '' : null">
         <div
-            :dir="uiDirection"
+            :dir="direction"
             v-if="label || $slots.label || $slots.actions || (instructions && !instructionsBelow)"
             class="flex flex-col gap-1.5"
             data-ui-field-header

--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -11,6 +11,8 @@ defineOptions({
     inheritAttrs: false,
 });
 
+const uiDirection = computed(() => document.documentElement.dir || 'ltr');
+
 const props = defineProps({
     /** When `true`, the field is styled as a configuration field with a two-column grid layout. */
     inline: { type: Boolean, default: false },
@@ -82,6 +84,7 @@ const hasErrors = computed(() => {
 <template>
     <div :class="[rootClasses, $attrs.class]" data-ui-input-group :data-ui-field-has-errors="hasErrors ? '' : null">
         <div
+            :dir="uiDirection"
             v-if="label || $slots.label || $slots.actions || (instructions && !instructionsBelow)"
             class="flex flex-col gap-1.5"
             data-ui-field-header

--- a/resources/js/components/ui/Field.vue
+++ b/resources/js/components/ui/Field.vue
@@ -6,12 +6,13 @@ import Label from './Label.vue';
 import ErrorMessage from './ErrorMessage.vue';
 import markdown from '@/util/markdown.js';
 import { twMerge } from 'tailwind-merge';
+import { useUiDirection } from '@/composables/ui-direction.js';
 
 defineOptions({
     inheritAttrs: false,
 });
 
-const uiDirection = computed(() => document.documentElement.dir || 'ltr');
+const { uiDirection } = useUiDirection();
 
 const props = defineProps({
     /** When `true`, the field is styled as a configuration field with a two-column grid layout. */

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -105,7 +105,7 @@ const meta = ref(props.meta);
 const previews = ref({});
 const localizedFields = ref(props.modifiedFields || []);
 const components = ref([]);
-const { uiDirection } = useUiDirection();
+const { direction: uiDirection } = useUiDirection();
 const direction = computed(() => Statamic.$config.get('sites').find(s => s.handle === props.site)?.direction ?? uiDirection.value);
 
 const visibleValues = computed(() => {

--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -11,6 +11,7 @@ import Component from '@/components/Component.js';
 import Tabs from './Tabs.vue';
 import Values from '@/components/publish/Values.js';
 import { data_get } from '@/bootstrap/globals.js';
+import { useUiDirection } from '@/composables/ui-direction.js';
 
 const emit = defineEmits(['update:modelValue', 'update:visibleValues', 'update:modifiedFields', 'update:meta']);
 
@@ -104,7 +105,8 @@ const meta = ref(props.meta);
 const previews = ref({});
 const localizedFields = ref(props.modifiedFields || []);
 const components = ref([]);
-const direction = computed(() => Statamic.$config.get('sites').find(s => s.handle === props.site)?.direction ?? document.documentElement.dir ?? 'ltr');
+const { uiDirection } = useUiDirection();
+const direction = computed(() => Statamic.$config.get('sites').find(s => s.handle === props.site)?.direction ?? uiDirection.value);
 
 const visibleValues = computed(() => {
     const omittable = Object.keys(hiddenFields.value).filter(

--- a/resources/js/composables/ui-direction.js
+++ b/resources/js/composables/ui-direction.js
@@ -1,7 +1,13 @@
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+
+const direction = ref(document.documentElement.dir || 'ltr');
+
+new MutationObserver(() => {
+    direction.value = document.documentElement.dir || 'ltr';
+}).observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
 
 export function useUiDirection() {
     return {
-        uiDirection: computed(() => document.documentElement.dir || 'ltr'),
+        uiDirection: computed(() => direction.value),
     };
 }

--- a/resources/js/composables/ui-direction.js
+++ b/resources/js/composables/ui-direction.js
@@ -1,13 +1,13 @@
 import { computed, ref } from 'vue';
 
-const direction = ref(document.documentElement.dir || 'ltr');
+const dir = ref(document.documentElement.dir || 'ltr');
 
 new MutationObserver(() => {
-    direction.value = document.documentElement.dir || 'ltr';
+    dir.value = document.documentElement.dir || 'ltr';
 }).observe(document.documentElement, { attributes: true, attributeFilter: ['dir'] });
 
 export function useUiDirection() {
     return {
-        uiDirection: computed(() => direction.value),
+        direction: computed(() => dir.value),
     };
 }

--- a/resources/js/composables/ui-direction.js
+++ b/resources/js/composables/ui-direction.js
@@ -1,0 +1,7 @@
+import { computed } from 'vue';
+
+export function useUiDirection() {
+    return {
+        uiDirection: computed(() => document.documentElement.dir || 'ltr'),
+    };
+}

--- a/resources/js/tests/Package.test.js
+++ b/resources/js/tests/Package.test.js
@@ -40,6 +40,7 @@ it('exports core', async () => {
         'requireElevatedSession',
         'requireElevatedSessionIf',
         'resetValuesFromResponse',
+        'useUiDirection',
     ];
 
     expect(Object.keys(modules.core).toSorted()).toEqual(expected)


### PR DESCRIPTION
Noticed that the bard fields had all text, including the labels etc where ltr, even when the browser is set to ltr.

I think it's better to have those based on the browser.

Not sure if this should be configurable?