### PR TITLE
[6.x] Upgrade PHPUnit and add laravel/pao

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,11 +45,12 @@
         "doctrine/dbal": "^3.6",
         "fakerphp/faker": "~1.10",
         "google/cloud-translate": "^1.6",
+        "laravel/pao": "^1.1",
         "laravel/pint": "1.16.0",
         "laravel/socialite": "^5.28",
         "mockery/mockery": "^1.6.10",
         "orchestra/testbench": "^10.8 || ^11.0",
-        "phpunit/phpunit": "^11.5.3",
+        "phpunit/phpunit": "^12.5.23",
         "spatie/laravel-ray": "^1.43.6"
     },
     "conflict": {


### PR DESCRIPTION
Bumps `phpunit/phpunit` from `^11.5.3` to `^12.5.23` and adds `laravel/pao` as a dev dependency.

PAO detects when tests are running inside an AI coding agent and compresses PHPUnit's output to compact JSON, cutting token usage significantly with no impact on normal terminal usage.

`^12.5.23` was chosen specifically (rather than a broader `^12.0`) since it's the minimum version PAO supports, and PHPUnit 13.1+ requires PHP 8.4.1+, which would drop support for PHP 8.3 in our test matrix.