### PR TITLE
[6.x] Ensure REST API authentication errors return consistent JSON

### DIFF
--- a/src/API/Middleware/HandleAuthentication.php
+++ b/src/API/Middleware/HandleAuthentication.php
@@ -3,6 +3,7 @@
 namespace Statamic\API\Middleware;
 
 use Closure;
+use Statamic\Exceptions\ApiAuthenticationException;
 
 class HandleAuthentication
 {
@@ -18,7 +19,7 @@ class HandleAuthentication
             ($token = config('statamic.api.auth_token'))
             && ($request->bearerToken() !== $token)
         ) {
-            abort(401);
+            throw new ApiAuthenticationException;
         }
 
         return $next($request);

--- a/src/Exceptions/ApiAuthenticationException.php
+++ b/src/Exceptions/ApiAuthenticationException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+use Illuminate\Auth\AuthenticationException as Exception;
+use Illuminate\Contracts\Support\Responsable;
+
+class ApiAuthenticationException extends Exception implements Responsable
+{
+    public function toResponse($request)
+    {
+        return response()->json(
+            ['message' => $this->getMessage()],
+            401,
+        );
+    }
+}

--- a/src/Exceptions/ApiAuthenticationException.php
+++ b/src/Exceptions/ApiAuthenticationException.php
@@ -12,6 +12,7 @@ class ApiAuthenticationException extends Exception implements Responsable
         return response()->json(
             ['message' => $this->getMessage()],
             401,
+            ['WWW-Authenticate' => 'Bearer'],
         );
     }
 }

--- a/src/GraphQL/Middleware/HandleAuthentication.php
+++ b/src/GraphQL/Middleware/HandleAuthentication.php
@@ -3,6 +3,7 @@
 namespace Statamic\GraphQL\Middleware;
 
 use Closure;
+use Statamic\Exceptions\ApiAuthenticationException;
 
 class HandleAuthentication
 {
@@ -18,7 +19,7 @@ class HandleAuthentication
             ($token = config('statamic.graphql.auth_token'))
             && ($request->bearerToken() !== $token)
         ) {
-            abort(401);
+            throw new ApiAuthenticationException;
         }
 
         return $next($request);

--- a/tests/API/AuthenticationTest.php
+++ b/tests/API/AuthenticationTest.php
@@ -73,7 +73,7 @@ class AuthenticationTest extends TestCase
     }
 
     #[Test]
-    public function it_returns_json_for_unauthenticated_requests()
+    public function it_returns_json_even_when_html_is_requested()
     {
         Facades\Config::set('statamic.api.auth_token', 'foobar');
 

--- a/tests/API/AuthenticationTest.php
+++ b/tests/API/AuthenticationTest.php
@@ -40,14 +40,11 @@ class AuthenticationTest extends TestCase
         Facades\Config::set('statamic.api.auth_token', 'foobar');
 
         $this
-            ->withToken($token = 'invalid')
-            ->getJson($url = '/api/collections/articles/entries')
-            ->assertUnauthorized();
-
-        $this
-            ->withToken($token)
-            ->get($url)
-            ->assertUnauthorized();
+            ->withToken('invalid')
+            ->getJson('/api/collections/articles/entries')
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
     }
 
     #[Test]
@@ -56,12 +53,37 @@ class AuthenticationTest extends TestCase
         Facades\Config::set('statamic.api.auth_token', 'foobar');
 
         $this
-            ->getJson($url = '/api/collections/articles/entries')
-            ->assertUnauthorized();
+            ->getJson('/api/collections/articles/entries')
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
+    }
+
+    #[Test]
+    public function it_returns_the_same_json_response_when_debug_mode_is_enabled()
+    {
+        Facades\Config::set('app.debug', true);
+        Facades\Config::set('statamic.api.auth_token', 'foobar');
 
         $this
-            ->get($url)
-            ->assertUnauthorized();
+            ->getJson('/api/collections/articles/entries')
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
+    }
+
+    #[Test]
+    public function it_returns_json_for_unauthenticated_requests()
+    {
+        Facades\Config::set('statamic.api.auth_token', 'foobar');
+
+        $this
+            ->withHeader('Accept', 'text/html')
+            ->get('/api/collections/articles/entries')
+            ->assertUnauthorized()
+            ->assertHeader('Content-Type', 'application/json')
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
     }
 
     #[Test]

--- a/tests/Feature/GraphQL/AuthenticationTest.php
+++ b/tests/Feature/GraphQL/AuthenticationTest.php
@@ -30,14 +30,11 @@ class AuthenticationTest extends TestCase
         Config::set('statamic.graphql.auth_token', 'foobar');
 
         $this
-            ->withToken($token = 'invalid')
-            ->postJson($url = '/graphql', ['query' => '{ping}'])
-            ->assertUnauthorized();
-
-        $this
-            ->withToken($token)
-            ->post($url, ['query' => '{ping}'])
-            ->assertUnauthorized();
+            ->withToken('invalid')
+            ->postJson('/graphql', ['query' => '{ping}'])
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
     }
 
     #[Test]
@@ -46,12 +43,37 @@ class AuthenticationTest extends TestCase
         Config::set('statamic.graphql.auth_token', 'foobar');
 
         $this
-            ->postJson($url = '/graphql', ['query' => '{ping}'])
-            ->assertUnauthorized();
+            ->postJson('/graphql', ['query' => '{ping}'])
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
+    }
+
+    #[Test]
+    public function it_returns_the_same_json_response_when_debug_mode_is_enabled()
+    {
+        Config::set('app.debug', true);
+        Config::set('statamic.graphql.auth_token', 'foobar');
 
         $this
-            ->post($url, ['query' => '{ping}'])
-            ->assertUnauthorized();
+            ->postJson('/graphql', ['query' => '{ping}'])
+            ->assertUnauthorized()
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
+    }
+
+    #[Test]
+    public function it_returns_json_even_when_html_is_requested()
+    {
+        Config::set('statamic.graphql.auth_token', 'foobar');
+
+        $this
+            ->withHeader('Accept', 'text/html')
+            ->post('/graphql', ['query' => '{ping}'])
+            ->assertUnauthorized()
+            ->assertHeader('Content-Type', 'application/json')
+            ->assertHeader('WWW-Authenticate', 'Bearer')
+            ->assertExactJson(['message' => 'Unauthenticated.']);
     }
 
     #[Test]


### PR DESCRIPTION
- Always send a JSON response for unauthenticated REST API requests
- Include a [WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/WWW-Authenticate) header, required by [RFC 7235](https://datatracker.ietf.org/doc/html/rfc7235#section-4.1) to communicate authentication requirements
- Fixes #15076

```
WWW-Authenticate: Bearer
```

```json
{
    "message": "Unauthenticated."
}
```