### PR TITLE
[6.x] Public dictionaries

### DIFF
--- a/resources/js/tests/components/fieldtypes/DictionaryFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/DictionaryFieldtype.test.js
@@ -14,7 +14,7 @@ function mountFieldtype({ value, maxItems, selectedOptions, fetchedOptions, shal
             handle: 'country',
             value,
             config: { max_items: maxItems },
-            meta: { url: '/cp/fieldtypes/dictionaries/partial_countries', selectedOptions },
+            meta: { url: '/!/fieldtypes/dictionaries/partial_countries', selectedOptions },
         },
         global: {
             mocks: {

--- a/routes/cp.php
+++ b/routes/cp.php
@@ -57,7 +57,6 @@ use Statamic\Http\Controllers\CP\Fields\FieldsController;
 use Statamic\Http\Controllers\CP\Fields\FieldsetController;
 use Statamic\Http\Controllers\CP\Fields\FieldtypesController;
 use Statamic\Http\Controllers\CP\Fields\MetaController;
-use Statamic\Http\Controllers\CP\Fieldtypes\DictionaryFieldtypeController;
 use Statamic\Http\Controllers\CP\Fieldtypes\FilesFieldtypeController;
 use Statamic\Http\Controllers\CP\Fieldtypes\IconFieldtypeController;
 use Statamic\Http\Controllers\CP\Fieldtypes\MarkdownFieldtypeController;
@@ -385,7 +384,6 @@ Route::middleware('statamic.cp.authenticated')->group(function () {
         Route::get('relationship/filters', [RelationshipFieldtypeController::class, 'filters'])->name('relationship.filters');
         Route::post('markdown', [MarkdownFieldtypeController::class, 'preview'])->name('markdown.preview');
         Route::post('files/upload', [FilesFieldtypeController::class, 'upload'])->name('files.upload');
-        Route::get('dictionaries/{dictionary}', DictionaryFieldtypeController::class)->name('dictionary-fieldtype');
         Route::post('icons', IconFieldtypeController::class)->name('icon-fieldtype');
         Route::post('replicator/set', ReplicatorSetController::class)->name('replicator-fieldtype.set');
     });

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,7 +42,7 @@ Route::name('statamic.')->group(function () {
         Route::get('protect/password', [PasswordProtectController::class, 'show'])->name('protect.password.show')->middleware([HandleInertiaRequests::class]);
         Route::post('protect/password', [PasswordProtectController::class, 'store'])->name('protect.password.store');
 
-        Route::get('fieldtypes/dictionaries/{dictionary}', DictionaryFieldtypeController::class)->name('dictionary-fieldtype');
+        Route::get('fieldtypes/dictionaries/{dictionary}', DictionaryFieldtypeController::class)->middleware('throttle:statamic.dictionaries')->name('dictionary-fieldtype');
 
         Route::group(['prefix' => 'auth', 'middleware' => [AuthGuard::class]], function () {
             Route::get('logout', [LoginController::class, 'logout'])->name('logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use Statamic\Facades\OAuth;
 use Statamic\Facades\TwoFactor;
 use Statamic\Http\Controllers\ActivateAccountController;
 use Statamic\Http\Controllers\Auth\ElevatedSessionController;
+use Statamic\Http\Controllers\DictionaryFieldtypeController;
 use Statamic\Http\Controllers\ForgotPasswordController;
 use Statamic\Http\Controllers\FormController;
 use Statamic\Http\Controllers\FrontendController;
@@ -40,6 +41,8 @@ Route::name('statamic.')->group(function () {
 
         Route::get('protect/password', [PasswordProtectController::class, 'show'])->name('protect.password.show')->middleware([HandleInertiaRequests::class]);
         Route::post('protect/password', [PasswordProtectController::class, 'store'])->name('protect.password.store');
+
+        Route::get('fieldtypes/dictionaries/{dictionary}', DictionaryFieldtypeController::class)->name('dictionary-fieldtype');
 
         Route::group(['prefix' => 'auth', 'middleware' => [AuthGuard::class]], function () {
             Route::get('logout', [LoginController::class, 'logout'])->name('logout');

--- a/src/Dictionaries/Countries.php
+++ b/src/Dictionaries/Countries.php
@@ -343,4 +343,9 @@ class Countries extends BasicDictionary
             ['name' => __('statamic::dictionary-countries.names.ZWE'), 'iso3' => 'ZWE', 'iso2' => 'ZW', 'region' => $this->regions['africa'], 'subregion' => $this->subregions['eastern_africa'], 'emoji' => '🇿🇼'],
         ];
     }
+
+    public function allowsPublicAccess(): bool
+    {
+        return true;
+    }
 }

--- a/src/Dictionaries/Currencies.php
+++ b/src/Dictionaries/Currencies.php
@@ -173,4 +173,9 @@ class Currencies extends BasicDictionary
             ['code' => 'ZWG', 'name' => __('statamic::dictionary-currencies.ZWG'), 'symbol' => '$', 'decimals' => 2],
         ];
     }
+
+    public function allowsPublicAccess(): bool
+    {
+        return true;
+    }
 }

--- a/src/Dictionaries/Dictionary.php
+++ b/src/Dictionaries/Dictionary.php
@@ -81,4 +81,9 @@ abstract class Dictionary
     {
         return $this->keywords;
     }
+
+    public function allowsPublicAccess(): bool
+    {
+        return false;
+    }
 }

--- a/src/Dictionaries/Languages.php
+++ b/src/Dictionaries/Languages.php
@@ -109,4 +109,9 @@ class Languages extends BasicDictionary
             ['code' => 'gl', 'name' => __('statamic::dictionary-languages.gl')],
         ];
     }
+
+    public function allowsPublicAccess(): bool
+    {
+        return true;
+    }
 }

--- a/src/Dictionaries/Locales.php
+++ b/src/Dictionaries/Locales.php
@@ -43,4 +43,9 @@ class Locales extends BasicDictionary
 
         return ['locale', '-a'];
     }
+
+    public function allowsPublicAccess(): bool
+    {
+        return true;
+    }
 }

