### PR TITLE
[6.x] Fix origin() on null when fetching nav tree with origin_id field

### DIFF
--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -201,6 +201,11 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Cont
         return optional($this->entry())->slug();
     }
 
+    public function origin()
+    {
+        return optional($this->entry())->origin();
+    }
+
     public function uri()
     {
         if ($this->url) {

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -251,6 +251,29 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function it_gets_origin_id_in_nav_route_when_an_item_is_not_linked_to_an_entry()
+    {
+        Facades\Config::set('statamic.api.resources.navs', true);
+
+        Facades\Collection::make('pages')->save();
+
+        $nav = Facades\Nav::make('footer');
+        $nav->makeTree('en', [
+            ['entry' => 'one'],
+            ['title' => 'Balki Bartokomous', 'url' => 'https://balki.com'],
+        ])->save();
+        $nav->save();
+
+        Facades\Entry::make()->collection('pages')->id('one')->slug('one')->published(true)->save();
+
+        $this
+            ->get('/api/navs/footer/tree?fields=title,origin_id')
+            ->assertSuccessful()
+            ->assertJsonPath('data.1.page.title', 'Balki Bartokomous')
+            ->assertJsonPath('data.1.page.origin_id', null);
+    }
+
+    #[Test]
     public function it_filters_by_taxonomy_terms()
     {
         Facades\Config::set('statamic.api.resources.collections.test', [


### PR DESCRIPTION
This pull request fixes an issue where fetching a nav tree via the REST API with `?fields=origin_id` would throw a `Call to a member function origin() on null` error when the nav contained an item not linked to an entry (e.g. a custom URL or text label).

This was happening because `Page` has no `origin()` method, so the call was forwarded to the page's entry via `__call`, which is `null` for items without an entry reference.

This PR fixes it by giving `Page` an `origin()` method that safely returns `null` when there's no entry, matching its other entry-delegating methods like `slug()` and `status()`.

Fixes #13315