### PR TITLE
[6.x] Pass field prefix to custom conditions

### DIFF
--- a/resources/js/components/field-conditions/Validator.js
+++ b/resources/js/components/field-conditions/Validator.js
@@ -264,6 +264,7 @@ export default class {
             values: this.values,
             root: this.rootValues,
             fieldPath: this.currentFieldPath,
+            prefix: this.field.prefix,
             ...this.extraPayload,
         });
 

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -480,6 +480,20 @@ test('it can call a custom function', () => {
     expect(Fields.showField({ unless: 'custom reallyLovesAnimals' })).toBe(true);
 });
 
+test('it can call a custom function that uses `prefix` param to evaluate prefixed fields', () => {
+    setValues({
+        first_favorite_animals: ['cats', 'dogs', 'giraffes', 'lions'],
+        second_favorite_animals: ['cats', 'dogs'],
+    });
+
+    Statamic.$conditions.add('reallyLovesAnimals', function ({ prefix, values }) {
+        return values[`${prefix}favorite_animals`].length > 3;
+    });
+
+    expect(Fields.showField({ prefix: 'first_', if: 'custom reallyLovesAnimals' })).toBe(true);
+    expect(Fields.showField({ prefix: 'second_', if: 'custom reallyLovesAnimals' })).toBe(false);
+});
+
 test('it can call a custom function that uses `fieldPath` param to evaluate nested fields', () => {
     setValues({
         nested: [{ favorite_animals: ['cats', 'dogs'] }, { favorite_animals: ['cats', 'dogs', 'giraffes', 'lions'] }],


### PR DESCRIPTION
This pull request fixes an issue where custom field conditions had no way of knowing which prefixed instance of an imported fieldset they were being evaluated for.

When a fieldset containing a custom condition is imported into a blueprint multiple times with different prefixes, the condition function receives the same `values` payload for every instance, making it impossible to scope the condition to the fields of the relevant fieldset instance.

This PR fixes it by passing the field's `prefix` into the custom condition payload, allowing conditions to be scoped dynamically:

```js
Statamic.$conditions.add('shouldShow', ({ prefix, values }) => {
    return values[`${prefix ?? ''}my_field`] === 'something';
});
```

Fixes #8439