### PR TITLE
[6.x] Fix nullable return types in form docblocks

### DIFF
--- a/src/Contracts/Forms/Form.php
+++ b/src/Contracts/Forms/Form.php
@@ -40,7 +40,7 @@ interface Form extends Arrayable
      * Get a submission.
      *
      * @param  string  $id
-     * @return Submission
+     * @return Submission|null
      */
     public function submission($id);
 

--- a/src/Facades/Form.php
+++ b/src/Facades/Form.php
@@ -8,7 +8,7 @@ use Statamic\Contracts\Forms\Submission;
 use Statamic\Forms\Exporters\ExporterRepository;
 
 /**
- * @method static \Statamic\Contracts\Forms\Form find(string $handle)
+ * @method static \Statamic\Contracts\Forms\Form|null find(string $handle)
  * @method static \Statamic\Contracts\Forms\Form findOrFail(string $handle)
  * @method static \Illuminate\Support\Collection all()
  * @method static int count()

--- a/src/Facades/FormSubmission.php
+++ b/src/Facades/FormSubmission.php
@@ -12,7 +12,7 @@ use Statamic\Contracts\Forms\SubmissionRepository;
  * @method static Collection all()
  * @method static Collection whereForm(string $handle)
  * @method static Collection whereInForm(array $handles)
- * @method static SubmissionContract find($id)
+ * @method static SubmissionContract|null find($id)
  * @method static void save(SubmissionContract $submission)
  * @method static void delete(SubmissionContract $submission)
  * @method static SubmissionQueryBuilder query()

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -349,7 +349,7 @@ class Form implements Arrayable, Augmentable, ContainsQueryableValues, FormContr
      * Get a submission.
      *
      * @param  string  $id
-     * @return Submission
+     * @return Submission|null
      */
     public function submission($id)
     {

--- a/src/Forms/FormRepository.php
+++ b/src/Forms/FormRepository.php
@@ -22,7 +22,7 @@ class FormRepository implements Contract
      * Find a form.
      *
      * @param  string  $handle
-     * @return FormContract
+     * @return FormContract|null
      */
     public function find($handle)
     {


### PR DESCRIPTION
## Problem

Several docblocks in the Forms domain declare non-nullable return types for methods that can return `null`:

- `Form::submission($id)` (concrete class and contract) is annotated `@return Submission`, but it delegates to `FormSubmission::find($id)`, whose repository implementation returns `?Submission`.
- The `FormSubmission` facade annotates `@method static SubmissionContract find($id)` for the same nullable lookup.
- `FormRepository::find($handle)` is annotated `@return FormContract`, but returns `null` when the form's YAML file doesn't exist, and the `Form` facade's `@method` annotation repeats the non-nullable type.

This breaks static analysis in apps consuming Statamic. For example, PHPStan (with default `treatPhpDocTypesAsCertain: true`) reports a guard like this as dead code:

```php
$submission = Form::find($handle)->submission($id);

if (! $submission) { // "Negated boolean expression is always false" (booleanNot.alwaysFalse)
    return;
}
```

…even though the null check is genuinely reachable at runtime. It also gives IDEs false confidence, hiding potential null-dereference bugs.

## Solution

Correct the five docblocks to `|null`, matching what the methods actually return. Docblock-only change — no behavior changes, so no new test case.