### PR TITLE
[6.x] Invalidate old static cache entries on entry URL changes

### DIFF
--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -8,6 +8,7 @@ use Statamic\Contracts\Entries\Collection;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Forms\Form;
 use Statamic\Contracts\Globals\Variables;
+use Statamic\Contracts\Routing\UrlBuilder;
 use Statamic\Contracts\Structures\Nav;
 use Statamic\Contracts\Structures\NavTree;
 use Statamic\Facades\Antlers;
@@ -32,6 +33,11 @@ class DefaultInvalidator implements Invalidator
 
     public function invalidate($item)
     {
+        // Old URLs no longer resolve so they cannot be recached, only invalidated.
+        if ($this->refreshing && ($oldUrls = $this->getItemOldUrls($item))) {
+            $this->cacher->invalidateUrls($oldUrls);
+        }
+
         if ($this->rules === 'all') {
             $this->refreshing
                 ? $this->cacher->refreshUrls($this->cacher->getUrls()->all())
@@ -44,7 +50,7 @@ class DefaultInvalidator implements Invalidator
 
         $this->refreshing
             ? $this->cacher->refreshUrls($urls)
-            : $this->cacher->invalidateUrls($urls);
+            : $this->cacher->invalidateUrls([...$urls, ...$this->getItemOldUrls($item)]);
     }
 
     public function refresh($item)
@@ -90,6 +96,32 @@ class DefaultInvalidator implements Invalidator
         }
 
         return $urls;
+    }
+
+    protected function getItemOldUrls($item)
+    {
+        return $item instanceof Entry ? $this->getOldEntryUrls($item) : [];
+    }
+
+    protected function getOldEntryUrls($entry)
+    {
+        if (
+            is_null($originalSlug = $entry->getOriginal('slug'))
+            || $originalSlug === $entry->slug()
+            || ! ($route = $entry->route())
+        ) {
+            return [];
+        }
+
+        $uri = app(UrlBuilder::class)->content($entry)->merge([
+            'parent_uri' => $entry->parent()?->uri(),
+            'slug' => $originalSlug,
+        ])->build($route);
+
+        $oldUrl = URL::tidy($entry->site()->url().'/'.$uri);
+
+        // Anything cached under the old URL (descendants, mounted collections) is stale too.
+        return [$oldUrl, Str::finish($oldUrl, '/').'*'];
     }
 
     protected function getFormUrls($form)

--- a/tests/StaticCaching/DefaultInvalidatorTest.php
+++ b/tests/StaticCaching/DefaultInvalidatorTest.php
@@ -314,6 +314,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('descendants')->andReturn(collect());
             $m->shouldReceive('site')->andReturn(Site::default());
             $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->andReturnNull();
             $m->shouldReceive('toAugmentedCollection')
                 ->andReturnSelf()
                 ->shouldReceive('merge')
@@ -368,6 +369,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('descendants')->andReturn(collect());
             $m->shouldReceive('site')->andReturn(Site::get('fr'));
             $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->andReturnNull();
             $m->shouldReceive('toAugmentedCollection')
                 ->andReturnSelf()
                 ->shouldReceive('merge')
@@ -417,6 +419,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('descendants')->andReturn(collect());
             $m->shouldReceive('site')->andReturn(Site::default());
             $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->andReturnNull();
             $m->shouldReceive('toAugmentedCollection')
                 ->andReturnSelf()
                 ->shouldReceive('merge')
@@ -456,6 +459,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('collectionHandle')->andReturn('blog');
             $m->shouldReceive('descendants')->andReturn(collect());
             $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->andReturnNull();
             $m->shouldReceive('site')->andReturn(Site::default());
             $m->shouldReceive('toAugmentedCollection')
                 ->andReturnSelf()
@@ -475,6 +479,68 @@ class DefaultInvalidatorTest extends TestCase
                 ],
             ],
         ]);
