### PR TITLE
[6.x] Fix performance issue when duplicating entries in large collections

### DIFF
--- a/src/Actions/DuplicateEntry.php
+++ b/src/Actions/DuplicateEntry.php
@@ -162,7 +162,7 @@ class DuplicateEntry extends Action
         $slug .= '-'.$attempt;
 
         // If the slug we've just built already exists, we'll try again, recursively.
-        if ($entry->collection()->queryEntries()->where('locale', $entry->locale())->where('slug', $slug)->count()) {
+        if ($entry->collection()->queryEntries()->where('site', $entry->locale())->where('slug', $slug)->count()) {
             [$title, $slug] = $this->generateTitleAndSlug($entry, $attempt + 1);
         }
 


### PR DESCRIPTION
This pull request fixes an issue where duplicating an entry in a large collection (especially multisite, with many entries per site) could result in a 504 Gateway Timeout.

This was happening because the slug uniqueness check in `DuplicateEntry::generateTitleAndSlug()` queried entries by `locale`, which isn't a registered Stache index. Since nothing else in the codebase queries entries by `locale`, that index was never warmed, so the first time it was needed it had to hydrate every entry file in the collection (across all sites) from disk just to build it.

This PR fixes it by querying by `site` instead, which holds the same values but is already a registered Stache index that's warmed by normal Control Panel usage (like viewing a collection's entry listing), making the check effectively instant in practice.

Fixes #14992