### PR TITLE
[6.x] Fix Custom Invalidator background recache

### DIFF
--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -22,6 +22,7 @@ class DefaultInvalidator implements Invalidator
 {
     protected $cacher;
     protected $rules;
+    protected $refreshing = false;
 
     public function __construct(Cacher $cacher, $rules = [])
     {
@@ -32,14 +33,18 @@ class DefaultInvalidator implements Invalidator
     public function invalidate($item)
     {
         if ($this->rules === 'all') {
-            $this->cacher->flush();
+            $this->refreshing
+                ? $this->cacher->refreshUrls($this->cacher->getUrls()->all())
+                : $this->cacher->flush();
 
             return;
         }
 
         $urls = $this->getItemUrls($item);
 
-        $this->cacher->invalidateUrls($urls);
+        $this->refreshing
+            ? $this->cacher->refreshUrls($urls)
+            : $this->cacher->invalidateUrls($urls);
     }
 
     public function refresh($item)
@@ -50,15 +55,11 @@ class DefaultInvalidator implements Invalidator
             return;
         }
 
-        if ($this->rules === 'all') {
-            $this->cacher->refreshUrls($this->cacher->getUrls()->all());
+        $this->refreshing = true;
 
-            return;
-        }
+        $this->invalidate($item);
 
-        $urls = $this->getItemUrls($item);
-
-        $this->cacher->refreshUrls($urls);
+        $this->refreshing = false;
     }
 
     protected function getItemUrls($item)

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -22,9 +22,6 @@ class DefaultInvalidator implements Invalidator
 {
     protected $cacher;
     protected $rules;
-
-    // Read by invalidate() to pick refreshUrls() over invalidateUrls()/flush(). Subclasses
-    // overriding invalidate() must check this themselves to get refresh-vs-invalidate semantics.
     protected $refreshing = false;
 
     public function __construct(Cacher $cacher, $rules = [])

--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -22,6 +22,9 @@ class DefaultInvalidator implements Invalidator
 {
     protected $cacher;
     protected $rules;
+
+    // Read by invalidate() to pick refreshUrls() over invalidateUrls()/flush(). Subclasses
+    // overriding invalidate() must check this themselves to get refresh-vs-invalidate semantics.
     protected $refreshing = false;
 
     public function __construct(Cacher $cacher, $rules = [])
@@ -55,11 +58,14 @@ class DefaultInvalidator implements Invalidator
             return;
         }
 
+        $previous = $this->refreshing;
         $this->refreshing = true;
 
-        $this->invalidate($item);
-
-        $this->refreshing = false;
+        try {
+            $this->invalidate($item);
+        } finally {
+            $this->refreshing = $previous;
+        }
     }
 
     protected function getItemUrls($item)

--- a/tests/StaticCaching/DefaultInvalidatorTest.php
+++ b/tests/StaticCaching/DefaultInvalidatorTest.php
@@ -1020,4 +1020,27 @@ class DefaultInvalidatorTest extends TestCase
 
         $this->assertNull($invalidator->refresh($entry));
     }
+
+    #[Test]
+    public function it_calls_the_custom_invalidate_method_when_background_recache_is_enabled()
+    {
+        config()->set('statamic.static_caching.background_recache', true);
+
+        $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
+            $cacher->shouldReceive('refreshUrls')->never();
+            $cacher->shouldReceive('invalidateUrls')->once()->with([
+                'http://localhost/custom',
+            ]);
+        });
+
+        $invalidator = new class($cacher, []) extends Invalidator
+        {
+            public function invalidate($item)
+            {
+                $this->cacher->invalidateUrls(['http://localhost/custom']);
+            }
+        };
+
+        $invalidator->refresh(new \stdClass);
+    }
 }

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -2,17 +2,11 @@
 
 namespace Tests\StaticCaching;
 
-use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
-use Statamic\Console\Commands\StaticWarmJob;
-use Statamic\Events\EntrySaved;
 use Statamic\Facades\File;
 use Statamic\Facades\StaticCache;
 use Statamic\StaticCaching\Cacher;
-use Statamic\StaticCaching\DefaultInvalidator;
-use Statamic\StaticCaching\Invalidate;
 use Statamic\StaticCaching\NoCache\Session;
