### PR TITLE
[6.x] Fix asset filters not applying the first time

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -686,6 +686,10 @@ watch(parameters, (newParams, oldParams) => {
     pushState();
 });
 
+// When the URL changes (e.g. the asset browser swaps between its folder and
+// search endpoints as filters are toggled), re-request so the results reflect it.
+watch(() => props.url, () => request());
+
 watch(loading, (loading) => Statamic.$progress.loading(id, loading));
 
 onMounted(() => {

--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -686,8 +686,6 @@ watch(parameters, (newParams, oldParams) => {
     pushState();
 });
 
-// When the URL changes (e.g. the asset browser swaps between its folder and
-// search endpoints as filters are toggled), re-request so the results reflect it.
 watch(() => props.url, () => request());
 
 watch(loading, (loading) => Statamic.$progress.loading(id, loading));


### PR DESCRIPTION
This pull request fixes an issue where applying a filter in the asset browser for the first time did nothing. The listing stayed unfiltered until the filter was changed a second time or pagination was used.

This was happening because the asset browser swaps between two endpoints — a "folder" endpoint that ignores filters, and a "search" endpoint that applies them — based on whether any filters are active. When a filter is first applied, the listing fired its request against the stale (folder) URL before the browser had recomputed the URL to the search endpoint, so the filter was never sent to an endpoint that respects it. On subsequent changes the URL was already correct, so it worked.

This PR fixes it by re-requesting the listing whenever its URL changes, so the results always reflect the current endpoint. The stale in-flight request is aborted by the listing's existing `AbortController`.

Thanks for Juri for reporting this via support!

## Before

https://github.com/user-attachments/assets/c81191f2-9bef-4331-be67-f4cc1e49c975


## After


https://github.com/user-attachments/assets/b651f9c1-da95-45f5-84a7-aa447e8e9420

