### PR TITLE
[6.x] Fix Control Panel not scrolling to top on navigation

### DIFF
--- a/resources/js/pages/layout/Layout.vue
+++ b/resources/js/pages/layout/Layout.vue
@@ -82,7 +82,7 @@ onUnmounted(() => {
         <main id="main" class="flex bg-body-bg dark:border-t dark:border-body-border rounded-t-2xl fixed top-14 inset-x-0 bottom-0 min-h-[calc(100vh-3.5rem)]">
             <Nav />
             <!-- The data attribute allows CSS to target elements when max-width is disabled. -->
-            <div id="main-content" class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
+            <div id="main-content" scroll-region class="main-content sm:p-2 h-full flex-1 overflow-y-auto focus:outline-none rounded-t-2xl" :data-max-width-enabled="isMaxWidthEnabled">
                 <div id="content-card" tabindex="-1" class="focus:outline-none relative content-card grid min-h-full mx-auto">
                     <!-- Data attribute used by the CSS style tag below to override max-width when disabled.-->
                     <div class="w-full min-w-0 mx-auto max-w-page max-[1220px]:mb-18" data-max-width-wrapper>


### PR DESCRIPTION
This pull request fixes an issue where the Control Panel wouldn't scroll back to the top when navigating between pages — after scrolling down a tall page, the next page would open scrolled down (clamped to its max scroll height) instead of at the top.

This was happening because the CP's real scroll container is `#main-content` — the window itself never scrolls. Inertia's scroll reset only acts on the window and elements marked with the `scroll-region` attribute, so it had nothing to reset and the previous scroll position persisted across navigations.

This PR fixes it by marking `#main-content` as a `scroll-region`, so Inertia now resets its [scroll position](https://inertiajs.com/docs/v3/advanced/scroll-management#scroll-regions) on navigation and also restores it natively when navigating back/forward through browser history.

Fixes #14954