### PR TITLE
[5.x] Fix relationship-based fields showing raw ids after saving

### DIFF
--- a/resources/js/components/inputs/relationship/RelationshipInput.vue
+++ b/resources/js/components/inputs/relationship/RelationshipInput.vue
@@ -234,6 +234,16 @@ export default {
         itemData(data, olddata) {
             if (this.initializing) return;
             this.$emit('item-data-updated', data);
+        },
+
+        value(value) {
+            if (this.initializing || this.loading) return;
+
+            // Values set from outside (e.g. from a save response, where a new term's id gets
+            // normalized) may reference items we have no data for, which would display raw ids.
+            if (value?.some(selection => !_.find(this.data, (item) => item.id == selection))) {
+                this.getDataForSelections(value);
+            }
         }
 
     },


### PR DESCRIPTION
When you type a new term into a terms field (max_items 1, select or typeahead mode) and save, the field switches to showing the raw id (e.g. `tags::bob`) instead of the label until you reload. The publish form resets the values from the save response, where the typed text has been normalized to a `taxonomy::slug` id — but the relationship input's item data is never refreshed, so it can't resolve a title for the new id and falls back to displaying the id itself.

This makes the relationship input refetch its item data whenever the value references items it has no data for. That also heals the other stale-item-data paths reported in the issue (e.g. inside grids), since the input now recovers by itself instead of relying on the meta staying in sync.

Fixes #14785