### PR TITLE
[5.x] Fix error on out-of-range pagination page number

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -72,7 +72,16 @@ abstract class Builder implements Contract
 
     public function offset($value)
     {
-        $this->offset = max(0, $value);
+        $value = max(0, $value);
+
+        // A large page number can overflow the offset arithmetic in forPage()/chunk() into a
+        // float, which array_slice() rejects. Clamp an out-of-range offset to PHP_INT_MAX so it
+        // yields an empty page instead of throwing.
+        if (is_float($value)) {
+            $value = $value >= PHP_INT_MAX ? PHP_INT_MAX : (int) $value;
+        }
+
+        $this->offset = $value;
 
         return $this;
     }

--- a/src/Query/OrderedQueryBuilder.php
+++ b/src/Query/OrderedQueryBuilder.php
@@ -87,7 +87,15 @@ class OrderedQueryBuilder implements Builder
 
     public function offset($value)
     {
-        $this->offset = max(0, $value);
+        $value = max(0, $value);
+
+        // Mirrors the overflow guard in Query\Builder::offset() - an out-of-range offset
+        // shouldn't reach Collection::skip() as a float.
+        if (is_float($value)) {
+            $value = $value >= PHP_INT_MAX ? PHP_INT_MAX : (int) $value;
+        }
+
+        $this->offset = $value;
 
         return $this;
     }

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -799,6 +799,18 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_an_empty_page_when_the_offset_overflows()
+    {
+        $this->createDummyCollectionAndEntries();
+
+        // A page number large enough to overflow the offset arithmetic used to crash
+        // array_slice() with a float; it should just yield an empty page.
+        $entries = Entry::query()->forPage(PHP_INT_MAX, 6)->get();
+
+        $this->assertCount(0, $entries);
+    }
+
+    #[Test]
     public function entries_are_found_using_where_has_when_max_items_1()
     {
         $blueprint = Blueprint::makeFromFields(['entries_field' => ['type' => 'entries', 'max_items' => 1]]);


### PR DESCRIPTION
This backports the already-merged 6.x fix (#14981) to 5.x so 5.x sites are covered as well. The source and test changes are identical to that PR.

### Problem

A large `?page=` value on a front-end paginated listing returns an HTTP 500 instead of an empty page. When the page number is large enough, the offset arithmetic in `Query\Builder::forPage()` (`($page - 1) * $perPage`) overflows `PHP_INT_MAX` and PHP silently converts the result to a float. `offset()` only clamped with `max(0, $value)`, preserving the float, so `array_slice()` later throws:

```
TypeError: array_slice(): Argument #2 ($offset) must be of type int, float given
```

Reproducible with e.g. `?page=9223372036854775807`.

### Fix

Clamp a float-overflowed offset back to `PHP_INT_MAX` inside `offset()` itself, so every path that feeds it (`forPage()`, `chunk()`, the Stache driver) yields an empty page instead of throwing. The same guard is mirrored in `OrderedQueryBuilder::offset()`.

Includes a test that asserts an out-of-range page returns an empty result set.
