### PR TITLE
[6.x] Fix Bard read-only background

### DIFF
--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -52,7 +52,7 @@
 =================================================== */
 @layer ui {
     .bard-editor.mode\:read-only .ProseMirror {
-        @apply bg-gray-300 text-gray-700 dark:bg-gray-600 dark:text-gray-100;
+        @apply bg-white text-gray-925 dark:bg-gray-900 dark:text-gray-300;
     }
 
     .bard-editor.mode\:minimal .ProseMirror {

--- a/resources/css/components/fieldtypes/bard.css
+++ b/resources/css/components/fieldtypes/bard.css
@@ -5,6 +5,9 @@
     .bard-fieldtype:not(.form-group, .grid-cell, [data-ui-input-group]) {
         @apply relative rounded-lg border outline-hidden dark:border-gray-700 with-contrast:border-gray-500;
     }
+    .bard-fieldtype:not(.form-group, .grid-cell, [data-ui-input-group]):has(.mode\:read-only) {
+        @apply border-dashed;
+    }
 }
 /* BARD / EDITOR
 =================================================== */


### PR DESCRIPTION
This updates the Bard fieldtype to use the standard dashed read-only input appearance, replacing the gray background that doesn't quite match other read-only states. The CSS replicates the simpler CSS-only parts of PR #14667 by @jaygeorge, isolated here as a quick fix for the Bard field and in hopes for an easy merge ☺️

Fixes #14615.

## Before

<img width="1144" height="693" alt="Screenshot 2026-07-22 at 14 42 10" src="https://github.com/user-attachments/assets/1f499070-a388-4848-9be0-767eee80d576" />
<img width="1144" height="693" alt="Screenshot 2026-07-22 at 14 42 19" src="https://github.com/user-attachments/assets/52700afe-d104-4f21-b5c0-e122cf7cd7ca" />

## After

<img width="1144" height="693" alt="Screenshot 2026-07-22 at 14 48 09" src="https://github.com/user-attachments/assets/675c836f-0fbe-49ff-ad1b-d03f8d176751" />
<img width="1144" height="693" alt="Screenshot 2026-07-22 at 14 48 17" src="https://github.com/user-attachments/assets/1ee45646-e410-4467-b36b-219ab9cec47e" />
