### PR TITLE
[6.x] Fix CodeQL parse error for import.meta.glob

### DIFF
--- a/resources/js/index.js
+++ b/resources/js/index.js
@@ -7,7 +7,7 @@ import Cookies from 'cookies-js';
 import * as cms from './bootstrap/cms/index.js';
 import hmr from './bootstrap/hmr';
 
-import.meta.glob(['../img/**'], { eager: true });
+void import.meta.glob(['../img/**'], { eager: true });
 
 let global_functions = Object.keys(Globals);
 global_functions.forEach((fnName) => {


### PR DESCRIPTION
`import.meta.glob(['../img/**'], { eager: true })` in `resources/js/index.js` was flagged by CodeQL as a syntax error ("Unexpected token"). This is a false positive caused by the statement starting with the `import` keyword — CodeQL's parser tries to match it against `ImportDeclaration` grammar and chokes on `.meta` in that position. Every other `import.meta.glob` usage in the codebase is nested inside a larger expression (assignment/argument), which avoids the issue.

Prefixing with `void` moves `import` out of statement-initial position without changing behavior.