### PR TITLE
[6.x] Forms 2: Allow multiple forms when Forms Pro is installed

### DIFF
--- a/resources/js/pages/forms/Index.vue
+++ b/resources/js/pages/forms/Index.vue
@@ -2,7 +2,6 @@
 import { computed } from 'vue';
 import Head from '@/pages/layout/Head.vue';
 import { Header, Button, Badge, CommandPaletteItem, EmptyStateMenu, EmptyStateItem, DocsCallout, Icon, Listing, DropdownItem } from '@ui';
-import useStatamicPageProps from '@/composables/page-props.js';
 import { Link, router } from '@inertiajs/vue3';
 
 const props = defineProps([
@@ -14,7 +13,6 @@ const props = defineProps([
     'configureEmailUrl',
 ]);
 
-const { isPro } = useStatamicPageProps();
 const isEmpty = computed(() => props.forms.length === 0);
 
 const reloadPage = () => router.reload();
@@ -54,7 +52,7 @@ const reloadPage = () => router.reload();
         <template v-else>
             <Header :title="__('Forms')" icon="forms">
                 <CommandPaletteItem
-                    v-if="isPro && canCreate"
+                    v-if="canCreate"
                     category="Actions"
                     :text="__('Create Form')"
                     icon="forms"

--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -11,6 +11,7 @@ use Statamic\Facades\Form;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Rules\Handle;
+use Statamic\Statamic;
 use Statamic\Support\Str;
 
 use function Statamic\trans as __;
@@ -48,7 +49,7 @@ class FormsController extends CpController
             'forms' => $forms,
             'initialColumns' => $columns,
             'actionUrl' => cp_route('forms.actions.run'),
-            'canCreate' => User::current()->can('create', FormContract::class),
+            'canCreate' => User::current()->can('create', FormContract::class) && $this->canCreateAdditionalForms(),
             'createUrl' => cp_route('forms.create'),
             'configureEmailUrl' => cp_route('utilities.email'),
         ]);
@@ -65,7 +66,7 @@ class FormsController extends CpController
 
     public function create()
     {
-        $this->authorizeProIf(Form::all()->count() >= 1);
+        $this->authorizeProIf(! $this->canCreateAdditionalForms());
 
         $this->authorize('create', FormContract::class);
 
@@ -76,7 +77,7 @@ class FormsController extends CpController
 
     public function store(Request $request)
     {
-        $this->authorizeProIf(Form::all()->count() >= 1);
+        $this->authorizeProIf(! $this->canCreateAdditionalForms());
 
         $this->authorize('create', FormContract::class, __('You are not authorized to create forms.'));
 
@@ -156,6 +157,13 @@ class FormsController extends CpController
         $this->authorize('delete', $form, 'You are not authorized to delete this form.');
 
         $form->delete();
+    }
+
+    private function canCreateAdditionalForms(): bool
+    {
+        return Form::all()->isEmpty()
+            || Statamic::pro()
+            || Statamic::formsProInstalled();
     }
 
     protected function editFormBlueprint($form)

--- a/tests/Feature/Forms/CreateFormTest.php
+++ b/tests/Feature/Forms/CreateFormTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Forms;
 
+use Facades\Statamic\Console\Processes\Composer;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Form;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -12,6 +14,13 @@ class CreateFormTest extends TestCase
 {
     use FakesRoles;
     use PreventSavingStacheItemsToDisk;
+
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app['config']['statamic.forms.forms'] = $this->fakeStacheDirectory.'/forms';
+    }
 
     #[Test]
     public function it_shows_the_create_page_if_you_have_permission()
@@ -37,5 +46,67 @@ class CreateFormTest extends TestCase
             ->get(cp_route('forms.create'))
             ->assertRedirect('/original')
             ->assertSessionHas('error');
+    }
+
+    #[Test]
+    public function it_allows_the_first_form_without_statamic_pro_or_forms_pro()
+    {
+        config(['statamic.editions.pro' => false]);
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(false);
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->get(cp_route('forms.create'))
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_denies_access_to_a_second_form_without_statamic_pro_or_forms_pro()
+    {
+        config(['statamic.editions.pro' => false]);
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(false);
+
+        Form::make('contact')->save();
+
+        $this
+            ->from('/original')
+            ->actingAs($this->userWithPermission())
+            ->get(cp_route('forms.create'))
+            ->assertRedirect('/original')
+            ->assertSessionHas('error', 'Statamic Pro is required.');
+    }
+
+    #[Test]
+    public function it_allows_a_second_form_with_statamic_pro()
+    {
+        config(['statamic.editions.pro' => true]);
+
+        Form::make('contact')->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->get(cp_route('forms.create'))
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_allows_a_second_form_with_forms_pro_installed()
+    {
+        config(['statamic.editions.pro' => false]);
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(true);
+
+        Form::make('contact')->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->get(cp_route('forms.create'))
+            ->assertSuccessful();
+    }
+
+    private function userWithPermission()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'configure forms']]);
+
+        return tap(User::make()->assignRole('test'))->save();
     }
 }

--- a/tests/Feature/Forms/StoreFormTest.php
+++ b/tests/Feature/Forms/StoreFormTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Forms;
 
+use Facades\Statamic\Console\Processes\Composer;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Form;
 use Statamic\Facades\User;
@@ -81,6 +82,69 @@ class StoreFormTest extends TestCase
             ->assertSessionHasErrors('handle');
 
         $this->assertCount(0, Form::all());
+    }
+
+    #[Test]
+    public function it_stores_the_first_form_without_statamic_pro_or_forms_pro()
+    {
+        config(['statamic.editions.pro' => false]);
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(false);
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->post(cp_route('forms.store'), $this->validParams())
+            ->assertJson(['redirect' => cp_route('forms.show', 'test')]);
+
+        $this->assertCount(1, Form::all());
+    }
+
+    #[Test]
+    public function it_denies_storing_a_second_form_without_statamic_pro_or_forms_pro()
+    {
+        config(['statamic.editions.pro' => false]);
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(false);
+
+        Form::make('contact')->save();
+
+        $this
+            ->from('/original')
+            ->actingAs($this->userWithPermission())
+            ->post(cp_route('forms.store'), $this->validParams())
+            ->assertRedirect('/original')
+            ->assertSessionHas('error', 'Statamic Pro is required.');
+
+        $this->assertCount(1, Form::all());
+    }
+
+    #[Test]
+    public function it_stores_a_second_form_with_statamic_pro()
+    {
+        config(['statamic.editions.pro' => true]);
+
+        Form::make('contact')->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->post(cp_route('forms.store'), $this->validParams())
+            ->assertJson(['redirect' => cp_route('forms.show', 'test')]);
+
+        $this->assertCount(2, Form::all());
+    }
+
+    #[Test]
+    public function it_stores_a_second_form_with_forms_pro_installed()
+    {
+        config(['statamic.editions.pro' => false]);
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(true);
+
+        Form::make('contact')->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->post(cp_route('forms.store'), $this->validParams())
+            ->assertJson(['redirect' => cp_route('forms.show', 'test')]);
+
+        $this->assertCount(2, Form::all());
     }
 
     #[Test]


### PR DESCRIPTION
The ability to create multiple forms is currently gated behind whether [Statamic Pro](https://statamic.com/pricing) is enabled.

This PR updates the feature gate to also allow multiple forms to be created when the Forms Pro addon is installed (coming soon!).