### PR TITLE
[6.x] Fix blueprint assignment of entries using custom entry class

### DIFF
--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -899,8 +899,8 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
     public function makeLocalization($site)
     {
         $localization = Facades\Entry::make()
-            ->collection($this->collection)
             ->origin($this)
+            ->collection($this->collection)
             ->locale($site)
             ->published($this->published)
             ->slug($this->slug());

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -2867,6 +2867,36 @@ class EntryTest extends TestCase
     }
 
     #[Test]
+    public function localization_of_custom_entry_class_uses_the_origins_blueprint()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://domain.com/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://domain.com/fr/', 'locale' => 'fr'],
+        ]);
+
+        BlueprintRepository::shouldReceive('in')->with('collections/custom')->andReturn(collect([
+            'default' => (new Blueprint)->setHandle('default'),
+            'another' => (new Blueprint)->setHandle('another'),
+        ]));
+
+        $collection = tap(Collection::make('custom')->sites(['en', 'fr'])->entryClass(CustomEntry::class))->save();
+
+        $origin = EntryFactory::id('origin-id')
+            ->locale('en')
+            ->collection($collection)
+            ->slug('alfa')
+            ->blueprint('another')
+            ->create();
+
+        $this->assertEquals('another', $origin->blueprint()->handle());
+
+        $localization = $origin->makeLocalization('fr');
+
+        $this->assertInstanceOf(CustomEntry::class, $localization);
+        $this->assertEquals('another', $localization->blueprint()->handle());
+    }
+
+    #[Test]
     public function it_clones_internal_collections()
     {
         $entry = EntryFactory::collection('test')->create();


### PR DESCRIPTION
Fixes #15016 

## Issue

Localizing an entry can assign the wrong blueprint to the localization if two conditions are met:

- the collection has multiple blueprints
- the collection uses a custom entry class

This will lead to the default blueprint of the collection being assigned, instead of the origin entry's blueprint. The blueprint is not resolved because at the point of newing up the custom entry class, no origin is set.

## Fix

 Assigning the origin before the collection during localization allows resolving the correct blueprint.
