### PR TITLE
[6.x] Fix video thumbnail generation logging an error on success

### DIFF
--- a/src/Console/Processes/Ffmpeg.php
+++ b/src/Console/Processes/Ffmpeg.php
@@ -36,12 +36,15 @@ class Ffmpeg extends Process
     {
         return collect([
             escapeshellarg($ffmpegBinary),
+            '-hide_banner',
+            '-loglevel error',
             '-y',
             '-ss',
             escapeshellarg($this->startTimestamp),
             '-i',
             escapeshellarg($path),
-            '-vframes 1',
+            '-frames:v 1',
+            '-update 1',
             escapeshellarg($output),
         ])->join(' ');
     }

--- a/tests/Console/FfmpegTest.php
+++ b/tests/Console/FfmpegTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests\Console;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Console\Processes\Ffmpeg;
+use Tests\TestCase;
+
+class FfmpegTest extends TestCase
+{
+    #[Test]
+    public function it_builds_a_thumbnail_command_that_only_writes_errors_to_stderr()
+    {
+        $command = $this->buildCommand('/usr/bin/ffmpeg', '/path/to/video.mov', '/path/to/thumb.jpg');
+
+        $this->assertStringContainsString('-hide_banner', $command);
+        $this->assertStringContainsString('-loglevel error', $command);
+        $this->assertStringContainsString('-frames:v 1', $command);
+        $this->assertStringContainsString('-update 1', $command);
+        $this->assertStringNotContainsString('-vframes', $command);
+    }
+
+    private function buildCommand(...$arguments)
+    {
+        $method = (new \ReflectionClass(Ffmpeg::class))->getMethod('buildCommand');
+
+        return $method->invoke(new Ffmpeg, ...$arguments);
+    }
+}


### PR DESCRIPTION
Generating a video thumbnail runs `ffmpeg`, which writes its banner and progress output to stderr even on a successful run. Since `Process::logErrorOutput()` logs any stderr output at error level regardless of the exit code, every successful thumbnail generation still logged an error (surfacing in Sentry, Bugsnag, etc.), and on FFmpeg 8 the image2 muxer additionally warned about the missing `-update` option when writing a single image. This adds `-hide_banner` and `-loglevel error` so the command only writes to stderr on an actual error, and switches `-vframes 1` to `-frames:v 1 -update 1` to write the single frame without the warning.

Fixes #14944
