### PR TITLE
[6.x] Logic tree leap calculation

### DIFF
--- a/resources/css/components/forms/logic-tree.css
+++ b/resources/css/components/forms/logic-tree.css
@@ -215,6 +215,16 @@
                     bottom: calc(anchor(center --start-connection) + var(--buffer-top-pull));
                     left: calc(anchor(right --start-connection) + var(--gap));
                 }
+                /* When there's no adjacent cell, we don't need the extra leap connector, because we don't need to "cut" through a join */
+                &:not(.has-adjacent-cell) {
+                    &::before {
+                        bottom: anchor(center --start-connection);
+                        left: anchor(right --start-connection);
+                    }
+                    .linked-list__extra-leap-connector {
+                        display: none;
+                    }
+                }
             }
         }
     }

--- a/resources/css/components/forms/logic-tree.css
+++ b/resources/css/components/forms/logic-tree.css
@@ -321,9 +321,9 @@
     [data-field-item-selected] {
         z-index: var(--z-index-above);
     }
-    
+
     .linked-list:has([data-field-item-selected]) {
-        --_border-color: var(--color-blue-100);
+        --_border-color: var(--color-blue-200);
 
         /* When an item is selected, get all columns that don't have an end connection */
         .linked-list__column:not(.linked-list__column--has-end-connection) {

--- a/resources/css/components/forms/logic-tree.css
+++ b/resources/css/components/forms/logic-tree.css
@@ -324,6 +324,9 @@
 
     .linked-list:has([data-field-item-selected]) {
         --_border-color: var(--color-blue-200);
+        .dark & {
+            --_border-color: var(--color-blue-925);
+        }
 
         /* When an item is selected, get all columns that don't have an end connection */
         .linked-list__column:not(.linked-list__column--has-end-connection) {

--- a/resources/js/components/forms/logic/LogicTree.vue
+++ b/resources/js/components/forms/logic/LogicTree.vue
@@ -23,7 +23,7 @@ import FieldInspector from '@/components/forms/builder/FieldInspector.vue';
 import PageInspector from '@/components/forms/builder/PageInspector.vue';
 import { Button, Icon } from '@ui';
 import { useSortable } from '@/composables/forms/use-drag-and-drop';
-import { computed, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue';
+import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue';
 import type { PropType } from 'vue';
 
 const emit = defineEmits(['update:pages', 'select']);
@@ -37,6 +37,8 @@ const props = defineProps({
 const tree = useTemplateRef('tree');
 const isInspectorOpen = ref(false);
 const isRightPanelCollapsed = ref(true);
+const adjacentRightCells = ref<Record<string, boolean>>({});
+let resizeObserver: ResizeObserver | null = null;
 
 const pageAnchor = (pageIndex) => `--page-${pageIndex + 1}`;
 
@@ -63,6 +65,39 @@ const fieldConnections = computed(() => {
 
     return connections;
 });
+
+const measureAdjacentRightCells = () => {
+    if (! tree.value) return;
+
+    const columns = [...tree.value.querySelectorAll('.linked-list__column')];
+    const adjacent = {};
+
+    columns.forEach((column, index) => {
+        const nextColumn = columns[index + 1];
+        if (! nextColumn) return;
+
+        const nextRects = [...nextColumn.querySelectorAll('[data-field-item]')].map((cell) =>
+            cell.getBoundingClientRect(),
+        );
+
+        column.querySelectorAll('[data-field-item][data-field-id]').forEach((cell) => {
+            const rect = cell.getBoundingClientRect();
+            adjacent[cell.dataset.fieldId] = nextRects.some((next) => rect.top < next.bottom && rect.bottom > next.top);
+        });
+    });
+
+    adjacentRightCells.value = adjacent;
+};
+
+const observeLayout = async () => {
+    await nextTick();
+    resizeObserver?.disconnect();
+    resizeObserver = new ResizeObserver(measureAdjacentRightCells);
+    if (tree.value) {
+        resizeObserver.observe(tree.value);
+        measureAdjacentRightCells();
+    }
+};
 
 const pageTitle = (page, pageIndex) => page.display || __('Page :number', { number: pageIndex + 1 });
 
@@ -148,6 +183,8 @@ watch(() => props.selected, (selection) => {
     }
 });
 
+watch(() => [props.pages, props.density], () => observeLayout(), { deep: true });
+
 const onEscape = (event: KeyboardEvent) => {
     if (event.key !== 'Escape') return;
 
@@ -166,8 +203,16 @@ const onEscape = (event: KeyboardEvent) => {
     }
 };
 
-onMounted(() => document.addEventListener('keydown', onEscape));
-onUnmounted(() => document.removeEventListener('keydown', onEscape));
+onMounted(() => {
+    document.addEventListener('keydown', onEscape);
+    observeLayout();
+});
+
+onUnmounted(() => {
+    document.removeEventListener('keydown', onEscape);
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+});
 </script>
 
 <template>
@@ -234,6 +279,7 @@ onUnmounted(() => document.removeEventListener('keydown', onEscape));
                                         v-for="field in section.fields"
                                         :key="field._id"
                                         data-field-item
+                                        :data-field-id="field._id"
                                         :data-field-item-selected="isFieldSelected(field) ? '' : undefined"
                                         class="cursor-pointer"
                                         :class="{
@@ -241,6 +287,7 @@ onUnmounted(() => document.removeEventListener('keydown', onEscape));
                                             'linked-list__hidden-field': field.config?.hidden,
                                             'linked-list__connector': fieldConnection(field),
                                             'linked-list__page-leap': fieldConnection(field)?.leap,
+                                            'test': fieldConnection(field)?.leap && adjacentRightCells[field._id],
                                             'ring-1 ring-blue-500': isFieldSelected(field),
                                         }"
                                         :style="fieldConnection(field) ? { '--end-connection': fieldConnection(field).endConnection } : null"

--- a/resources/js/components/forms/logic/LogicTree.vue
+++ b/resources/js/components/forms/logic/LogicTree.vue
@@ -37,9 +37,9 @@ const props = defineProps({
 const tree = useTemplateRef('tree');
 const isInspectorOpen = ref(false);
 const isRightPanelCollapsed = ref(true);
-// Page-leap connectors need to know whether a field cell sits immediately to their
-// right (in the next page column). That depends on live layout — section markers,
-// density, etc. — so we measure bounding boxes rather than counting fields.
+// Page-leap connectors need to know whether a field cell sits beside them in any
+// subsequent page column. That depends on live layout — section markers, density,
+// etc. — so we measure bounding boxes rather than counting fields.
 const adjacentRightCells = ref<Record<string, boolean>>({});
 let resizeObserver: ResizeObserver | null = null;
 
@@ -69,8 +69,8 @@ const fieldConnections = computed(() => {
     return connections;
 });
 
-// For each field, check whether any field in the next column overlaps it vertically.
-// Overlap means there is a cell immediately to the right at that row.
+// For each field, check whether any field in a later column overlaps it vertically.
+// Overlap means the leap connector passes beside a real cell at that row.
 const measureAdjacentRightCells = () => {
     if (! tree.value) return;
 
@@ -78,16 +78,17 @@ const measureAdjacentRightCells = () => {
     const adjacent = {};
 
     columns.forEach((column, index) => {
-        const nextColumn = columns[index + 1];
-        if (! nextColumn) return;
-
-        const nextRects = [...nextColumn.querySelectorAll('[data-field-item]')].map((cell) =>
-            cell.getBoundingClientRect(),
+        const subsequentRects = columns.slice(index + 1).flatMap((nextColumn) =>
+            [...nextColumn.querySelectorAll('[data-field-item]')].map((cell) =>
+                cell.getBoundingClientRect(),
+            ),
         );
+
+        if (! subsequentRects.length) return;
 
         column.querySelectorAll('[data-field-item][data-field-id]').forEach((cell) => {
             const rect = cell.getBoundingClientRect();
-            adjacent[cell.dataset.fieldId] = nextRects.some((next) => rect.top < next.bottom && rect.bottom > next.top);
+            adjacent[cell.dataset.fieldId] = subsequentRects.some((next) => rect.top < next.bottom && rect.bottom > next.top);
         });
     });
 

--- a/resources/js/components/forms/logic/LogicTree.vue
+++ b/resources/js/components/forms/logic/LogicTree.vue
@@ -37,6 +37,9 @@ const props = defineProps({
 const tree = useTemplateRef('tree');
 const isInspectorOpen = ref(false);
 const isRightPanelCollapsed = ref(true);
+// Page-leap connectors need to know whether a field cell sits immediately to their
+// right (in the next page column). That depends on live layout — section markers,
+// density, etc. — so we measure bounding boxes rather than counting fields.
 const adjacentRightCells = ref<Record<string, boolean>>({});
 let resizeObserver: ResizeObserver | null = null;
 
@@ -66,6 +69,8 @@ const fieldConnections = computed(() => {
     return connections;
 });
 
+// For each field, check whether any field in the next column overlaps it vertically.
+// Overlap means there is a cell immediately to the right at that row.
 const measureAdjacentRightCells = () => {
     if (! tree.value) return;
 
@@ -89,6 +94,7 @@ const measureAdjacentRightCells = () => {
     adjacentRightCells.value = adjacent;
 };
 
+// Remeasure after Vue paints, and whenever the tree's size changes (e.g. density toggle).
 const observeLayout = async () => {
     await nextTick();
     resizeObserver?.disconnect();
@@ -183,6 +189,7 @@ watch(() => props.selected, (selection) => {
     }
 });
 
+// Fields moving or density changing can shift rows without always resizing the tree.
 watch(() => [props.pages, props.density], () => observeLayout(), { deep: true });
 
 const onEscape = (event: KeyboardEvent) => {
@@ -287,7 +294,8 @@ onUnmounted(() => {
                                             'linked-list__hidden-field': field.config?.hidden,
                                             'linked-list__connector': fieldConnection(field),
                                             'linked-list__page-leap': fieldConnection(field)?.leap,
-                                            'test': fieldConnection(field)?.leap && adjacentRightCells[field._id],
+                                            // Leap connectors that pass beside a cell in the next column.
+                                            'has-adjacent-cell': fieldConnection(field)?.leap && adjacentRightCells[field._id],
                                             'ring-1 ring-blue-500': isFieldSelected(field),
                                         }"
                                         :style="fieldConnection(field) ? { '--end-connection': fieldConnection(field).endConnection } : null"

--- a/resources/js/components/forms/logic/LogicTree.vue
+++ b/resources/js/components/forms/logic/LogicTree.vue
@@ -69,7 +69,7 @@ const fieldConnections = computed(() => {
     return connections;
 });
 
-// For each field, check whether any field in a later column overlaps it vertically.
+// For each leap cell, check whether any field in a later column overlaps it vertically.
 // Overlap means the leap connector passes beside a real cell at that row.
 const measureAdjacentRightCells = () => {
     if (! tree.value) return;
@@ -77,33 +77,20 @@ const measureAdjacentRightCells = () => {
     const columns = [...tree.value.querySelectorAll('.linked-list__column')];
     const adjacent = {};
 
-    columns.forEach((column, index) => {
-        const subsequentRects = columns.slice(index + 1).flatMap((nextColumn) =>
-            [...nextColumn.querySelectorAll('[data-field-item]')].map((cell) =>
-                cell.getBoundingClientRect(),
-            ),
-        );
+    tree.value.querySelectorAll('.linked-list__page-leap').forEach((cell) => {
+        const index = columns.indexOf(cell.closest('.linked-list__column'));
+        const rect = cell.getBoundingClientRect();
 
-        if (! subsequentRects.length) return;
-
-        column.querySelectorAll('[data-field-item][data-field-id]').forEach((cell) => {
-            const rect = cell.getBoundingClientRect();
-            adjacent[cell.dataset.fieldId] = subsequentRects.some((next) => rect.top < next.bottom && rect.bottom > next.top);
-        });
+        adjacent[cell.dataset.fieldId] = columns
+            .slice(index + 1)
+            .flatMap((column) => [...column.querySelectorAll('[data-field-item]')])
+            .some((other) => {
+                const next = other.getBoundingClientRect();
+                return rect.top < next.bottom && rect.bottom > next.top;
+            });
     });
 
     adjacentRightCells.value = adjacent;
-};
-
-// Remeasure after Vue paints, and whenever the tree's size changes (e.g. density toggle).
-const observeLayout = async () => {
-    await nextTick();
-    resizeObserver?.disconnect();
-    resizeObserver = new ResizeObserver(measureAdjacentRightCells);
-    if (tree.value) {
-        resizeObserver.observe(tree.value);
-        measureAdjacentRightCells();
-    }
 };
 
 const pageTitle = (page, pageIndex) => page.display || __('Page :number', { number: pageIndex + 1 });
@@ -191,7 +178,7 @@ watch(() => props.selected, (selection) => {
 });
 
 // Fields moving or density changing can shift rows without always resizing the tree.
-watch(() => [props.pages, props.density], () => observeLayout(), { deep: true });
+watch(() => [props.pages, props.density], () => nextTick(measureAdjacentRightCells), { deep: true });
 
 const onEscape = (event: KeyboardEvent) => {
     if (event.key !== 'Escape') return;
@@ -213,7 +200,8 @@ const onEscape = (event: KeyboardEvent) => {
 
 onMounted(() => {
     document.addEventListener('keydown', onEscape);
-    observeLayout();
+    resizeObserver = new ResizeObserver(measureAdjacentRightCells);
+    resizeObserver.observe(tree.value);
 });
 
 onUnmounted(() => {


### PR DESCRIPTION
## Description of the Problem

"leap connectors" connect logic from one page to a page ahead.
These are styled as dashed lines as opposed to solid lines

### The problem

I originally got this working to err on the side of caution, and assume that subsequent page "columns" were longer—therefore to offset upwards slightly to "cut" through the joins

## What this PR Does

Uses some JavaScript to calculate whether the connector passes through adjacent cells

### Before

<img width="3420" height="2880" alt="2026-07-20 at 10 31 19@2x" src="https://github.com/user-attachments/assets/91b414d7-fd0a-4016-a279-7d01a58cbe20" />

### After

<img width="3420" height="2880" alt="2026-07-20 at 10 29 29@2x" src="https://github.com/user-attachments/assets/d98d5e28-5039-4b42-b2a6-947216ac9c01" />

## How to Reproduce

1. Add page logic connecting a cell to a future page, making sure pages in between have various lengths