### PR TITLE
[6.x] Fix stache:refresh flattening structured collection trees

### DIFF
--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Concurrency;
 use Statamic\Events\StacheCleared;
 use Statamic\Events\StacheWarmed;
 use Statamic\Extensions\FileStore;
+use Statamic\Facades\Blink;
 use Statamic\Facades\File;
 use Statamic\Stache\Stores\Store;
 use Statamic\Support\Str;
@@ -110,6 +111,9 @@ class Stache
         $this->duplicates()->clear();
 
         $this->cacheStore()->forget('stache::timing');
+
+        Blink::forget('collection-structure-tree*');
+        Blink::forget('structure-*');
 
         StacheCleared::dispatch();
 

--- a/tests/Stache/ColdStacheUriTest.php
+++ b/tests/Stache/ColdStacheUriTest.php
@@ -4,7 +4,6 @@ namespace Tests\Stache;
 
 use Facades\Tests\Factories\EntryFactory;
 use PHPUnit\Framework\Attributes\Test;
-use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Stache;
@@ -18,7 +17,6 @@ class ColdStacheUriTest extends TestCase
     private function simulateColdStache(): void
     {
         Stache::clear();
-        Blink::flush();
     }
 
     #[Test]

--- a/tests/Stache/StacheTest.php
+++ b/tests/Stache/StacheTest.php
@@ -6,6 +6,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blink;
 use Statamic\Stache\NullLockStore;
 use Statamic\Stache\Stache;
 use Statamic\Stache\Stores\ChildStore;
@@ -133,6 +134,22 @@ class StacheTest extends TestCase
     public function it_clears_its_cache()
     {
         $this->markTestIncomplete();
+    }
+
+    #[Test]
+    public function clearing_forgets_the_cached_collection_structure_trees()
+    {
+        Blink::put('collection-structure-tree-pages-en', 'cached');
+        Blink::put('collection-structure-tree-entries::pages::en', 'cached');
+        Blink::put('structure-pages-en-d751713988987e9331980363e24189ce', 'cached');
+        Blink::put('unrelated-cache', 'kept');
+
+        $this->stache->clear();
+
+        $this->assertFalse(Blink::has('collection-structure-tree-pages-en'));
+        $this->assertFalse(Blink::has('collection-structure-tree-entries::pages::en'));
+        $this->assertFalse(Blink::has('structure-pages-en-d751713988987e9331980363e24189ce'));
+        $this->assertTrue(Blink::has('unrelated-cache'));
     }
 
     #[Test]


### PR DESCRIPTION
Running `php please stache:refresh` on a structured collection (`structure.root: true`) can flatten the tree in the warmed Stache cache: entries end up at the root level and whichever one sorts first becomes the site root, even though the on-disk tree file is untouched. Running `stache:clear` then `stache:warm` as separate commands is always correct.

`Stache::clear()` never invalidated the Blink caches that hold a collection's structured tree. Since `stache:refresh` runs `clear()` and `warm()` in one process, `warm()` could see stale, already-computed tree data from before the clear. Two Blink keys were involved:

- the tree object cached in `CollectionStructure::in()`
- the `validateTree()` result memoized in `Tree::tree()`, which is content-addressed only on the raw tree array, but `validateTree()` also reads `queryEntries()`, so the same cache key can go stale as entries are created without the key itself changing

This PR makes `clear()` forget both, mirroring the existing forget already done on tree save/delete (`Tree::save()`/`Tree::delete()`).

I couldn't reproduce the exact flattening with an explicit, already-ordered tree in an isolated repro, but I found the existing `ColdStacheUriTest` had a manual `Blink::flush()` worked into its cold-stache simulation specifically to paper over this same gap. I removed that manual flush and confirmed the production fix makes the test pass on its own, which is direct proof `Stache::clear()` was leaving this stale.

Fixes #14996

🤖 Generated with [Claude Code](https://claude.com/claude-code)