-use Statamic\Support\Str;
 use Tests\FakesContent;
 use Tests\FakesViews;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -248,65 +242,5 @@ class FullMeasureStaticCachingTest extends TestCase
 
         // The page should not be cached.
         $this->assertFalse(file_exists($this->dir.'/about_.html'));
-    }
-
-    #[Test]
-    public function custom_invalidator_class_fires_when_background_recache_is_enabled()
-    {
-        // https://github.com/statamic/cms/issues/15025
-        //
-        // 1. Enable Full Measure Caching (done in getEnvironmentSetUp) and
-        //    register a Custom Invalidator Class.
-        // 2. The custom invalidator has a condition where saving the "one"
-        //    entry also invalidates the "/two" page's URL.
-        // 3. Enable background re-cache.
-        // 4. Save the "one" entry.
-        // 5. The relevant files (both "one" and "two") should have been invalidated.
-
-        Queue::fake();
-
-        $this->withFakeViews();
-        $this->viewShouldReturnRaw('layout', '<html><body>{{ template_content }}</body></html>');
-        $this->viewShouldReturnRaw('default', '{{ title }}');
-
-        $one = $this->createPage('one');
-        $this->createPage('two');
-
-        $this->get('/one')->assertOk();
-        $this->get('/two')->assertOk();
-
-        $this->assertTrue(file_exists($this->dir.'/one_.html'));
-        $this->assertTrue(file_exists($this->dir.'/two_.html'));
-
-        $customInvalidator = new class(app(Cacher::class)) extends DefaultInvalidator
-        {
-            public function invalidate($item)
-            {
-                parent::invalidate($item);
-
-                if ($item->slug() === 'one') {
-                    $this->cacher->invalidateUrls(['http://localhost/two']);
-                }
-            }
-        };
-
-        config()->set('statamic.static_caching.background_recache', true);
-
-        // This mirrors what actually happens on an entry save: the "EntrySaved"
-        // event is handled by the Invalidate subscriber, which calls refresh()
-        // on the configured Invalidator.
-        $invalidate = new Invalidate($customInvalidator, app(Cacher::class));
-        $invalidate->refreshEntry(new EntrySaved($one));
-
-        // The entry's own page should get recached (soft, via the warm queue).
-        Queue::assertPushed(StaticWarmJob::class, function ($job) {
-            return Str::startsWith((string) $job->request->getUri(), 'http://localhost/one');
-        });
-
-        // Per our custom Invalidator's condition, saving "one" should have
-        // also hard-invalidated "/two". It currently doesn't, because
-        // DefaultInvalidator::refresh() bypasses invalidate() entirely when
-        // background_recache is enabled.
-        $this->assertFalse(file_exists($this->dir.'/two_.html'));
     }
 }

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -298,17 +298,15 @@ class FullMeasureStaticCachingTest extends TestCase
         $invalidate = new Invalidate($customInvalidator, app(Cacher::class));
         $invalidate->refreshEntry(new EntrySaved($one));
 
-        // The entry's own page should always get recached.
+        // The entry's own page should get recached (soft, via the warm queue).
         Queue::assertPushed(StaticWarmJob::class, function ($job) {
             return Str::startsWith((string) $job->request->getUri(), 'http://localhost/one');
         });
 
         // Per our custom Invalidator's condition, saving "one" should have
-        // also caused "/two" to be recached. It currently doesn't, because
+        // also hard-invalidated "/two". It currently doesn't, because
         // DefaultInvalidator::refresh() bypasses invalidate() entirely when
         // background_recache is enabled.
-        Queue::assertPushed(StaticWarmJob::class, function ($job) {
-            return Str::startsWith((string) $job->request->getUri(), 'http://localhost/two');
-        });
+        $this->assertFalse(file_exists($this->dir.'/two_.html'));
     }
 }

--- a/tests/StaticCaching/FullMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/FullMeasureStaticCachingTest.php
@@ -2,11 +2,17 @@
 
 namespace Tests\StaticCaching;
 
+use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Console\Commands\StaticWarmJob;
+use Statamic\Events\EntrySaved;
 use Statamic\Facades\File;
 use Statamic\Facades\StaticCache;
 use Statamic\StaticCaching\Cacher;
+use Statamic\StaticCaching\DefaultInvalidator;
+use Statamic\StaticCaching\Invalidate;
 use Statamic\StaticCaching\NoCache\Session;
