### PR TITLE
[6.x] Fix stale Stache entry order when reordering structured collection

### DIFF
--- a/src/Entries/UpdateStructuredEntryOrderAndParent.php
+++ b/src/Entries/UpdateStructuredEntryOrderAndParent.php
@@ -3,6 +3,7 @@
 namespace Statamic\Entries;
 
 use Statamic\Events\CollectionTreeSaved;
+use Statamic\Structures\CollectionTree;
 
 class UpdateStructuredEntryOrderAndParent
 {
@@ -23,7 +24,7 @@ class UpdateStructuredEntryOrderAndParent
         $collection->updateEntryOrder($this->idsWithDescendants($tree, $moved, $ids));
     }
 
-    private function idsWithDescendants($tree, array $moved, array $ids): array
+    private function idsWithDescendants(CollectionTree $tree, array $moved, array $ids): array
     {
         return collect($moved)
             ->flatMap(function ($id) use ($tree) {

--- a/src/Entries/UpdateStructuredEntryOrderAndParent.php
+++ b/src/Entries/UpdateStructuredEntryOrderAndParent.php
@@ -12,13 +12,31 @@ class UpdateStructuredEntryOrderAndParent
         $collection = $tree->collection();
         $diff = $tree->diff();
 
-        $ids = array_merge($diff->moved(), $diff->added());
+        $moved = $diff->moved();
+        $ids = array_merge($moved, $diff->added());
 
         if (empty($ids)) {
             return;
         }
 
-        $collection->updateEntryOrder($ids);
         $collection->updateEntryParent($ids);
+        $collection->updateEntryOrder($this->idsWithDescendants($tree, $moved, $ids));
+    }
+
+    private function idsWithDescendants($tree, array $moved, array $ids): array
+    {
+        return collect($moved)
+            ->flatMap(function ($id) use ($tree) {
+                if (! $page = $tree->find($id)) {
+                    return [];
+                }
+
+                return $page->flattenedPages()->map->reference()->all();
+            })
+            ->merge($ids)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/tests/Data/Structures/CollectionTreeTest.php
+++ b/tests/Data/Structures/CollectionTreeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Data\Structures;
 
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Events\CollectionTreeEntriesMovedOrRemoved;
@@ -9,6 +10,7 @@ use Statamic\Events\CollectionTreeSaving;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
 use Statamic\Structures\CollectionTree;
 use Statamic\Structures\CollectionTreeDiff;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -251,5 +253,59 @@ class CollectionTreeTest extends TestCase
         $tree->save();
 
         Event::assertNotDispatched(CollectionTreeEntriesMovedOrRemoved::class);
+    }
+
+    #[Test]
+    public function reordering_a_parent_keeps_the_order_index_of_its_descendants_in_sync()
+    {
+        $collection = tap(Collection::make('pages')->routes('{slug}')->structureContents(['root' => false]))->save();
+
+        foreach (['alfa', 'a1', 'a2', 'a3', 'bravo', 'charlie'] as $id) {
+            EntryFactory::collection('pages')->id($id)->slug($id)->data(['title' => $id])->create();
+        }
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'alfa', 'children' => [
+                ['entry' => 'a1'],
+                ['entry' => 'a2'],
+                ['entry' => 'a3'],
+            ]],
+            ['entry' => 'bravo'],
+            ['entry' => 'charlie'],
+        ])->save();
+
+        $this->assertEquals([
+            'alfa' => 1,
+            'a1' => 2,
+            'a2' => 3,
+            'a3' => 4,
+            'bravo' => 5,
+            'charlie' => 6,
+        ], $this->cachedOrderIndex('pages'));
+
+        // Move "alfa" (and its three children) to the bottom.
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'bravo'],
+            ['entry' => 'charlie'],
+            ['entry' => 'alfa', 'children' => [
+                ['entry' => 'a1'],
+                ['entry' => 'a2'],
+                ['entry' => 'a3'],
+            ]],
+        ])->save();
+
+        $this->assertEquals([
+            'alfa' => 3,
+            'a1' => 4,
+            'a2' => 5,
+            'a3' => 6,
+            'bravo' => 1,
+            'charlie' => 2,
+        ], $this->cachedOrderIndex('pages'));
+    }
+
+    private function cachedOrderIndex(string $collection): array
+    {
+        return Stache::store('entries')->store($collection)->index('order')->items()->all();
     }
 }


### PR DESCRIPTION
When in a structured collection with nested entries, reordering a parent entry from within the CP updates the tree correctly but on the frontend only the parent appears to move while its children keep their old positions until the Stache is manually cleared.

When a tree is saved `UpdateStructuredEntryOrderAndParent` only refreshed the `order` index for the IDs in `CollectionTreeDiff::moved()`. That excludes children of a moved parent so when a parent moved, its children's position shifted but their cached `order` was never updated leaving them stale until you cleared the Stache.

This refreshes the `order` index and expands it to include each moved entry's tree descendants.

Thanks to Ash for reporting it through support.