### PR TITLE
[6.x] Fix global variable references not resolving through the data repository

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -179,6 +179,7 @@ class AppServiceProvider extends ServiceProvider
                 ->setRepository('collection', \Statamic\Contracts\Entries\CollectionRepository::class)
                 ->setRepository('taxonomy', \Statamic\Contracts\Taxonomies\TaxonomyRepository::class)
                 ->setRepository('global', \Statamic\Contracts\Globals\GlobalRepository::class)
+                ->setRepository('globals', \Statamic\Contracts\Globals\GlobalVariablesRepository::class)
                 ->setRepository('asset', \Statamic\Contracts\Assets\AssetRepository::class)
                 ->setRepository('user', \Statamic\Contracts\Auth\UserRepository::class);
         });

--- a/tests/Data/Globals/VariablesTest.php
+++ b/tests/Data/Globals/VariablesTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades;
 use Statamic\Facades\Blueprint;
+use Statamic\Facades\Data;
 use Statamic\Facades\GlobalSet;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Value;
@@ -406,5 +407,18 @@ EOT;
 
         $this->assertEquals('A', $variables->getSupplement('bar'));
         $this->assertEquals('B', $clone->getSupplement('bar'));
+    }
+
+    #[Test]
+    public function it_can_be_found_via_the_data_repository_using_its_reference()
+    {
+        $global = tap(GlobalSet::make('test'))->save();
+        $variables = tap($global->inDefaultSite()->data(['foo' => 'bar']))->save();
+
+        $found = Data::find($variables->reference());
+
+        $this->assertInstanceOf(Variables::class, $found);
+        $this->assertEquals($variables->id(), $found->id());
+        $this->assertEquals('bar', $found->get('foo'));
     }
 }


### PR DESCRIPTION
Global variable references use a `globals::` prefix, but only the singular `global` repository was registered, so the reference fell through and got tried against every repository including entries, which throws an invalid ID error on database drivers (for example when adding a set to a Replicator inside a global set). This registers the `globals` prefix against the global variables repository so the reference resolves correctly.

Fixes statamic/eloquent-driver#537
