### PR TITLE
[6.x] Prevent errors when Stache indexes contain keys without files

### DIFF
--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -143,7 +143,7 @@ abstract class Builder extends BaseBuilder
 
     protected function getItems($keys)
     {
-        return $this->store->getItems($keys);
+        return $this->store->getItems($keys)->filter()->values();
     }
 
     protected function filterWhereBasic($values, $where)

--- a/tests/Stache/Repositories/EntryRepositoryTest.php
+++ b/tests/Stache/Repositories/EntryRepositoryTest.php
@@ -72,6 +72,21 @@ class EntryRepositoryTest extends TestCase
     }
 
     #[Test]
+    public function it_ignores_keys_in_indexes_that_no_longer_have_corresponding_files()
+    {
+        $store = $this->stache->store('entries')->store('alphabetical');
+
+        $store->index('title')->load();
+        (function () {
+            $this->paths = $this->paths()->forget('alphabetical-bravo');
+        })->call($store);
+
+        $entries = $this->repo->query()->whereIn('title', ['Alpha', 'Bravo', 'Zulu'])->get();
+
+        $this->assertEquals(['alphabetical-alpha', 'alphabetical-zulu'], $entries->map->id()->all());
+    }
+
+    #[Test]
     public function it_gets_entries_from_a_collection()
     {
         tap($this->repo->whereCollection('alphabetical'), function ($entries) {


### PR DESCRIPTION
Queries against the Stache can fail with:

```
Call to a member function selectedQueryColumns() on null
vendor/statamic/cms/src/Stache/Query/Builder.php:49
```

This results in a 500 on both the CP and the frontend.

Since paths and indexes are cached under separate keys and invalidated independently, a query using a `where` or `orderBy` resolves its keys from a field index, so the index hands back a key of a file that no longer exists.

Filtering out the nulls in `Builder::getItems()` resolves the issue. Refreshing the Stache remains the fix for the stale index itself but this stops throwing a 500 error.

Thank to Ivan for reporting this through support.