### PR TITLE
[6.x] Fix range date fields not updating with configured timezone

### DIFF
--- a/src/Fieldtypes/Date.php
+++ b/src/Fieldtypes/Date.php
@@ -251,7 +251,12 @@ class Date extends Fieldtype
             return $this->formatAndCast($date, $this->saveFormat());
         }
 
-        $date = Carbon::parse($value, 'UTC');
+        $timezone = $this->resolvedTimezone();
+        if ($timezone !== 'auto') {
+            $date = Carbon::parse($value, $timezone);
+        } else {
+            $date = Carbon::parse($value, 'UTC');
+        }
 
         return $this->formatAndCast($date, $this->saveFormat());
     }

--- a/tests/Fieldtypes/DateTest.php
+++ b/tests/Fieldtypes/DateTest.php
@@ -244,6 +244,18 @@ class DateTest extends TestCase
                 ['start' => '2012-08-29', 'end' => '2013-09-27'],
                 ['start' => '2012-08-29', 'end' => '2013-09-27'],
             ],
+            'range with field timezone' => [
+                'UTC',
+                ['mode' => 'range', 'time_enabled' => true, 'timezone' => 'America/New_York'],
+                ['start' => '2012-08-29T05:00:00', 'end' => '2013-09-27T23:59:00'],
+                ['start' => '2012-08-29 09:00', 'end' => '2013-09-28 03:59'],
+            ],
+            'date with time and field timezone' => [
+                'UTC',
+                ['time_enabled' => true, 'timezone' => 'America/New_York'],
+                '2012-08-29T05:00:00',
+                '2012-08-29 09:00',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #14636

Reworked from the original backend approach after @jasonvarga [pointed out](https://github.com/statamic/cms/pull/14984#issuecomment-4962305542) it was a no-op on real saves: the Control Panel always submits an absolute UTC value, and `Carbon::parse()` ignores its timezone argument once the string carries an offset. The real fix is on the frontend.

### Root cause

`DateFieldtype.vue`'s `datePickerUpdated()` handles single dates and ranges differently. For a single date, the naive `CalendarDateTime` from the picker is first interpreted in the field's configured timezone before being converted to UTC:

```js
if (!this.isRange && !value.offset && !value.timeZone) {
    value = toZoned(value, this.displayTimezone);
}
// ...
return this.update(toTimeZone(value, 'UTC').toAbsoluteString());
```

The range branch skipped that step and sent the naive `start`/`end` straight to UTC via `toZoned(start, 'UTC')`, so the field's wall-clock time was treated as if it were already UTC. Loading uses `parseAbsolute(value, displayTimezone)` (correct), so the load/save round-trip was asymmetric and the stored value drifted by the offset on every save.

### Fix

Interpret the range's naive `start`/`end` in `displayTimezone` before converting to UTC, the same way single dates already do.

### Test

Added a `DateFieldtype.test.js` case that drives `datePickerUpdated()` with the `CalendarDateTime` objects the picker actually emits (range + time mode, configured timezone). For a New York field, entering `05:00` now saves `09:00Z`; it fails on the current code (which saves `05:00Z`) and passes with the fix. Full unit suite green.
