### PR TITLE
[6.x] Fix customized listing columns being overridden by default preferences

### DIFF
--- a/src/Preferences/Preferences.php
+++ b/src/Preferences/Preferences.php
@@ -140,7 +140,30 @@ class Preferences
             }
         }
 
-        return array_merge(Arr::dot($array), $preserve);
+        return array_merge($this->dotPreferences($array), $preserve);
+    }
+
+    /**
+     * Flatten preferences into dotted keys, like `Arr::dot()`, but treating list values
+     * as leaves so they get replaced by higher precedence levels instead of merged.
+     *
+     * @param  array  $array
+     * @param  string  $prepend
+     * @return array
+     */
+    protected function dotPreferences($array, $prepend = '')
+    {
+        $results = [];
+
+        foreach ($array as $key => $value) {
+            if (is_array($value) && ! empty($value) && ! array_is_list($value)) {
+                $results = array_merge($results, $this->dotPreferences($value, $prepend.$key.'.'));
+            } else {
+                $results[$prepend.$key] = $value;
+            }
+        }
+
+        return $results;
     }
 
     /**

--- a/tests/Preferences/PrecedenceTest.php
+++ b/tests/Preferences/PrecedenceTest.php
@@ -246,6 +246,28 @@ class PrecedenceTest extends TestCase
     }
 
     #[Test]
+    public function it_replaces_list_preferences_instead_of_merging_them()
+    {
+        $this->actingAs(User::make()->preferences([
+            'collections' => [
+                'orders' => [
+                    'columns' => ['date', 'title', 'customer'],
+                ],
+            ],
+        ]));
+
+        Preference::default()->set([
+            'collections' => [
+                'orders' => [
+                    'columns' => ['date', 'title', 'customer', 'grand_total', 'order_status'],
+                ],
+            ],
+        ])->save();
+
+        $this->assertEquals(['date', 'title', 'customer'], Preference::get('collections.orders.columns'));
+    }
+
+    #[Test]
     public function it_merges_preferences_at_every_level_unless_otherwise_configured()
     {
         $this->actingAs(User::make()->assignRole('rabbit')->assignRole('bear')->preferences([


### PR DESCRIPTION
When default preferences exist in `resources/preferences.yaml` (or on a role), customizing listing columns in the CP doesn't stick. The selection saves correctly, but on the next page load any columns you removed come back.

Preferences from each level are flattened with `Arr::dot()` before merging, which splits lists into numeric keys. A shorter user list keeps its own indexes but inherits the extra ones from the level below, so the removed entries reappear in the merged result. This affects any list preference, on every listing type.

Lists are now treated as single values during the merge, so the highest precedence list wins wholesale.

Fixes #14314

🤖 Generated with [Claude Code](https://claude.com/claude-code)