### PR TITLE
[6.x] Fix browser crash when expanding a Bard set after a copy

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -116,7 +116,13 @@
                         </floating-menu>
 
                         <div class="bard-error" v-if="initError" v-text="initError"></div>
-                        <editor-content :editor="editor" :id="fieldId" />
+
+                        <!-- Revealing (laying out) a ProseMirror editor in the same trusted-click
+                             turn that made it visible, while a clipboard copy is pending, crashes
+                             the tab on Chrome/Edge >= 148 (a renderer CFI abort). Keeping the editor
+                             hidden until the frame after it becomes visible moves the layout off that
+                             turn, wherever the reveal comes from. See statamic/cms#14946. -->
+                        <editor-content v-show="editorLayoutReady" :editor="editor" :id="fieldId" />
                     </div>
                     <div
                         class="bard-footer-toolbar"
@@ -207,6 +213,8 @@ export default {
             fullScreenMode: false,
             buttons: [],
             collapsed: this.meta.collapsed,
+            editorLayoutReady: false,
+            visibilityObserver: null,
             mounted: false,
             initError: null,
             pageHeader: null,
@@ -388,6 +396,7 @@ export default {
 
         this.initToolbarButtons();
         this.initEditor();
+        this.deferEditorLayoutWhileHidden();
 
         this.json = this.editor.getJSON().content;
         this.html = this.editor.getHTML();
@@ -420,6 +429,7 @@ export default {
     beforeUnmount() {
         this.editor?.destroy();
         this.escBinding?.destroy();
+        this.visibilityObserver?.disconnect();
     },
 
     watch: {
@@ -836,6 +846,32 @@ export default {
 
         visibleButtons(buttons) {
             return buttons.filter((button) => this.buttonIsVisible(button));
+        },
+
+        deferEditorLayoutWhileHidden() {
+            if (typeof ResizeObserver === 'undefined') {
+                this.editorLayoutReady = true;
+                return;
+            }
+
+            let visible = null;
+
+            this.visibilityObserver = new ResizeObserver(([entry]) => {
+                const isVisible = entry.contentRect.width > 0 || entry.contentRect.height > 0;
+                if (isVisible === visible) return;
+                visible = isVisible;
+
+                // Wait a frame before showing the editor once it becomes visible, so ProseMirror
+                // never lays out during the trusted click that revealed it (see #14946). Hiding it
+                // again immediately means the next reveal defers the same way.
+                if (isVisible) {
+                    requestAnimationFrame(() => (this.editorLayoutReady = true));
+                } else {
+                    this.editorLayoutReady = false;
+                }
+            });
+
+            this.visibilityObserver.observe(this.$refs.container);
         },
 
         initEditor() {


### PR DESCRIPTION
Fixes #14946

## The bug

Copying some text and then expanding a collapsed Replicator/Bard set that contains a Bard field crashes the whole browser tab on Chrome/Edge ≥ 148 (Edge shows Error code 5, Chrome "Aw, Snap!"), losing unsaved edits. It's an upstream Chromium renderer crash — a CFI (Control Flow Integrity) abort triggered by laying out a ProseMirror editor in the same trusted-click turn that reveals it while a clipboard copy is pending. There's nothing to *fix* on our side, only avoid.

## The approach

Collapsed sets keep their fields mounted (`v-show`), so the Bard editor already exists while hidden — the trigger is the **reveal** (going `display:none` → visible), which forces ProseMirror to lay out during the click. Deferring that layout by one frame moves it off the trusted-click turn and the crash can't happen.

Rather than deferring the reveal at every surface that can expose a Bard editor (Replicator sets, nested Bard sets, Group fields, the Revealer, tabs, sections, freshly-added sets…), this puts a **single guard inside Bard itself**. A `ResizeObserver` watches the field; when it becomes visible, the editor's content is shown one frame later. This covers every reveal path — current and future — in one place.

Thanks to @o1y for #14951, which diagnosed the trigger and prototyped the per-surface deferral this builds on.

## Testing

⚠️ The crash has only been reported on Windows and Linux with Chrome/Edge ≥ 148; it does **not** appear to reproduce on macOS (likely platform-specific CFI instrumentation), so this hasn't been verified against the actual crash. Normal Bard behaviour (expand/collapse, typing, toolbar, nested sets, fullscreen, adding sets) is unaffected. Would appreciate the original reporters verifying the crash is gone.