### PR TITLE
[6.x] Fix runtime assignment in a partial blanking a later partial's slot

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -2589,7 +2589,7 @@ class NodeProcessor
                 foreach ($___antlersVarAfter as $___varKey => $___varValue) {
                     if (
                         str_starts_with($___varKey, '___') ||
-                        (isset($___antlersVarBefore[$___varKey]) && $___antlersVarBefore[$___varKey] === $___varValue)
+                        (array_key_exists($___varKey, $___antlersVarBefore) && $___antlersVarBefore[$___varKey] === $___varValue)
                     ) {
                         continue;
                     }

--- a/tests/Antlers/Runtime/PartialsTest.php
+++ b/tests/Antlers/Runtime/PartialsTest.php
@@ -82,4 +82,17 @@ ANTLERS;
 
         $this->renderString($template, [], true);
     }
+
+    public function test_assignments_in_earlier_partials_do_not_blank_a_later_partials_slot()
+    {
+        $template = <<<'EOT'
+{{? $foo = 'bar' ?}}{{ partial:filter /}}{{ partial:card }}KEEPME{{ /partial:card }}
+EOT;
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('filter', "{{? \$values = 'v' ?}}FILTER");
+        $this->viewShouldReturnRaw('card', "{{ trans key='hi' }}<slot>{{ slot }}</slot>");
+
+        $this->assertSame('FILTERhi<slot>KEEPME</slot>', $this->renderString($template, [], true));
+    }
 }


### PR DESCRIPTION
Fixes #14833.

A runtime assignment inside a non-pair partial could blank the `{{ slot }}` of a later pair partial on the same page. With these three templates:

```antlers
{{# page #}}
{{? $foo = 'bar' ?}}
{{ partial:filter }}
{{ partial:card }}KEEPME{{ /partial:card }}

{{# filter (non-pair) #}}
{{? $values = 'v' ?}}FILTER

{{# card (pair) #}}
{{ trans key='hi' }}<slot>{{ slot }}</slot>
```

the card rendered `<slot></slot>` instead of `<slot>KEEPME</slot>`, silently and with no errors logged.

The cause is in `evaluatePhpBuffer()`, which captures assignments from `{{? ?}}` nodes by diffing `get_defined_vars()` before and after the eval. The guard that skips unchanged scope variables uses `isset()`, which returns false for pre-existing null values. A non-pair partial's `slot` is exactly that (`null`), so it was misclassified as a fresh assignment and pushed into the traced runtime assignments, where it later overwrote the pair partial's real slot content once any tag ran in its body. The guard was added in #13939 to stop PHP nodes clobbering the parent scope, but the `isset()` check left this null hole open.

This changes the check to `array_key_exists()`, so pre-existing null scope variables are recognized as unchanged. New variables (absent from the before-snapshot) and genuine null-to-value changes are still captured exactly as before.

Verified against the repro from the issue: before, the page rendered `FILTERhi<slot></slot>`; after, `FILTERhi<slot>KEEPME</slot>`. The full Antlers suite passes, including the #13939 guard test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)