### PR TITLE
[5.x] Tighten front-end form upload validation

### DIFF
--- a/src/Http/Requests/FrontendFormRequest.php
+++ b/src/Http/Requests/FrontendFormRequest.php
@@ -2,10 +2,12 @@
 
 namespace Statamic\Http\Requests;
 
+use Facades\Statamic\Fields\Validator as FieldValidator;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
+use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Rules\AllowedFile;
@@ -80,10 +82,27 @@ class FrontendFormRequest extends FormRequest
     private function extraRules($fields)
     {
         return $fields->all()
-            ->filter(fn ($field) => $field->fieldtype()->handle() === 'assets')
+            ->filter(fn ($field) => in_array($field->fieldtype()->handle(), ['assets', 'files']))
             ->mapWithKeys(function ($field) {
-                return [$field->handle().'.*' => ['file', new AllowedFile]];
+                $rules = $field->fieldtype()->handle() === 'assets'
+                    ? array_merge(['file', new AllowedFile], $this->assetContainerRules($field))
+                    : ['file', new AllowedFile($field->fieldtype()->config('allowed_extensions'))];
+
+                return [$field->handle().'.*' => $rules];
             })
+            ->all();
+    }
+
+    private function assetContainerRules($field)
+    {
+        $configured = $field->fieldtype()->config('container');
+
+        $container = $configured
+            ? AssetContainer::find($configured)
+            : (($containers = AssetContainer::all())->count() === 1 ? $containers->first() : null);
+
+        return collect($container?->validationRules())
+            ->map(fn ($rule) => FieldValidator::parse($rule))
             ->all();
     }
 

--- a/tests/Tags/Form/FormUploadValidationTest.php
+++ b/tests/Tags/Form/FormUploadValidationTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Tags\Form;
+
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\AssetContainer;
+
+class FormUploadValidationTest extends FormTestCase
+{
+    #[Test]
+    public function it_rejects_disallowed_extensions_uploaded_to_a_files_field()
+    {
+        Storage::fake('local');
+
+        $this->createForm([
+            'fields' => [
+                ['handle' => 'document', 'field' => ['type' => 'files']],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'document' => UploadedFile::fake()->create('evil.php', 10),
+            ])
+            ->assertSessionHasErrors('document.0', null, 'form.survey');
+    }
+
+    #[Test]
+    public function it_allows_permitted_extensions_uploaded_to_a_files_field()
+    {
+        Storage::fake('local');
+
+        $this->createForm([
+            'fields' => [
+                ['handle' => 'document', 'field' => ['type' => 'files']],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'document' => UploadedFile::fake()->create('notes.txt', 10),
+            ])
+            ->assertSessionHasNoErrors();
+    }
+
+    #[Test]
+    public function it_enforces_asset_container_validation_rules_on_an_assets_field()
+    {
+        Storage::fake('avatars');
+        AssetContainer::make('avatars')->disk('avatars')->validationRules(['extensions:jpg,png'])->save();
+
+        $this->createForm([
+            'fields' => [
+                ['handle' => 'bravo', 'field' => ['type' => 'assets', 'container' => 'avatars', 'max_files' => 1]],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'bravo' => UploadedFile::fake()->create('script.js', 10),
+            ])
+            ->assertSessionHasErrors('bravo.0', null, 'form.survey');
+    }
+
+    #[Test]
+    public function it_allows_uploads_permitted_by_the_asset_container_validation_rules()
+    {
+        Storage::fake('avatars');
+        AssetContainer::make('avatars')->disk('avatars')->validationRules(['extensions:jpg,png'])->save();
+
+        $this->createForm([
+            'fields' => [
+                ['handle' => 'bravo', 'field' => ['type' => 'assets', 'container' => 'avatars', 'max_files' => 1]],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'bravo' => UploadedFile::fake()->image('avatar.jpg'),
+            ])
+            ->assertSessionHasNoErrors();
+    }
+}


### PR DESCRIPTION
Front-end form submissions weren't applying the same upload validation that the Control Panel does for the `assets` and `files` fieldtypes.