### PR TITLE
[6.x] Fix fieldtype picker showing wrong list after switching blueprint modes

### DIFF
--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -112,11 +112,18 @@ export default {
         fieldtypes() {
             if (!this.fieldtypesLoaded) return;
 
-            return loadedFieldtypes.value;
+            return loadedFieldtypes.value.data;
+        },
+
+        isFormBlueprint() {
+            return !!this.$config.get('isFormBlueprint');
         },
 
         fieldtypesLoaded() {
-            return Array.isArray(loadedFieldtypes.value);
+            // The cache is shared across every picker instance, but form and regular blueprints
+            // request different lists. Only treat it as loaded when the cached list matches the
+            // current blueprint mode, otherwise we'll refetch the correct one.
+            return Array.isArray(loadedFieldtypes.value?.data) && loadedFieldtypes.value.forms === this.isFormBlueprint;
         },
 
         allFieldtypes() {
@@ -225,12 +232,14 @@ export default {
     created() {
         if (this.fieldtypesLoaded) return;
 
+        const forms = this.isFormBlueprint;
+
         let url = cp_url('fields/fieldtypes?selectable=true');
 
-        if (this.$config.get('isFormBlueprint')) url += '&forms=true';
+        if (forms) url += '&forms=true';
 
         this.$axios.get(url)
-            .then((response) => (loadedFieldtypes.value = response.data))
+            .then((response) => (loadedFieldtypes.value = { forms, data: response.data }))
             .catch((e) => {
                 this.$toast.error(e.response?.data?.message || __('Something went wrong'));
                 this.close();


### PR DESCRIPTION
This pull request fixes an issue where the fieldtype picker shows the wrong list of fieldtypes after switching between a form blueprint and a regular blueprint (until a full page reload).

This was happening because the picker caches its fieldtype list in a module-level singleton shared across every instance, but the two modes request different lists — regular blueprints fetch all selectable fieldtypes, while form blueprints fetch a smaller list that respects `Fieldtype::makeUnselectableInForms()`. Since the cache was only checked for "is it an array?", the first picker to load won, and every later picker early-returned regardless of its blueprint mode. Reloading fixed it because the module state reset.

This PR fixes it by keying the cache on the blueprint mode. The cache now stores `{ forms, data }` and is only treated as loaded when the cached mode matches the current picker's mode, otherwise it refetches the correct list. Cross-picker caching is preserved within a mode.

FWIW: I've removed `isFormBlueprint` on the `forms-2` branch because forms won't be using blueprints with the new form builder / form fieldtypes system.

Fixes #14903