### PR TITLE
[6.x] Fix search:update ignoring the index argument when index names are customized

### DIFF
--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -6,7 +6,6 @@ use Illuminate\Console\Command;
 use Statamic\Console\RunsInPlease;
 use Statamic\Events\SearchIndexUpdated;
 use Statamic\Facades\Search;
-use Statamic\Support\Str;
 
 use function Laravel\Prompts\select;
 
@@ -35,7 +34,7 @@ class Update extends Command
 
     private function getIndexes()
     {
-        if ($requestedIndex = $this->getRequestedIndex()) {
+        if (! is_null($requestedIndex = $this->getRequestedIndex())) {
             return $requestedIndex;
         }
 
@@ -71,10 +70,10 @@ class Update extends Command
             return [$this->indexes()->get($arg)];
         }
 
-        // They might have entered a name as it appears in the config, but if it
+        // They might have entered a handle as it appears in the config, but if it
         // should be localized we'll get all of the localized versions.
-        if (collect(config('statamic.search.indexes'))->put('cp', [])->has($arg)) {
-            return $this->indexes()->filter(fn ($index) => Str::startsWith($index->name(), $arg))->all();
+        if ($indexes = $this->indexes()->filter(fn ($index) => $index->handle() === $arg)->all()) {
+            return $indexes;
         }
 
         throw new \InvalidArgumentException("Index [$arg] does not exist.");

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -41,6 +41,11 @@ abstract class Index
         return $this->name;
     }
 
+    public function handle()
+    {
+        return $this->handle;
+    }
+
     public static function resolveNameUsing(?Closure $callback)
     {
         static::$nameCallback = $callback;

--- a/tests/Search/Commands/UpdateTest.php
+++ b/tests/Search/Commands/UpdateTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Search\Commands;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Search\Commands\Update;
+use Statamic\Search\Index;
+use Tests\TestCase;
+
+class UpdateTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        // Reset the static state of the Index class
+        Index::resolveNameUsing(null);
+
+        parent::tearDown();
+    }
+
+    private function setUpIndexes()
+    {
+        $this->setSites([
+            'en' => ['url' => '/'],
+            'fr' => ['url' => '/fr/'],
+        ]);
+
+        config(['statamic.search.indexes' => [
+            'test' => ['driver' => 'null', 'sites' => ['en', 'fr']],
+            'cp' => ['driver' => 'null'],
+        ]]);
+    }
+
+    #[Test]
+    public function it_updates_the_localized_indexes_matching_the_configured_handle()
+    {
+        $this->setUpIndexes();
+
+        $this->artisan(Update::class, ['index' => 'test'])
+            ->expectsOutputToContain('Index test_en updated.')
+            ->expectsOutputToContain('Index test_fr updated.')
+            ->doesntExpectOutputToContain('Index cp updated.')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_updates_the_localized_indexes_when_the_names_have_been_customized()
+    {
+        // When a custom resolver prefixes the name, the resolved name can no longer be
+        // reversed back into the configured handle by string manipulation.
+        Index::resolveNameUsing(fn ($name, $locale) => 'local_'.$name.'_'.$locale);
+
+        $this->setUpIndexes();
+
+        // The argument is the handle as it appears in the config, so it should still
+        // match both localized versions, and it should leave the cp index alone.
+        $this->artisan(Update::class, ['index' => 'test'])
+            ->expectsOutputToContain('Index local_test_en updated.')
+            ->expectsOutputToContain('Index local_test_fr updated.')
+            ->doesntExpectOutputToContain('Index local_cp_ updated.')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_errors_when_the_index_doesnt_exist()
+    {
+        $this->setUpIndexes();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Index [unknown] does not exist.');
+
+        $this->artisan(Update::class, ['index' => 'unknown'])->run();
+    }
+}


### PR DESCRIPTION
### The problem

[Customizing index names](https://statamic.dev/frontend/search#customizing-index-names) lets you rename an index at runtime, e.g. prefixing it per-environment:

```php
Index::resolveNameUsing(fn ($name, $locale) => 'local_'.$name.'_'.$locale);
```

With a `test` index configured that way, `php please search:update test` doesn't update the index. It silently drops the argument and shows the "Which search index would you like to update?" prompt instead — and if you're not paying attention, accepting the default reindexes *everything*. On a single-index site it's worse: `getIndexes()` returns all indexes without prompting at all.

### The cause

`getRequestedIndex()` resolved a configured handle by prefix-matching it against the *resolved* name:

```php
if (collect(config('statamic.search.indexes'))->put('cp', [])->has($arg)) {
    return $this->indexes()->filter(fn ($index) => Str::startsWith($index->name(), $arg))->all();
}
```

That assumes the resolved name still starts with the handle, which holds for the default `{handle}_{locale}` naming but not once a resolver renames the index — `local_test_en` doesn't start with `test`. The filter comes up empty and returns `[]`, which is falsy, so it slips past the `if ($requestedIndex = $this->getRequestedIndex())` guard in `getIndexes()` and falls through to the prompt rather than erroring.

This is the same assumption that was already fixed for the insert job — `Index::insertMultiple()` passes `$this->handle` to `InsertMultipleJob` precisely because the resolved name can't be reversed back into the handle. `Update` is the remaining caller doing it by string manipulation.

### The fix

Match on the configured handle, which `Index` already tracks in `$this->handle`. This adds a public `handle()` accessor to `Index` and uses it:

```php
if ($indexes = $this->indexes()->filter(fn ($index) => $index->handle() === $arg)->all()) {
    return $indexes;
}
```

This was written by good ol' Claude. I've reviewed the change and the tests, and confirmed the new test fails on `6.x` and passes with the fix.
