### PR TITLE
[6.x] Update site:clear config stubs to match current defaults

### DIFF
--- a/src/Console/Commands/stubs/config/stache.php.stub
+++ b/src/Console/Commands/stubs/config/stache.php.stub
@@ -15,14 +15,27 @@ return [
     |
     */
 
-    'watcher' => env('STATAMIC_STACHE_WATCHER', true),
+    'watcher' => env('STATAMIC_STACHE_WATCHER', 'auto'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure which Cache Store the Stache uses.
+    |
+    */
+
+    'cache_store' => null,
 
     /*
     |--------------------------------------------------------------------------
     | Stores
     |--------------------------------------------------------------------------
     |
-    | Here you may configure which stores are used inside the Stache.
+    | Here you may configure the stores that are used inside the Stache.
+    |
+    | https://statamic.dev/stache#stores
     |
     */
 
@@ -53,8 +66,23 @@ return [
             'directory' => base_path('content/navigation'),
         ],
 
+        'collection-trees' => [
+            'class' => Stores\CollectionTreeStore::class,
+            'directory' => base_path('content/trees/collections'),
+        ],
+
+        'nav-trees' => [
+            'class' => Stores\NavTreeStore::class,
+            'directory' => base_path('content/trees/navigation'),
+        ],
+
         'globals' => [
             'class' => Stores\GlobalsStore::class,
+            'directory' => base_path('content/globals'),
+        ],
+
+        'global-variables' => [
+            'class' => Stores\GlobalVariablesStore::class,
             'directory' => base_path('content/globals'),
         ],
 
@@ -63,9 +91,25 @@ return [
             'directory' => base_path('content/assets'),
         ],
 
+        'assets' => [
+            'class' => Stores\AssetsStore::class,
+        ],
+
         'users' => [
             'class' => Stores\UsersStore::class,
             'directory' => base_path('users'),
+        ],
+
+        'form-submissions' => [
+            'class' => Stores\SubmissionsStore::class,
+            'directory' => storage_path('forms'),
+        ],
+
+        'revisions' => [
+            'class' => Stores\RevisionsStore::class,
+            'directory' => env('STATAMIC_REVISIONS_PATH')
+                ? base_path(env('STATAMIC_REVISIONS_PATH'))
+                : config('statamic.revisions.path', storage_path('statamic/revisions')),
         ],
 
     ],
@@ -90,9 +134,9 @@ return [
     | Locking
     |--------------------------------------------------------------------------
     |
-    | In order to prevent concurrent requests from updating the Stache at
-    | the same and wasting resources, it will be "locked" so subsequent
-    | requests will have to wait until the first has been completed.
+    | In order to prevent concurrent requests from updating the Stache at the
+    | same time and wasting resources, it will be locked so that subsequent
+    | requests will have to wait until the first one has been completed.
     |
     | https://statamic.dev/stache#locks
     |
@@ -101,6 +145,29 @@ return [
     'lock' => [
         'enabled' => true,
         'timeout' => 30,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Warming Optimization
+    |--------------------------------------------------------------------------
+    |
+    | These options control performance optimizations during Stache warming.
+    |
+    */
+
+    'warming' => [
+        // Enable parallel store processing for faster warming on multi-core systems
+        'parallel_processing' => env('STATAMIC_STACHE_PARALLEL_WARMING', false),
+
+        // Maximum number of parallel processes (0 = auto-detect CPU cores)
+        'max_processes' => env('STATAMIC_STACHE_MAX_PROCESSES', 0),
+
+        // Minimum number of stores required to enable parallel processing
+        'min_stores_for_parallel' => env('STATAMIC_STACHE_MIN_STORES_PARALLEL', 3),
+
+        // Concurrency driver: 'process', 'fork', or 'sync'
+        'concurrency_driver' => env('STATAMIC_STACHE_CONCURRENCY_DRIVER', 'process'),
     ],
 
 ];

--- a/src/Console/Commands/stubs/config/stache.php.stub
+++ b/src/Console/Commands/stubs/config/stache.php.stub
@@ -1,7 +1,5 @@
 <?php
 
-use Statamic\Stache\Stores;
-
 return [
 
     /*
@@ -40,78 +38,7 @@ return [
     */
 
     'stores' => [
-
-        'taxonomies' => [
-            'class' => Stores\TaxonomiesStore::class,
-            'directory' => base_path('content/taxonomies'),
-        ],
-
-        'terms' => [
-            'class' => Stores\TermsStore::class,
-            'directory' => base_path('content/taxonomies'),
-        ],
-
-        'collections' => [
-            'class' => Stores\CollectionsStore::class,
-            'directory' => base_path('content/collections'),
-        ],
-
-        'entries' => [
-            'class' => Stores\EntriesStore::class,
-            'directory' => base_path('content/collections'),
-        ],
-
-        'navigation' => [
-            'class' => Stores\NavigationStore::class,
-            'directory' => base_path('content/navigation'),
-        ],
-
-        'collection-trees' => [
-            'class' => Stores\CollectionTreeStore::class,
-            'directory' => base_path('content/trees/collections'),
-        ],
-
-        'nav-trees' => [
-            'class' => Stores\NavTreeStore::class,
-            'directory' => base_path('content/trees/navigation'),
-        ],
-
-        'globals' => [
-            'class' => Stores\GlobalsStore::class,
-            'directory' => base_path('content/globals'),
-        ],
-
-        'global-variables' => [
-            'class' => Stores\GlobalVariablesStore::class,
-            'directory' => base_path('content/globals'),
-        ],
-
-        'asset-containers' => [
-            'class' => Stores\AssetContainersStore::class,
-            'directory' => base_path('content/assets'),
-        ],
-
-        'assets' => [
-            'class' => Stores\AssetsStore::class,
-        ],
-
-        'users' => [
-            'class' => Stores\UsersStore::class,
-            'directory' => base_path('users'),
-        ],
-
-        'form-submissions' => [
-            'class' => Stores\SubmissionsStore::class,
-            'directory' => storage_path('forms'),
-        ],
-
-        'revisions' => [
-            'class' => Stores\RevisionsStore::class,
-            'directory' => env('STATAMIC_REVISIONS_PATH')
-                ? base_path(env('STATAMIC_REVISIONS_PATH'))
-                : config('statamic.revisions.path', storage_path('statamic/revisions')),
-        ],
-
+        //
     ],
 
     /*

--- a/src/Console/Commands/stubs/config/users.php.stub
+++ b/src/Console/Commands/stubs/config/users.php.stub
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'repository' => 'eloquent',
+    'repository' => 'file',
 
     'repositories' => [
 

--- a/src/Console/Commands/stubs/config/users.php.stub
+++ b/src/Console/Commands/stubs/config/users.php.stub
@@ -15,14 +15,13 @@ return [
     |
     */
 
-    'repository' => 'file',
+    'repository' => 'eloquent',
 
     'repositories' => [
 
         'file' => [
             'driver' => 'file',
             'paths' => [
-                'users' => base_path('users'),
                 'roles' => resource_path('users/roles.yaml'),
                 'groups' => resource_path('users/groups.yaml'),
             ],
@@ -78,6 +77,32 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Registration form honeypot field
+    |--------------------------------------------------------------------------
+    |
+    | When registering new users through the user:register_form tag,
+    | specify the field to act as a honeypot for bots
+    |
+    */
+
+    'registration_form_honeypot_field' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Wizard Invitation Email
+    |--------------------------------------------------------------------------
+    |
+    | When creating new users through the wizard in the control panel,
+    | you may choose whether to be able to send an invitation email.
+    | Setting to true will give the user the option. But setting
+    | it to false will disable the invitation option entirely.
+    |
+    */
+
+    'wizard_invitation' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Password Brokers
     |--------------------------------------------------------------------------
     |
@@ -106,7 +131,10 @@ return [
     'tables' => [
         'users' => 'users',
         'role_user' => 'role_user',
+        'roles' => false,
         'group_user' => 'group_user',
+        'groups' => false,
+        'webauthn' => 'webauthn',
     ],
 
     /*
@@ -124,5 +152,91 @@ return [
         'cp' => 'web',
         'web' => 'web',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Impersonation
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure if impersonation is available, and what URL to
+    | redirect to after impersonation begins.
+    |
+    */
+
+    'impersonate' => [
+        'enabled' => env('STATAMIC_IMPERSONATE_ENABLED', true),
+        'redirect' => env('STATAMIC_IMPERSONATE_REDIRECT', null),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Elevated Sessions
+    |--------------------------------------------------------------------------
+    |
+    | Users may be required to reauthorize before performing certain
+    | sensitive actions. This is called an elevated session. Here
+    | you may configure the duration of the session in minutes.
+    | You may also disable the elevated session entirely.
+    |
+    */
+
+    'elevated_sessions_enabled' => env('STATAMIC_ELEVATED_SESSIONS_ENABLED', true),
+
+    'elevated_session_duration' => 15,
+
+    'elevated_sessions_url' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Two-Factor Authentication
+    |--------------------------------------------------------------------------
+    |
+    | Here you may disable two-factor authentication entirely. This can be
+    | useful on local or staging environments, or when using OAuth.
+    |
+    */
+
+    'two_factor_enabled' => env('STATAMIC_TWO_FACTOR_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Enforce Two-Factor Authentication
+    |--------------------------------------------------------------------------
+    |
+    | Specify which user roles should be required to enable two-factor
+    | authentication. Use "*" to enforce 2FA for all users, or "super_users"
+    | to enforce it for super users.
+    |
+    */
+
+    'two_factor_enforced_roles' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Two-Factor Authentication URLs
+    |--------------------------------------------------------------------------
+    |
+    | When users log in to the frontend and need to verify a two-factor code
+    | or set up two-factor authentication, they will be redirected to these
+    | URLs. Leave null to use the built-in pages. Control panel flows are
+    | unaffected and always use their own pages.
+    |
+    */
+
+    'two_factor_challenge_url' => null,
+
+    'two_factor_setup_url' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Sorting
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the default sort behavior for user listings.
+    |
+    */
+
+    'sort_field' => 'email',
+    'sort_direction' => 'asc',
 
 ];

--- a/tests/Console/Commands/SiteClearTest.php
+++ b/tests/Console/Commands/SiteClearTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Console\Commands;
 
+use Illuminate\Support\Arr;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -12,34 +13,34 @@ class SiteClearTest extends TestCase
     {
         // site:clear overwrites the published stache.php and users.php with these
         // stubs (see SiteClear::resetStatamicConfigs), copying them verbatim, so
-        // they need to keep the same defaults as a fresh Statamic install.
+        // they need to stay in sync with the package's own config defaults, aside
+        // from the values a fresh Statamic site intentionally overrides.
         $stubs = statamic_path('src/Console/Commands/stubs/config');
 
         $stache = require $stubs.'/stache.php.stub';
+        $stacheDefaults = require statamic_path('config/stache.php');
 
-        $this->assertArrayHasKey('watcher', $stache);
-        $this->assertArrayHasKey('cache_store', $stache);
-        $this->assertArrayHasKey('warming', $stache);
-        $this->assertArrayHasKey('collection-trees', $stache['stores']);
-        $this->assertArrayHasKey('nav-trees', $stache['stores']);
-        $this->assertArrayHasKey('global-variables', $stache['stores']);
-        $this->assertArrayHasKey('assets', $stache['stores']);
-        $this->assertArrayHasKey('form-submissions', $stache['stores']);
-        $this->assertArrayHasKey('revisions', $stache['stores']);
+        // A fresh Statamic install leaves 'stores' empty and relies on the
+        // native defaults being merged in by Stache\ServiceProvider, rather
+        // than duplicating every store definition in the published config.
+        $this->assertSame([], $stache['stores']);
+
+        $this->assertEquals(
+            Arr::except($stacheDefaults, 'stores'),
+            Arr::except($stache, 'stores')
+        );
 
         $users = require $stubs.'/users.php.stub';
+        $usersDefaults = require statamic_path('config/users.php');
 
-        $this->assertSame('eloquent', $users['repository']);
-        $this->assertArrayHasKey('registration_form_honeypot_field', $users);
-        $this->assertArrayHasKey('wizard_invitation', $users);
-        $this->assertArrayHasKey('roles', $users['tables']);
-        $this->assertArrayHasKey('groups', $users['tables']);
-        $this->assertArrayHasKey('webauthn', $users['tables']);
-        $this->assertArrayHasKey('impersonate', $users);
-        $this->assertArrayHasKey('elevated_sessions_enabled', $users);
-        $this->assertArrayHasKey('elevated_session_duration', $users);
-        $this->assertArrayHasKey('two_factor_enabled', $users);
-        $this->assertArrayHasKey('two_factor_enforced_roles', $users);
-        $this->assertArrayHasKey('sort_field', $users);
+        // Fresh Statamic sites intentionally use the file repository, not
+        // eloquent, which is only the default when installing into an
+        // existing Laravel app.
+        $this->assertSame('file', $users['repository']);
+
+        $this->assertEquals(
+            Arr::except($usersDefaults, 'repository'),
+            Arr::except($users, 'repository')
+        );
     }
 }

--- a/tests/Console/Commands/SiteClearTest.php
+++ b/tests/Console/Commands/SiteClearTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Console\Commands;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class SiteClearTest extends TestCase
+{
+    #[Test]
+    public function it_has_up_to_date_config_stubs()
+    {
+        // site:clear overwrites the published stache.php and users.php with these
+        // stubs (see SiteClear::resetStatamicConfigs), copying them verbatim, so
+        // they need to keep the same defaults as a fresh Statamic install.
+        $stubs = statamic_path('src/Console/Commands/stubs/config');
+
+        $stache = require $stubs.'/stache.php.stub';
+
+        $this->assertArrayHasKey('watcher', $stache);
+        $this->assertArrayHasKey('cache_store', $stache);
+        $this->assertArrayHasKey('warming', $stache);
+        $this->assertArrayHasKey('collection-trees', $stache['stores']);
+        $this->assertArrayHasKey('nav-trees', $stache['stores']);
+        $this->assertArrayHasKey('global-variables', $stache['stores']);
+        $this->assertArrayHasKey('assets', $stache['stores']);
+        $this->assertArrayHasKey('form-submissions', $stache['stores']);
+        $this->assertArrayHasKey('revisions', $stache['stores']);
+
+        $users = require $stubs.'/users.php.stub';
+
+        $this->assertSame('eloquent', $users['repository']);
+        $this->assertArrayHasKey('registration_form_honeypot_field', $users);
+        $this->assertArrayHasKey('wizard_invitation', $users);
+        $this->assertArrayHasKey('roles', $users['tables']);
+        $this->assertArrayHasKey('groups', $users['tables']);
+        $this->assertArrayHasKey('webauthn', $users['tables']);
+        $this->assertArrayHasKey('impersonate', $users);
+        $this->assertArrayHasKey('elevated_sessions_enabled', $users);
+        $this->assertArrayHasKey('elevated_session_duration', $users);
+        $this->assertArrayHasKey('two_factor_enabled', $users);
+        $this->assertArrayHasKey('two_factor_enforced_roles', $users);
+        $this->assertArrayHasKey('sort_field', $users);
+    }
+}


### PR DESCRIPTION
The `site:clear` command was using outdated config file stubs that were missing several configuration options introduced in recent versions. This caused the config files to differ after running site:clear compared to a fresh installation.

The stubs for stache.php and users.php have been updated to include all current configuration options, including cache_store, warming optimizations, and user authentication features like two-factor authentication and impersonation settings.

Fixes #14737