### PR TITLE
[6.x] Forms 2: Remember panel widths

### DIFF
--- a/resources/js/composables/use-resizable.js
+++ b/resources/js/composables/use-resizable.js
@@ -1,9 +1,36 @@
 import { watch, nextTick, onUnmounted } from 'vue';
 
+function getStoredWidth(key) {
+    if (!key) return null;
+
+    const stored = localStorage.getItem(key);
+    if (stored === null) return null;
+
+    const width = parseInt(stored, 10);
+
+    return Number.isFinite(width) ? width : null;
+}
+
+function setStoredWidth(key, width) {
+    if (!key) return;
+
+    localStorage.setItem(key, String(width));
+}
+
+function clearStoredWidth(key) {
+    if (!key) return;
+
+    localStorage.removeItem(key);
+}
+
 export default function useResizable() {
     const cleanupFns = [];
 
-    function makeResizable(panelRef, activeRef, { edge = 'right', minWidth = 200, maxWidth = 800, defaultWidth = null } = {}) {
+    function makeResizable(
+        panelRef,
+        activeRef,
+        { edge = 'right', minWidth = 200, maxWidth = 800, defaultWidth = null, storageKey = null } = {},
+    ) {
         let cleanup = null;
 
         watch(activeRef, (active) => {
@@ -16,11 +43,13 @@ export default function useResizable() {
                     const resolvedEdge = isRtl ? (edge === 'right' ? 'left' : 'right') : edge;
                     const resolveDefaultWidth = () =>
                         typeof defaultWidth === 'function' ? defaultWidth() : defaultWidth;
+                    const clampWidth = (width) => Math.min(maxWidth, Math.max(minWidth, width));
 
-                    const initialDefaultWidth = resolveDefaultWidth();
+                    const storedWidth = getStoredWidth(storageKey);
+                    const initialWidth = storedWidth ?? resolveDefaultWidth();
 
-                    if (initialDefaultWidth !== null && initialDefaultWidth !== undefined) {
-                        panel.style.width = `${initialDefaultWidth}px`;
+                    if (initialWidth !== null && initialWidth !== undefined) {
+                        panel.style.width = `${clampWidth(initialWidth)}px`;
                     }
 
                     const handle = document.createElement('div');
@@ -36,10 +65,11 @@ export default function useResizable() {
                     panel.appendChild(handle);
 
                     const resetToDefaultWidth = () => {
+                        clearStoredWidth(storageKey);
+
                         const currentDefaultWidth = resolveDefaultWidth();
                         if (currentDefaultWidth !== null && currentDefaultWidth !== undefined) {
-                            const width = Math.min(maxWidth, Math.max(minWidth, currentDefaultWidth));
-                            panel.style.width = `${width}px`;
+                            panel.style.width = `${clampWidth(currentDefaultWidth)}px`;
                             return;
                         }
 
@@ -61,7 +91,7 @@ export default function useResizable() {
 
                         const onMove = (e) => {
                             const diff = resolvedEdge === 'right' ? e.clientX - startX : startX - e.clientX;
-                            const newWidth = Math.min(maxWidth, Math.max(minWidth, startWidth + diff));
+                            const newWidth = clampWidth(startWidth + diff);
                             panel.style.width = `${newWidth}px`;
                         };
 
@@ -70,6 +100,7 @@ export default function useResizable() {
                             document.body.style.userSelect = '';
                             document.removeEventListener('pointermove', onMove);
                             document.removeEventListener('pointerup', onUp);
+                            setStoredWidth(storageKey, panel.offsetWidth);
                         };
 
                         document.addEventListener('pointermove', onMove);

--- a/resources/js/pages/layout/PanelLayout.vue
+++ b/resources/js/pages/layout/PanelLayout.vue
@@ -11,6 +11,7 @@ const left = {
     active: ref(false),
     edge: 'right',
     defaults: [minWidth, 262, 320],
+    storageKey: 'statamic.panels.left-width',
 };
 
 const right = {
@@ -18,6 +19,7 @@ const right = {
     active: ref(false),
     edge: 'left',
     defaults: [300, 290, 320],
+    storageKey: 'statamic.panels.right-width',
 };
 
 provide('leftPanelActive', left.active);
@@ -38,6 +40,7 @@ const { makeResizable } = useResizable();
         minWidth,
         maxWidth,
         defaultWidth: () => getDefaultWidth(panel),
+        storageKey: panel.storageKey,
     });
 
     // Pre-compute the set of pixel strings we treat as "unmodified by the user"
@@ -47,6 +50,7 @@ const { makeResizable } = useResizable();
 function applyBreakpointDefaults() {
     [left, right].forEach((panel) => {
         if (!panel.active.value) return;
+        if (localStorage.getItem(panel.storageKey)) return;
 
         const el = panel.ref.value;
         if (!el) return;


### PR DESCRIPTION
When you go to Logic, Connect, etc and come back to Edit, it would be great to see those panels just as you left 'em.