### PR TITLE
[6.x] Fix Bard set disappearing after save

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -448,7 +448,7 @@ export default {
             const content = this.valueToContent(value);
 
             if (JSON.stringify(content) !== JSON.stringify(oldContent)) {
-                this.editor.commands.clearContent();
+                this.editor.commands.clearContent(false);
                 this.editor.commands.setContent(content, true);
             }
         },

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -632,6 +632,36 @@ class BardTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_remove_sets_when_trimming_empty_nodes()
+    {
+        $content = [
+            ['type' => 'paragraph'],
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => 'test-set',
+                    'values' => [
+                        'type' => 'one',
+                    ],
+                ],
+            ],
+            ['type' => 'paragraph'],
+        ];
+
+        $this->assertEquals([
+            [
+                'type' => 'set',
+                'attrs' => [
+                    'id' => 'test-set',
+                    'values' => [
+                        'type' => 'one',
+                    ],
+                ],
+            ],
+        ], $this->bard(['remove_empty_nodes' => 'trim'])->process($content));
+    }
+
+    #[Test]
     #[DataProvider('groupedSetsProvider')]
     public function it_preloads($areSetsGrouped)
     {


### PR DESCRIPTION
Fixes statamic/cms#14688.

## Summary

This fixes a Bard CP sync issue where a Bard field containing only a single set could appear to lose that set after the first save when `remove_empty_nodes` is configured to trim empty nodes at the start and end.

The backend processing is not actually deleting the set. With `remove_empty_nodes: trim`, PHP correctly trims the surrounding empty paragraph nodes and preserves the set. That also matches the reported behavior: refreshing the page makes the set appear again, which means the saved value is still present.

The problem is in the frontend watcher that syncs an externally updated Bard value back into the Tiptap editor after save:

```js
this.editor.commands.clearContent();
this.editor.commands.setContent(content, true);
```

`clearContent()` emits an update with an empty paragraph before `setContent()` applies the real server value. For a Bard field whose server-trimmed value is only a set, that intermediate empty update can be picked up by the publish state, making the set disappear visually until the page is refreshed.

This PR changes the clear step to be silent:

```js
this.editor.commands.clearContent(false);
this.editor.commands.setContent(content, true);
```

That keeps the editor replacement behavior the same, but avoids emitting the temporary empty Bard value. The final `setContent(content, true)` still emits the real updated value.

## Tests

- `vendor/bin/phpunit tests/Fieldtypes/BardTest.php`
- `npm run test`

I also added a regression test confirming that trimming empty Bard nodes preserves a set surrounded by empty paragraphs.

## Note

This PR is being submitted from eminos GitHub account, but the investigation, patch, and PR write-up were prepared by Codex GPT 5.5.
