### PR TITLE
[5.x] fix save crash after deleting a Bard set containing a hidden field

### DIFF
--- a/resources/js/components/publish/Values.js
+++ b/resources/js/components/publish/Values.js
@@ -7,11 +7,12 @@ function data_delete(obj, path) {
     var parts = path.split('.');
     while (parts.length - 1) {
         var key = parts.shift();
+        if (obj === null || typeof obj !== 'object') return;
         var shouldBeArray = parts.length ? new RegExp('^[0-9]+$').test(parts[0]) : false;
         if (! (key in obj)) obj[key] = shouldBeArray ? [] : {};
         obj = obj[key];
     }
-    delete obj[parts[0]];
+    if (obj !== null && typeof obj === 'object') delete obj[parts[0]];
 }
 
 export default class Values {

--- a/resources/js/tests/PublishValues.test.js
+++ b/resources/js/tests/PublishValues.test.js
@@ -574,3 +574,22 @@ test('it properly sets keys that javascript considers having numeric separators'
 
     expect(newValues).toEqual(expected);
 });
+
+
+test('it does not throw when rejecting a value nested under a null node', () => {
+    let values = {
+        first_name: 'Han',
+        ship: {
+            crew: null,
+        },
+    };
+
+    let rejected = new Values(values).except(['ship.crew.0.name']);
+
+    expect(rejected).toEqual({
+        first_name: 'Han',
+        ship: {
+            crew: null,
+        },
+    });
+});


### PR DESCRIPTION
Fixes #15007 for 5.x. See https://github.com/statamic/cms/pull/15008 for same issue in 6.x branch.

Deleting a Bard set leaves a `null` node in the in-memory value, which makes `forgetValue()` → `data_delete()` throw a `TypeError` on save. See the issue for the full root-cause analysis and reproduction.

### Fix (`resources/js/components/publish/Values.js`)

- `missingValue()`: treat a `null` intermediate as missing, so `forgetValue()` correctly bails out.
- `data_delete()`: guard against non-object intermediates (and the final `delete`) as a safety net for all callers.

Test added in `resources/js/tests/PublishValues.test.js`.