### PR TITLE
[6.x] Fix timezone handling in `whereDate` and `whereTime`

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -432,7 +432,7 @@ abstract class Builder implements Contract
             $value = Carbon::parse($value);
         }
 
-        $value = Carbon::parse($value->format('Y-m-d')); // we only care about the date part
+        $value = Carbon::instance($value)->setTimezone(config('app.timezone'))->startOfDay(); // we only care about the date part
 
         $this->wheres[] = [
             'type' => 'Date',
@@ -558,7 +558,7 @@ abstract class Builder implements Contract
             $value = Carbon::parse($value);
         }
 
-        $value = $value->format('H:i:s'); // we only care about the time part
+        $value = Carbon::instance($value)->setTimezone(config('app.timezone'))->format('H:i:s'); // we only care about the time part
 
         $this->wheres[] = [
             'type' => 'Time',

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -174,6 +174,21 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function entries_are_found_using_where_date_with_a_carbon_instance_in_a_different_timezone()
+    {
+        $this->createWhereDateTestEntries();
+
+        // 2021-11-15 02:00 in Moscow (+03:00) is 2021-11-14 23:00 in the app's (UTC) timezone,
+        // so it should match Post 2 (stored as 2021-11-14) and not Post 1 or Post 3 (2021-11-15).
+        $value = Carbon::create(2021, 11, 15, 2, 0, 0, 'Europe/Moscow');
+
+        $entries = Entry::query()->whereDate('test_date', $value)->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 2'], $entries->map->title->all());
+    }
+
+    #[Test]
     public function entries_are_found_using_where_month()
     {
         $this->createWhereDateTestEntries();
@@ -247,6 +262,21 @@ class EntryQueryBuilderTest extends TestCase
         $this->assertEquals(['Post 2'], $entries->map->title->all());
 
         $entries = Entry::query()->whereTime('test_date', Carbon::createFromFormat('Y-m-d H:i', '2021-11-13 09:00'))->get();
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 2'], $entries->map->title->all());
+    }
+
+    #[Test]
+    public function entries_are_found_using_where_time_with_a_carbon_instance_in_a_different_timezone()
+    {
+        $this->createWhereDateTestEntries();
+
+        // 2021-11-13 12:00 in Moscow (+03:00) is 09:00 in the app's (UTC) timezone,
+        // matching Post 2's stored time.
+        $value = Carbon::create(2021, 11, 13, 12, 0, 0, 'Europe/Moscow');
+
+        $entries = Entry::query()->whereTime('test_date', $value)->get();
+
         $this->assertCount(1, $entries);
         $this->assertEquals(['Post 2'], $entries->map->title->all());
     }


### PR DESCRIPTION
Closes: #14939 

## Summary

- `whereDate()` / `whereTime()` reparsed `Carbon`/`DateTimeInterface` values using the app's default timezone instead of converting them, silently shifting the compared instant when the passed value was in a different timezone.
- Both now convert the value to `config('app.timezone')` before truncating to the date/time part.

## Test plan

- [x] Added tests covering `whereDate`/`whereTime` with a `Carbon` instance in a non-app timezone
- [x] Existing `whereDate`/`whereMonth`/`whereDay`/`whereYear`/`whereTime` tests still pass
