### PR TITLE
[6.x] Fix progress bar triggering excessive recursion

### DIFF
--- a/resources/js/composables/progress-bar.js
+++ b/resources/js/composables/progress-bar.js
@@ -1,4 +1,4 @@
-import { ref, watch } from 'vue';
+import { ref } from 'vue';
 import progress from 'nprogress';
 
 progress.configure({ showSpinner: false });
@@ -25,6 +25,8 @@ function stop() {
 function add(name) {
     if (progressNames.value.indexOf(name) == -1) {
         progressNames.value = [...progressNames.value, name];
+
+        if (!progressing.value) start();
     }
 }
 
@@ -36,6 +38,8 @@ function remove(name) {
 
     newValues.splice(i, 1);
     progressNames.value = newValues;
+
+    if (newValues.length === 0 && progressing.value) stop();
 }
 
 function loading(name, loading) {
@@ -47,22 +51,14 @@ function count() {
 }
 
 function isComplete() {
-    return count() === 0;
+    // Derived from the coarse `progressing` boolean rather than the length of
+    // `progressNames` so that reactive consumers (e.g. a form's "is loading"
+    // state) are only notified when loading starts and stops, not on every
+    // individual operation. Otherwise many fields loading at once (e.g. lots of
+    // relationship fields) can trigger enough updates to exceed Vue's recursive
+    // update limit. See https://github.com/statamic/cms/issues/14787
+    return !progressing.value;
 }
-
-watch(
-    names,
-    (newNames) => {
-        if (newNames.length > 0 && !progressing.value) {
-            start();
-        }
-
-        if (newNames.length === 0 && progressing.value) {
-            stop();
-        }
-    },
-    { immediate: true },
-);
 
 export default function useProgressBar() {
     return {

--- a/resources/js/composables/progress-bar.js
+++ b/resources/js/composables/progress-bar.js
@@ -51,12 +51,6 @@ function count() {
 }
 
 function isComplete() {
-    // Derived from the coarse `progressing` boolean rather than the length of
-    // `progressNames` so that reactive consumers (e.g. a form's "is loading"
-    // state) are only notified when loading starts and stops, not on every
-    // individual operation. Otherwise many fields loading at once (e.g. lots of
-    // relationship fields) can trigger enough updates to exceed Vue's recursive
-    // update limit. See https://github.com/statamic/cms/issues/14787
     return !progressing.value;
 }
 

--- a/resources/js/tests/ProgressBar.test.js
+++ b/resources/js/tests/ProgressBar.test.js
@@ -1,0 +1,65 @@
+import { test, expect, beforeEach } from 'vitest';
+import { effect, nextTick } from 'vue';
+import useProgressBar from '@/composables/progress-bar.js';
+
+const progress = useProgressBar();
+
+beforeEach(() => {
+    // Reset any leftover operations between tests.
+    progress.names().slice().forEach((name) => progress.complete(name));
+});
+
+test('loading is reported while operations are in flight', () => {
+    expect(progress.isComplete()).toBe(true);
+
+    progress.loading('a', true);
+    expect(progress.isComplete()).toBe(false);
+    expect(progress.count()).toBe(1);
+
+    progress.loading('a', false);
+    expect(progress.isComplete()).toBe(true);
+    expect(progress.count()).toBe(0);
+});
+
+// Regression test for https://github.com/statamic/cms/issues/14787
+// Many fields loading at once (e.g. lots of relationship fields) used to notify
+// reactive consumers of the loading state once per operation. With enough
+// operations in a single tick this exceeded Vue's recursive update limit and
+// crashed the publish form. Consumers should only be notified when loading
+// transitions between "idle" and "in progress", regardless of how many
+// individual operations are added or removed.
+test('reactive consumers are only notified on start and stop transitions', async () => {
+    let runs = 0;
+    let lastComplete;
+
+    effect(() => {
+        lastComplete = progress.isComplete();
+        runs++;
+    });
+
+    expect(runs).toBe(1); // initial run
+    expect(lastComplete).toBe(true);
+
+    // Add a large batch of operations synchronously.
+    for (let i = 0; i < 200; i++) {
+        progress.loading(`op-${i}`, true);
+    }
+    await nextTick();
+
+    // Only one additional run for the idle -> loading transition.
+    expect(runs).toBe(2);
+    expect(lastComplete).toBe(false);
+
+    // Remove all but the last operation. Still loading, so no new notification.
+    for (let i = 0; i < 199; i++) {
+        progress.loading(`op-${i}`, false);
+    }
+    await nextTick();
+    expect(runs).toBe(2);
+
+    // Remove the final operation. Now one run for the loading -> idle transition.
+    progress.loading('op-199', false);
+    await nextTick();
+    expect(runs).toBe(3);
+    expect(lastComplete).toBe(true);
+});

--- a/resources/js/tests/ProgressBar.test.js
+++ b/resources/js/tests/ProgressBar.test.js
@@ -21,13 +21,6 @@ test('loading is reported while operations are in flight', () => {
     expect(progress.count()).toBe(0);
 });
 
-// Regression test for https://github.com/statamic/cms/issues/14787
-// Many fields loading at once (e.g. lots of relationship fields) used to notify
-// reactive consumers of the loading state once per operation. With enough
-// operations in a single tick this exceeded Vue's recursive update limit and
-// crashed the publish form. Consumers should only be notified when loading
-// transitions between "idle" and "in progress", regardless of how many
-// individual operations are added or removed.
 test('reactive consumers are only notified on start and stop transitions', async () => {
     let runs = 0;
     let lastComplete;


### PR DESCRIPTION
Fixes #14787

## Problem

On entries with many fields that load asynchronously on mount (e.g. lots of relationship/link fields), the publish form throws `Uncaught (in promise) Maximum recursive updates exceeded` and never finishes rendering — the progress bar stays visible and Save is disabled.

## Root cause

Each field that loads registers a loading operation through the progress bar (`$progress.loading(...)`), which mutates the shared reactive `progressNames` array. The loading state was reactive at the *per-operation* level, so every add/remove notified consumers.

The publish form's "is loading" state (`somethingIsLoading` → `canSave` → `$progress.isComplete()`) and the progress bar's own `watch` both read that per-operation state. When ~90+ operations fire synchronously in a single tick, those reactive consumers get re-queued past Vue's `RECURSION_LIMIT` (100), Vue aborts the flush, and the form is left half-rendered.

This is why it's data-size dependent — the reproduction's entries scale linearly in link count, and it starts failing right around the 100 threshold.

## Fix

Expose the loading state *coarsely* so consumers are only notified when loading transitions between idle and in-progress, not on every individual operation:

- `start()`/`stop()` are driven from `add()`/`remove()` on the 0↔N transitions (replacing the per-mutation `watch`).
- `isComplete()` derives from the `progressing` boolean instead of `progressNames.length`.

With this, 90 operations notify consumers twice (start + stop) instead of ~180 times.

## Testing

- Added `ProgressBar.test.js` asserting reactive consumers are only notified on start/stop transitions. It fails against the old behaviour (`expected 201 to be 2`) and passes with the fix.
- Verified in a browser against the reproduction repo: the previously-crashing entry now loads fully with all nested fields rendered and Save enabled.