+
+        $this->assertNull($invalidator->invalidate($entry));
+    }
+
+    #[Test]
+    public function old_entry_url_is_invalidated_when_the_slug_changes()
+    {
+        $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
+            $cacher->shouldReceive('invalidateUrls')->with([
+                'http://localhost/blog/new-slug',
+                'http://localhost/blog/old-slug',
+                'http://localhost/blog/old-slug/*',
+            ])->once();
+        });
+
+        $entry = tap(Mockery::mock(Entry::class), function ($m) {
+            $m->shouldReceive('isRedirect')->andReturn(false);
+            $m->shouldReceive('absoluteUrl')->andReturn('http://localhost/blog/new-slug');
+            $m->shouldReceive('collectionHandle')->andReturn('blog');
+            $m->shouldReceive('descendants')->andReturn(collect());
+            $m->shouldReceive('site')->andReturn(Site::default());
+            $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->with('slug')->andReturn('old-slug');
+            $m->shouldReceive('slug')->andReturn('new-slug');
+            $m->shouldReceive('route')->andReturn('/blog/{slug}');
+            $m->shouldReceive('routeData')->andReturn(['slug' => 'new-slug']);
+            $m->shouldReceive('toAugmentedCollection')
+                ->andReturnSelf()
+                ->shouldReceive('merge')
+                ->andReturn(collect(['parent_uri' => null]));
+        });
+
+        $invalidator = new Invalidator($cacher, []);
+
+        $this->assertNull($invalidator->invalidate($entry));
+    }
+
+    #[Test]
+    public function old_entry_url_is_not_invalidated_when_the_slug_is_unchanged()
+    {
+        $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
+            $cacher->shouldReceive('invalidateUrls')->with([
+                'http://localhost/blog/my-slug',
+            ])->once();
+        });
+
+        $entry = tap(Mockery::mock(Entry::class), function ($m) {
+            $m->shouldReceive('isRedirect')->andReturn(false);
+            $m->shouldReceive('absoluteUrl')->andReturn('http://localhost/blog/my-slug');
+            $m->shouldReceive('collectionHandle')->andReturn('blog');
+            $m->shouldReceive('descendants')->andReturn(collect());
+            $m->shouldReceive('site')->andReturn(Site::default());
+            $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->with('slug')->andReturn('my-slug');
+            $m->shouldReceive('slug')->andReturn('my-slug');
+            $m->shouldReceive('toAugmentedCollection')
+                ->andReturnSelf()
+                ->shouldReceive('merge')
+                ->andReturn(collect(['parent_uri' => null]));
+        });
+
+        $invalidator = new Invalidator($cacher, []);
 
         $this->assertNull($invalidator->invalidate($entry));
     }
@@ -961,6 +1027,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('descendants')->andReturn(collect());
             $m->shouldReceive('site')->andReturn(Site::default());
             $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->andReturnNull();
             $m->shouldReceive('toAugmentedCollection')
                 ->andReturnSelf()
                 ->shouldReceive('merge')
@@ -1001,6 +1068,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('descendants')->andReturn(collect());
             $m->shouldReceive('site')->andReturn(Site::default());
             $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->andReturnNull();
             $m->shouldReceive('toAugmentedCollection')
                 ->andReturnSelf()
                 ->shouldReceive('merge')
@@ -1017,6 +1085,43 @@ class DefaultInvalidatorTest extends TestCase
                 ],
             ],
         ]);
+
+        $this->assertNull($invalidator->refresh($entry));
+    }
+
+    #[Test]
+    public function old_entry_url_is_invalidated_rather_than_recached_when_background_recache_is_enabled()
+    {
+        config()->set('statamic.static_caching.background_recache', true);
+
+        $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
+            $cacher->shouldReceive('invalidateUrls')->once()->with([
+                'http://localhost/blog/old-slug',
+                'http://localhost/blog/old-slug/*',
+            ]);
+            $cacher->shouldReceive('refreshUrls')->once()->with([
+                'http://localhost/blog/new-slug',
+            ]);
+        });
+
+        $entry = tap(Mockery::mock(Entry::class), function ($m) {
+            $m->shouldReceive('isRedirect')->andReturn(false);
+            $m->shouldReceive('absoluteUrl')->andReturn('http://localhost/blog/new-slug');
+            $m->shouldReceive('collectionHandle')->andReturn('blog');
+            $m->shouldReceive('descendants')->andReturn(collect());
+            $m->shouldReceive('site')->andReturn(Site::default());
+            $m->shouldReceive('parent')->andReturnNull();
+            $m->shouldReceive('getOriginal')->with('slug')->andReturn('old-slug');
+            $m->shouldReceive('slug')->andReturn('new-slug');
+            $m->shouldReceive('route')->andReturn('/blog/{slug}');
+            $m->shouldReceive('routeData')->andReturn(['slug' => 'new-slug']);
+            $m->shouldReceive('toAugmentedCollection')
+                ->andReturnSelf()
+                ->shouldReceive('merge')
+                ->andReturn(collect(['parent_uri' => null]));
+        });
+
+        $invalidator = new Invalidator($cacher, []);
 
         $this->assertNull($invalidator->refresh($entry));
     }


### PR DESCRIPTION
When a static-cached entry's route changes — slug, date, or any other field the route references — the cache for the old URL was never invalidated . The old cached response kept being served instead of a redirect to the new URL.

This rebuilds the old URL from whichever route fields actually changed (via `UrlBuilder`, so it works with any route shape) and invalidates it, plus an `/old-url/*` wildcard so pages cached beneath it (children of a renamed parent, mounted collections) are cleaned up too. In background recache mode, old URLs are invalidated rather than refreshed, since they no longer resolve.

Fixes #14876