### PR TITLE
[6.x] Forms 2: Site Filter

### DIFF
--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -373,7 +373,7 @@ class Submission implements Augmentable, ContainsQueryableValues, SubmissionCont
     private function queryableMethods(): array
     {
         return [
-            'blueprint', 'date', 'form', 'formattedDate', 'id', 'path',
+            'blueprint', 'date', 'form', 'formattedDate', 'id', 'path', 'site',
         ];
     }
 

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -200,6 +200,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Scopes\Filters\Fields::class,
         Scopes\Filters\Blueprint::class,
         Scopes\Filters\Status::class,
+        Scopes\Filters\SubmissionSite::class,
         Scopes\Filters\SubmissionStatus::class,
         Scopes\Filters\Site::class,
         Scopes\Filters\UserRole::class,

--- a/src/Query/Scopes/Filters/SubmissionSite.php
+++ b/src/Query/Scopes/Filters/SubmissionSite.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Statamic\Query\Scopes\Filters;
+
+use Illuminate\Support\Arr;
+use Statamic\Facades;
+use Statamic\Facades\Collection;
+use Statamic\Query\Scopes\Filter;
+
+use function Statamic\trans as __;
+
+class SubmissionSite extends Filter
+{
+    protected $pinned = true;
+
+    public static function title()
+    {
+        return __('Site');
+    }
+
+    public function fieldItems()
+    {
+        $options = $this->options()->all();
+
+        return [
+            'site' => [
+                'display' => __('Site'),
+                'type' => count($options) > 5 ? 'select' : 'radio',
+                'options' => $options,
+            ],
+        ];
+    }
+
+    public function autoApply()
+    {
+        return [
+            'site' => Facades\Site::selected()->handle(),
+        ];
+    }
+
+    public function apply($query, $values)
+    {
+        $query->where('site', $values['site']);
+    }
+
+    public function badge($values)
+    {
+        $site = Facades\Site::get($values['site']);
+
+        return __('Site').': '.__($site->name());
+    }
+
+    public function visibleTo($key)
+    {
+        return $key === 'form-submissions' $this->availableSites()->count() > 1;
+    }
+
+    protected function options()
+    {
+        return $this->availableSites()
+            ->mapWithKeys(fn ($site) => [$site->handle() => __($site->name())]);
+    }
+
+    protected function availableSites()
+    {
+        if (! Facades\Site::hasMultiple()) {
+            return collect();
+        }
+
+        return Facades\Site::authorized();
+    }
+}

--- a/src/Query/Scopes/Filters/SubmissionSite.php
+++ b/src/Query/Scopes/Filters/SubmissionSite.php
@@ -52,7 +52,7 @@ class SubmissionSite extends Filter
 
     public function visibleTo($key)
     {
-        return $key === 'form-submissions' $this->availableSites()->count() > 1;
+        return $key === 'form-submissions' && $this->availableSites()->count() > 1;
     }
 
     protected function options()

--- a/src/Query/Scopes/Filters/SubmissionSite.php
+++ b/src/Query/Scopes/Filters/SubmissionSite.php
@@ -2,9 +2,7 @@
 
 namespace Statamic\Query\Scopes\Filters;
 
-use Illuminate\Support\Arr;
 use Statamic\Facades;
-use Statamic\Facades\Collection;
 use Statamic\Query\Scopes\Filter;
 
 use function Statamic\trans as __;


### PR DESCRIPTION
This pull request adds a "Site" filter to the form submissions listing which is automatically applied when using multi-site, consistent with how we filter the entries listing in a multi-site.

This PR also adds `site` to the queryable methods allowlist, fixing an issue where submissions wouldn't fall back to the default site in queries.