### PR TITLE
[6.x] Prevent bogus content when dragging inside a node-selected Bard set

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -16,6 +16,7 @@
             @copy.stop
             @paste.stop
             @cut.stop
+            @dragstart="preventNodeSelectionDrag"
         >
             <div ref="content" hidden />
             <header
@@ -350,6 +351,19 @@ export default {
         disableDragging() {
             this.$el.setAttribute('draggable', false);
             this._draggableObserver?.observe(this.$el, { attributes: true, attributeFilter: ['draggable'] });
+        },
+
+        preventNodeSelectionDrag(event) {
+            // When the set is node-selected, an invisible DOM selection spans the whole set.
+            // Dragging from anywhere inside it (e.g. a grid row's drag handle) would natively
+            // drag that selection and dump a serialized copy of the set into the editor.
+            const target = event.target instanceof Element ? event.target : event.target.parentElement;
+            if (target?.closest('[draggable="true"]')) return;
+
+            const selection = window.getSelection();
+            if (selection?.rangeCount && selection.containsNode(this.$el, false)) {
+                event.preventDefault();
+            }
         },
     },
 

--- a/resources/js/tests/components/fieldtypes/bard/Set.test.js
+++ b/resources/js/tests/components/fieldtypes/bard/Set.test.js
@@ -1,0 +1,92 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, expect, test, vi } from 'vitest';
+import * as Globals from '@/bootstrap/globals';
+import Set from '@/components/fieldtypes/bard/Set.vue';
+import { containerContextKey } from '@/components/ui/Publish/Container.vue';
+
+Object.keys(Globals).forEach((fn) => (window[fn] = Globals[fn]));
+window.Statamic = { $fieldActions: { get: () => [] } };
+
+function mountSet() {
+    return mount(Set, {
+        shallow: true,
+        props: {
+            editor: {},
+            node: { attrs: { id: 'set-1', enabled: true, values: { type: 'my_set' } } },
+            decorations: [],
+            selected: false,
+            extension: {
+                options: {
+                    bard: {
+                        meta: { existing: {} },
+                        collapsed: [],
+                        setIndexes: { 'set-1': 0 },
+                        config: { previews: false },
+                        name: 'content',
+                        handle: 'content',
+                        fieldPathPrefix: null,
+                        metaPathPrefix: null,
+                        setHasError: () => false,
+                    },
+                },
+            },
+            getPos: () => 0,
+            updateAttributes: vi.fn(),
+            deleteNode: vi.fn(),
+        },
+        global: {
+            stubs: { NodeViewWrapper: { template: '<div><slot /></div>' } },
+            provide: {
+                bard: { setConfigs: [{ handle: 'my_set', fields: [] }], isReadOnly: false, hasBeenFocused: false },
+                bardSets: [],
+                [containerContextKey]: {
+                    values: { value: {} },
+                    previews: { value: {} },
+                    setFieldValue: vi.fn(),
+                    setFieldMeta: vi.fn(),
+                },
+            },
+        },
+    });
+}
+
+function mockSelection({ containsSet }) {
+    vi.spyOn(window, 'getSelection').mockReturnValue({
+        rangeCount: 1,
+        containsNode: () => containsSet,
+    });
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+test('dragging from inside the set is prevented while the selection covers the whole set', async () => {
+    const wrapper = mountSet();
+    mockSelection({ containsSet: true });
+
+    const event = new Event('dragstart', { bubbles: true, cancelable: true });
+    wrapper.find('header').element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+});
+
+test('dragging from inside the set is allowed when the selection does not cover the whole set', async () => {
+    const wrapper = mountSet();
+    mockSelection({ containsSet: false });
+
+    const event = new Event('dragstart', { bubbles: true, cancelable: true });
+    wrapper.find('header').element.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+});
+
+test('dragging a draggable element inside the set is allowed', async () => {
+    const wrapper = mountSet();
+    mockSelection({ containsSet: true });
+
+    const header = wrapper.find('header').element;
+    header.setAttribute('draggable', 'true');
+    const event = new Event('dragstart', { bubbles: true, cancelable: true });
+    header.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+});


### PR DESCRIPTION
This pull request fixes an issue where dragging a Grid row inside a Bard set could dump a copy of the set's content into the editor as a table.

This was happening because clicking a non-interactive area inside a set makes ProseMirror node-select it (the blue border). That node selection is backed by a real DOM selection spanning the whole set, which ProseMirror hides visually — so when you drag from anywhere inside the set (like a Grid row's drag handle), the browser starts a native drag of that invisible selection instead of the row sort. And since ProseMirror ignores `dragstart` events originating inside node views, the drag data ends up being the set's raw HTML, meaning Bard parses the Grid's `<table>` markup into an actual table node on drop.

This PR fixes it by preventing native `dragstart` events that originate inside the set while the document selection covers the whole set. Drags of genuinely draggable elements (like Bard images, or nested sets via their drag handles) are unaffected, as is dragging the set itself using its own drag handle.

Fixes #14920