### PR TITLE
[6.x] Handle download responses in Inertia requests

### DIFF
--- a/src/Http/Middleware/CP/HandleInertiaRequests.php
+++ b/src/Http/Middleware/CP/HandleInertiaRequests.php
@@ -3,9 +3,13 @@
 namespace Statamic\Http\Middleware\CP;
 
 use Illuminate\Http\Request;
+use Inertia\Inertia;
 use Inertia\Middleware;
 use Statamic\CP\Toasts\Manager;
 use Statamic\Statamic;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 use function Statamic\trans as __;
 
@@ -36,6 +40,15 @@ class HandleInertiaRequests extends Middleware
             ],
             '_toasts' => $this->toasts($request),
         ]);
+    }
+
+    public function onEmptyResponse(Request $request, Response $response): Response
+    {
+        if ($response instanceof StreamedResponse || $response instanceof BinaryFileResponse) {
+            return Inertia::location($request->fullUrl());
+        }
+
+        return parent::onEmptyResponse($request, $response);
     }
 
     private function logos()

--- a/tests/Http/Middleware/HandleInertiaRequestsTest.php
+++ b/tests/Http/Middleware/HandleInertiaRequestsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Http\Middleware;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User;
+use Statamic\Statamic;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class HandleInertiaRequestsTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        Statamic::pushCpRoutes(function () {
+            Route::get('streamed-download-test', function () {
+                return response()->streamDownload(fn () => print 'id,name', 'data.csv');
+            });
+
+            Route::get('file-download-test', function () {
+                return response()->download(__FILE__);
+            });
+
+            Route::get('empty-response-test', function () {
+                return response()->noContent(200);
+            });
+        });
+    }
+
+    #[Test]
+    public function it_converts_streamed_downloads_into_location_visits_for_inertia_requests()
+    {
+        // Inertia requests are made over XHR, which can't trigger downloads. Returning
+        // 409 + X-Inertia-Location makes the client do a full browser visit instead,
+        // which lets the browser handle the download natively.
+
+        $this
+            ->actingAs(User::make()->makeSuper())
+            ->get('/cp/streamed-download-test', ['X-Inertia' => 'true'])
+            ->assertStatus(409)
+            ->assertHeader('X-Inertia-Location', 'http://localhost/cp/streamed-download-test');
+    }
+
+    #[Test]
+    public function it_converts_file_downloads_into_location_visits_for_inertia_requests()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper())
+            ->get('/cp/file-download-test', ['X-Inertia' => 'true'])
+            ->assertStatus(409)
+            ->assertHeader('X-Inertia-Location', 'http://localhost/cp/file-download-test');
+    }
+
+    #[Test]
+    public function it_leaves_downloads_untouched_for_non_inertia_requests()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper())
+            ->get('/cp/streamed-download-test')
+            ->assertOk()
+            ->assertDownload('data.csv');
+    }
+
+    #[Test]
+    public function it_redirects_back_for_empty_inertia_responses()
+    {
+        $this
+            ->actingAs(User::make()->makeSuper())
+            ->from('/cp/utilities')
+            ->get('/cp/empty-response-test', ['X-Inertia' => 'true'])
+            ->assertRedirect('/cp/utilities');
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where utilities registered with a custom controller action that returns a download wouldn't work — clicking the utility in the Control Panel did nothing.

This was happening because Control Panel links are Inertia visits, and download responses (`StreamedResponse` / `BinaryFileResponse`) have no content for Inertia to work with, so Inertia's middleware treated them as "empty responses" and redirected back to the previous page.

This PR fixes it by overriding `onEmptyResponse` in the `HandleInertiaRequests` middleware, so download responses return `Inertia::location()` instead. This triggers a full browser visit, allowing the browser to handle the download natively.

Fixes #14751