--- a/src/Dictionaries/Locales.php
+++ b/src/Dictionaries/Locales.php
@@ -3,6 +3,7 @@
 namespace Statamic\Dictionaries;
 
 use Facades\Statamic\Console\Processes\Process;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 class Locales extends BasicDictionary
@@ -17,17 +18,19 @@ class Locales extends BasicDictionary
 
     protected function getItems(): array
     {
-        $output = Process::run($this->buildLocalesCommand());
+        return Cache::rememberForever('statamic.dictionaries.locales', function () {
+            $output = Process::run($this->buildLocalesCommand());
 
-        return collect(explode(PHP_EOL, $output))
-            ->filter(fn ($locale) => mb_check_encoding($locale, 'UTF-8'))
-            ->map(fn ($locale) => Str::before($locale, '.'))
-            ->reject(fn ($locale) => in_array($locale, ['C', 'POSIX']))
-            ->filter()
-            ->sort()
-            ->values()
-            ->map(fn ($locale) => ['name' => $locale])
-            ->all();
+            return collect(explode(PHP_EOL, $output))
+                ->filter(fn ($locale) => mb_check_encoding($locale, 'UTF-8'))
+                ->map(fn ($locale) => Str::before($locale, '.'))
+                ->reject(fn ($locale) => in_array($locale, ['C', 'POSIX']))
+                ->filter()
+                ->sort()
+                ->values()
+                ->map(fn ($locale) => ['name' => $locale])
+                ->all();
+        });
     }
 
     private function buildLocalesCommand(): array

--- a/src/Dictionaries/Timezones.php
+++ b/src/Dictionaries/Timezones.php
@@ -31,4 +31,9 @@ class Timezones extends BasicDictionary
 
         return stripos($offsetInSecs, '-') === false ? "+{$hoursAndSec}" : "-{$hoursAndSec}";
     }
+
+    public function allowsPublicAccess(): bool
+    {
+        return true;
+    }
 }

--- a/src/Fieldtypes/Dictionary.php
+++ b/src/Fieldtypes/Dictionary.php
@@ -76,7 +76,7 @@ class Dictionary extends Fieldtype
     public function preload(): array
     {
         return [
-            'url' => cp_route('dictionary-fieldtype', $this->dictionary()->handle()),
+            'url' => route('statamic.dictionary-fieldtype', $this->dictionary()->handle()),
             'selectedOptions' => $this->getItemData($this->field->value()),
         ];
     }

