### PR TITLE
[6.x] Fix Glide route double slash for path-prefixed sites

### DIFF
--- a/routes/glide.php
+++ b/routes/glide.php
@@ -7,9 +7,9 @@ use Statamic\Facades\URL;
 use Statamic\Http\Controllers\GlideController;
 
 Site::all()->map(function ($site) {
-    return URL::makeRelative($site->url());
+    return trim(URL::makeRelative($site->url()), '/');
 })->unique()->each(function ($sitePrefix) {
-    Route::group(['prefix' => trim($sitePrefix, '/').'/'.Glide::route()], function () {
+    Route::group(['prefix' => $sitePrefix.'/'.Glide::route()], function () {
         Route::get('/asset/{container}/{path?}', [GlideController::class, 'generateByAsset'])->where('path', '.*');
         Route::get('/http/{url}/{filename?}', [GlideController::class, 'generateByUrl']);
         Route::get('{path}', [GlideController::class, 'generateByPath'])->where('path', '.*');

--- a/routes/glide.php
+++ b/routes/glide.php
@@ -9,7 +9,7 @@ use Statamic\Http\Controllers\GlideController;
 Site::all()->map(function ($site) {
     return URL::makeRelative($site->url());
 })->unique()->each(function ($sitePrefix) {
-    Route::group(['prefix' => $sitePrefix.'/'.Glide::route()], function () {
+    Route::group(['prefix' => trim($sitePrefix, '/').'/'.Glide::route()], function () {
         Route::get('/asset/{container}/{path?}', [GlideController::class, 'generateByAsset'])->where('path', '.*');
         Route::get('/http/{url}/{filename?}', [GlideController::class, 'generateByUrl']);
         Route::get('{path}', [GlideController::class, 'generateByPath'])->where('path', '.*');

--- a/tests/Imaging/GlideRoutePrefixTest.php
+++ b/tests/Imaging/GlideRoutePrefixTest.php
@@ -12,6 +12,14 @@ class GlideRoutePrefixTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    public function tearDown(): void
+    {
+        URL::enforceTrailingSlashes(false);
+        URL::clearUrlCache();
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function it_registers_glide_routes_without_a_double_slash_for_a_path_prefixed_site_with_trailing_slashes()
     {

--- a/tests/Imaging/GlideRoutePrefixTest.php
+++ b/tests/Imaging/GlideRoutePrefixTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Imaging;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\URL;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class GlideRoutePrefixTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_registers_glide_routes_without_a_double_slash_for_a_path_prefixed_site_with_trailing_slashes()
+    {
+        URL::enforceTrailingSlashes();
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => '/nl/'],
+        ]);
+
+        require __DIR__.'/../../routes/glide.php';
+
+        $uris = collect(Route::getRoutes()->getRoutes())
+            ->map->uri()
+            ->filter(fn ($uri) => str_contains($uri, 'img/asset'))
+            ->values();
+
+        $this->assertContains('nl/img/asset/{container}/{path?}', $uris->all());
+        $this->assertEmpty(
+            $uris->filter(fn ($uri) => str_contains($uri, '//'))->all(),
+            'Glide route prefix should not contain a double slash.'
+        );
+    }
+}


### PR DESCRIPTION
### Problem

When a site's `url` has a **path prefix** (e.g. `https://example.com/nl/`) **and** trailing-slash enforcement is enabled via `URL::enforceTrailingSlashes()`, every Glide-served image 404s.

`routes/glide.php` builds the route group prefix by concatenating without normalizing the join:

```php
Route::group(['prefix' => $sitePrefix.'/'.Glide::route()], ...)
```

`$sitePrefix` comes from `URL::makeRelative($site->url())`. With `enforceTrailingSlashes()` on, `makeRelative()` keeps the trailing slash, so a `/nl/` site yields `/nl/`. The prefix then becomes:

```
"/nl/" . "/" . "img"  =>  "/nl//img"
```

Laravel only trims the **outer** edges of a route prefix (`rtrim($prefix, '/')` / `ltrim($uri, '/')`), so the **interior** `//` survives and the route registers as `nl//img/asset/...`. A real request for `/nl/img/asset/...` (single slash) never matches → 404.

Root sites are unaffected, because their prefix is `//img` where the double slash is leading and tolerated by Laravel's path matching. The bug only surfaces for sites with a non-empty URL path prefix.

### Reproduction

1. Single site with `url: https://example.com/nl/`.
2. Call `URL::enforceTrailingSlashes()` in a service provider's `boot()`.
3. Request any `{{ glide }}`-generated image at `/nl/img/asset/...` → 404.

### Fix

Trim the site prefix before joining, so an interior double slash can't occur:

```php
Route::group(['prefix' => trim($sitePrefix, '/').'/'.Glide::route()], ...)
```

This yields `nl/img` for prefixed sites and `img` for root sites — both correct. The included test asserts the registered route URI is `nl/img/asset/...` (not `nl//img/...`) and fails without the fix. Existing Glide test suites (`tests/Imaging/GlideTest.php`, `tests/Tags/GlideTest.php`, `tests/Imaging/GlideUrlBuilderTest.php`) still pass.
