### PR TITLE
[6.x] Persist OAuth connections in the database for the eloquent user repository

### DIFF
--- a/config/users.php
+++ b/config/users.php
@@ -135,6 +135,7 @@ return [
         'group_user' => 'group_user',
         'groups' => false,
         'webauthn' => 'webauthn',
+        'oauth_connections' => 'oauth_connections',
     ],
 
     /*

--- a/src/Auth/Eloquent/OAuthConnections.php
+++ b/src/Auth/Eloquent/OAuthConnections.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Statamic\Auth\Eloquent;
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Persists OAuth provider-account-to-user links in the database.
+ *
+ * Statamic\OAuth\Provider's default storage writes these to a plain PHP
+ * file under storage_path(), which doesn't survive on ephemeral or
+ * multi-instance deployments. When the Eloquent user repository is
+ * active, links should live in the database the same way users, roles,
+ * and groups already do (see OAuthProvider/OAuthManager).
+ */
+class OAuthConnections
+{
+    public function __construct(protected string $provider)
+    {
+    }
+
+    /**
+     * Get all provider->user id links for this provider.
+     *
+     * @return array<string, string> Statamic user id => provider account id
+     */
+    public function all(): array
+    {
+        return $this->table()
+            ->where('provider', $this->provider)
+            ->pluck('provider_user_id', 'user_id')
+            ->all();
+    }
+
+    /**
+     * Replace all links for this provider with the given set.
+     *
+     * @param  array<string, string>  $ids  Statamic user id => provider account id
+     */
+    public function sync(array $ids): void
+    {
+        $this->table()->where('provider', $this->provider)->delete();
+
+        $now = now();
+
+        foreach ($ids as $userId => $providerUserId) {
+            $this->table()->insert([
+                'provider' => $this->provider,
+                'user_id' => $userId,
+                'provider_user_id' => $providerUserId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+    }
+
+    private function table()
+    {
+        return DB::connection(config('statamic.users.database'))
+            ->table(config('statamic.users.tables.oauth_connections', 'oauth_connections'));
+    }
+}

--- a/src/Auth/Eloquent/OAuthProvider.php
+++ b/src/Auth/Eloquent/OAuthProvider.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Statamic\Auth\Eloquent;
+
+use Statamic\OAuth\Provider;
+
+/**
+ * Persists OAuth provider links via OAuthConnections (database) instead
+ * of Provider's default storage_path() file.
+ */
+class OAuthProvider extends Provider
+{
+    protected function getIds()
+    {
+        return (new OAuthConnections($this->name))->all();
+    }
+
+    protected function setIds($ids)
+    {
+        (new OAuthConnections($this->name))->sync($ids);
+    }
+}

--- a/src/Console/Commands/AuthMigration.php
+++ b/src/Console/Commands/AuthMigration.php
@@ -49,6 +49,7 @@ class AuthMigration extends Command
         $this->createRolesTable();
 
         $this->createWebauthTable();
+        $this->createOAuthConnectionsTable();
 
         $this->composer->dumpAutoloads();
     }
@@ -102,6 +103,23 @@ class AuthMigration extends Command
         $contents = File::get($from);
 
         $contents = str_replace('WEBAUTHN_TABLE', config('statamic.users.tables.webauthn', 'webauthn'), $contents);
+
+        File::put($to, $contents);
+
+        $this->components->info("Migration [$file] created successfully.");
+    }
+
+    private function createOAuthConnectionsTable()
+    {
+        $from = __DIR__.'/stubs/auth/statamic_oauth_connections_table.php.stub';
+        $file = Carbon::now()->format('Y_m_d_His').'_statamic_oauth_connections_table';
+
+        $to = ($path = $this->option('path')) ? $path."/{$file}.php" : database_path("migrations/{$file}.php");
+
+        $contents = File::get($from);
+
+        $contents = str_replace('OAUTH_CONNECTIONS_TABLE', config('statamic.users.tables.oauth_connections', 'oauth_connections'), $contents);
+        $contents = str_replace('USERS_TABLE', config('statamic.users.tables.users', 'users'), $contents);
 
         File::put($to, $contents);
 

--- a/src/Console/Commands/stubs/auth/statamic_oauth_connections_table.php.stub
+++ b/src/Console/Commands/stubs/auth/statamic_oauth_connections_table.php.stub
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class StatamicOAuthConnectionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('OAUTH_CONNECTIONS_TABLE', function (Blueprint $table) {
+            $table->id();
+            $table->string('provider');
+            $table->foreignId('user_id')->constrained('USERS_TABLE')->cascadeOnDelete();
+            $table->string('provider_user_id');
+            $table->timestamps();
+
+            $table->unique(['provider', 'user_id']);
+            $table->unique(['provider', 'provider_user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down()
+    {
+        Schema::dropIfExists('OAUTH_CONNECTIONS_TABLE');
+    }
+}

--- a/src/Console/Commands/stubs/config/users.php.stub
+++ b/src/Console/Commands/stubs/config/users.php.stub
@@ -135,6 +135,7 @@ return [
         'group_user' => 'group_user',
         'groups' => false,
         'webauthn' => 'webauthn',
+        'oauth_connections' => 'oauth_connections',
     ],
 
     /*

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -2,10 +2,10 @@
 
 namespace Statamic\OAuth;
 
+use Statamic\Auth\Eloquent\OAuthProvider as EloquentProvider;
+
 class Manager
 {
-    protected static $providers = [];
-
     public function enabled()
     {
         return config('statamic.oauth.enabled')
@@ -14,17 +14,30 @@ class Manager
 
     public function provider($provider)
     {
-        if (isset(static::$providers[$provider])) {
-            return static::$providers[$provider];
-        }
-
-        return static::$providers[$provider] = $this->providers()->get($provider);
+        // Not cached: providers() is cheap (no I/O), and a static, by-name
+        // cache here previously meant the first-resolved provider for a
+        // given name stuck around for the life of the process (or Octane
+        // worker) regardless of later config changes -- the same class of
+        // staleness that motivated persisting connections in the database
+        // instead of a file in the first place.
+        return $this->providers()->get($provider);
     }
 
     public function providers()
     {
+        // Providers persist their connected-account links via getIds()/setIds(),
+        // which default to a plain file at storage_path("statamic/oauth/*.php").
+        // That's fine for the file user repository, which has no database to
+        // lean on -- but it doesn't survive ephemeral or multi-instance
+        // deployments, and is inconsistent with the eloquent user repository,
+        // where users/roles/groups already live in the database. When the
+        // eloquent repository is active, persist connections there too.
+        $providerClass = config('statamic.users.repository') === 'eloquent'
+            ? EloquentProvider::class
+            : Provider::class;
+
         return collect(config('statamic.oauth.providers'))
-            ->mapWithKeys(function ($value, $key) {
+            ->mapWithKeys(function ($value, $key) use ($providerClass) {
                 $provider = $value;
                 $config = [];
 
@@ -35,7 +48,7 @@ class Manager
                     $config = is_array($value) ? $value : ['label' => $value];
                 }
 
-                return [$provider => new Provider($provider, $config)];
+                return [$provider => new $providerClass($provider, $config)];
             });
     }
 }

--- a/src/OAuth/Manager.php
+++ b/src/OAuth/Manager.php
@@ -6,6 +6,8 @@ use Statamic\Auth\Eloquent\OAuthProvider as EloquentProvider;
 
 class Manager
 {
+    protected static $providers = [];
+
     public function enabled()
     {
         return config('statamic.oauth.enabled')
@@ -14,13 +16,24 @@ class Manager
 
     public function provider($provider)
     {
-        // Not cached: providers() is cheap (no I/O), and a static, by-name
-        // cache here previously meant the first-resolved provider for a
-        // given name stuck around for the life of the process (or Octane
-        // worker) regardless of later config changes -- the same class of
-        // staleness that motivated persisting connections in the database
-        // instead of a file in the first place.
-        return $this->providers()->get($provider);
+        // Caching the resolved instance (not just its class) matters:
+        // consuming apps commonly configure a provider once via
+        // withUserData()/withUser() and expect that same instance to be
+        // reused for the life of the request. But keying purely by name
+        // meant the first-resolved instance for that name stuck around for
+        // the life of the process (or Octane worker) regardless of later
+        // config changes -- the same class of staleness that motivated
+        // persisting connections in the database instead of a file in the
+        // first place. Keying by name *and* the current repository setting
+        // keeps the "configure once, reuse" behavior while still handing
+        // back a fresh instance whenever that config changes.
+        $key = $provider.':'.config('statamic.users.repository');
+
+        if (isset(static::$providers[$key])) {
+            return static::$providers[$key];
+        }
+
+        return static::$providers[$key] = $this->providers()->get($provider);
     }
 
     public function providers()

--- a/tests/Auth/Eloquent/EloquentOAuthTest.php
+++ b/tests/Auth/Eloquent/EloquentOAuthTest.php
@@ -102,6 +102,27 @@ class EloquentOAuthTest extends TestCase
     }
 
     #[Test]
+    public function a_callback_configured_on_the_provider_once_still_applies_on_later_calls()
+    {
+        // Regression test: consuming apps commonly configure a provider once
+        // (e.g. in a service provider's boot()) via withUserData()/withUser(),
+        // expecting that configuration to still apply whenever the same
+        // named provider is resolved later, e.g. during the actual OAuth
+        // callback request. An earlier version of this fix made provider()
+        // return a brand new instance on every call (to avoid stale-type
+        // caching across config changes), which silently broke this -- the
+        // callback was attached to an instance nothing else ever saw again.
+        OAuth::provider('test')->withUserData(function () {
+            return ['name' => 'Configured Name'];
+        });
+
+        $this->assertSame(
+            ['name' => 'Configured Name'],
+            OAuth::provider('test')->userData(null)
+        );
+    }
+
+    #[Test]
     public function it_persists_a_provider_link_to_the_database_instead_of_a_file()
     {
         $user = $this->makeUser();

--- a/tests/Auth/Eloquent/EloquentOAuthTest.php
+++ b/tests/Auth/Eloquent/EloquentOAuthTest.php
@@ -1,0 +1,229 @@
+<?php
+
+namespace Tests\Auth\Eloquent;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Auth\Eloquent\OAuthProvider;
+use Statamic\Facades\OAuth;
+use Statamic\Facades\User as UserFacade;
+use Statamic\OAuth\Provider;
+use Tests\TestCase;
+
+class EloquentOAuthTest extends TestCase
+{
+    use WithFaker;
+
+    public static $migrationsGenerated = false;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('statamic.users.repository', 'eloquent');
+        $app['config']->set('statamic.oauth.enabled', true);
+        $app['config']->set('statamic.oauth.providers', ['test' => 'Test']);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create(2019, 11, 21, 23, 39, 29));
+
+        $this->loadMigrationsFrom(static::migrationsDir());
+
+        $tmpDir = static::migrationsDir().'/tmp';
+
+        if (! self::$migrationsGenerated) {
+            $this->artisan('statamic:auth:migration', ['--path' => $tmpDir]);
+
+            self::$migrationsGenerated = true;
+        }
+
+        $this->loadMigrationsFrom($tmpDir);
+    }
+
+    private static function migrationsDir()
+    {
+        return __DIR__.'/__migrations__';
+    }
+
+    public function tearDown(): void
+    {
+        UserFacade::all()->each->delete();
+
+        // In case a test falls through to the file-backed default (which
+        // would indicate the eloquent binding didn't take effect).
+        app('files')->deleteDirectory(storage_path('statamic/oauth'));
+
+        parent::tearDown();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        (new Filesystem)->deleteDirectory(static::migrationsDir().'/tmp');
+
+        parent::tearDownAfterClass();
+    }
+
+    private function makeUser(?string $email = null)
+    {
+        return UserFacade::make()
+            ->email($email ?? $this->faker->unique()->safeEmail)
+            ->data(['name' => $this->faker->name])
+            ->save();
+    }
+
+    #[Test]
+    public function the_provider_is_eloquent_backed_when_the_eloquent_repository_is_active()
+    {
+        $this->assertInstanceOf(OAuthProvider::class, OAuth::provider('test'));
+    }
+
+    #[Test]
+    public function the_provider_class_is_chosen_fresh_each_time_rather_than_baked_in_at_boot()
+    {
+        // Manager::providers() checks config('statamic.users.repository')
+        // live rather than being swapped via a container binding decided at
+        // boot time, specifically so that switching the repository at
+        // runtime (as Tests\Auth\Eloquent\EloquentUserGroupTest and others
+        // already rely on being able to do) keeps working.
+        config(['statamic.users.repository' => 'file']);
+        $this->assertInstanceOf(Provider::class, OAuth::provider('test'));
+        $this->assertNotInstanceOf(OAuthProvider::class, OAuth::provider('test'));
+
+        config(['statamic.users.repository' => 'eloquent']);
+        $this->assertInstanceOf(OAuthProvider::class, OAuth::provider('test'));
+    }
+
+    #[Test]
+    public function it_persists_a_provider_link_to_the_database_instead_of_a_file()
+    {
+        $user = $this->makeUser();
+        $provider = OAuth::provider('test');
+
+        $this->assertFalse($provider->isConnectedTo($user));
+
+        $provider->setUserProviderId($user, 'sub-123');
+
+        $this->assertTrue($provider->isConnectedTo($user));
+
+        $this->assertDatabaseHas('oauth_connections', [
+            'provider' => 'test',
+            'user_id' => $user->id(),
+            'provider_user_id' => 'sub-123',
+        ]);
+
+        $this->assertFalse(is_file(storage_path('statamic/oauth/test.php')));
+    }
+
+    #[Test]
+    public function it_resolves_a_user_id_by_provider_id()
+    {
+        $user = $this->makeUser();
+        $provider = OAuth::provider('test');
+
+        $provider->setUserProviderId($user, 'sub-456');
+
+        $this->assertEquals($user->id(), $provider->getUserId('sub-456'));
+        $this->assertNull($provider->getUserId('unknown-id'));
+    }
+
+    #[Test]
+    public function it_forgets_a_provider_link()
+    {
+        $user = $this->makeUser();
+        $provider = OAuth::provider('test');
+
+        $provider->setUserProviderId($user, 'sub-789');
+        $provider->forgetUser($user);
+
+        $this->assertFalse($provider->isConnectedTo($user));
+        $this->assertEquals(0, DB::table('oauth_connections')->where('provider', 'test')->count());
+    }
+
+    #[Test]
+    public function it_keeps_other_users_unaffected_when_one_link_is_updated()
+    {
+        $userA = $this->makeUser();
+        $userB = $this->makeUser();
+        $provider = OAuth::provider('test');
+
+        $provider->setUserProviderId($userA, 'sub-a');
+        $provider->setUserProviderId($userB, 'sub-b');
+
+        $this->assertEquals($userA->id(), $provider->getUserId('sub-a'));
+        $this->assertEquals($userB->id(), $provider->getUserId('sub-b'));
+    }
+
+    #[Test]
+    public function a_guest_logging_in_for_the_first_time_is_created_and_linked_via_the_eloquent_backend()
+    {
+        // Mirrors Tests\OAuth\OAuthCallbackTest::guest_with_a_new_email_is_created_and_logged_in(),
+        // against the eloquent repository instead of the default file one.
+        $this->assertCount(0, UserFacade::all());
+
+        $this->fakeProvider('test', [], 'sub-1', 'new@example.com');
+
+        $response = $this
+            ->withSession(['statamic.oauth.guard' => 'web'])
+            ->get(route('statamic.oauth.callback', 'test'));
+
+        $this->assertCount(1, UserFacade::all());
+        $user = UserFacade::findByEmail('new@example.com');
+        $this->assertNotNull($user);
+        $this->assertAuthenticated();
+        $this->assertEquals($user->id(), auth('web')->id());
+
+        $this->assertEquals($user->id(), OAuth::provider('test')->getUserId('sub-1'));
+        $this->assertDatabaseHas('oauth_connections', [
+            'provider' => 'test',
+            'user_id' => $user->id(),
+            'provider_user_id' => 'sub-1',
+        ]);
+        $this->assertFalse(is_file(storage_path('statamic/oauth/test.php')));
+
+        $response->assertRedirect();
+    }
+
+    /**
+     * Replace the provider with a real one whose only mocked method is
+     * getSocialiteUser(), so the Socialite facade is never called but the
+     * storage map and user lookups behave for real. Mirrors
+     * Tests\OAuth\OAuthCallbackTest's helper of the same name.
+     */
+    private function fakeProvider(string $name, array $config, string $id, string $email, string $displayName = 'Foo Bar'): void
+    {
+        $socialiteUser = new class($id, $email, $displayName)
+        {
+            public function __construct(private string $id, private string $email, private string $name)
+            {
+            }
+
+            public function getId()
+            {
+                return $this->id;
+            }
+
+            public function getEmail()
+            {
+                return $this->email;
+            }
+
+            public function getName()
+            {
+                return $this->name;
+            }
+        };
+
+        $provider = Mockery::mock(OAuthProvider::class.'[getSocialiteUser]', [$name, $config]);
+        $provider->shouldReceive('getSocialiteUser')->andReturn($socialiteUser);
+
+        OAuth::partialMock()->shouldReceive('provider')->with($name)->andReturn($provider);
+    }
+}


### PR DESCRIPTION
Fixes #15069.

`Statamic\OAuth\Provider`'s default storage (`storage_path("statamic/oauth/*.php")`) isn't durable on ephemeral/multi-instance deployments. When the `eloquent` user repository is active, this adds a database-backed alternative so OAuth connections persist the same way users/roles/groups already do.

## Changes
- `Statamic\Auth\Eloquent\OAuthConnections` — the storage primitive, mirroring the existing `Roles`/`Groups` query-builder pattern (not a full Eloquent model).
- `Statamic\Auth\Eloquent\OAuthProvider` — extends `Provider`, overrides `getIds()`/`setIds()` to persist via `OAuthConnections`.
- `Statamic\OAuth\Manager::providers()` — picks the provider class based on `config('statamic.users.repository')`, checked live on each call (not baked in via a container binding at boot), so switching repositories at runtime (as some existing tests already do) keeps working.
- `statamic:auth:migration` now also generates the `oauth_connections` migration, matching the existing pattern for `role_user`/`group_user`/`webauthn`.
- `config/users.php` + the install config stub — new `tables.oauth_connections` key.

`Manager::provider()`'s cache is now keyed by provider name *and* the current repository setting, rather than name alone. Caching by name alone meant the first-resolved provider for a name stuck around for the life of the process/Octane worker regardless of later config changes — the same class of staleness this whole PR is about — and it's what caused real cross-test pollution while building this (a stale eloquent-backed instance leaked into an unrelated `OAuthDisconnectTest`). Caching *nothing* (an earlier version of this PR) turned out to be too aggressive in the other direction — it silently broke `withUserData()`/`withUser()` configuration, since that's attached to a specific instance and expected to survive for the life of the request. Both are covered by regression tests.

## Test plan
- New `tests/Auth/Eloquent/EloquentOAuthTest.php` (8 tests): provider/manager selection, persistence round-trip, id lookup, disconnect, multi-user isolation, live repository-switching, the `withUserData` regression, and a full end-to-end guest-login HTTP flow.
- Full package suite passing.