### PR TITLE
[6.x] Use correct parameter name in Scope class

### DIFF
--- a/src/Query/Scopes/Scope.php
+++ b/src/Query/Scopes/Scope.php
@@ -14,7 +14,7 @@ abstract class Scope
     /**
      * Apply the scope to a given query builder.
      *
-     * @param  \Statamic\Query\Builder  $builder
+     * @param  \Statamic\Query\Builder  $query
      * @param  array  $values
      * @return void
      */


### PR DESCRIPTION
Fix a typo in the Scope class docblock to get better type info / autocompletion in the IDE.