### PR TITLE
[6.x] Preserve unregistered permissions when saving a role

### DIFF
--- a/src/Http/Controllers/CP/Users/RolesController.php
+++ b/src/Http/Controllers/CP/Users/RolesController.php
@@ -179,18 +179,15 @@ class RolesController extends CpController
         return response('', 204);
     }
 
-    protected function preserveUnregisteredPermissions($role, $permissions)
+    private function preserveUnregisteredPermissions($role, $permissions)
     {
+        $registered = Permission::boot()->flattened()->map->value();
+
         $unregistered = $role->permissions()
-            ->diff($this->registeredPermissions())
+            ->diff($registered)
             ->reject(fn ($permission) => $permission === 'super');
 
         return collect($permissions)->merge($unregistered)->unique()->values()->all();
-    }
-
-    protected function registeredPermissions()
-    {
-        return Permission::boot()->flattened()->map->value();
     }
 
     protected function updateTree($tree, $role = null)

--- a/src/Http/Controllers/CP/Users/RolesController.php
+++ b/src/Http/Controllers/CP/Users/RolesController.php
@@ -190,11 +190,7 @@ class RolesController extends CpController
 
     protected function registeredPermissions()
     {
-        $flatten = function ($permissions) use (&$flatten) {
-            return collect($permissions)->flatMap(fn ($permission) => [$permission['value'], ...$flatten($permission['children'])]);
-        };
-
-        return Permission::boot()->tree()->flatMap(fn ($group) => $flatten($group['permissions']));
+        return Permission::boot()->flattened()->map->value();
     }
 
     protected function updateTree($tree, $role = null)

--- a/src/Http/Controllers/CP/Users/RolesController.php
+++ b/src/Http/Controllers/CP/Users/RolesController.php
@@ -155,8 +155,8 @@ class RolesController extends CpController
 
         if ($request->super && User::current()->isSuper()) {
             $role->permissions(['super']);
-        } elseif (! in_array('super', $request->permissions ?? [])) {
-            $role->permissions($request->permissions);
+        } elseif ($request->has('permissions') && ! in_array('super', $request->permissions)) {
+            $role->permissions($this->preserveUnregisteredPermissions($role, $request->permissions));
         }
 
         $role->save();
@@ -177,6 +177,24 @@ class RolesController extends CpController
         $role->delete();
 
         return response('', 204);
+    }
+
+    protected function preserveUnregisteredPermissions($role, $permissions)
+    {
+        $unregistered = $role->permissions()
+            ->diff($this->registeredPermissions())
+            ->reject(fn ($permission) => $permission === 'super');
+
+        return collect($permissions)->merge($unregistered)->unique()->values()->all();
+    }
+
+    protected function registeredPermissions()
+    {
+        $flatten = function ($permissions) use (&$flatten) {
+            return collect($permissions)->flatMap(fn ($permission) => [$permission['value'], ...$flatten($permission['children'])]);
+        };
+
+        return Permission::boot()->tree()->flatMap(fn ($group) => $flatten($group['permissions']));
     }
 
     protected function updateTree($tree, $role = null)

--- a/tests/Feature/Roles/UpdateRoleTest.php
+++ b/tests/Feature/Roles/UpdateRoleTest.php
@@ -78,7 +78,7 @@ class UpdateRoleTest extends TestCase
         $role = tap(
             Role::make('test')
                 ->title('Test')
-                ->permissions(['one', 'two'])
+                ->permissions(['configure fields', 'manage preferences'])
         )->save();
 
         $this
@@ -87,7 +87,7 @@ class UpdateRoleTest extends TestCase
             ->update($role, [
                 'title' => 'Updated',
                 'handle' => 'changed',
-                'permissions' => ['one', 'three'],
+                'permissions' => ['configure fields', 'resolve duplicate ids'],
             ])
             ->assertOk()
             ->assertJson(['redirect' => cp_route('roles.index')]);
@@ -95,7 +95,53 @@ class UpdateRoleTest extends TestCase
         $this->assertNull(Role::find('test'));
         $role = Role::find('changed');
         $this->assertEquals('Updated', $role->title());
-        $this->assertEquals(['one', 'three'], $role->permissions()->all());
+        $this->assertEquals(['configure fields', 'resolve duplicate ids'], $role->permissions()->all());
+        $this->assertFalse($role->isSuper());
+    }
+
+    #[Test]
+    public function it_preserves_permissions_that_are_no_longer_registered()
+    {
+        // A permission that used to be registered, but no longer is. For example, one
+        // belonging to an addon that's been disabled, or a deprecated core permission.
+        $role = tap(
+            Role::make('test')
+                ->title('Test')
+                ->permissions(['configure fields', 'manage preferences', 'do addon things'])
+        )->save();
+
+        $this
+            ->actingAsUserWithPermissions(['edit roles'])
+            ->withActiveElevatedSession()
+            ->update($role, [
+                'permissions' => ['configure fields'],
+            ])
+            ->assertOk();
+
+        $role = Role::find('test');
+        $this->assertEquals(['configure fields', 'do addon things'], $role->permissions()->all());
+    }
+
+    #[Test]
+    public function demoting_a_super_role_does_not_resurrect_the_super_permission()
+    {
+        $role = tap(
+            Role::make('test')
+                ->title('Test')
+                ->permissions(['super'])
+        )->save();
+
+        $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->withActiveElevatedSession()
+            ->update($role, [
+                'super' => false,
+                'permissions' => [],
+            ])
+            ->assertOk();
+
+        $role = Role::find('test');
+        $this->assertEquals([], $role->permissions()->all());
         $this->assertFalse($role->isSuper());
     }
 


### PR DESCRIPTION
Saving a role in the Control Panel replaces its permissions with what the UI submitted. That payload only contains *currently registered* permissions, so anything else the role held gets silently dropped. This bites two cases:

- **Addon permissions** — disable an addon, save any role, and its addon permissions are gone. Re-enabling doesn't bring them back.
- **Deprecated core permissions** — ones unregistered but still honored for backward compatibility, lost on the next save.

Now `update()` merges any permission the role already holds that isn't in the registered tree back into what's saved. `super` is excluded (otherwise demoting a super role would resurrect it), and registered-but-unchecked permissions are still removed, so "Uncheck All" is unaffected. `store()` is untouched since a new role has nothing to preserve.

### Accepted tradeoff

The registered tree resolves per-item permissions from collections, taxonomies, forms, etc. that currently exist. So deleting a collection makes its permissions (`view blog entries`) unregistered, and they'll now persist in the role's YAML instead of being pruned on save. Not a security concern — a permission naming a nonexistent collection grants nothing — and it means a deleted-then-recreated collection keeps its permissions. The cost is some potential YAML cruft, which beats trying to tell "unregistered because deprecated" apart from "unregistered because deleted".

### Why this surfaced

In #14957 we're adjusting some permissions. Removing `config form fields`, but keeping it referenced in appropriate policies for backwards compatibility. But when you saved the role, you lost that permission if you weren't paying attention.

### Note on the existing test

`it_updates_a_role` used fake handles (`one`, `two`, `three`) that were never registered, so they now count as unregistered and get preserved — breaking its full-replace assertion. Swapped for real core handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)