### PR TITLE
[6.x] Fix range date fields ignoring the configured timezone on save

### DIFF
--- a/resources/js/components/fieldtypes/DateFieldtype.vue
+++ b/resources/js/components/fieldtypes/DateFieldtype.vue
@@ -188,13 +188,21 @@ export default {
                 let start = value.start;
                 let end = value.end;
 
+                if (!start.offset && !start.timeZone) {
+                    start = toZoned(start, this.displayTimezone);
+                }
+
+                if (!end.offset && !end.timeZone) {
+                    end = toZoned(end, this.displayTimezone);
+                }
+
                 if (!this.hasTime) {
                     end.set({ hour: 23, minute: 59, second: 59 });
                 }
 
                 return this.update({
-                    start: toZoned(start, 'UTC').toAbsoluteString(),
-                    end: toZoned(end, 'UTC').toAbsoluteString(),
+                    start: toTimeZone(start, 'UTC').toAbsoluteString(),
+                    end: toTimeZone(end, 'UTC').toAbsoluteString(),
                 });
             }
 

--- a/resources/js/tests/components/fieldtypes/DateFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DateFieldtype.test.js
@@ -123,6 +123,33 @@ test('range dates use configured timezone', () => {
     expect(value.end.toString()).toBe('2025-12-26T02:23:00+00:00[Europe/London]');
 });
 
+test('range dates with time are saved in the configured timezone', async () => {
+    process.env.TZ = 'America/New_York';
+
+    const { CalendarDateTime } = await import('@internationalized/date');
+
+    const dateField = makeDateField({
+        meta: { timezone: 'America/New_York' },
+        config: {
+            mode: 'range',
+            time_enabled: true,
+            earliest_date: { date: null, time: null },
+            latest_date: { date: null, time: null },
+        },
+    });
+
+    dateField.vm.datePickerUpdated({
+        start: new CalendarDateTime(2012, 8, 29, 5, 0, 0),
+        end: new CalendarDateTime(2013, 9, 27, 23, 59, 0),
+    });
+
+    // 05:00 in New York (EDT, -04:00) is 09:00 UTC; 23:59 becomes 03:59 the next day.
+    expect(dateField.emitted('update:value')[0][0]).toEqual({
+        start: '2012-08-29T09:00:00.000Z',
+        end: '2013-09-28T03:59:00.000Z',
+    });
+});
+
 test.each([
     ['UTC'],
     ['America/New_York'],


### PR DESCRIPTION
Fixes #14636. Supersedes #14984.

This replaces #14984, which took a backend approach that @jasonvarga correctly identified as a no-op on real saves: the Control Panel always submits an absolute UTC value, and `Carbon::parse()` ignores its timezone argument once the string carries an offset. He pinpointed the real cause in `DateFieldtype.vue` and offered to reopen, but the branch had been force-pushed with this rework and GitHub won't let the old PR reopen, so this is a fresh PR from the same branch.

### Root cause

`DateFieldtype.vue`'s `datePickerUpdated()` handles single dates and ranges differently. For a single date, the naive `CalendarDateTime` from the picker is first interpreted in the field's configured timezone before being converted to UTC:

```js
if (!this.isRange && !value.offset && !value.timeZone) {
    value = toZoned(value, this.displayTimezone);
}
// ...
return this.update(toTimeZone(value, 'UTC').toAbsoluteString());
```

The range branch skipped that step and sent the naive `start`/`end` straight to UTC via `toZoned(start, 'UTC')`, so the field's wall-clock time was treated as if it were already UTC. Loading uses `parseAbsolute(value, displayTimezone)` (correct), so the load/save round-trip was asymmetric and the stored value drifted by the offset on every save.

### Fix

Interpret the range's naive `start`/`end` in `displayTimezone` before converting to UTC, the same way single dates already do.

### Test

Added a `DateFieldtype.test.js` case that drives `datePickerUpdated()` with the `CalendarDateTime` objects the picker actually emits (range + time mode, configured timezone). For a New York field, entering `05:00` now saves `09:00Z`; it fails on the current code (which saves `05:00Z`) and passes with the fix. Full unit suite green.
