### PR TITLE
[6.x] Fix `default: current` Users fieldtype behavior

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -194,6 +194,7 @@ return [
     'invalid_two_factor_code' => 'The provided two factor authentication code was invalid.',
     'invalid_two_factor_recovery_code' => 'The provided two factor recovery code was invalid.',
     'bard_container_required_by_button' => 'This field is required by a toolbar button.',
+    'users_fieldtype_default_max_items' => 'The number of default users may not be greater than the field’s max items (:max).',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
+++ b/resources/js/components/fieldtypes/relationship/RelationshipFieldtype.vue
@@ -49,7 +49,15 @@ export default {
 
     computed: {
         maxItems() {
-            return this.config.max_items || Infinity;
+            if (this.config.max_items) {
+                return this.config.max_items;
+            }
+
+            if (this.publishContainer?.asConfig && this.handle === 'default') {
+                return this.publishContainer.values?.max_items || Infinity;
+            }
+
+            return Infinity;
         },
 
         columns() {

--- a/src/Fieldtypes/Users.php
+++ b/src/Fieldtypes/Users.php
@@ -87,6 +87,7 @@ class Users extends Relationship
                         'display' => __('Default'),
                         'instructions' => __('statamic::messages.fields_default_instructions'),
                         'type' => 'users',
+                        'allow_current' => true,
                     ],
                 ],
             ],
@@ -95,20 +96,36 @@ class Users extends Relationship
 
     public function preProcess($data)
     {
-        if ($data === 'current') {
-            $data = User::current()->id();
-        }
+        $data = collect(Arr::wrap($data))
+            ->map(function ($id) {
+                if ($id !== 'current' || $this->config('allow_current')) {
+                    return $id;
+                }
+
+                return User::current()?->id();
+            })
+            ->filter()
+            ->values()
+            ->all();
 
         return parent::preProcess($data);
     }
 
     protected function authorizeItemData($id): bool
     {
+        if ($id === 'current' && $this->config('allow_current')) {
+            return true;
+        }
+
         return $this->authorizeViewable(User::find($id));
     }
 
     protected function toItemArray($id, $site = null)
     {
+        if ($id === 'current' && $this->config('allow_current')) {
+            return $this->currentUserOption();
+        }
+
         if ($user = User::find($id)) {
             $canViewUsers = $this->canViewUser($user);
 
@@ -188,7 +205,34 @@ class Users extends Relationship
             return $users;
         }
 
-        return $query->get()->map($userFields);
+        $users = $query->get()->map($userFields);
+
+        return $this->prependCurrentUserOption($users, $request);
+    }
+
+    private function prependCurrentUserOption(Collection $users, $request): Collection
+    {
+        if (! $this->config('allow_current')) {
+            return $users;
+        }
+
+        if (in_array('current', $request->exclusions ?? [])) {
+            return $users;
+        }
+
+        if (($search = $request->search) && ! str_contains(strtolower(__('Current User')), strtolower($search))) {
+            return $users;
+        }
+
+        return collect([$this->currentUserOption()])->concat($users);
+    }
+
+    private function currentUserOption(): array
+    {
+        return [
+            'id' => 'current',
+            'title' => __('Current User'),
+        ];
     }
 
     protected function getColumns()

--- a/src/Http/Controllers/CP/Fields/FieldsController.php
+++ b/src/Http/Controllers/CP/Fields/FieldsController.php
@@ -128,6 +128,11 @@ class FieldsController extends CpController
             $customMessages['mode.in'] = __('statamic::validation.date_fieldtype_only_single_mode_allowed');
         }
 
+        if ($request->type === 'users' && ($maxItems = Arr::get($request->values, 'max_items'))) {
+            $extraRules['default'] = ['array', 'max:'.$maxItems];
+            $customMessages['default.max'] = __('statamic::validation.users_fieldtype_default_max_items', ['max' => $maxItems]);
+        }
+
         $fields->validate($extraRules, $customMessages);
 
         $values = array_merge($request->values, $fields->process()->values()->all());

--- a/tests/Fieldtypes/UsersTest.php
+++ b/tests/Fieldtypes/UsersTest.php
@@ -91,6 +91,73 @@ class UsersTest extends TestCase
     }
 
     #[Test]
