### PR TITLE
[6.x] Hide unauthorized sections in nav

### DIFF
--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -21,6 +21,7 @@ class NavBuilder
     protected $withHidden = false;
     protected $itemsWithChildrenClosures = [];
     protected $sections = [];
+    protected $sectionsEmptiedByAuthorization = [];
     protected $sectionsOriginalItemIds = [];
     protected $sectionsManipulations = [];
     protected $sectionsOrder = [];
@@ -154,10 +155,33 @@ class NavBuilder
      */
     protected function authorizeItems()
     {
+        $sectionsBefore = $this->sectionsWithItems($this->items);
+
         $this->items = $this->filterAuthorizedNavItems($this->items);
         $this->itemsKeyedById = null;
 
+        $this->sectionsEmptiedByAuthorization = $sectionsBefore
+            ->diff($this->sectionsWithItems($this->items))
+            ->values()
+            ->all();
+
         return $this;
+    }
+
+    /**
+     * Get the sections that currently contain at least one top-level item.
+     *
+     * @param  mixed  $items
+     * @return \Illuminate\Support\Collection
+     */
+    protected function sectionsWithItems($items)
+    {
+        return collect($items)
+            ->reject(fn ($item) => $item->isChild())
+            ->map(fn ($item) => $item->section())
+            ->filter()
+            ->unique()
+            ->values();
     }
 
     /**
@@ -906,7 +930,7 @@ class NavBuilder
         // Collect and order each section's items...
         $built = collect($sections)
             ->reject(fn ($items, $section) => $this->withHidden ? false : Arr::get($manipulations, "{$section}.action") === '@hide')
-            ->filter(fn ($items) => $items || $this->withHidden)
+            ->filter(fn ($items, $section) => $items || ($this->withHidden && ! in_array($section, $this->sectionsEmptiedByAuthorization)))
             ->map(function ($items, $section) {
                 return collect($this->sectionsWithReorderedItems)->contains($section)
                     ? collect($items)->sortBy(fn ($item) => $item->order())->values()

--- a/tests/CP/Navigation/NavTest.php
+++ b/tests/CP/Navigation/NavTest.php
@@ -188,6 +188,21 @@ class NavTest extends TestCase
     }
 
     #[Test]
+    public function it_doesnt_build_unauthorized_sections_when_building_with_hidden()
+    {
+        $this->setTestRoles(['limited' => ['access cp']]);
+        $this->actingAs(tap(User::make()->assignRole('limited'))->save());
+
+        Nav::fields('Fields Management')->can('manage fields');
+        Nav::users('Users Management')->can('manage users');
+
+        $nav = Nav::build(true, true)->pluck('items', 'display');
+
+        $this->assertFalse($nav->has('Fields'));
+        $this->assertFalse($nav->has('Users'));
+    }
+
+    #[Test]
     public function it_can_create_a_nav_item_with_children()
     {
         $this->actingAs(tap(User::make()->makeSuper())->save());


### PR DESCRIPTION
Users without certain permissions still see sections in their nav preferences. This fix ensures sections are not displayed when all items in them are filtered due to lack of authorization.

Fixes #14405