### PR TITLE
[6.x] Do not hide the primary save button for mobile

### DIFF
--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -48,7 +48,7 @@
                 @update:modelValue="localizationSelected"
             />
 
-            <div class="hidden items-center gap-2 sm:gap-3 md:flex">
+            <div class="items-center gap-2 sm:gap-3 md:flex">
                 <Button
                     v-if="canEdit"
                     variant="primary"


### PR DESCRIPTION
## Description of the Problem

The primary "Save" button was hidden on mobile for globals. I believe this is an accident, as it appears on other publish forms

## What this PR Does

Remove the `hidden` class

## How to Reproduce

1. Go to `/cp/globals/some-global` at a small viewport, where the "Save" button is hidden