### PR TITLE
[6.x] Fix fieldtype picker showing the wrong list after switching blueprint types

### DIFF
--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -53,7 +53,9 @@ import { ref } from 'vue';
 import { mapValues } from 'lodash-es';
 import { Icon } from '@/components/ui';
 
-const loadedFieldtypes = ref(null);
+// Keyed by blueprint mode: form and regular blueprints load different fieldtype lists, so a single
+// shared value would let whichever picker opens first stick until a full page reload.
+const loadedFieldtypes = ref({});
 
 export default {
     components: {
@@ -109,14 +111,18 @@ export default {
     },
 
     computed: {
+        mode() {
+            return this.$config.get('isFormBlueprint') ? 'forms' : 'default';
+        },
+
         fieldtypes() {
             if (!this.fieldtypesLoaded) return;
 
-            return loadedFieldtypes.value;
+            return loadedFieldtypes.value[this.mode];
         },
 
         fieldtypesLoaded() {
-            return Array.isArray(loadedFieldtypes.value);
+            return Array.isArray(loadedFieldtypes.value[this.mode]);
         },
 
         allFieldtypes() {
@@ -225,12 +231,16 @@ export default {
     created() {
         if (this.fieldtypesLoaded) return;
 
+        // Capture the mode now so an in-flight request can't land under a different key if the
+        // blueprint mode changes before it resolves.
+        const mode = this.mode;
+
         let url = cp_url('fields/fieldtypes?selectable=true');
 
-        if (this.$config.get('isFormBlueprint')) url += '&forms=true';
+        if (mode === 'forms') url += '&forms=true';
 
         this.$axios.get(url)
-            .then((response) => (loadedFieldtypes.value = response.data))
+            .then((response) => (loadedFieldtypes.value[mode] = response.data))
             .catch((e) => {
                 this.$toast.error(e.response?.data?.message || __('Something went wrong'));
                 this.close();

--- a/resources/js/tests/components/fields/FieldtypeSelector.test.js
+++ b/resources/js/tests/components/fields/FieldtypeSelector.test.js
@@ -1,0 +1,64 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { describe, expect, test, vi } from 'vitest';
+
+globalThis.__ = (key) => key;
+globalThis.cp_url = (path) => `/cp/${path}`;
+
+import FieldtypeSelector from '@/components/fields/FieldtypeSelector.vue';
+
+const stubs = {
+    Icon: true,
+    'ui-input': true,
+    'ui-panel': true,
+    'ui-panel-header': true,
+    'ui-description': true,
+    'ui-icon': true,
+};
+
+function mountSelector({ isFormBlueprint, get }) {
+    return mount(FieldtypeSelector, {
+        global: {
+            mocks: {
+                $axios: { get },
+                $config: { get: (key) => (key === 'isFormBlueprint' ? isFormBlueprint : undefined) },
+                $toast: { error: () => {} },
+            },
+            stubs,
+        },
+    });
+}
+
+describe('FieldtypeSelector fieldtype list caching', () => {
+    // The list is cached in a module-level ref shared across every picker in the SPA session, so it
+    // must be keyed on the blueprint mode or the first picker's list sticks until a page reload.
+    // https://github.com/statamic/cms/issues/14903
+    test('refetches the correct list when switching between regular and form blueprints without reload', async () => {
+        const regular = [{ handle: 'bard', title: 'Bard', categories: ['text'], icon: 'bard', config: [] }];
+        const forms = [{ handle: 'text', title: 'Text', categories: ['text'], icon: 'text', config: [] }];
+
+        const get = vi.fn((url) => Promise.resolve({ data: url.includes('forms=true') ? forms : regular }));
+
+        // Regular blueprint picker loads first.
+        const a = mountSelector({ isFormBlueprint: false, get });
+        await flushPromises();
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(get.mock.calls[0][0]).not.toContain('forms=true');
+
+        // Navigate (no reload) to a form blueprint picker: it must refetch its own filtered list.
+        const b = mountSelector({ isFormBlueprint: true, get });
+        await flushPromises();
+        expect(get).toHaveBeenCalledTimes(2);
+        expect(get.mock.calls[1][0]).toContain('forms=true');
+        expect(b.vm.fieldtypes).toEqual(forms);
+
+        // Back on a regular blueprint: the cached list for that mode is reused, not refetched.
+        const c = mountSelector({ isFormBlueprint: false, get });
+        await flushPromises();
+        expect(get).toHaveBeenCalledTimes(2);
+        expect(c.vm.fieldtypes).toEqual(regular);
+
+        a.unmount();
+        b.unmount();
+        c.unmount();
+    });
+});


### PR DESCRIPTION
The fieldtype picker caches its list in a module-level ref that isn't keyed on whether you're in a form blueprint. Since the CP is an SPA, whichever picker you open first sticks — navigate from a regular blueprint to a form blueprint (or the other way around) and you get the wrong list until a full page reload.

This keys the cache by mode so each mode fetches and reuses its own list.

Fixes #14903