### PR TITLE
[6.x] Fix required validation on empty code fields

### DIFF
--- a/src/Fieldtypes/Code.php
+++ b/src/Fieldtypes/Code.php
@@ -168,6 +168,15 @@ class Code extends Fieldtype
         return $value;
     }
 
+    public function preProcessValidatable($value)
+    {
+        if (is_array($value)) {
+            return $value['code'] ?? null;
+        }
+
+        return $value;
+    }
+
     public function process($value)
     {
         if (! $value) {

--- a/tests/Fieldtypes/CodeTest.php
+++ b/tests/Fieldtypes/CodeTest.php
@@ -49,6 +49,46 @@ class CodeTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('preProcessValidatableValuesProvider')]
+    public function it_preprocesses_validatable_values($value, $expected)
+    {
+        $field = (new Code)->setField(new Field('test', ['type' => 'code']));
+
+        $this->assertEquals($expected, $field->preProcessValidatable($value));
+    }
+
+    public static function preProcessValidatableValuesProvider()
+    {
+        return [
+            'string' => ['bar', 'bar'],
+            'null' => [null, null],
+            'array with code' => [['code' => 'bar', 'mode' => 'htmlmixed'], 'bar'],
+            'array without code' => [['code' => null, 'mode' => 'htmlmixed'], null],
+        ];
+    }
+
+    #[Test]
+    public function required_rule_fails_on_an_empty_code_field()
+    {
+        $fields = (new \Statamic\Fields\Fields)->setItems([[
+            'handle' => 'test',
+            'field' => ['type' => 'code', 'validate' => ['required']],
+        ]]);
+
+        $empty = (new \Statamic\Fields\Validator)->fields(
+            $fields->addValues(['test' => ['code' => null, 'mode' => 'application/ld+json']])
+        );
+
+        $this->assertFalse($empty->validator()->passes());
+
+        $filled = (new \Statamic\Fields\Validator)->fields(
+            $fields->addValues(['test' => ['code' => 'bar', 'mode' => 'application/ld+json']])
+        );
+
+        $this->assertTrue($filled->validator()->passes());
+    }
+
+    #[Test]
     public function it_doesnt_do_any_preprocessing_for_config()
     {
         $field = (new Code)->setField(new Field('test', ['type' => 'code']));


### PR DESCRIPTION
This pull request fixes an issue where setting a `code` fieldtype to `required` had no effect — an empty field would pass validation and the entry would save.

This was happening because the code fieldtype submits an object (`{ code: null, mode: '...' }`) rather than a scalar. Since that object is a non-empty array, Laravel's `required` rule considered it present and passed.

This PR fixes it by adding a `preProcessValidatable` method to the fieldtype, which unwraps the object so validation rules run against the code string itself. When the field is empty, `required` now correctly fails.

Fixes #14907