### PR TITLE
[6.x] Fix toasts breaking when sessions are serialized as JSON

### DIFF
--- a/src/CP/Toasts/Toast.php
+++ b/src/CP/Toasts/Toast.php
@@ -4,11 +4,12 @@ namespace Statamic\CP\Toasts;
 
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
 
 /**
  * Holds information about a toast message to show to the user.
  */
-class Toast implements Arrayable
+class Toast implements Arrayable, JsonSerializable
 {
     private const TYPES = ['error', 'success', 'info'];
     private $message;
@@ -41,6 +42,11 @@ class Toast implements Arrayable
             'type' => $this->type,
             'duration' => $this->duration,
         ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
     }
 
     /**

--- a/tests/CP/Toasts/ManagerTest.php
+++ b/tests/CP/Toasts/ManagerTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\CP\Toasts;
+
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\CP\Toasts\Manager;
+use Tests\TestCase;
+
+class ManagerTest extends TestCase
+{
+    #[Test]
+    public function toasts_survive_json_session_serialization()
+    {
+        $handler = new ArraySessionHandler(120);
+        $sessionId = str_repeat('a', 40);
+
+        // Flash a toast, then persist the session using json serialization,
+        // like a request ending with a redirect would.
+        $session = new Store('test', $handler, $sessionId, 'json');
+        $session->start();
+        (new Manager($session))->success('Saved!');
+        $session->save();
+
+        // Read it back on the "next request".
+        $session = new Store('test', $handler, $sessionId, 'json');
+        $session->start();
+
+        $this->assertSame(
+            [['message' => 'Saved!', 'type' => 'success', 'duration' => null]],
+            (new Manager($session))->toArray()
+        );
+    }
+}


### PR DESCRIPTION
Fixes #14797.

Flashing a toast and redirecting, like this:

```php
Toast::success('Success!');

return Inertia::back();
```

made the next request receive `_toasts: [[]]` and throw `Uncaught TypeError: this[type] is not a function` in the console instead of showing the toast.

The toast manager flashes `Toast` objects into the session. When the response is a redirect, the toast has to survive session persistence into the next request. Laravel supports serializing session data as JSON (`session.serialization`), and current app skeletons ship `'serialization' => 'json'` as the default. `Toast` only has private properties and didn't implement `JsonSerializable`, so `json_encode()` turned it into `{}`, which decoded back to an empty array on the next request. Flows that deliver toasts in the same response (like saving an entry) never round-trip through the session, which is why they were unaffected.

This makes `Toast` implement `JsonSerializable`, so it survives the round-trip. Sessions serialized with the `php` strategy are unchanged, and the fluent `->duration()` chaining after push keeps working since the session still holds the object itself.

Verified in a live CP with JSON session serialization: before, the follow-up request's `_toasts` prop was `[[]]`; after, it's `[{"message":"Sandbox toast test","type":"success","duration":null}]` and the toast displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)