### PR TITLE
[6.x] Do not set the Inertia root view globally

### DIFF
--- a/src/Exceptions/Concerns/RendersControlPanelExceptions.php
+++ b/src/Exceptions/Concerns/RendersControlPanelExceptions.php
@@ -7,6 +7,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
 use Statamic\Facades\URL;
+use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Statamic;
 
 trait RendersControlPanelExceptions
@@ -23,6 +24,7 @@ trait RendersControlPanelExceptions
             Statamic::$isRenderingCpException = true;
 
             return Inertia::render('errors/Error', ['status' => $response->getStatusCode()])
+                ->rootView(HandleInertiaRequests::ROOT_VIEW)
                 ->toResponse($request)
                 ->setStatusCode($response->getStatusCode());
         }

--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -9,6 +9,7 @@ use Inertia\Inertia;
 use Statamic\Exceptions\AuthenticationException;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\User;
+use Statamic\Http\Middleware\CP\HandleInertiaRequests;
 use Statamic\Statamic;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\Cachers\ApplicationCacher;
@@ -30,6 +31,7 @@ trait RendersHttpExceptions
             }
 
             return Inertia::render('errors/'.$this->getStatusCode())
+                ->rootView(HandleInertiaRequests::ROOT_VIEW)
                 ->toResponse(request())
                 ->setStatusCode($this->getStatusCode());
         }

--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -11,7 +11,9 @@ use function Statamic\trans as __;
 
 class HandleInertiaRequests extends Middleware
 {
-    protected $rootView = 'statamic::layout';
+    public const ROOT_VIEW = 'statamic::layout';
+
+    protected $rootView = self::ROOT_VIEW;
 
     public function version(Request $request): ?string
     {

--- a/src/Providers/CpServiceProvider.php
+++ b/src/Providers/CpServiceProvider.php
@@ -6,7 +6,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
-use Inertia\Inertia;
 use Statamic\CP\Utilities\UtilityRepository;
 use Statamic\Extensions\Translation\Loader;
 use Statamic\Extensions\Translation\Translator;
@@ -21,8 +20,6 @@ class CpServiceProvider extends ServiceProvider
 {
     public function boot()
     {
-        Inertia::setRootView('statamic::layout');
-
         View::composer('statamic::*', function ($view) {
             $view->with('user', User::current());
         });

--- a/tests/Feature/InertiaRootViewTest.php
+++ b/tests/Feature/InertiaRootViewTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class InertiaRootViewTest extends TestCase
+{
+    #[Test]
+    public function it_does_not_set_the_inertia_root_view_globally()
+    {
+        $response = Inertia::render('Test')->toResponse(Request::create('/'));
+
+        $this->assertEquals('app', $response->getOriginalContent()->name());
+    }
+}

--- a/tests/__fixtures__/views/app.blade.php
+++ b/tests/__fixtures__/views/app.blade.php
@@ -1,0 +1,1 @@
+<div id="app" data-page="{{ json_encode($page) }}"></div>


### PR DESCRIPTION
`CpServiceProvider::boot()` set the Inertia root view globally with `Inertia::setRootView('statamic::layout')`, so apps that render their own Inertia frontend outside the control panel inherited it and their pages (including Inertia error responses) rendered inside Statamic's CP layout. The control panel already sets its own root view via the `HandleInertiaRequests` middleware on every CP route, so the global call isn't needed and just leaks into the host app.

Fixes #14619