### PR TITLE
[6.x] Fix errors when a structure tree contains a null item

### DIFF
--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -55,7 +55,25 @@ abstract class Tree implements ContainsQueryableValues, Contract, Localization
                     return $this->structure()->validateTree($tree, $this->locale());
                 });
             })
+            ->setter(function ($tree) {
+                return $this->removeNullItems($tree);
+            })
             ->args(func_get_args());
+    }
+
+    protected function removeNullItems($tree)
+    {
+        return collect($tree)
+            ->reject(fn ($item) => is_null($item))
+            ->map(function ($item) {
+                if (isset($item['children'])) {
+                    $item['children'] = $this->removeNullItems($item['children']);
+                }
+
+                return $item;
+            })
+            ->values()
+            ->all();
     }
 
     public function root()

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -1186,6 +1186,32 @@ class EntryTest extends TestCase
     }
 
     #[Test]
+    public function it_gets_the_order_from_the_collections_structure_when_the_tree_contains_a_null_item()
+    {
+        $collection = tap(Collection::make('ordered'))->save();
+
+        $one = tap((new Entry)->locale('en')->id('one')->collection($collection))->save();
+        $two = tap((new Entry)->locale('en')->id('two')->collection($collection))->save();
+        $three = tap((new Entry)->locale('en')->id('three')->collection($collection))->save();
+
+        $collection->structureContents([
+            'max_depth' => 3,
+        ])->save();
+        $collection->structure()->in('en')->tree(
+            [
+                ['entry' => 'three'],
+                null,
+                ['entry' => 'one'],
+                ['entry' => 'two'],
+            ]
+        )->save();
+
+        $this->assertEquals(2, $one->order());
+        $this->assertEquals(3, $two->order());
+        $this->assertEquals(1, $three->order());
+    }
+
+    #[Test]
     public function it_gets_the_order_from_the_data_if_not_structured()
     {
         $collection = tap(Collection::make('test'))->save();

--- a/tests/Data/Structures/TreeTest.php
+++ b/tests/Data/Structures/TreeTest.php
@@ -426,8 +426,8 @@ class TreeTest extends TestCase
         $structure = $this->mock(Structure::class);
         $structure->shouldReceive('handle')->andReturn('test');
 
-        $firstContents = ['first' => 'time'];
-        $secondContents = ['second' => 'time'];
+        $firstContents = [['entry' => 'first']];
+        $secondContents = [['entry' => 'second']];
 
         $structure->shouldReceive('validateTree')->with($firstContents, 'the-locale')->once()->andReturn($firstContents);
         $structure->shouldReceive('validateTree')->with($secondContents, 'the-locale')->once()->andReturn($secondContents);
@@ -449,6 +449,40 @@ class TreeTest extends TestCase
         $tree->tree($secondContents);
         $tree->tree();
         $tree->tree();
+    }
+
+    #[Test]
+    public function it_removes_null_items_when_setting_the_tree()
+    {
+        $tree = $this->tree([
+            [
+                'id' => 'pages-home',
+            ],
+            null,
+            [
+                'id' => 'pages-about',
+                'children' => [
+                    [
+                        'id' => 'pages-board',
+                    ],
+                    null,
+                ],
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                'id' => 'pages-home',
+            ],
+            [
+                'id' => 'pages-about',
+                'children' => [
+                    [
+                        'id' => 'pages-board',
+                    ],
+                ],
+            ],
+        ], $tree->tree());
     }
 
     #[Test]


### PR DESCRIPTION
When a structure tree somehow ends up with a `null` item (e.g. `[{entry: ...}, null]` in the yaml — the reporter isn't sure how it got there), reading an entry's `order()` — including through augmentation — blows up with `array_flip(): Can only flip string and integer values`, and saving the tree crashes the diff with an undefined array key error.

This removes null items (including nested ones under `children`) when the tree is set, so trees hydrated from disk, set programmatically, or saved through the CP are always clean — and the next save writes a healed file.

Supersedes #14802, which was closed for targeting 5.x.

Fixes #14801