### PR TITLE
[6.x] Update link to permission docs

### DIFF
--- a/resources/js/pages/roles/Empty.vue
+++ b/resources/js/pages/roles/Empty.vue
@@ -26,5 +26,5 @@ useArchitecturalBackground();
         />
     </EmptyStateMenu>
 
-    <DocsCallout :topic="__('Roles & Permissions')" url="users#permissions" />
+    <DocsCallout :topic="__('Roles & Permissions')" url="permissions" />
 </template>

--- a/resources/js/pages/roles/Index.vue
+++ b/resources/js/pages/roles/Index.vue
@@ -64,6 +64,6 @@ const reloadPage = () => router.reload();
             </template>
         </Listing>
 
-        <DocsCallout :topic="__('Roles & Permissions')" url="users#permissions" />
+        <DocsCallout :topic="__('Roles & Permissions')" url="permissions" />
     </div>
 </template>


### PR DESCRIPTION
This PR updates the link to the permission docs after https://github.com/statamic/docs/pull/1950 breaks up the user docs into smaller pages (the `#permissions` section is removed in favour of a full page).