### PR TITLE
[5.x] Fix failing Guzzle tests

### DIFF
--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -22,7 +22,6 @@ use Stringy\StaticStringy;
 
 class Statamic
 {
-    //
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';
 

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -22,6 +22,7 @@ use Stringy\StaticStringy;
 
 class Statamic
 {
+    //
     const CORE_SLUG = 'statamic';
     const PACKAGE = 'statamic/cms';
 

--- a/tests/Console/Commands/StaticWarmJobTest.php
+++ b/tests/Console/Commands/StaticWarmJobTest.php
@@ -21,7 +21,7 @@ class StaticWarmJobTest extends TestCase
 
         $handlerStack = HandlerStack::create($mock);
 
-        $job = new StaticWarmJob(new Request('GET', '/about'), ['handler' => $handlerStack]);
+        $job = new StaticWarmJob(new Request('GET', 'http://localhost/about'), ['handler' => $handlerStack]);
 
         $job->handle();
 

--- a/tests/Console/Commands/StaticWarmUncachedJobTest.php
+++ b/tests/Console/Commands/StaticWarmUncachedJobTest.php
@@ -23,7 +23,7 @@ class StaticWarmUncachedJobTest extends TestCase
 
         $handlerStack = HandlerStack::create($mock);
 
-        $job = new StaticWarmUncachedJob(new Request('GET', '/about'), ['handler' => $handlerStack]);
+        $job = new StaticWarmUncachedJob(new Request('GET', 'http://localhost/about'), ['handler' => $handlerStack]);
 
         $job->handle();
 
@@ -44,7 +44,7 @@ class StaticWarmUncachedJobTest extends TestCase
 
         $handlerStack = HandlerStack::create($mock);
 
-        $job = new StaticWarmUncachedJob(new Request('GET', '/about'), ['handler' => $handlerStack]);
+        $job = new StaticWarmUncachedJob(new Request('GET', 'http://localhost/about'), ['handler' => $handlerStack]);
 
         $job->handle();
 


### PR DESCRIPTION
Guzzle 7.13.0 added a check that [rejects request URIs missing a scheme or host before transfer](https://github.com/guzzle/guzzle/pull/3715). The `StaticWarmJob` tests pass relative URIs (e.g. `/about`) to a mocked client with no `base_uri`, so they now throw before the mock handler runs:

> `GuzzleHttp\Exception\InvalidArgumentException: URI must include a scheme and host. Use an absolute URI, a network-path reference starting with //, or configure a base_uri.`

Because `composer update --prefer-stable` resolves the latest Guzzle on each run, this surfaced as soon as 7.13.0 was released, regardless of the change being tested.

This only affected the tests. In production the warm command and cacher build absolute URLs (`->absoluteUrl()`, base-url-prefixed), so real requests already include a scheme and host. The fix makes the test URIs absolute; assertions still check `getPath()`, which is unchanged.