### PR TITLE
[6.x] Fix CP tab crash when expanding a Bard set after a copy

### DIFF
--- a/resources/js/components/fieldtypes/GroupFieldtype.vue
+++ b/resources/js/components/fieldtypes/GroupFieldtype.vue
@@ -106,7 +106,16 @@ export default {
         },
 
         toggleCollapsed() {
-            this.isCollapsed = !this.isCollapsed;
+            if (! this.isCollapsed) {
+                this.isCollapsed = true;
+                return;
+            }
+
+            // Expanding: defer the reveal by one frame so the nested Bard editor is
+            // shown after the click, not during it. Revealing a ProseMirror editor in
+            // the same trusted click as a pending rich-text copy crashes the tab on
+            // Chrome/Edge >= 148 (a renderer CFI abort). See statamic/cms#14946.
+            requestAnimationFrame(() => (this.isCollapsed = false));
         },
 
         toggleFullScreen() {

--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -633,15 +633,21 @@ export default {
         },
 
         expandSet(id) {
-            if (this.config.collapse === 'accordion') {
-                this.collapsed = Object.keys(this.meta.existing).filter((v) => v !== id);
-                return;
-            }
+            // Defer the reveal by one frame so the nested Bard editor is shown
+            // after the click, not during it. Revealing a ProseMirror editor in
+            // the same trusted click as a pending rich-text copy crashes the tab
+            // on Chrome/Edge >= 148 (a renderer CFI abort). See statamic/cms#14946.
+            requestAnimationFrame(() => {
+                if (this.config.collapse === 'accordion') {
+                    this.collapsed = Object.keys(this.meta.existing).filter((v) => v !== id);
+                    return;
+                }
 
-            if (this.collapsed.includes(id)) {
-                var index = this.collapsed.indexOf(id);
-                this.collapsed.splice(index, 1);
-            }
+                if (this.collapsed.includes(id)) {
+                    var index = this.collapsed.indexOf(id);
+                    this.collapsed.splice(index, 1);
+                }
+            });
         },
 
         collapseAll() {
@@ -649,7 +655,10 @@ export default {
         },
 
         expandAll() {
-            this.collapsed = [];
+            // Defer the reveal one frame — same reason as expandSet() (statamic/cms#14946).
+            requestAnimationFrame(() => {
+                this.collapsed = [];
+            });
         },
 
         toggleCollapseSets() {

--- a/resources/js/components/fieldtypes/replicator/Replicator.vue
+++ b/resources/js/components/fieldtypes/replicator/Replicator.vue
@@ -313,15 +313,21 @@ export default {
         },
 
         expandSet(id) {
-            if (this.config.collapse === 'accordion') {
-                this.collapsed = this.value.map((v) => v._id).filter((v) => v !== id);
-                return;
-            }
+            // Defer the reveal by one frame so a nested Bard editor is shown
+            // after the click, not during it. Revealing a ProseMirror editor in
+            // the same trusted click as a pending rich-text copy crashes the tab
+            // on Chrome/Edge >= 148 (a renderer CFI abort). See statamic/cms#14946.
+            requestAnimationFrame(() => {
+                if (this.config.collapse === 'accordion') {
+                    this.collapsed = this.value.map((v) => v._id).filter((v) => v !== id);
+                    return;
+                }
 
-            if (this.collapsed.includes(id)) {
-                var index = this.collapsed.indexOf(id);
-                this.collapsed.splice(index, 1);
-            }
+                if (this.collapsed.includes(id)) {
+                    var index = this.collapsed.indexOf(id);
+                    this.collapsed.splice(index, 1);
+                }
+            });
         },
 
         collapseAll() {
@@ -329,7 +335,10 @@ export default {
         },
 
         expandAll() {
-            this.collapsed = [];
+            // Defer the reveal one frame — same reason as expandSet() (statamic/cms#14946).
+            requestAnimationFrame(() => {
+                this.collapsed = [];
+            });
         },
 
         toggleFullscreen() {


### PR DESCRIPTION
Fixes #14946

The chromium render crash ("Aw, Snap") fires when all of these line up in the same click

 1. A **rich copy** is on the clipboard (text copied from inside a Bard editor).
 2. A hidden **Bard editor is revealed** (the set's content goes from `display:none` to visible).
 3. The set's content **animates as it appears** (the header transition + the fields fading in). This was not there in V5, so this is why this bug was probably not triggering there.

When all three happen inside the one click, Chrome _probably_ trips over its own editing/clipboard code and kills the tab.

In this commit we defer the reveal by _one animation frame_ so the Bard editor is shown just after the click. That moves the work off the click, and the crash can't happen.