### PR TITLE
[5.x] Tighten up dynamic method resolution

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -30,6 +30,7 @@ use Statamic\Fieldtypes\Link\ArrayableLink;
 use Statamic\Support\Arr;
 use Statamic\Support\Dumper;
 use Statamic\Support\Html;
+use Statamic\Support\MethodDenylist;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 use Stringy\StaticStringy as Stringy;
@@ -862,13 +863,13 @@ class CoreModifiers extends Modifier
         // available data. Then grab the requested variable from there.
         $array = $item instanceof Augmentable ? $item->toDeferredAugmentedArray() : $item->toArray();
 
-        if ($arrayValue = Arr::get($array, $var)) {
-            return $arrayValue;
+        if (Arr::has($array, $var)) {
+            return Arr::get($array, $var);
         }
 
         // Finally, try to call a method on the object
         $method = Str::slug($var);
-        if (method_exists($item, $method)) {
+        if (method_exists($item, $method) && ! MethodDenylist::blocks($method)) {
             return $item->$method();
         }
 

--- a/src/Query/ResolveValue.php
+++ b/src/Query/ResolveValue.php
@@ -5,16 +5,11 @@ namespace Statamic\Query;
 use Statamic\Contracts\Query\ContainsQueryableValues;
 use Statamic\Contracts\Query\QueryableValue;
 use Statamic\Support\Arr;
+use Statamic\Support\MethodDenylist;
 use Statamic\Support\Str;
 
 class ResolveValue
 {
-    private array $denylist = [
-        'delete', 'deleteFile', 'deleteQuietly',
-        'destroy', 'forceDelete', 'save', 'saveQuietly',
-        'truncate', 'update', 'updateQuietly', 'write', 'writeFile',
-    ];
-
     public function __invoke($item, $name)
     {
         if (Str::startsWith($name, 'data->')) {
@@ -58,7 +53,7 @@ class ResolveValue
             return $item->getQueryableValue($name);
         }
 
-        if (method_exists($item, $method = Str::camel($name)) && ! in_array($method, $this->denylist)) {
+        if (method_exists($item, $method = Str::camel($name)) && ! MethodDenylist::blocks($method)) {
             return $item->{$method}();
         }
 

--- a/src/Support/MethodDenylist.php
+++ b/src/Support/MethodDenylist.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Support;
+
+class MethodDenylist
+{
+    private const array METHODS = [
+        'delete', 'deleteFile', 'deleteQuietly',
+        'destroy', 'forceDelete', 'save', 'saveQuietly',
+        'truncate', 'update', 'updateQuietly', 'write', 'writeFile',
+    ];
+
+    public static function blocks(string $method): bool
+    {
+        return in_array(strtolower($method), array_map('strtolower', self::METHODS), true);
+    }
+}

--- a/src/Support/MethodDenylist.php
+++ b/src/Support/MethodDenylist.php
@@ -4,7 +4,7 @@ namespace Statamic\Support;
 
 class MethodDenylist
 {
-    private const array METHODS = [
+    private const METHODS = [
         'delete', 'deleteFile', 'deleteQuietly',
         'destroy', 'forceDelete', 'save', 'saveQuietly',
         'truncate', 'update', 'updateQuietly', 'write', 'writeFile',

--- a/src/View/Antlers/Language/Runtime/PathDataManager.php
+++ b/src/View/Antlers/Language/Runtime/PathDataManager.php
@@ -17,6 +17,7 @@ use Statamic\Contracts\View\Antlers\Parser;
 use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Value;
 use Statamic\Fields\Values;
+use Statamic\Support\MethodDenylist;
 use Statamic\View\Antlers\AntlersString;
 use Statamic\View\Antlers\Language\Errors\AntlersErrorCodes;
 use Statamic\View\Antlers\Language\Errors\ErrorFactory;
@@ -859,12 +860,20 @@ class PathDataManager
             $this->unlockData();
         }
 
-        if (is_object($this->reducedVar) && method_exists($this->reducedVar, Str::camel($varPath))) {
-            $this->reducedVar = call_user_func_array([$this->reducedVar, Str::camel($varPath)], []);
-            $this->resolvedPath[] = '{method:'.$varPath.'}';
+        if (is_object($this->reducedVar) && method_exists($this->reducedVar, $method = Str::camel($varPath))) {
+            if (MethodDenylist::blocks($method)) {
+                // The method name derives from user-influenceable data, so never
+                // dispatch to methods that mutate or destroy data. Resolve to null.
+                $this->reducedVar = null;
+                $this->didFind = false;
+                $this->doBreak = true;
+            } else {
+                $this->reducedVar = call_user_func_array([$this->reducedVar, $method], []);
+                $this->resolvedPath[] = '{method:'.$varPath.'}';
 
-            if ($doCompact) {
-                $this->compact($path->isFinal);
+                if ($doCompact) {
+                    $this->compact($path->isFinal);
+                }
             }
         } elseif (is_array($this->reducedVar)) {
             if (is_numeric($varPath) && ! Arr::isAssoc($this->reducedVar) && $varPath < count($this->reducedVar) && array_key_exists($varPath, $this->reducedVar)) {

--- a/tests/Antlers/Runtime/TemplateTest.php
+++ b/tests/Antlers/Runtime/TemplateTest.php
@@ -160,6 +160,18 @@ EOT;
             'key' => 'saveQuietly',
         ]));
         $this->assertFalse($object->savedQuietly);
+
+        // The same guard covers literal colon path syntax, which flows through
+        // the same dispatch branch.
+        $this->assertEquals('', $this->renderString('{{ object:delete }}', [
+            'object' => $object,
+        ]));
+        $this->assertFalse($object->deleted);
+
+        $this->assertEquals('', $this->renderString('{{ object:forceDelete }}', [
+            'object' => $object,
+        ]));
+        $this->assertFalse($object->forceDeleted);
     }
 
     #[Test]

--- a/tests/Antlers/Runtime/TemplateTest.php
+++ b/tests/Antlers/Runtime/TemplateTest.php
@@ -131,6 +131,38 @@ EOT;
     }
 
     #[Test]
+    public function dynamic_key_access_on_an_object_does_not_dispatch_destructive_methods()
+    {
+        $object = new MethodDispatchObject;
+
+        // A benign accessor method still dispatches.
+        $this->assertEquals('the title', $this->renderString('{{ object:title }}', [
+            'object' => $object,
+        ]));
+
+        // Destructive methods must not be dispatched; the expression resolves to empty.
+        $this->assertEquals('', $this->renderString('{{ object[key] }}', [
+            'object' => $object,
+            'key' => 'delete',
+        ]));
+        $this->assertFalse($object->deleted);
+
+        // Str::camel() reaches camelCase mutators too (e.g. "force-delete" => "forceDelete"),
+        // and method_exists() is case-insensitive, so these must be blocked regardless of casing.
+        $this->assertEquals('', $this->renderString('{{ object[key] }}', [
+            'object' => $object,
+            'key' => 'force-delete',
+        ]));
+        $this->assertFalse($object->forceDeleted);
+
+        $this->assertEquals('', $this->renderString('{{ object[key] }}', [
+            'object' => $object,
+            'key' => 'saveQuietly',
+        ]));
+        $this->assertFalse($object->savedQuietly);
+    }
+
+    #[Test]
     public function complex_array_variable()
     {
         $template = <<<'EOT'
@@ -2714,5 +2746,32 @@ class AugmentableObject extends ArrayableObject implements Augmentable
         return (new Blueprint)->setContents(['fields' => [
             ['handle' => 'one', 'field' => ['type' => 'test']],
         ]]);
+    }
+}
+
+class MethodDispatchObject
+{
+    public $deleted = false;
+    public $forceDeleted = false;
+    public $savedQuietly = false;
+
+    public function title()
+    {
+        return 'the title';
+    }
+
+    public function delete()
+    {
+        $this->deleted = true;
+    }
+
+    public function forceDelete()
+    {
+        $this->forceDeleted = true;
+    }
+
+    public function saveQuietly()
+    {
+        $this->savedQuietly = true;
     }
 }

--- a/tests/Modifiers/GetTest.php
+++ b/tests/Modifiers/GetTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Modifiers\Modify;
+use Tests\TestCase;
+
+class GetTest extends TestCase
+{
+    private function modify($value, $key)
+    {
+        return Modify::value($value)->get([$key])->fetch();
+    }
+
+    #[Test]
+    public function it_gets_a_field_value()
+    {
+        $item = new GetTestItem;
+
+        $this->assertEquals('Hello', $this->modify($item, 'title'));
+    }
+
+    #[Test]
+    public function it_returns_falsy_field_values_instead_of_falling_through_to_a_method()
+    {
+        $item = new GetTestItem;
+
+        $this->assertSame('', $this->modify($item, 'empty'));
+        $this->assertSame(0, $this->modify($item, 'zero'));
+        $this->assertSame(false, $this->modify($item, 'false'));
+    }
+
+    #[Test]
+    public function it_dispatches_to_a_non_destructive_accessor_method()
+    {
+        $item = new GetTestItem;
+
+        $this->assertEquals('https://example.com', $this->modify($item, 'url'));
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_to_destructive_methods()
+    {
+        $item = new GetTestItem;
+
+        $result = $this->modify($item, 'delete');
+
+        $this->assertFalse($item->deleted);
+        $this->assertSame($item, $result);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_to_destructive_methods_case_insensitively()
+    {
+        // Str::slug() lowercases the parameter (e.g. "deleteQuietly" => "deletequietly"),
+        // but method_exists() is case-insensitive, so the denylist must match regardless of case.
+        $item = new GetTestItem;
+
+        $this->modify($item, 'deletequietly');
+        $this->assertFalse($item->deletedQuietly);
+
+        $this->modify($item, 'savequietly');
+        $this->assertFalse($item->savedQuietly);
+    }
+}
+
+class GetTestItem
+{
+    public $deleted = false;
+    public $deletedQuietly = false;
+    public $saved = false;
+    public $savedQuietly = false;
+
+    public function toArray()
+    {
+        return [
+            'title' => 'Hello',
+            'empty' => '',
+            'zero' => 0,
+            'false' => false,
+        ];
+    }
+
+    public function url()
+    {
+        return 'https://example.com';
+    }
+
+    public function delete()
+    {
+        $this->deleted = true;
+    }
+
+    public function deleteQuietly()
+    {
+        $this->deletedQuietly = true;
+    }
+
+    public function save()
+    {
+        $this->saved = true;
+    }
+
+    public function saveQuietly()
+    {
+        $this->savedQuietly = true;
+    }
+}

--- a/tests/Query/ResolveValueTest.php
+++ b/tests/Query/ResolveValueTest.php
@@ -98,6 +98,33 @@ class ResolveValueTest extends TestCase
 
         $this->assertEquals('test', $value);
     }
+
+    #[Test]
+    public function it_does_not_resolve_by_dispatching_to_destructive_methods()
+    {
+        $item = new ContainsDestructiveMethods;
+
+        // "delete" resolves via Str::camel to the denylisted "delete" method,
+        // so it must not be dispatched; it falls through to get() instead.
+        $this->assertEquals('fell through to get', (new ResolveValue)($item, 'delete'));
+        $this->assertFalse($item->deleted);
+    }
+
+    #[Test]
+    public function it_does_not_dispatch_to_destructive_methods_case_insensitively()
+    {
+        $item = new ContainsDestructiveMethods;
+
+        // Str::camel("force-delete") is "forceDelete", and method_exists() is
+        // case-insensitive, so the denylist must match regardless of casing.
+        $this->assertEquals('fell through to get', (new ResolveValue)($item, 'force-delete'));
+        $this->assertFalse($item->forceDeleted);
+
+        // "deletequietly" resolves to a lowercased name that still matches the
+        // denylisted "deleteQuietly" method case-insensitively.
+        $this->assertEquals('fell through to get', (new ResolveValue)($item, 'deletequietly'));
+        $this->assertFalse($item->deletedQuietly);
+    }
 }
 
 class ContainsData
@@ -136,6 +163,33 @@ class ContainsMethod extends ContainsValues
     public function theFooField()
     {
         return 'theFooField method';
+    }
+}
+
+class ContainsDestructiveMethods
+{
+    public $deleted = false;
+    public $forceDeleted = false;
+    public $deletedQuietly = false;
+
+    public function get($field)
+    {
+        return 'fell through to get';
+    }
+
+    public function delete()
+    {
+        $this->deleted = true;
+    }
+
+    public function forceDelete()
+    {
+        $this->forceDeleted = true;
+    }
+
+    public function deleteQuietly()
+    {
+        $this->deletedQuietly = true;
     }
 }
 


### PR DESCRIPTION
Adds some internal guarding around how method names get resolved dynamically from data, so a few methods that shouldn't be reachable that way no longer are. Also tidies up a related edge case in the `get` modifier where certain field values weren't returned as expected.