### PR TITLE
[6.x] Add JSON language modes to code editor

### DIFF
--- a/resources/js/components/ui/CodeEditor.vue
+++ b/resources/js/components/ui/CodeEditor.vue
@@ -82,6 +82,8 @@ const modes = ref([
     { value: 'nginx', label: 'Nginx' },
     { value: 'text/x-java', label: 'Java' },
     { value: 'javascript', label: 'JavaScript' },
+    { value: 'application/json', label: 'JSON' },
+    { value: 'application/ld+json', label: 'JSON-LD' },
     { value: 'jsx', label: 'JSX' },
     { value: 'text/x-objectivec', label: 'Objective-C' },
     { value: 'php', label: 'PHP' },

--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -106,6 +106,8 @@ class Code extends Fieldtype
                             'nginx' => 'Nginx',
                             'text/x-java' => 'Java',
                             'javascript' => 'JavaScript',
+                            'application/json' => 'JSON',
+                            'application/ld+json' => 'JSON-LD',
                             'jsx' => 'JSX',
                             'text/x-objectivec' => 'Objective-C',
                             'php' => 'PHP',


### PR DESCRIPTION
Add JSON language modes to CodeMirror instances and the Code fieldtype.

The JSON-LD mode especially is a nice improvement over the standard JS mode.

### (JS mode)

<img width="714" height="254" alt="Screenshot 2026-06-30 at 12 37 38" src="https://github.com/user-attachments/assets/a70312e6-ea5e-49d1-a7d2-f332cca72246" />

### (JSON-LD mode)

<img width="714" height="251" alt="Screenshot 2026-06-30 at 12 37 11" src="https://github.com/user-attachments/assets/70a51f7b-cc7c-44b1-b295-e1dd339a9d07" />
