### PR TITLE
[6.x] Fix link fieldtype ignoring sometimes validator

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -181,7 +181,7 @@ class Field implements Arrayable
         return collect($this->rules()[$this->handle])->contains('required');
     }
 
-    private function hasSometimesRule()
+    public function hasSometimesRule()
     {
         return collect($this->rules()[$this->handle])->contains('sometimes');
     }

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -146,7 +146,7 @@ class Link extends Fieldtype
     private function initialOption($value, $entry, $asset)
     {
         if (! $value) {
-            $fallback = $this->field->isRequired() && ! collect($this->field->rules()[$this->field->handle()])->contains('sometimes') ? 'url' : null;
+            $fallback = $this->field->isRequired() && ! $this->field->hasSometimesRule() ? 'url' : null;
             $option = $this->field->get('default_option', $fallback);
 
             if ($option === 'first-child' && ! $this->showFirstChildOption()) {

--- a/src/Fieldtypes/Link.php
+++ b/src/Fieldtypes/Link.php
@@ -146,7 +146,7 @@ class Link extends Fieldtype
     private function initialOption($value, $entry, $asset)
     {
         if (! $value) {
-            $fallback = $this->field->isRequired() ? 'url' : null;
+            $fallback = $this->field->isRequired() && ! collect($this->field->rules()[$this->field->handle()])->contains('sometimes') ? 'url' : null;
             $option = $this->field->get('default_option', $fallback);
 
             if ($option === 'first-child' && ! $this->showFirstChildOption()) {

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -295,6 +295,7 @@ class LinkTest extends TestCase
             'asset falls back to url when unavailable and required' => [['type' => 'link', 'default_option' => 'asset', 'required' => true], null, false, 'url'],
             'asset falls back to null when unavailable and optional' => [['type' => 'link', 'default_option' => 'asset'], null, false, null],
             'existing value overrides default option' => [['type' => 'link', 'default_option' => 'entry'], 'https://example.com', false, 'url'],
+            'null when has sometimes rule even if required' => [['type' => 'link', 'required' => true, 'validate' => 'sometimes'], null, false, null],
         ];
     }
 }


### PR DESCRIPTION
The Link fieldtype was not accounting for the `sometimes` validator when determining the initial option fallback. Fields with the `sometimes` rule are conditionally required and should fallback to null, not 'url'.

Fixes #13922