### PR TITLE
[6.x] Fix English CP locale showing fallback locale translations

### DIFF
--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -126,6 +126,11 @@ class JavascriptComposer
     protected function translations(): array
     {
         $translations = app('translator')->toJson();
+
+        if (app('translator')->locale() === 'en') {
+            return $translations;
+        }
+
         $fallbackTranslations = tap(app('translator'))->setLocale(app('translator')->getFallback())->toJson();
 
         return array_merge($fallbackTranslations, $translations);

--- a/tests/Http/View/Composers/JavascriptComposerTest.php
+++ b/tests/Http/View/Composers/JavascriptComposerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Http\View\Composers;
 
+use Illuminate\Support\Facades\Lang;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
 use Statamic\Http\View\Composers\JavascriptComposer;
@@ -36,5 +37,43 @@ class JavascriptComposerTest extends TestCase
             ['label' => '9:16', 'value' => 9 / 16],
             ['label' => 'US Letter', 'value' => 8.5 / 11],
         ], $json['cropAspectRatios']);
+    }
+
+    #[Test]
+    public function it_does_not_leak_fallback_locale_json_translations_when_locale_is_english()
+    {
+        app()->setFallbackLocale('de');
+        app()->setLocale('en');
+        Lang::addJsonPath(__DIR__.'/../../../__fixtures__/lang-composer-fallback');
+
+        $user = User::make()->makeSuper()->save();
+        $this->actingAs($user);
+
+        $view = app('view')->make('statamic::partials.scripts');
+
+        (new JavascriptComposer)->compose($view);
+
+        $json = Statamic::jsonVariables(request());
+
+        $this->assertArrayNotHasKey('*.Only in fallback', $json['translations']);
+    }
+
+    #[Test]
+    public function it_still_uses_fallback_locale_json_translations_for_non_english_locales()
+    {
+        app()->setFallbackLocale('de');
+        app()->setLocale('fr');
+        Lang::addJsonPath(__DIR__.'/../../../__fixtures__/lang-composer-fallback');
+
+        $user = User::make()->makeSuper()->save();
+        $this->actingAs($user);
+
+        $view = app('view')->make('statamic::partials.scripts');
+
+        (new JavascriptComposer)->compose($view);
+
+        $json = Statamic::jsonVariables(request());
+
+        $this->assertSame('Nur im Fallback', $json['translations']['*.Only in fallback']);
     }
 }

--- a/tests/__fixtures__/lang-composer-fallback/de.json
+++ b/tests/__fixtures__/lang-composer-fallback/de.json
@@ -1,0 +1,3 @@
+{
+    "Only in fallback": "Nur im Fallback"
+}


### PR DESCRIPTION
Fixes #14096.

When `app.fallback_locale` is set to a non-English locale (e.g. `de`) and a user selects English as their CP locale, `JavascriptComposer::translations()` merged the fallback locale's JSON-catalog translations (`lang/{locale}.json`) into the English payload. Since `lang/en.json` doesn't exist by design (the JSON translation key IS the base English string), English had zero `*.`-prefixed keys to override the fallback's values with, so the fallback locale's strings (e.g. German) leaked into the English CP for sidebar items, buttons, etc. sourced from the JSON catalog.

The fix skips the fallback merge entirely when the target locale is English, since a missing English JSON-catalog key is supposed to fall through to the key itself on the frontend (see `resources/js/translations/translator.js`), not inherit another language's translation. Non-English locales are unaffected.

This replaces #14989, which patched the symptom by adding a maintained `lang/en.json` shadow file. That approach would need manual upkeep for every future translatable string and drift was already observed among the other locale files — this PR fixes the root cause in `JavascriptComposer::translations()` instead, so no `en.json` is needed at all.