### PR TITLE
[6.x] Fix validation rules being lost when saving without pressing enter

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -55,7 +55,7 @@
                 v-model="customRule"
                 ref="customRuleInput"
                 @keydown.enter.prevent="add(customRule)"
-                @blur="add(customRule)"
+                @focusout="add(customRule)"
             />
 
             <sortable-list
@@ -238,7 +238,7 @@ export default {
                 this.rules.push(rule);
             }
 
-            this.$nextTick(() => this.$refs.rulesSelect.focus());
+            this.$nextTick(() => this.$refs.rulesSelect?.focus());
         },
 
         add(rule) {
@@ -248,7 +248,7 @@ export default {
                 this.resetState();
                 this.selectedLaravelRule = rule;
                 this.customRule = rule;
-                this.$nextTick(() => this.$refs.customRuleInput.focus());
+                this.$nextTick(() => this.$refs.customRuleInput?.focus());
             } else {
                 this.ensure(rule);
             }

--- a/resources/js/tests/components/field-validation/Builder.test.js
+++ b/resources/js/tests/components/field-validation/Builder.test.js
@@ -1,0 +1,50 @@
+import { mount } from '@vue/test-utils';
+import { expect, test, vi } from 'vitest';
+import Builder from '@/components/field-validation/Builder.vue';
+
+vi.mock('@inertiajs/vue3', () => ({
+    usePage: () => ({ props: { extensionRules: [] } }),
+}));
+
+globalThis.__ = (key) => key;
+globalThis.__n = (key) => key;
+globalThis.clone = (value) => structuredClone(value);
+
+const mountBuilder = () =>
+    mount(Builder, {
+        props: { config: {} },
+        global: {
+            mocks: {
+                $config: { get: () => '12.0.0' },
+            },
+            stubs: {
+                SortableList: true,
+            },
+        },
+    });
+
+test('a typed rule parameter is committed when the input loses focus', async () => {
+    const wrapper = mountBuilder();
+
+    // Picking a parameterized rule swaps the combobox for a plain input holding "after:"
+    wrapper.vm.add('after:');
+    await wrapper.vm.$nextTick();
+
+    const input = wrapper.find('input');
+    await input.setValue('after:{this}.start_time');
+    await input.trigger('focusout');
+
+    expect(wrapper.emitted('updated').at(-1)[0]).toEqual(['after:{this}.start_time']);
+});
+
+test('an unfinished rule is not committed when the input loses focus', async () => {
+    const wrapper = mountBuilder();
+
+    wrapper.vm.add('after:');
+    await wrapper.vm.$nextTick();
+
+    const emitsBefore = wrapper.emitted('updated')?.length ?? 0;
+    await wrapper.find('input').trigger('focusout');
+
+    expect(wrapper.emitted('updated')?.length ?? 0).toBe(emitsBefore);
+});


### PR DESCRIPTION
When you add a parameterized validation rule (like `after:{this}.start_time`) and click Save without pressing enter first, the typed rule is silently dropped. The toast says "Saved" but the rule never reaches the YAML. Reported with `{this}` but it affects any rule entered through the parameter input.

The input commits its value on blur, but listeners passed to the `Input` component land on its outer wrapper via attribute fallthrough, and blur doesn't bubble, so the handler never fired. Enter worked because keydown does bubble up to the wrapper. Switching to `focusout` commits the rule on the way out, whichever way you leave the field. The two ref focus calls are optional-chained since focusout can also fire while the field settings stack is closing.

Worth noting: the underlying component behavior (non-bubbling listeners passed to `Input` never fire) still exists and also affects the focus/blur emits of the text-based fieldtypes. Fixing that properly touches the publish field focus handling, so it felt like its own PR rather than a drive-by here.

Fixes #14806

🤖 Generated with [Claude Code](https://claude.com/claude-code)