+    public function it_resolves_the_current_value_when_preprocessing_for_the_field()
+    {
+        $this->actingAs(Facades\User::find('123'));
+
+        $this->assertEquals(['123'], $this->fieldtype()->preProcess('current'));
+        $this->assertEquals(['123'], $this->fieldtype()->preProcess(['current']));
+        $this->assertEquals(['123', '456'], $this->fieldtype()->preProcess(['current', '456']));
+    }
+
+    #[Test]
+    public function it_keeps_the_current_value_when_preprocessing_the_config()
+    {
+        $this->actingAs(Facades\User::find('123'));
+
+        // The default picker keeps "current" as-is so it round-trips through the
+        // blueprint editor instead of being resolved to the current user's id.
+        $this->assertEquals(['current'], $this->fieldtype(['allow_current' => true])->preProcessConfig('current'));
+        $this->assertEquals(['current'], $this->fieldtype(['allow_current' => true])->preProcessConfig(['current']));
+    }
+
+    #[Test]
+    public function it_includes_a_current_user_option_when_allowed()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp', 'view users']));
+
+        $items = $this->fieldtype(['allow_current' => true])->getIndexItems(new Request(['paginate' => false]));
+
+        $this->assertEquals(['id' => 'current', 'title' => 'Current User'], $items->first());
+    }
+
+    #[Test]
+    public function it_does_not_include_a_current_user_option_by_default()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp', 'view users']));
+
+        $items = $this->fieldtype()->getIndexItems(new Request(['paginate' => false]));
+
+        $this->assertFalse($items->contains(fn ($item) => $item['id'] === 'current'));
+    }
+
+    #[Test]
+    public function it_excludes_the_current_user_option_when_it_does_not_match_the_search()
+    {
+        $this->actingAs($this->cpUserWithPermissions(['access cp', 'view users']));
+
+        $fieldtype = $this->fieldtype(['allow_current' => true]);
+
+        $this->assertTrue(
+            $fieldtype->getIndexItems(new Request(['paginate' => false, 'search' => 'curr']))
+                ->contains(fn ($item) => $item['id'] === 'current')
+        );
+
+        $this->assertFalse(
+            $fieldtype->getIndexItems(new Request(['paginate' => false, 'search' => 'zzz']))
+                ->contains(fn ($item) => $item['id'] === 'current')
+        );
+    }
+
+    #[Test]
+    public function it_provides_item_data_for_the_current_user_option()
+    {
+        $data = $this->fieldtype(['allow_current' => true])->getItemData(['current']);
+
+        $this->assertEquals([['id' => 'current', 'title' => 'Current User']], $data->all());
+    }
+
+    #[Test]
     public function it_shallow_augments_to_a_collection_of_users()
     {
         $augmented = $this->fieldtype()->shallowAugment(['123', 456]);


### PR DESCRIPTION
The Users fieldtype supports `current` as a default value which sets the currently logged in user as the default. However, this is only available by editing the blueprint's YAML directly and not an option in the UI. There is also another issue with it right now. If you set `default: current` in the YAML and then opened the blueprint and field in the CP, the current user was shown but saving would then hardcode that user's id into the blueprint which is obviously not the intended behavior of that setting.

This PR introduces both selecting it via the UI and also fixes the hardcoding of the ID on save.

The `default` config field is flagged internally with `allow_current`, which is what tells the picker to treat `current` as a real, selectable value in this context (and only this context). With that flag set the fieldtype:

- offers a synthetic **Current User** option in the dropdown,
- keeps the value as `current` instead of resolving it to an id, so it round-trips
  cleanly through the CP, and
- renders it as a proper "Current User" item when the field is re-opened.

For actual `users` fields (no `allow_current`), `current` continues to resolve to the logged-in user as before, so existing `default: current` blueprints keep working exactly the same. The resolution logic now also handles `current` inside an array, matching how `augment()` already worked.

---

While working on those fixes I noticed another potential bug: The default picker ignored the field's own `max_items` config value so you could select (and save) more default users than the field itself allowed.

- The default picker previously had no `max_items` of its own, so it was always unbounded. It now reactively mirrors the field's configured max items in the field's settings UI so you can't select more default users than the field permits. It also adds server side validation so you can't circumvent it easily. Otherwise you can allow three users, select three, lower it to allow 2, and still successfully save the blueprint.

It now respects that config:

<img width="1386" height="479" alt="image" src="https://github.com/user-attachments/assets/2bddf6a9-3f98-495b-814e-d711c780bd1c" />

Closes https://github.com/statamic/cms/issues/8796.