### PR TITLE
[6.x] Forms 2: Tighten form upload validation in `SubmitForm` action

### DIFF
--- a/src/Forms/SubmitForm.php
+++ b/src/Forms/SubmitForm.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Forms;
 
+use Facades\Statamic\Fields\Validator as FieldValidator;
 use Illuminate\Support\Traits\Localizable;
 use Illuminate\Validation\ValidationException;
 use Statamic\Contracts\Forms\Form;
@@ -10,6 +11,7 @@ use Statamic\Events\FormSubmitted;
 use Statamic\Exceptions\FormRestrictedException;
 use Statamic\Exceptions\SilentFormFailureException;
 use Statamic\Facades\Asset;
+use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Site;
 use Statamic\Forms\Logic\PageLogic;
 use Statamic\Rules\AllowedFile;
@@ -214,7 +216,26 @@ class SubmitForm
     {
         return $fields->all()
             ->filter(fn ($field): bool => in_array($field->fieldtype()->handle(), ['assets', 'files']))
-            ->mapWithKeys(fn ($field): array => [$field->handle().'.*' => ['file', new AllowedFile]])
+            ->mapWithKeys(function ($field): array {
+                $rules = $field->fieldtype()->handle() === 'assets'
+                    ? array_merge(['file', new AllowedFile], $this->assetContainerRules($field))
+                    : ['file', new AllowedFile($field->fieldtype()->config('allowed_extensions'))];
+
+                return [$field->handle().'.*' => $rules];
+            })
+            ->all();
+    }
+
+    private function assetContainerRules($field): array
+    {
+        $configured = $field->fieldtype()->config('container');
+
+        $container = $configured
+            ? AssetContainer::find($configured)
+            : (($containers = AssetContainer::all())->count() === 1 ? $containers->first() : null);
+
+        return collect($container?->validationRules())
+            ->map(fn ($rule) => FieldValidator::parse($rule))
             ->all();
     }
 

--- a/tests/Tags/Form/FormUploadValidationTest.php
+++ b/tests/Tags/Form/FormUploadValidationTest.php
@@ -10,7 +10,7 @@ use Statamic\Facades\AssetContainer;
 class FormUploadValidationTest extends FormTestCase
 {
     #[Test]
-    public function it_rejects_disallowed_extensions_uploaded_to_a_files_field()
+    public function it_enforces_default_allowed_extensions_on_a_files_field()
     {
         Storage::fake('local');
 
@@ -28,7 +28,7 @@ class FormUploadValidationTest extends FormTestCase
     }
 
     #[Test]
-    public function it_allows_permitted_extensions_uploaded_to_a_files_field()
+    public function it_allows_uploads_permitted_by_the_default_allowed_extensions()
     {
         Storage::fake('local');
 
@@ -41,6 +41,42 @@ class FormUploadValidationTest extends FormTestCase
         $this
             ->post('/!/forms/survey', [
                 'document' => UploadedFile::fake()->create('notes.txt', 10),
+            ])
+            ->assertSessionHasNoErrors();
+    }
+
+    #[Test]
+    public function it_enforces_allowed_extensions_on_a_files_field()
+    {
+        Storage::fake('local');
+
+        $this->createForm([
+            'fields' => [
+                ['handle' => 'document', 'field' => ['type' => 'files', 'allowed_extensions' => ['pdf']]],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'document' => UploadedFile::fake()->create('notes.txt', 10),
+            ])
+            ->assertSessionHasErrors('document.0', null, 'form.survey');
+    }
+
+    #[Test]
+    public function it_allows_uploads_permitted_by_the_allowed_extensions()
+    {
+        Storage::fake('local');
+
+        $this->createForm([
+            'fields' => [
+                ['handle' => 'document', 'field' => ['type' => 'files', 'allowed_extensions' => ['pdf']]],
+            ],
+        ], 'survey');
+
+        $this
+            ->post('/!/forms/survey', [
+                'document' => UploadedFile::fake()->create('notes.pdf', 10),
             ])
             ->assertSessionHasNoErrors();
     }


### PR DESCRIPTION
#14958 tightened front-end form upload validation in the `FrontendFormRequest`. However, that form request is soon to be deprecated so this PR applies the fix to the new `SubmitForm` action.