### PR TITLE
[6.x] Fix nested Bard data loss when reordering sets

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -442,7 +442,7 @@ export default {
         value(value, oldValue) {
             if (!this.editor) return;
 
-            if (document.activeElement?.closest('.bard-content')) return;
+            if (this.editor.view.dom.contains(document.activeElement)) return;
 
             const oldContent = this.editor.getJSON();
             const content = this.valueToContent(value);


### PR DESCRIPTION
Fixes #14966.

Reordering sets in a Bard field whose sets contain another Bard field mixes up the set contents and can lose data. The set titles move correctly, but each nested Bard editor keeps showing the content that was previously at its position. As soon as you type in one of those editors, the stale content gets written back to the wrong set and the original content is gone.

This is a regression from #14808, which skips syncing the editor from the `value` prop while the user is focused inside a Bard field:

```js
if (document.activeElement?.closest('.bard-content')) return;
```

That check matches any `.bard-content` ancestor. Since sets are rendered inside the editor's DOM, a nested Bard sits inside the outer Bard's `.bard-content`, and after dragging a set the focus is inside the outer editor. So every nested editor skipped syncing its shifted value.

This PR scopes the guard to the editor's own element instead:

```js
if (this.editor.view.dom.contains(document.activeElement)) return;
```

The nested editor's DOM is a descendant of the outer editor's DOM, so focusing a nested set still prevents the outer editor from re-rendering, and the behavior #14808 fixed stays fixed.

Verified both directions against the repro from the issue: reordering sets now keeps content and images with their sets, and typing in a nested set still doesn't clobber the outer editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)