### PR TITLE
[6.x] Prevent vertical focus clipping on listing pages

### DIFF
--- a/resources/js/components/ui/Listing/Listing.vue
+++ b/resources/js/components/ui/Listing/Listing.vue
@@ -732,7 +732,7 @@ autoApplyState();
         <slot v-if="!initializing" :items="items" :is-column-visible="isColumnVisible" :loading="loading">
             <Presets v-if="showPresets" />
             <div v-if="allowSearch || hasFilters || allowCustomizingColumns" class="relative overflow-clip flex items-center gap-2 sm:gap-3 min-h-16 starting-style-transition st-overflow-clip-margin">
-                <div class="flex flex-1 items-center gap-2 sm:gap-3 overflow-x-auto -ms-1 ps-1">
+                <div class="flex flex-1 items-center gap-2 sm:gap-3 overflow-x-auto -ms-1 ps-1 py-1">
                     <Search v-if="allowSearch" />
                     <Filters v-if="hasFilters" />
                 </div>


### PR DESCRIPTION
## Description of the Problem

Related to https://github.com/statamic/cms/pull/14953, I found another instance of focus clipping on certain listing pages like `/forms`

## What this PR Does

Adds a small amount of vertical padding to fix the clipping

### Before

The focus is vertically clipped ever so slightly

<img width="3420" height="2146" alt="2026-07-10 at 14 28 58@2x" src="https://github.com/user-attachments/assets/6eb791a6-f1d0-4971-857b-17cfe0b24f52" />

### After

<img width="3420" height="2146" alt="2026-07-10 at 14 28 34@2x" src="https://github.com/user-attachments/assets/bc374089-8c04-48f7-92d3-324cf1980848" />

## How to Reproduce

1. Go to `/cp/forms`
2. Statamic will automatically focus on the search box where you'll see the focus clipped vertically