### PR TITLE
[6.x] Invalidate cached error responses instead of warming them

### DIFF
--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -262,7 +262,15 @@ abstract class AbstractCacher implements Cacher
     {
         $this->getUrls($domain)->filter(function ($value) use ($url) {
             return $value === $url || Str::startsWith($value, $url.'?');
-        })->each(function ($url) use ($domain) {
+        })->each(function ($url, $key) use ($domain) {
+            // Warming an error response would just fail with the same error,
+            // so invalidate it and let the next request cache a fresh copy.
+            if ($this->hasCachedErrorResponse($key)) {
+                $this->invalidateUrl($url, $domain);
+
+                return;
+            }
+
             $url = ($domain ?: $this->getBaseUrl()).$url;
 
             $url = RecacheToken::addToUrl($url);
@@ -273,6 +281,17 @@ abstract class AbstractCacher implements Cacher
                 ->onConnection(config('statamic.static_caching.warm_queue_connection') ?? config('queue.default'))
                 ->onQueue(config('statamic.static_caching.warm_queue'));
         });
+    }
+
+    /**
+     * Check if the cached response for a URL key is an error response.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function hasCachedErrorResponse($key)
+    {
+        return false;
     }
 
     /**

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -3,6 +3,7 @@
 namespace Statamic\StaticCaching\Cachers;
 
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Support\Facades\Event;
 use Statamic\Events\UrlInvalidated;
@@ -38,8 +39,10 @@ class ApplicationCacher extends AbstractCacher
         // and other URL characters wouldn't work as a cache key.
         $key = $this->makeHash($url);
 
-        // Keep track of the URL and key the response content is about to be stored within.
-        $this->cacheUrl($key, ...$this->getPathAndDomain($url));
+        if ($this->shouldTrackUrl($url, $content)) {
+            // Keep track of the URL and key the response content is about to be stored within.
+            $this->cacheUrl($key, ...$this->getPathAndDomain($url));
+        }
 
         $key = $this->normalizeKey('responses:'.$key);
         $value = $this->normalizeContent($content);
@@ -59,6 +62,21 @@ class ApplicationCacher extends AbstractCacher
                 ? $this->cache->put($key, $cacheValue, now()->addMinutes($this->getDefaultExpiration()))
                 : $this->cache->forever($key, $cacheValue);
         });
+    }
+
+    /**
+     * Determine whether a URL should be tracked in the cacher's URL set.
+     *
+     * @param  string  $url
+     * @param  mixed  $content
+     */
+    private function shouldTrackUrl($url, $content): bool
+    {
+        if (! $content instanceof Response || $content->isSuccessful()) {
+            return true;
+        }
+
+        return str_contains($url, '/__shared-errors/');
     }
 
     /**

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -3,7 +3,6 @@
 namespace Statamic\StaticCaching\Cachers;
 
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Support\Facades\Event;
 use Statamic\Events\UrlInvalidated;
@@ -39,15 +38,25 @@ class ApplicationCacher extends AbstractCacher
         // and other URL characters wouldn't work as a cache key.
         $key = $this->makeHash($url);
 
-        if ($this->shouldTrackUrl($url, $content)) {
-            // Keep track of the URL and key the response content is about to be stored within.
-            $this->cacheUrl($key, ...$this->getPathAndDomain($url));
-        }
+        // Keep track of the URL and key the response content is about to be stored within.
+        $this->cacheUrl($key, ...$this->getPathAndDomain($url));
 
         $key = $this->normalizeKey('responses:'.$key);
         $value = $this->normalizeContent($content);
 
-        Event::listen(ResponsePrepared::class, function (ResponsePrepared $event) use ($key, $value) {
+        // The listener stays registered for the lifetime of the process, so it should
+        // only handle the response for the request that's currently being cached.
+        // Otherwise, in long-running processes (e.g. Octane, tests) it would
+        // re-store this entry using later requests' statuses and headers.
+        $handled = false;
+
+        Event::listen(ResponsePrepared::class, function (ResponsePrepared $event) use ($key, $value, &$handled) {
+            if ($handled) {
+                return;
+            }
+
+            $handled = true;
+
             $headers = collect($event->response->headers->all())
                 ->reject(fn ($value, $key) => in_array($key, ['date', 'x-powered-by', 'cache-control', 'expires', 'set-cookie']))
                 ->all();
@@ -62,21 +71,6 @@ class ApplicationCacher extends AbstractCacher
                 ? $this->cache->put($key, $cacheValue, now()->addMinutes($this->getDefaultExpiration()))
                 : $this->cache->forever($key, $cacheValue);
         });
-    }
-
-    /**
-     * Determine whether a URL should be tracked in the cacher's URL set.
-     *
-     * @param  string  $url
-     * @param  mixed  $content
-     */
-    private function shouldTrackUrl($url, $content): bool
-    {
-        if (! $content instanceof Response || $content->isSuccessful()) {
-            return true;
-        }
-
-        return str_contains($url, '/__shared-errors/');
     }
 
     /**
@@ -108,6 +102,23 @@ class ApplicationCacher extends AbstractCacher
         $key = $this->makeHash($url);
 
         return $this->cache->get($this->normalizeKey('responses:'.$key));
+    }
+
+    /**
+     * Check if the cached response for a URL key is an error response.
+     *
+     * @param  string  $key
+     * @return bool
+     */
+    protected function hasCachedErrorResponse($key)
+    {
+        $cached = $this->cache->get($this->normalizeKey('responses:'.$key));
+
+        if (! is_array($cached)) {
+            return false;
+        }
+
+        return ($cached['status'] ?? 200) >= 400;
     }
 
     /**

--- a/tests/StaticCaching/ApplicationCacherTest.php
+++ b/tests/StaticCaching/ApplicationCacherTest.php
@@ -71,53 +71,32 @@ class ApplicationCacherTest extends TestCase
     }
 
     #[Test]
-    public function caching_a_successful_page_tracks_the_url()
+    #[DataProvider('cachedResponseProvider')]
+    public function caching_a_page_tracks_the_url($status, $content)
     {
         $cache = app(Repository::class);
         $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
         $request = Request::create('http://example.com/about', 'GET');
+        $response = response($content, $status);
 
-        $cacher->cachePage($request, response('about page', 200));
-        event(new ResponsePrepared($request, response('about page', 200)));
+        $cacher->cachePage($request, $response);
+        event(new ResponsePrepared($request, $response));
 
         $this->assertEquals(['/about'], $cacher->getUrls()->values()->all());
-    }
-
-    #[Test]
-    public function caching_a_404_page_does_not_track_the_url()
-    {
-        $cache = app(Repository::class);
-        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
-        $request = Request::create('http://example.com/this-does-not-exist', 'GET');
-        $response = response('not found', 404);
-
-        $cacher->cachePage($request, $response);
-        event(new ResponsePrepared($request, $response));
-
-        // The URL isn't tracked in the `.urls` set...
-        $this->assertEquals([], $cacher->getUrls()->all());
-
-        // ...but the 404 response is still cached and served directly by URL hash.
         $this->assertTrue($cacher->hasCachedPage($request));
-        $this->assertEquals('not found', $cacher->getCachedPage($request)->content);
+        $this->assertEquals($content, $cacher->getCachedPage($request)->content);
     }
 
-    #[Test]
-    public function caching_a_shared_error_page_is_always_tracked()
+    public static function cachedResponseProvider()
     {
-        $cache = app(Repository::class);
-        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
-        $request = Request::createFrom(Request::create('http://example.com/'))->fakeStaticCacheStatus(404);
-        $response = response('shared not found', 404);
-
-        $cacher->cachePage($request, $response);
-        event(new ResponsePrepared($request, $response));
-
-        $this->assertEquals(['/__shared-errors/'.\Statamic\Facades\Site::current()->handle().'/404'], $cacher->getUrls()->values()->all());
+        return [
+            'successful response' => [200, 'about page'],
+            'error response' => [404, 'not found'],
+        ];
     }
 
     #[Test]
-    public function wildcard_refresh_does_not_warm_untracked_404_urls()
+    public function refreshing_a_wildcard_warms_successful_urls_and_invalidates_error_urls()
     {
         Queue::fake();
 
@@ -140,6 +119,31 @@ class ApplicationCacherTest extends TestCase
         Queue::assertNotPushed(StaticWarmJob::class, function ($job) {
             return str_contains((string) $job->request->getUri(), 'scanner-junk');
         });
+
+        // The error response is invalidated rather than warmed, so the
+        // tracked set converges to real pages.
+        $this->assertEquals(['/rail/one'], $cacher->getUrls()->values()->all());
+        $this->assertFalse($cacher->hasCachedPage($junkRequest));
+    }
+
+    #[Test]
+    public function refreshing_an_error_url_invalidates_it_instead_of_warming_it()
+    {
+        Queue::fake();
+
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = response('not found', 404);
+
+        $cacher->cachePage($request, $response);
+        event(new ResponsePrepared($request, $response));
+
+        $cacher->refreshUrls(['/foo']);
+
+        Queue::assertNothingPushed();
+        $this->assertEquals([], $cacher->getUrls()->all());
+        $this->assertFalse($cacher->hasCachedPage($request));
     }
 
     #[Test]
@@ -165,6 +169,23 @@ class ApplicationCacherTest extends TestCase
         $this->assertNull($cache->get('static-cache:responses:one'));
         $this->assertNotNull($cache->get('static-cache:responses:onemore'));
         $this->assertNotNull($cache->get('static-cache:responses:two'));
+    }
+
+    #[Test]
+    public function invalidating_a_url_removes_a_cached_error_response()
+    {
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = response('not found', 404);
+
+        $cacher->cachePage($request, $response);
+        event(new ResponsePrepared($request, $response));
+
+        $cacher->invalidateUrl('/foo');
+
+        $this->assertEquals([], $cacher->getUrls()->all());
+        $this->assertFalse($cacher->hasCachedPage($request));
     }
 
     #[Test]
@@ -305,6 +326,23 @@ class ApplicationCacherTest extends TestCase
         $this->assertNull($cache->get('static-cache:responses:four'));
         $this->assertEquals([], $cacher->getUrls('http://example.com')->all());
         $this->assertEquals([], $cacher->getUrls('http://another.com')->all());
+    }
+
+    #[Test]
+    public function flushing_removes_cached_error_responses()
+    {
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+        $request = Request::create('http://example.com/foo', 'GET');
+        $response = response('not found', 404);
+
+        $cacher->cachePage($request, $response);
+        event(new ResponsePrepared($request, $response));
+
+        $cacher->flush();
+
+        $this->assertEquals([], $cacher->getUrls()->all());
+        $this->assertFalse($cacher->hasCachedPage($request));
     }
 
     #[Test]

--- a/tests/StaticCaching/ApplicationCacherTest.php
+++ b/tests/StaticCaching/ApplicationCacherTest.php
@@ -4,9 +4,12 @@ namespace Tests\StaticCaching;
 
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Queue;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Console\Commands\StaticWarmJob;
 use Statamic\Events\UrlInvalidated;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\Cachers\ApplicationCacher;
@@ -65,6 +68,78 @@ class ApplicationCacherTest extends TestCase
         $cachedPage = $cacher->getCachedPage($request);
         $this->assertEquals('html content', $cachedPage->content);
         $this->assertEquals('application/html', $cachedPage->headers['Content-Type']);
+    }
+
+    #[Test]
+    public function caching_a_successful_page_tracks_the_url()
+    {
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+        $request = Request::create('http://example.com/about', 'GET');
+
+        $cacher->cachePage($request, response('about page', 200));
+        event(new ResponsePrepared($request, response('about page', 200)));
+
+        $this->assertEquals(['/about'], $cacher->getUrls()->values()->all());
+    }
+
+    #[Test]
+    public function caching_a_404_page_does_not_track_the_url()
+    {
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+        $request = Request::create('http://example.com/this-does-not-exist', 'GET');
+        $response = response('not found', 404);
+
+        $cacher->cachePage($request, $response);
+        event(new ResponsePrepared($request, $response));
+
+        // The URL isn't tracked in the `.urls` set...
+        $this->assertEquals([], $cacher->getUrls()->all());
+
+        // ...but the 404 response is still cached and served directly by URL hash.
+        $this->assertTrue($cacher->hasCachedPage($request));
+        $this->assertEquals('not found', $cacher->getCachedPage($request)->content);
+    }
+
+    #[Test]
+    public function caching_a_shared_error_page_is_always_tracked()
+    {
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+        $request = Request::createFrom(Request::create('http://example.com/'))->fakeStaticCacheStatus(404);
+        $response = response('shared not found', 404);
+
+        $cacher->cachePage($request, $response);
+        event(new ResponsePrepared($request, $response));
+
+        $this->assertEquals(['/__shared-errors/'.\Statamic\Facades\Site::current()->handle().'/404'], $cacher->getUrls()->values()->all());
+    }
+
+    #[Test]
+    public function wildcard_refresh_does_not_warm_untracked_404_urls()
+    {
+        Queue::fake();
+
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+
+        $goodRequest = Request::create('http://example.com/rail/one', 'GET');
+        $cacher->cachePage($goodRequest, response('one', 200));
+        event(new ResponsePrepared($goodRequest, response('one', 200)));
+
+        $junkRequest = Request::create('http://example.com/rail/scanner-junk', 'GET');
+        $cacher->cachePage($junkRequest, response('not found', 404));
+        event(new ResponsePrepared($junkRequest, response('not found', 404)));
+
+        $cacher->refreshUrls(['/rail/*']);
+
+        Queue::assertPushed(StaticWarmJob::class, function ($job) {
+            return str_contains((string) $job->request->getUri(), '/rail/one');
+        });
+        Queue::assertNotPushed(StaticWarmJob::class, function ($job) {
+            return str_contains((string) $job->request->getUri(), 'scanner-junk');
+        });
     }
 
     #[Test]

--- a/tests/StaticCaching/HalfMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/HalfMeasureStaticCachingTest.php
@@ -3,8 +3,11 @@
 namespace Tests\StaticCaching;
 
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Console\Commands\StaticWarmJob;
+use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\Replacer;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\FakesContent;
@@ -203,6 +206,56 @@ class HalfMeasureStaticCachingTest extends TestCase
             $store->get('nocache::session.'.md5('/__shared-errors/en/404')),
             'Expected nocache session to be stored under the shared-errors URL.'
         );
+    }
+
+    #[Test]
+    public function it_does_not_track_404_urls()
+    {
+        \Illuminate\Support\Facades\Cache::flush();
+
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('errors.404', '404 not found');
+
+        $this->get('/this-does-not-exist')->assertNotFound();
+
+        $cacher = app(Cacher::class);
+        $this->assertEquals([], $cacher->getUrls()->all());
+
+        // The 404 response is still served from the cache on a repeat hit,
+        // even though it was never added to the tracked `.urls` set.
+        $response = $this->get('/this-does-not-exist')->assertNotFound();
+        $this->assertTrue($response->wasStaticallyCached());
+    }
+
+    #[Test]
+    public function wildcard_invalidation_does_not_warm_untracked_404_urls()
+    {
+        \Illuminate\Support\Facades\Cache::flush();
+
+        Queue::fake();
+
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('default', '{{ title }}');
+        $this->viewShouldReturnRaw('errors.404', '404 not found');
+
+        $this->createPage('about', ['with' => ['title' => 'The About Page']]);
+
+        // A real page, matching the wildcard `/about*` rule below.
+        $this->get('/about')->assertOk();
+
+        // A junk URL that also matches the wildcard prefix, but doesn't resolve
+        // to real content (e.g. a bot/scanner probe under the same path).
+        $this->get('/about-this-does-not-exist')->assertNotFound();
+
+        app(Cacher::class)->refreshUrls(['/about*']);
+
+        Queue::assertPushed(StaticWarmJob::class, function ($job) {
+            return str_contains((string) $job->request->getUri(), '/about')
+                && ! str_contains((string) $job->request->getUri(), 'this-does-not-exist');
+        });
+        Queue::assertNotPushed(StaticWarmJob::class, function ($job) {
+            return str_contains((string) $job->request->getUri(), 'this-does-not-exist');
+        });
     }
 
     #[Test]

--- a/tests/StaticCaching/HalfMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/HalfMeasureStaticCachingTest.php
@@ -209,7 +209,7 @@ class HalfMeasureStaticCachingTest extends TestCase
     }
 
     #[Test]
-    public function it_does_not_track_404_urls()
+    public function it_caches_and_tracks_404s()
     {
         \Illuminate\Support\Facades\Cache::flush();
 
@@ -218,17 +218,34 @@ class HalfMeasureStaticCachingTest extends TestCase
 
         $this->get('/this-does-not-exist')->assertNotFound();
 
-        $cacher = app(Cacher::class);
-        $this->assertEquals([], $cacher->getUrls()->all());
+        $this->assertEquals(['/this-does-not-exist'], app(Cacher::class)->getUrls()->values()->all());
 
-        // The 404 response is still served from the cache on a repeat hit,
-        // even though it was never added to the tracked `.urls` set.
         $response = $this->get('/this-does-not-exist')->assertNotFound();
         $this->assertTrue($response->wasStaticallyCached());
     }
 
     #[Test]
-    public function wildcard_invalidation_does_not_warm_untracked_404_urls()
+    public function invalidating_a_cached_404_lets_new_content_be_served()
+    {
+        \Illuminate\Support\Facades\Cache::flush();
+
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('default', '{{ title }}');
+        $this->viewShouldReturnRaw('errors.404', '404 not found');
+
+        // The URL 404s before the page exists, and the 404 gets cached.
+        $this->get('/about')->assertNotFound();
+
+        // Publishing a page at that URL invalidates the cached 404...
+        $this->createPage('about', ['with' => ['title' => 'The About Page']]);
+        app(Cacher::class)->invalidateUrls(['/about']);
+
+        // ...so the new page is served instead of the stale 404.
+        $this->get('/about')->assertOk()->assertSee('The About Page');
+    }
+
+    #[Test]
+    public function wildcard_refresh_invalidates_cached_404s_instead_of_warming_them()
     {
         \Illuminate\Support\Facades\Cache::flush();
 
@@ -256,6 +273,10 @@ class HalfMeasureStaticCachingTest extends TestCase
         Queue::assertNotPushed(StaticWarmJob::class, function ($job) {
             return str_contains((string) $job->request->getUri(), 'this-does-not-exist');
         });
+
+        // The junk URL is invalidated rather than warmed, so the tracked
+        // set converges to real pages.
+        $this->assertEquals(['/about'], app(Cacher::class)->getUrls()->values()->all());
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where sites using the "half measure" static caching strategy would dispatch cache warming jobs for every URL ever cached — including 404s and other error responses. On busy public sites, every bot/scanner junk URL ever hit (`.env`/`.php` probes, dead URLs, etc.) got cached and tracked alongside real pages, so when `STATAMIC_BACKGROUND_RECACHE` is enabled and a wildcard invalidation rule matches, a `StaticWarmJob` was dispatched for every one of them — flooding `failed_jobs` and delaying real content updates from appearing live.

This was happening because the refresh path warms every URL tracked in the static cache's `.urls` set, regardless of what's actually cached for it. Warming an error response just fails with the same error again.

This PR fixes it by having `refreshUrl()` check the status of the cached response: error responses are invalidated instead of being warmed, so the stale entry is evicted and the next visitor caches a fresh copy. As a bonus, junk URLs converge out of the tracked set over time as wildcard refreshes touch them.

Error responses remain tracked in the `.urls` set, so they stay reachable by `invalidateUrl()` and `flush()` — publishing an entry at a previously-404'd URL invalidates the cached 404 as before. One caveat: when an `expiry` is configured and a tracked entry has expired, its status can't be known, so it's warmed once (and fails), re-cached by the next visitor, then invalidated on the next refresh — it converges after one cycle rather than failing forever.

This PR also guards the `ResponsePrepared` listener in `ApplicationCacher::cachePage()` so it only handles the response for the request being cached. Previously, in long-running processes, stale listeners would re-store earlier cache entries using later requests' statuses and headers.

Fixes #10863
Fixes #15054
