### PR TITLE
[6.x] Allow taxonomy create button customization

### DIFF
--- a/src/Taxonomies/Taxonomy.php
+++ b/src/Taxonomies/Taxonomy.php
@@ -465,7 +465,7 @@ class Taxonomy implements Arrayable, ArrayAccess, AugmentableContract, ContainsQ
 
     public function createLabel()
     {
-        $key = "statamic::messages.{$this->handle()}_taxonomy_create_term";
+        $key = "messages.{$this->handle()}_taxonomy_create_term";
 
         $translation = __($key);
 


### PR DESCRIPTION
This updates the `createLabel()` function in Taxonomy.php to parallel the same function in Collection.php. With the `statamic::` prefix removed, users can use `/lang/en/messages.php` to create custom create button labels for taxonomies. I imagine this was the original intent and just got lost along the way somewhere? In any case, I would really like to be able to update taxonomy labels and not just collection labels.