### PR TITLE
[5.x] Fix user wizard authorization check

### DIFF
--- a/src/Http/Controllers/CP/Users/UserWizardController.php
+++ b/src/Http/Controllers/CP/Users/UserWizardController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Users;
 
 use Illuminate\Http\Request;
+use Statamic\Contracts\Auth\User as UserContract;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 
@@ -10,6 +11,8 @@ class UserWizardController extends CpController
 {
     public function __invoke(Request $request)
     {
+        $this->authorize('index', UserContract::class);
+
         $user = User::findByEmail($request->email);
 
         return ['exists' => (bool) $user];

--- a/tests/Feature/Users/UserExistsTest.php
+++ b/tests/Feature/Users/UserExistsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Users;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class UserExistsTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_denies_users_without_permission_to_view_users()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        tap(User::make()->email('existing@domain.com'))->save();
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAs($me)
+            ->postJson(cp_route('user.exists'), ['email' => 'existing@domain.com'])
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_reports_an_existing_user_for_authorized_users()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view users']]);
+        tap(User::make()->email('existing@domain.com'))->save();
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAs($me)
+            ->postJson(cp_route('user.exists'), ['email' => 'existing@domain.com'])
+            ->assertOk()
+            ->assertExactJson(['exists' => true]);
+    }
+
+    #[Test]
+    public function it_reports_a_missing_user_for_authorized_users()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view users']]);
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAs($me)
+            ->postJson(cp_route('user.exists'), ['email' => 'unknown@domain.com'])
+            ->assertOk()
+            ->assertExactJson(['exists' => false]);
+    }
+
+    #[Test]
+    public function it_allows_super_users()
+    {
+        tap(User::make()->email('existing@domain.com'))->save();
+        $me = tap(User::make()->email('admin@domain.com')->makeSuper())->save();
+
+        $this
+            ->actingAs($me)
+            ->postJson(cp_route('user.exists'), ['email' => 'existing@domain.com'])
+            ->assertOk()
+            ->assertExactJson(['exists' => true]);
+    }
+}


### PR DESCRIPTION
This adds missing authorization to the endpoint that the user creation wizard uses to check for email existence.
