### PR TITLE
[6.x] Forms 2: Fix false dirty state when opening field inspector in Logic Tree view

### DIFF
--- a/resources/js/components/forms/builder/FieldInspector.vue
+++ b/resources/js/components/forms/builder/FieldInspector.vue
@@ -45,6 +45,8 @@ const blueprint = ref(null);
 const activeTab = ref<FieldInspectorTabs>(FieldInspectorTabs.Settings);
 const modifiedFields = ref<string[]>([]);
 
+let skipNextPreviewUpdate = false;
+
 const shouldShowValidationTab = computed(() => !['structure', 'information'].includes(getFieldtypeCategory(field.value.config.type).handle));
 
 const adjustedBlueprint = computed(() => {
@@ -68,7 +70,8 @@ const load = () => {
         loading.value = false;
         fieldtype.value = cached.fieldtype;
         blueprint.value = cached.blueprint;
-        values.value = cached.values;
+        skipNextPreviewUpdate = true;
+        withoutDirtying(() => (values.value = cached.values));
         meta.value = cached.meta;
         originValues.value = cached.originValues;
         originMeta.value = cached.originMeta;
@@ -87,6 +90,7 @@ const load = () => {
             loading.value = false;
             fieldtype.value = response.data.fieldtype;
             blueprint.value = response.data.blueprint;
+            skipNextPreviewUpdate = true;
             withoutDirtying(() => (values.value = response.data.values));
             meta.value = response.data.meta;
             originValues.value = response.data.originValues;
@@ -186,6 +190,12 @@ watch(field, () => {
 
 watch(values, () => {
     dirty();
+
+    if (skipNextPreviewUpdate) {
+        skipNextPreviewUpdate = false;
+        return;
+    }
+
     updatePreview();
 }, { deep: true });
 


### PR DESCRIPTION
This pull request fixes an issue where selecting a field in the Logic tab's tree view marked the page as having unsaved changes, even though nothing had actually been edited.

This was happening because selecting a field loads its config into the field inspector, which unconditionally triggered a debounced preview refresh. That refresh mutated the live field object after the `withoutDirtying` guard had already reset, tripping the deep watcher on the form's fields and marking the page dirty.

This PR fixes it by skipping that preview refresh when a field's values are being loaded programmatically (i.e. on selection), rather than being edited by the user.