### PR TITLE
[6.x] Fix grid min_rows breaking CP navigation

### DIFF
--- a/src/Fieldtypes/Grid.php
+++ b/src/Fieldtypes/Grid.php
@@ -206,9 +206,11 @@ class Grid extends Fieldtype
 
     public function preload()
     {
+        $defaults = $this->defaultRowData()->all();
+
         return [
-            'defaults' => $this->defaultRowData()->all(),
-            'new' => $this->fields()->meta()->all(),
+            'defaults' => $defaults,
+            'new' => $this->fields()->addValues($defaults)->meta()->all(),
             'existing' => collect($this->field->value())->mapWithKeys(function ($row, $index) {
                 return [$row['_id'] => $this->fields($index)->addValues($row)->meta()];
             })->toArray(),

--- a/src/Http/Controllers/CP/Fields/MetaController.php
+++ b/src/Http/Controllers/CP/Fields/MetaController.php
@@ -14,13 +14,13 @@ class MetaController extends CpController
 
         $field = (new Field($config['handle'], $config))->setValue($request->value);
 
-        $fieldtype = $field->fieldtype();
+        $value = $field->fieldtype()->preProcess($request->value);
 
-        $value = $fieldtype->preProcess($request->value);
+        $field->setValue($value);
 
         return [
             'value' => $value,
-            'meta' => $fieldtype->preload(),
+            'meta' => $field->fieldtype()->preload(),
         ];
     }
 }

--- a/tests/Feature/Fields/MetaControllerTest.php
+++ b/tests/Feature/Fields/MetaControllerTest.php
@@ -175,6 +175,24 @@ class MetaControllerTest extends TestCase
     }
 
     #[Test]
+    public function it_preloads_meta_using_the_preprocessed_value()
+    {
+        $response = $this->fieldMeta(User::make()->makeSuper()->save(), [
+            'handle' => 'test',
+            'type' => 'grid',
+            'min_rows' => 2,
+            'fields' => [
+                ['handle' => 'words', 'field' => ['type' => 'text']],
+            ],
+        ], [])->assertOk();
+
+        $ids = collect($response->json('value'))->pluck('_id')->all();
+
+        $this->assertCount(2, $ids);
+        $this->assertEquals($ids, array_keys($response->json('meta.existing')));
+    }
+
+    #[Test]
     public function it_gates_assets_through_the_preload_path()
     {
         Storage::fake('private', ['url' => '/assets']);

--- a/tests/Fieldtypes/GridTest.php
+++ b/tests/Fieldtypes/GridTest.php
@@ -453,6 +453,39 @@ class GridTest extends TestCase
     }
 
     #[Test]
+    public function it_preloads_new_row_meta_using_the_default_values()
+    {
+        $this->partialMock(RowId::class, function (MockInterface $mock) {
+            $mock->shouldReceive('generate')->twice()->andReturn('random-string-1', 'random-string-2');
+        });
+
+        $field = (new Field('test', [
+            'type' => 'grid',
+            'fields' => [
+                ['handle' => 'nested', 'field' => [
+                    'type' => 'grid',
+                    'min_rows' => 2,
+                    'fields' => [
+                        ['handle' => 'words', 'field' => ['type' => 'text']],
+                    ],
+                ]],
+            ],
+        ]));
+
+        $preloaded = $field->fieldtype()->preload();
+
+        $this->assertEquals(
+            ['random-string-1', 'random-string-2'],
+            collect($preloaded['defaults']['nested'])->pluck('_id')->all()
+        );
+
+        $this->assertEquals(
+            ['random-string-1', 'random-string-2'],
+            array_keys($preloaded['new']['nested']['existing'])
+        );
+    }
+
+    #[Test]
     public function it_augments()
     {
         (new class extends Fieldtype


### PR DESCRIPTION
This pull request fixes an issue where a grid field using `min_rows` could break Control Panel navigation until a hard refresh.

This was happening because `preProcess` pads empty grids to `min_rows` using rows with freshly generated `_id`s, but in two places the meta was built from a different value than the one being returned, so the padded rows had no entry in `meta.existing`:

* `Grid::preload` built the `new` meta without passing along the default row values, so adding a new row containing a nested grid with `min_rows` produced rows without meta. (Replicator, Bard and Group already pass the defaults along.)
* The field meta endpoint returned the preprocessed value, but built the meta while the field still held the raw value, giving lazily-loaded fields the same mismatch.

Nested fieldtypes then received `undefined` meta, leaving behind a broken component tree whose unmount throws the `Cannot destructure property...` error seen in the issue, breaking Inertia navigation until a hard refresh.

This PR fixes it by building the `new` meta from the default row values, and by setting the preprocessed value on the field before building the meta in the `MetaController`.

Fixes #14929