### PR TITLE
[6.x] Fix global variables being lost when migrated alongside addon update scripts

### DIFF
--- a/src/UpdateScripts/UpdateGlobalVariables.php
+++ b/src/UpdateScripts/UpdateGlobalVariables.php
@@ -76,7 +76,7 @@ class UpdateGlobalVariables extends UpdateScript
 
             $globalSet->save();
 
-            File::put($variablesPath, YAML::dump($data));
+            $globalSet->inDefaultSite()->data($data)->saveQuietly();
         });
     }
 }

--- a/tests/UpdateScripts/UpdateGlobalVariablesTest.php
+++ b/tests/UpdateScripts/UpdateGlobalVariablesTest.php
@@ -92,8 +92,7 @@ YAML;
 
         $this->runUpdateScript(UpdateGlobalVariables::class);
 
-        // Simulates an addon update script saving variables after the migration,
-        // like Peak SEO's AddRobots script does.
+        // Simulates an addon update script saving variables after the migration
         $variables = GlobalSet::findByHandle('test')->inDefaultSite();
         $variables->set('baz', 'Qux');
         $variables->save();

--- a/tests/UpdateScripts/UpdateGlobalVariablesTest.php
+++ b/tests/UpdateScripts/UpdateGlobalVariablesTest.php
@@ -4,6 +4,7 @@ namespace Tests\UpdateScripts;
 
 use Illuminate\Support\Facades\File;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\GlobalSet;
 use Statamic\Facades\YAML;
 use Statamic\UpdateScripts\UpdateGlobalVariables;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -74,6 +75,33 @@ YAML;
 
         // Empty data should produce an empty array, not null
         $this->assertEquals([], YAML::parse(File::get($this->globalsPath.'/en/test.yaml')));
+
+        unlink($this->globalsPath.'/test.yaml');
+        unlink($this->globalsPath.'/en/test.yaml');
+    }
+
+    #[Test]
+    public function migrated_variables_survive_being_saved_later_in_the_same_process()
+    {
+        File::put($this->globalsPath.'/test.yaml', Yaml::dump([
+            'title' => 'Test',
+            'data' => [
+                'foo' => 'Bar',
+            ],
+        ]));
+
+        $this->runUpdateScript(UpdateGlobalVariables::class);
+
+        // Simulates an addon update script saving variables after the migration,
+        // like Peak SEO's AddRobots script does.
+        $variables = GlobalSet::findByHandle('test')->inDefaultSite();
+        $variables->set('baz', 'Qux');
+        $variables->save();
+
+        $this->assertEquals(
+            ['foo' => 'Bar', 'baz' => 'Qux'],
+            YAML::parse(File::get($this->globalsPath.'/en/test.yaml'))
+        );
 
         unlink($this->globalsPath.'/test.yaml');
         unlink($this->globalsPath.'/en/test.yaml');


### PR DESCRIPTION
This pull request fixes an issue where global variables could be lost when updating to v6 and an addon in one go, when the addon's own update script saves global variables (eg. Peak SEO's [`AddRobots`](https://github.com/studio1902/statamic-peak-seo/blob/main/src/Updates/AddRobots.php) script).

This was happening because the `UpdateGlobalVariables` update script wrote the migrated variables directly to disk using `File::put`, after `$globalSet->save()` had already created an empty variables localization through the repository. This left the Stache holding empty variables, so when an addon's update script saved global variables later in the same process, it would overwrite the migrated data on disk with only its own changes.

This PR fixes it by saving the migrated data through the `GlobalVariables` repository instead, keeping the Stache in sync with what's on disk.

Caused by #11585