### PR TITLE
[6.x] Pass the configured index name to the search insert job

### DIFF
--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -9,6 +9,7 @@ use Statamic\Support\Str;
 abstract class Index
 {
     protected $name;
+    protected $handle;
     protected $locale;
     protected $config;
     protected static ?Closure $nameCallback = null;
@@ -25,6 +26,8 @@ abstract class Index
 
     public function __construct($name, array $config, ?string $locale = null)
     {
+        $this->handle = $name;
+
         $this->name = static::$nameCallback
             ? call_user_func(static::$nameCallback, $name, $locale)
             : ($locale ? $name.'_'.$locale : $name);
@@ -91,7 +94,7 @@ abstract class Index
         $documents
             ->chunk(config('statamic.search.chunk_size'))
             ->each(fn ($documents) => InsertMultipleJob::dispatch(
-                name: $this->locale ? Str::before($this->name, "_{$this->locale}") : $this->name,
+                name: $this->handle,
                 locale: $this->locale,
                 documents: $documents
             ));

--- a/tests/Search/IndexTests.php
+++ b/tests/Search/IndexTests.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Search;
 
+use Illuminate\Support\Facades\Bus;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Search\Index;
+use Statamic\Search\InsertMultipleJob;
 
 trait IndexTests
 {
@@ -45,5 +47,27 @@ trait IndexTests
             'resolver' => ['test', [], null, fn ($name, $locale) => 'prefix_'.$name.'_'.$locale, 'prefix_test_'],
             'resolver with locale' => ['test', [], 'en', fn ($name, $locale) => 'prefix_'.$name.'_'.$locale, 'prefix_test_en'],
         ];
+    }
+
+    #[Test]
+    public function it_dispatches_the_insert_job_with_the_configured_handle_not_the_resolved_name()
+    {
+        Bus::fake();
+
+        // A custom resolver that prefixes the name. The resolved name can no longer be
+        // reversed back into the configured handle by string manipulation.
+        $this->getIndexClass()::resolveNameUsing(fn ($name, $locale) => 'prefix_'.$name.'_'.$locale);
+
+        $index = $this->getIndex('test', [], 'en');
+        $this->assertEquals('prefix_test_en', $index->name());
+
+        $index->insertMultiple(collect(['foo::bar']));
+
+        // The job re-resolves the index via Search::index($name, $locale), so it must
+        // receive the configured handle ('test'), not the resolved name ('prefix_test_en').
+        Bus::assertDispatched(
+            InsertMultipleJob::class,
+            fn (InsertMultipleJob $job) => $job->name === 'test' && $job->locale === 'en'
+        );
     }
 }


### PR DESCRIPTION
A while back I added resolveNameUsing() for customising search index names (#10435). It's also in the docs: https://statamic.dev/frontend/search#customizing-index-names. I use it to prefix indexes per environment so staging and production don't collide on the same Algolia app.

Upgrading that same project to v6, indexing silently stopped, the index just stayed empty. 

Since the insert job was moved to the queue (#13126), insertMultiple() [rebuilds the index name for the job from the already-resolved name](https://github.com/statamic/cms/blob/2ba4f0210533d159131a744c9cf1618d01e92c3d/src/Search/Index.php#L94).

With a resolver set, that reconstructed name is wrong, so the job looks up an index that doesn't exist and fails on the queue. `update()` has already cleared the index by then, so it just ends up empty - no error in sight.

Imho the job should always get the index's own name so the resolver is reapplied when it re-resolves. So I store it and pass it through instead of reconstructing it. Added a test to the shared index tests.