### PR TITLE
[6.x] Fix error on out-of-range pagination page number

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -72,7 +72,16 @@ abstract class Builder implements Contract
 
     public function offset($value)
     {
-        $this->offset = max(0, $value);
+        $value = max(0, $value);
+
+        // A large page number can overflow the offset arithmetic in forPage()/chunk() into a
+        // float, which array_slice() rejects. Clamp an out-of-range offset to PHP_INT_MAX so it
+        // yields an empty page instead of throwing.
+        if (is_float($value)) {
+            $value = $value >= PHP_INT_MAX ? PHP_INT_MAX : (int) $value;
+        }
+
+        $this->offset = $value;
 
         return $this;
     }

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -87,7 +87,15 @@ class OrderedQueryBuilder implements Builder
 
     public function offset($value)
     {
-        $this->offset = max(0, $value);
+        $value = max(0, $value);
+
+        // Mirrors the overflow guard in Query\Builder::offset() - an out-of-range offset
+        // shouldn't reach Collection::skip() as a float.
+        if (is_float($value)) {
+            $value = $value >= PHP_INT_MAX ? PHP_INT_MAX : (int) $value;
+        }
+
+        $this->offset = $value;
 
         return $this;
     }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -860,6 +860,18 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_an_empty_page_when_the_offset_overflows()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        // A page number large enough to overflow the offset arithmetic used to crash
+        // array_slice() with a float; it should just yield an empty page.
+        $entries = Entry::query()->forPage(PHP_INT_MAX, 6)->get();
+
+        $this->assertCount(0, $entries);
+    }
+
+    #[Test]
     public function entries_are_found_using_where_has_when_max_items_1()
     {
         $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries', 'max_items' => 1]]);


### PR DESCRIPTION
Fixes #14979

## Summary

A large but valid `?page=` value on any front-end paginated listing returns HTTP 500 instead of an empty page.

`Query\Builder::forPage()` computes the offset as `($page - 1) * $perPage` with no clamp. Once the product overflows `PHP_INT_MAX`, PHP silently promotes it to a float. `offset()` only did `max(0, $value)`, which preserves the float, and the Stache driver passes it straight to `array_slice()`, which throws:

```
TypeError: array_slice(): Argument #2 ($offset) must be of type int, float given
```

The overflow is reachable through a real request: Laravel's pagination resolver validates `?page=` with `filter_var($page, FILTER_VALIDATE_INT)`, so any value up to `PHP_INT_MAX` passes through as-is. A crawler following a malformed link, or a scanner probing for this exact class of bug, can trigger it with `?page=9223372036854775807`.

## Fix

Clamp the overflow in `offset()` itself rather than in `forPage()`. Every path that can produce an out-of-range offset routes through it: `forPage()`, `chunk()`, and the Stache driver's `limitKeys()` read `$this->offset` that `offset()` sets. One fix covers all three.

Also hardened `OrderedQueryBuilder`'s own `offset()` override, which had the identical unclamped `max(0, $value)` shape. It isn't reachable through any first-party call path today (nothing calls `->offset()` directly on that wrapper), but it's the same footgun in a sibling `Builder` implementation and costs nothing to close now.

## Test plan

- [x] Added `EntryQueryBuilderTest::it_returns_an_empty_page_when_the_offset_overflows`, exercising the real Stache path (`forPage(PHP_INT_MAX, 6)` → offset-as-float → `array_slice`). Fails with the `TypeError` before the fix, passes after.
- [x] Full `EntryQueryBuilderTest`, `OrderedQueryBuilderTest`, and sibling Stache-backed builder suites (Assets/Terms/Users/Forms) pass.
- [x] Reproduced against a local sandbox via tinker: `Entry::query()->forPage(PHP_INT_MAX, 6)->get()` threw before the fix, returns an empty collection after.
- [x] `./vendor/bin/pint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)