### PR TITLE
[6.x] Fix broken asset reference when discarding a duplicate upload

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -627,7 +627,7 @@ export default {
 
         uploadSelected(upload) {
             const path = `${this.folder}/${upload.basename}`.replace(/^\/+/, '');
-            const id = `${this.container.handle}::${path}`;
+            const id = `${this.container.id}::${path}`;
 
             this.uploads.splice(this.uploads.indexOf(upload), 1);
 

--- a/resources/js/tests/components/fieldtypes/AssetsFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/AssetsFieldtype.test.js
@@ -1,0 +1,52 @@
+import { mount } from '@vue/test-utils';
+import { expect, test, vi } from 'vitest';
+import * as Globals from '@/bootstrap/globals';
+import { preferences } from '@api';
+import AssetsFieldtype from '@/components/fieldtypes/assets/AssetsFieldtype.vue';
+
+// Register the global helper functions (data_get, clone, etc.) onto the window
+// like the control panel bootstrap does, so the component can use them.
+Object.keys(Globals).forEach((fn) => (window[fn] = Globals[fn]));
+window.cp_url = (url) => url;
+window.__ = (key) => key;
+preferences.initialize({}, {});
+
+const makeField = ({ axiosPost = vi.fn(() => Promise.resolve({ data: [] })), props = {} } = {}) => {
+    return mount(AssetsFieldtype, {
+        shallow: true,
+        props: {
+            handle: 'image',
+            value: [],
+            config: {},
+            meta: {
+                container: { id: 'main', can_view: true, can_upload: true },
+                data: [],
+            },
+            ...props,
+        },
+        global: {
+            mocks: {
+                $axios: { post: axiosPost },
+                $progress: { loading: () => {} },
+            },
+        },
+    });
+};
+
+test('selecting the existing file references it by the container id', () => {
+    const post = vi.fn(() => Promise.resolve({ data: [] }));
+    const field = makeField({ axiosPost: post });
+
+    field.vm.uploadSelected({ basename: 'user.png' });
+
+    expect(post).toHaveBeenCalledWith('assets-fieldtype', { assets: ['main::user.png'] });
+});
+
+test('the existing file id includes the configured folder', () => {
+    const post = vi.fn(() => Promise.resolve({ data: [] }));
+    const field = makeField({ axiosPost: post, props: { config: { folder: 'sub' } } });
+
+    field.vm.uploadSelected({ basename: 'user.png' });
+
+    expect(post).toHaveBeenCalledWith('assets-fieldtype', { assets: ['main::sub/user.png'] });
+});


### PR DESCRIPTION
When choosing "Discard and use existing file" for a duplicate upload, `uploadSelected()` built the asset id from `this.container.handle`, but the container meta only exposes `id` (which is the container's handle), so the id came out as `undefined::filename` and saving the entry failed with `Asset [undefined::...] not found`. This switches it to `this.container.id`, matching how the rest of the fieldtype references the container.

Fixes #14843
