### PR TITLE
[6.x] Do not show a disabled cursor for start/end of pagination

### DIFF
--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -166,6 +166,7 @@ function getRange(start, end) {
             <Button
                 size="sm"
                 :variant="hasPrevious && !showPageLinks ? 'filled' : 'ghost'"
+                :class="{ 'disabled:cursor-default': !showPageLinks }"
                 round
                 icon="chevron-left"
                 :disabled="!hasPrevious"
@@ -187,6 +188,7 @@ function getRange(start, end) {
             <Button
                 size="sm"
                 :variant="hasNext && !showPageLinks ? 'filled' : 'ghost'"
+                :class="{ 'disabled:cursor-default': !showPageLinks }"
                 round
                 icon="chevron-right"
                 :disabled="!hasNext"

--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -166,7 +166,7 @@ function getRange(start, end) {
             <Button
                 size="sm"
                 :variant="hasPrevious && !showPageLinks ? 'filled' : 'ghost'"
-                :class="{ 'disabled:cursor-default': !showPageLinks }"
+                class="disabled:cursor-default"
                 round
                 icon="chevron-left"
                 :disabled="!hasPrevious"
@@ -178,6 +178,7 @@ function getRange(start, end) {
                 v-for="(page, i) in pages"
                 size="sm"
                 round
+                class="disabled:cursor-default"
                 :variant="page == currentPage ? 'filled' : 'ghost'"
                 :key="i"
                 @click="selectPage(page)"
@@ -188,7 +189,7 @@ function getRange(start, end) {
             <Button
                 size="sm"
                 :variant="hasNext && !showPageLinks ? 'filled' : 'ghost'"
-                :class="{ 'disabled:cursor-default': !showPageLinks }"
+                class="disabled:cursor-default"
                 round
                 icon="chevron-right"
                 :disabled="!hasNext"


### PR DESCRIPTION
## Description of the Problem

"Disabled" buttons receive a "disabled cursor" hover state. This usually works well, for example, when a publish action is unavailable.

### Permission Based rather than State Based

I think the disabled cursor works well when it's telling the user they **"don't have permission"**, or because the action is intentionally unavailable. Under the hood the CSS property is `cursor:not-allowed;`, which points to its intended use.

I don't think this should be used where a button is simply inactive – for example, when you've reached the last page in pagination. It isn’t unavailable due to a restriction—it simply isn’t available because you've reached an endpoint.

## What this PR Does

Pagination buttons are now simply inactive – `cursor: not-allowed` is effectively no longer applied

<img width="3420" height="2146" alt="2026-07-02 at 12 19 25@2x" src="https://github.com/user-attachments/assets/39b11842-ae8c-4924-a1dd-7afbbdf88a44" />

## How to Reproduce

1. Go the beginning/end of pagination. Dashboard widgets are a good example.
2. Hover over the inactive/disabled `prev/next` button