### PR TITLE
[6.x] Prevent the focus box on filters from being clipped

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -732,7 +732,7 @@ autoApplyState();
         <slot v-if="!initializing" :items="items" :is-column-visible="isColumnVisible" :loading="loading">
             <Presets v-if="showPresets" />
             <div v-if="allowSearch || hasFilters || allowCustomizingColumns" class="relative overflow-clip flex items-center gap-2 sm:gap-3 min-h-16 starting-style-transition st-overflow-clip-margin">
-                <div class="flex flex-1 items-center gap-2 sm:gap-3 overflow-x-auto">
+                <div class="flex flex-1 items-center gap-2 sm:gap-3 overflow-x-auto -ms-1 ps-1">
                     <Search v-if="allowSearch" />
                     <Filters v-if="hasFilters" />
                 </div>


### PR DESCRIPTION
## Description of the Problem

https://github.com/statamic/cms/pull/14885 caused some "search" box clipping

## What this PR Does

Fixes it by pushing and pulling the margin/padding by 1px.

### Before

<img width="3420" height="2146" alt="2026-07-07 at 17 27 48@2x" src="https://github.com/user-attachments/assets/3176d858-ebf8-4658-8a96-a54a3b928995" />

### After

<img width="3420" height="2146" alt="2026-07-07 at 17 27 26@2x" src="https://github.com/user-attachments/assets/bab500bb-6760-4740-b84d-c6b4e908081e" />

## How to Reproduce

1. Go to something like `/forms/yourform`
2. Focus on the Search field