### PR TITLE
[6.x] Fix Bard link entry selector not showing pre-selected entry

### DIFF
--- a/resources/js/components/fieldtypes/bard/LinkToolbar.vue
+++ b/resources/js/components/fieldtypes/bard/LinkToolbar.vue
@@ -119,7 +119,8 @@
             class="hidden"
             ref="relationshipInput"
             name="link"
-            :value="[]"
+            :value="selectedEntryValue"
+            :data="selectedEntryData"
             :config="relationshipConfig"
             :item-data-url="itemDataUrl"
             :selections-url="selectionsUrl"
@@ -259,6 +260,16 @@ export default {
             if (this.config.link_noopener) rel.push('noopener');
             if (this.config.link_noreferrer) rel.push('noreferrer');
             return rel.length ? rel.join(' ') : null;
+        },
+
+        selectedEntryValue() {
+            const { type, id } = this.parseDataUrl(this.url.entry);
+
+            return type === 'entry' && id ? [id] : [];
+        },
+
+        selectedEntryData() {
+            return this.itemData.entry ? [this.itemData.entry] : [];
         },
 
         relationshipConfig() {


### PR DESCRIPTION
This pull request fixes an issue where opening the entry selector from a Bard link's stack showed "0 out of 1 selected" with the already-linked entry left unchecked, even though the link already pointed to that entry.

This was happening because the Bard link editor embeds a hidden `relationship-input` to drive the entry selector, but its value was hardcoded to an empty array, so the selector always opened with nothing pre-selected.

This PR fixes it by passing the current entry's id and item data through to the `relationship-input`, so the selector opens with the linked entry already selected and highlighted.

Thanks to Juri for reporting it via support!

## Before

<img width="1150" height="836" alt="CleanShot 2026-07-02 at 09 44 43" src="https://github.com/user-attachments/assets/f5a3fe8d-0de6-4a63-8016-9332dda5b2b5" />


## After

<img width="1150" height="836" alt="CleanShot 2026-07-02 at 09 44 24" src="https://github.com/user-attachments/assets/b02b88f8-9c97-45c0-895f-79548ac95289" />

