### PR TITLE
[6.x] Fix nav preferences breaking when a collection title is renamed

### DIFF
--- a/src/CP/Navigation/CoreNav.php
+++ b/src/CP/Navigation/CoreNav.php
@@ -85,6 +85,7 @@ class CoreNav
                     })
                     ->map(function ($collection) {
                         return Nav::item($collection->title())
+                            ->id('content::collections::'.$collection->handle())
                             ->url(
                                 $collection->sites()->contains(Site::selected()->handle())
                                     ? $collection->showUrl()
@@ -122,6 +123,7 @@ class CoreNav
                             : true;
 
                         return Nav::item($nav->title())
+                            ->id('content::navigation::'.$nav->handle())
                             ->url($availableInSelectedSite ? $nav->showUrl() : $nav->editUrl())
                             ->can('view', $nav)
                             ->extra([
@@ -145,6 +147,7 @@ class CoreNav
             ->children(function () {
                 return TaxonomyAPI::all()->sortBy->title()->map(function ($taxonomy) {
                     return Nav::item($taxonomy->title())
+                        ->id('content::taxonomies::'.$taxonomy->handle())
                         ->url($taxonomy->showUrl())
                         ->can('view', $taxonomy)
                         ->extra([
@@ -168,6 +171,7 @@ class CoreNav
             ->children(function () {
                 return AssetContainerAPI::all()->sortBy->title()->map(function ($assetContainer) {
                     return Nav::item($assetContainer->title())
+                        ->id('content::assets::'.$assetContainer->handle())
                         ->url($assetContainer->showUrl())
                         ->can('view', $assetContainer)
                         ->extra([
@@ -198,6 +202,7 @@ class CoreNav
                         $localized = $globalSet->inSelectedSite();
 
                         return Nav::item($globalSet->title())
+                            ->id('content::globals::'.$globalSet->handle())
                             ->url($localized ? $localized->editUrl() : $globalSet->editUrl())
                             ->can('view', $globalSet)
                             ->extra([
@@ -251,6 +256,7 @@ class CoreNav
             ->children(function () {
                 return FormAPI::all()->sortBy->title()->map(function ($form) {
                     return Nav::item($form->title())
+                        ->id('tools::forms::'.$form->handle())
                         ->url($form->showUrl())
                         ->can('view', $form)
                         ->extra(['breadcrumbs' => ['configure_url' => $form->editUrl()]]);

--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -583,7 +583,27 @@ class NavBuilder
             }
         }
 
-        return $items->get($id);
+        return $items->get($id) ?? $this->findItemByLegacyId($id);
+    }
+
+    /**
+     * Find existing nav item by the ID it would have been given before child IDs
+     * were generated from handles, so that preferences saved against the older
+     * display-based IDs continue to work.
+     *
+     * @param  string  $id
+     * @return \Statamic\CP\Navigation\NavItem|null
+     */
+    protected function findItemByLegacyId($id)
+    {
+        if (! $parent = $this->findParentItem($id)) {
+            return null;
+        }
+
+        return $parent
+            ->resolveChildren()
+            ->children()
+            ?->first(fn ($child) => $parent->id().'::'.NavItem::snakeCase($child->display()) === $id);
     }
 
     /**

--- a/src/CP/Navigation/NavItem.php
+++ b/src/CP/Navigation/NavItem.php
@@ -87,6 +87,16 @@ class NavItem
     }
 
     /**
+     * Check if an ID has been explicitly set, rather than generated from the display.
+     *
+     * @return bool
+     */
+    public function hasCustomId()
+    {
+        return ! is_null($this->id);
+    }
+
+    /**
      * Preserve current ID.
      *
      * @return $this
@@ -277,7 +287,7 @@ class NavItem
             })
             ->map(function ($navItem) use ($generateNewIds) {
                 return $navItem
-                    ->id($generateNewIds ? $this->id().'::' : $navItem->id())
+                    ->id($generateNewIds && ! $navItem->hasCustomId() ? $this->id().'::' : $navItem->id())
                     ->icon($navItem->icon() ?? $this->icon())
                     ->section($this->section())
                     ->isChild(true);


### PR DESCRIPTION
If you have a custom nav order set in the CP, they're referenced by their title instead of their handle in `preferences.yaml`. Example: A collection using the handle `products` and title `Product Catalogue` gets saved as:

```
nav:
  sections:
    footer:
      items:
        'content::collections::product_catalogue': '@move'
```

Renaming the title changed the generated ID, so the saved `@move` no longer matches and the item silently returned to its default position.

`CoreNav` creates each child item with `$collection->title()` and no explicit ID. `NavItem::children()` then builds the child ID from the parent ID plus the snake cased display, so the handle never gets used. Only setting an ID in `CoreNav` isn't enough though since `children()` overwrites it unconditionally.

IDs are now built from the handle. This actually affected not only collections, but pretty much all content types so the PR covers them all. `NavItem::children()` no longer discards an explicitly set ID.

#### Important note:
As pointed out by @mynetx on the issue that reported the bug, this change can potentially  lead to some backwards compatibility issues. So `NavBuilder::findItem()` falls back to the previous display based ID when a preference doesn't match, so existing preferences keep working after this change ships. Exact matches take precedence and preferences are rewritten with the new IDs the next time they're saved. We could remove this fallback in the next major version.

Closes https://github.com/statamic/cms/issues/14945.