+use Statamic\Support\Str;
 use Tests\FakesContent;
 use Tests\FakesViews;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -242,5 +248,67 @@ class FullMeasureStaticCachingTest extends TestCase
 
         // The page should not be cached.
         $this->assertFalse(file_exists($this->dir.'/about_.html'));
+    }
+
+    #[Test]
+    public function custom_invalidator_class_fires_when_background_recache_is_enabled()
+    {
+        // https://github.com/statamic/cms/issues/15025
+        //
+        // 1. Enable Full Measure Caching (done in getEnvironmentSetUp) and
+        //    register a Custom Invalidator Class.
+        // 2. The custom invalidator has a condition where saving the "one"
+        //    entry also invalidates the "/two" page's URL.
+        // 3. Enable background re-cache.
+        // 4. Save the "one" entry.
+        // 5. The relevant files (both "one" and "two") should have been invalidated.
+
+        Queue::fake();
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '<html><body>{{ template_content }}</body></html>');
+        $this->viewShouldReturnRaw('default', '{{ title }}');
+
+        $one = $this->createPage('one');
+        $this->createPage('two');
+
+        $this->get('/one')->assertOk();
+        $this->get('/two')->assertOk();
+
+        $this->assertTrue(file_exists($this->dir.'/one_.html'));
+        $this->assertTrue(file_exists($this->dir.'/two_.html'));
+
+        $customInvalidator = new class(app(Cacher::class)) extends DefaultInvalidator
+        {
+            public function invalidate($item)
+            {
+                parent::invalidate($item);
+
+                if ($item->slug() === 'one') {
+                    $this->cacher->invalidateUrls(['http://localhost/two']);
+                }
+            }
+        };
+
+        config()->set('statamic.static_caching.background_recache', true);
+
+        // This mirrors what actually happens on an entry save: the "EntrySaved"
+        // event is handled by the Invalidate subscriber, which calls refresh()
+        // on the configured Invalidator.
+        $invalidate = new Invalidate($customInvalidator, app(Cacher::class));
+        $invalidate->refreshEntry(new EntrySaved($one));
+
+        // The entry's own page should always get recached.
+        Queue::assertPushed(StaticWarmJob::class, function ($job) {
+            return Str::startsWith((string) $job->request->getUri(), 'http://localhost/one');
+        });
+
+        // Per our custom Invalidator's condition, saving "one" should have
+        // also caused "/two" to be recached. It currently doesn't, because
+        // DefaultInvalidator::refresh() bypasses invalidate() entirely when
+        // background_recache is enabled.
+        Queue::assertPushed(StaticWarmJob::class, function ($job) {
+            return Str::startsWith((string) $job->request->getUri(), 'http://localhost/two');
+        });
     }
 }


### PR DESCRIPTION
Fixes #15025

## Problem

When `background_recache` is enabled, a custom `Invalidator` class never runs its `invalidate()` logic on entry save.

`Invalidate::refreshEntry()` calls `Invalidator::refresh()`. In `DefaultInvalidator::refresh()`, when `background_recache` was **off**, it delegated to `$this->invalidate($item)` — so a subclass overriding `invalidate()` fired correctly. When `background_recache` was **on**, it skipped `invalidate()` entirely and recomputed URLs itself, calling `$this->cacher->refreshUrls(...)` directly. Any custom `Invalidator` subclass overriding `invalidate()` (the documented extension point) was silently never called in this mode.

## Fix

`DefaultInvalidator::refresh()` now always delegates through `invalidate()`, guarded by a `$refreshing` flag. `invalidate()` uses that flag to decide whether to call `cacher->refreshUrls()` (soft, background re-cache) or `cacher->invalidateUrls()` / `cacher->flush()` (hard invalidate), preserving existing behavior for both the default flow and deletions, while letting custom subclasses actually execute in all cases.

The flag is set/reset around the delegated call via try/finally (so it can't get stuck on an exception) and saves/restores its previous value rather than resetting to `false` unconditionally (so nested `refresh()`/`invalidate()` calls, e.g. from a custom Invalidator that itself calls `refresh()` on a related item, don't clobber an in-progress outer call).

## Tests

Added a unit test in `DefaultInvalidatorTest.php` asserting a custom `invalidate()` override is exercised when `background_recache` is enabled.