--- a/src/Http/Controllers/DictionaryFieldtypeController.php
+++ b/src/Http/Controllers/DictionaryFieldtypeController.php
@@ -2,17 +2,24 @@
 
 namespace Statamic\Http\Controllers;
 
-use Facades\Statamic\Fields\FieldtypeRepository as Fieldtype;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Statamic\Exceptions\DictionaryNotFoundException;
 use Statamic\Exceptions\ForbiddenHttpException;
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Exceptions\UndefinedDictionaryException;
 use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Dictionary;
 
 class DictionaryFieldtypeController extends Controller
 {
     public function __invoke(Request $request, string $dictionary)
     {
-        $dictionary = $this->fieldtype($request)->dictionary();
+        try {
+            $dictionary = $this->fieldtype($request)->dictionary();
+        } catch (UndefinedDictionaryException|DictionaryNotFoundException $e) {
+            throw new NotFoundHttpException;
+        }
 
         if (Gate::denies('access cp') && ! $dictionary->allowsPublicAccess()) {
             throw new ForbiddenHttpException;
@@ -35,7 +42,11 @@ class DictionaryFieldtypeController extends Controller
     {
         $config = $this->getConfig($request);
 
-        return Fieldtype::find($config['type'])->setField(
+        if (! is_array($config)) {
+            throw new NotFoundHttpException;
+        }
+
+        return (new Dictionary)->setField(
             new Field('relationship', $config)
         );
     }

--- a/src/Http/Controllers/DictionaryFieldtypeController.php
+++ b/src/Http/Controllers/DictionaryFieldtypeController.php
@@ -4,13 +4,21 @@ namespace Statamic\Http\Controllers;
 
 use Facades\Statamic\Fields\FieldtypeRepository as Fieldtype;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Statamic\Exceptions\ForbiddenHttpException;
 use Statamic\Fields\Field;
 
 class DictionaryFieldtypeController extends Controller
 {
     public function __invoke(Request $request, string $dictionary)
     {
-        $options = $dictionary->dictionary()->options($request->search);
+        $dictionary = $this->fieldtype($request)->dictionary();
+
+        if (Gate::denies('access cp') && ! $dictionary->allowsPublicAccess()) {
+            throw new ForbiddenHttpException;
+        }
+
+        $options = $dictionary->options($request->search);
 
         // Return an ordered list of key/value pairs rather than a value-keyed object.
         // When the values are integers, the browser would re-sort the object's keys ascending,

--- a/src/Http/Controllers/DictionaryFieldtypeController.php
+++ b/src/Http/Controllers/DictionaryFieldtypeController.php
@@ -1,17 +1,16 @@
 <?php
 
-namespace Statamic\Http\Controllers\CP\Fieldtypes;
+namespace Statamic\Http\Controllers;
 
 use Facades\Statamic\Fields\FieldtypeRepository as Fieldtype;
 use Illuminate\Http\Request;
 use Statamic\Fields\Field;
-use Statamic\Http\Controllers\CP\CpController;
 
-class DictionaryFieldtypeController extends CpController
+class DictionaryFieldtypeController extends Controller
 {
     public function __invoke(Request $request, string $dictionary)
     {
-        $options = $this->fieldtype($request)->dictionary()->options($request->search);
+        $options = $dictionary->dictionary()->options($request->search);
 
         // Return an ordered list of key/value pairs rather than a value-keyed object.
         // When the values are integers, the browser would re-sort the object's keys ascending,

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -203,6 +203,10 @@ class AuthServiceProvider extends ServiceProvider
                 : Limit::perMinute(10)->by('submission:'.$request->ip());
         });
 
+        RateLimiter::for('statamic.dictionaries', function (Request $request) {
+            return Limit::perMinute(60)->by($request->ip());
+        });
+
         RateLimiter::for('two-factor', function (Request $request) {
             return Limit::perMinute(5)->by($request->session()->get('login.id'));
         });

--- a/tests/Dictionaries/LocalesTest.php
+++ b/tests/Dictionaries/LocalesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Dictionaries;
+
+use Facades\Statamic\Console\Processes\Process;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Dictionaries\Locales;
+use Tests\TestCase;
+
+class LocalesTest extends TestCase
+{
+    #[Test]
+    public function it_only_runs_the_locale_process_once_and_caches_the_result()
+    {
+        Process::shouldReceive('run')->once()->andReturn("en_US.UTF-8\nfr_FR.UTF-8\nC\nPOSIX");
+
+        $expected = ['en_US' => 'en_US', 'fr_FR' => 'fr_FR'];
+
+        $this->assertEquals($expected, (new Locales)->options());
+        $this->assertEquals($expected, (new Locales)->options());
+    }
+
+    #[Test]
+    public function cached_items_can_still_be_searched()
+    {
+        Process::shouldReceive('run')->once()->andReturn("en_US.UTF-8\nfr_FR.UTF-8");
+
+        (new Locales)->options();
+
+        $this->assertEquals(['fr_FR' => 'fr_FR'], (new Locales)->options('fr'));
+    }
+}

--- a/tests/Dictionaries/LocalesTest.php
+++ b/tests/Dictionaries/LocalesTest.php
@@ -12,7 +12,7 @@ class LocalesTest extends TestCase
     #[Test]
     public function it_only_runs_the_locale_process_once_and_caches_the_result()
     {
-        Process::shouldReceive('run')->once()->andReturn("en_US.UTF-8\nfr_FR.UTF-8\nC\nPOSIX");
+        Process::shouldReceive('run')->once()->andReturn(implode(PHP_EOL, ['en_US.UTF-8', 'fr_FR.UTF-8', 'C', 'POSIX']));
 
         $expected = ['en_US' => 'en_US', 'fr_FR' => 'fr_FR'];
 
@@ -23,7 +23,7 @@ class LocalesTest extends TestCase
     #[Test]
     public function cached_items_can_still_be_searched()
     {
-        Process::shouldReceive('run')->once()->andReturn("en_US.UTF-8\nfr_FR.UTF-8");
+        Process::shouldReceive('run')->once()->andReturn(implode(PHP_EOL, ['en_US.UTF-8', 'fr_FR.UTF-8']));
 
         (new Locales)->options();
 

--- a/tests/Feature/RateLimitingTest.php
+++ b/tests/Feature/RateLimitingTest.php
@@ -220,6 +220,29 @@ class RateLimitingTest extends TestCase
     }
 
     #[Test]
+    public function dictionary_fieldtype_endpoint_is_rate_limited()
+    {
+        $config = base64_encode(json_encode(['type' => 'dictionary', 'dictionary' => 'countries']));
+        $url = route('statamic.dictionary-fieldtype', 'countries').'?config='.$config;
+
+        collect(range(1, 60))->each(fn () => $this->getJson($url)->assertNotRateLimited());
+        $this->getJson($url)->assertRateLimited();
+    }
+
+    #[Test]
+    public function dictionary_fieldtype_rate_limiter_can_be_overridden()
+    {
+        RateLimiter::for('statamic.dictionaries', fn ($request) => Limit::perMinute(2)->by($request->ip()));
+
+        $config = base64_encode(json_encode(['type' => 'dictionary', 'dictionary' => 'countries']));
+        $url = route('statamic.dictionary-fieldtype', 'countries').'?config='.$config;
+
+        $this->getJson($url)->assertNotRateLimited();
+        $this->getJson($url)->assertNotRateLimited();
+        $this->getJson($url)->assertRateLimited();
+    }
+
+    #[Test]
     public function passkeys_rate_limiter_can_be_overridden()
     {
         RateLimiter::for('statamic.passkeys', fn ($request) => Limit::perMinute(2)->by($request->ip()));

--- a/tests/Fieldtypes/DictionaryTest.php
+++ b/tests/Fieldtypes/DictionaryTest.php
@@ -91,7 +91,7 @@ class DictionaryTest extends TestCase
         $preload = $fieldtype->preload();
 
         $this->assertArraySubset([
-            'url' => 'http://localhost/cp/fieldtypes/dictionaries/countries',
+            'url' => 'http://localhost/!/fieldtypes/dictionaries/countries',
             'selectedOptions' => [
                 ['value' => 'USA', 'label' => '🇺🇸 United States', 'invalid' => false],
                 ['value' => 'AUS', 'label' => '🇦🇺 Australia', 'invalid' => false],

--- a/tests/Fieldtypes/DictionaryTest.php
+++ b/tests/Fieldtypes/DictionaryTest.php
@@ -139,6 +139,26 @@ class DictionaryTest extends TestCase
             ->assertJsonStructure(['data' => [['key', 'value']]]);
     }
 
+    #[Test]
+    public function a_request_with_a_missing_dictionary_is_rejected()
+    {
+        $config = base64_encode(json_encode(['type' => 'dictionary']));
+
+        $this
+            ->getJson(route('statamic.dictionary-fieldtype', 'countries').'?config='.$config)
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function a_request_with_an_unknown_dictionary_is_rejected()
+    {
+        $config = base64_encode(json_encode(['type' => 'dictionary', 'dictionary' => 'not_a_real_dictionary']));
+
+        $this
+            ->getJson(route('statamic.dictionary-fieldtype', 'countries').'?config='.$config)
+            ->assertNotFound();
+    }
+
     private function optionsUrl(string $dictionary): string
     {
         $config = base64_encode(json_encode(['type' => 'dictionary', 'dictionary' => $dictionary]));

--- a/tests/Fieldtypes/DictionaryTest.php
+++ b/tests/Fieldtypes/DictionaryTest.php
@@ -6,14 +6,19 @@ use Facades\Statamic\Fields\FieldtypeRepository;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Dictionaries\Countries;
+use Statamic\Dictionaries\Dictionary;
 use Statamic\Dictionaries\Item;
 use Statamic\Exceptions\DictionaryNotFoundException;
 use Statamic\Exceptions\UndefinedDictionaryException;
+use Statamic\Facades\User;
 use Statamic\Fields\Field;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class DictionaryTest extends TestCase
 {
+    use PreventSavingStacheItemsToDisk;
+
     #[Test]
     #[DataProvider('dictionaryConfigProvider')]
     public function it_gets_the_dictionary($dictionaryConfig, $expectedConfig)
@@ -101,6 +106,44 @@ class DictionaryTest extends TestCase
                 ['value' => 'GBR', 'label' => '🇬🇧 United Kingdom', 'invalid' => false],
             ],
         ], $preload);
+    }
+
+    #[Test]
+    public function a_guest_can_request_options_from_a_dictionary_that_allows_public_access()
+    {
+        $this
+            ->getJson($this->optionsUrl('countries'))
+            ->assertOk()
+            ->assertJsonStructure(['data' => [['key', 'value']]]);
+    }
+
+    #[Test]
+    public function a_guest_cannot_request_options_from_a_dictionary_that_does_not_allow_public_access()
+    {
+        RestrictedDictionary::register();
+
+        $this
+            ->getJson($this->optionsUrl('restricted'))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function a_cp_user_can_request_options_from_a_dictionary_that_does_not_allow_public_access()
+    {
+        RestrictedDictionary::register();
+
+        $this
+            ->actingAs(User::make()->makeSuper())
+            ->getJson($this->optionsUrl('restricted'))
+            ->assertOk()
+            ->assertJsonStructure(['data' => [['key', 'value']]]);
+    }
+
+    private function optionsUrl(string $dictionary): string
+    {
+        $config = base64_encode(json_encode(['type' => 'dictionary', 'dictionary' => $dictionary]));
+
+        return route('statamic.dictionary-fieldtype', $dictionary).'?config='.$config;
     }
 
     #[Test]
@@ -278,5 +321,20 @@ class DictionaryTest extends TestCase
                 'USA' => '🇺🇸 United States',
             ],
         ], $extraRenderableFieldData);
+    }
+}
+
+class RestrictedDictionary extends Dictionary
+{
+    protected static $handle = 'restricted';
+
+    public function options(?string $search = null): array
+    {
+        return ['foo' => 'Foo', 'bar' => 'Bar'];
+    }
+
+    public function get(string $key): ?Item
+    {
+        return new Item($key, $this->options()[$key], []);
     }
 }


### PR DESCRIPTION
This pull request makes the dictionary fieldtype's route accessible outside of the Control Panel and to unauthenticated users.

## Use case

In Forms Pro, we have an option to give each form its own page, which ultimately renders a `PublishContainer` on the frontend to unauthorized users. 

The dictionary fieldtype uses an AJAX request on mount and when searching to fetch relevant options. However, as the dictionary fieldtype's route was in the `/cp` namespace, it was restricted to logged in users only.

This PR changes that (it's now open to guests) and adds authorization to ensure only specific dictionaries can be requested on the frontend.