### PR TITLE
[6.x] Convert date bindings to app timezone in raw SQL dump

### DIFF
--- a/src/Query/Dumper/Concerns/DumpsQueryValues.php
+++ b/src/Query/Dumper/Concerns/DumpsQueryValues.php
@@ -2,6 +2,9 @@
 
 namespace Statamic\Query\Dumper\Concerns;
 
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+
 trait DumpsQueryValues
 {
     protected function dumpQueryArrayValues($array): string
@@ -17,6 +20,10 @@ trait DumpsQueryValues
 
     protected function dumpQueryValue($value): string
     {
+        if ($value instanceof DateTimeInterface) {
+            $value = Carbon::instance($value)->setTimezone(config('app.timezone'));
+        }
+
         $this->bindings[] = $value;
 
         return '?';

--- a/tests/Query/FakesQueriesTest.php
+++ b/tests/Query/FakesQueriesTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Query;
 
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
 use Tests\TestCase;
@@ -20,6 +21,21 @@ class FakesQueriesTest extends TestCase
     {
         $query = User::query()->where('name', 'Jack');
         $this->assertSame("select * from users where name = 'Jack'", $query->toRawSql());
+    }
+
+    #[Test]
+    public function it_converts_date_bindings_to_the_app_timezone_in_raw_sql()
+    {
+        Carbon::setTestNow('2026-07-04 10:00:00');
+
+        $query = User::query()->where('created_at', Carbon::today('Europe/Zurich'));
+
+        $this->assertSame(
+            "select * from users where created_at = '2026-07-03 22:00:00'",
+            $query->toRawSql()
+        );
+
+        Carbon::setTestNow();
     }
 
     #[Test]


### PR DESCRIPTION
After passing a `Carbon` instance with a timezone other than UTC to a `where()` clause, I was confused as to why the dates in the fake query didn't show the correct time.

This PR fixes `toRawSql()` / raw SQL dumping so `DateTimeInterface` bindings (e.g. `Carbon` instances) are converted to the app timezone before being interpolated into the dumped SQL string. Previously, the raw SQL output could show a date/time in whatever timezone the value happened to be in, which didn't match what's actually sent to the "database".