### PR TITLE
[6.x] Fix save crash after deleting a Bard set containing a hidden field

### DIFF
--- a/resources/js/components/publish/Values.js
+++ b/resources/js/components/publish/Values.js
@@ -6,11 +6,12 @@ function data_delete(obj, path) {
     var parts = path.split('.');
     while (parts.length - 1) {
         var key = parts.shift();
+        if (obj === null || typeof obj !== 'object') return;
         var shouldBeArray = parts.length ? new RegExp('^[0-9]+$').test(parts[0]) : false;
         if (!(key in obj)) obj[key] = shouldBeArray ? [] : {};
         obj = obj[key];
     }
-    delete obj[parts[0]];
+    if (obj !== null && typeof obj === 'object') delete obj[parts[0]];
 }
 
 export default class Values {
@@ -82,7 +83,7 @@ export default class Values {
 
     missingValue(dottedKey) {
         var properties = Array.isArray(dottedKey) ? dottedKey : dottedKey.split('.');
-        var value = properties.reduce((prev, curr) => prev && prev[curr], clone(this.values));
+        var value = properties.reduce((prev, curr) => (prev == null ? undefined : prev[curr]), clone(this.values));
 
         return value === undefined;
     }

--- a/resources/js/tests/PublishValues.test.js
+++ b/resources/js/tests/PublishValues.test.js
@@ -562,3 +562,21 @@ test('it properly sets keys that javascript considers having numeric separators'
 
     expect(newValues).toEqual(expected);
 });
+
+test('it does not throw when rejecting a value nested under a null node', () => {
+    let values = {
+        first_name: 'Han',
+        ship: {
+            crew: null,
+        },
+    };
+
+    let rejected = new Values(values).except(['ship.crew.0.name']);
+
+    expect(rejected).toEqual({
+        first_name: 'Han',
+        ship: {
+            crew: null,
+        },
+    });
+});


### PR DESCRIPTION
Fixes #15007.

Deleting a Bard set leaves a `null` node in the in-memory value, which makes `forgetValue()` → `data_delete()` throw a `TypeError` on save. See the issue for the full root-cause analysis and reproduction.

### Fix (`resources/js/components/publish/Values.js`)

- `missingValue()`: treat a `null` intermediate as missing, so `forgetValue()` correctly bails out.
- `data_delete()`: guard against non-object intermediates (and the final `delete`) as a safety net for all callers.

Test added in `resources/js/tests/PublishValues.test.js`.