### PR TITLE
[6.x] Remove stale PHPStan ignore patterns

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -48,16 +48,3 @@ parameters:
       identifier: staticMethod.notFound
       message: '#^Call to an undefined static method Statamic\\Providers\\AppServiceProvider::this\(\)\.$#'
       path: src/Providers/AppServiceProvider.php
-
-    # keyByWithKey() is a public Collection macro kept for third-party/addon backward
-    # compatibility even though Statamic's own code no longer calls it, so its use of
-    # Collection's protected valueRetriever()/$items internals is left as-is rather than
-    # rewritten to public equivalents.
-    -
-      identifier: method.protected
-      message: '#^Call to protected method valueRetriever\(\) of class Illuminate\\Support\\Collection(<.*>)?\.$#'
-      path: src/Providers/CollectionsServiceProvider.php
-    -
-      identifier: property.protected
-      message: '#^Access to protected property Illuminate\\Support\\Collection::\$items\.$#'
-      path: src/Providers/CollectionsServiceProvider.php


### PR DESCRIPTION
This pull request removes two stale PHPStan ignore patterns for `CollectionsServiceProvider`. They've been failing CI on multiple pull requests this morning.

The patterns were ignoring `method.protected`/`property.protected` errors for the `keyByWithKey` macro's use of `Collection::valueRetriever()` and `$items`. Neither error is reported any more: PHPStan 2.2.6 [resolves `static`/`self`/`parent` relative to the `@param-closure-this` bound class](https://github.com/phpstan/phpstan-src/pull/6061), and `Macroable::macro()` is annotated with `@param-closure-this static $macro`, so the closure is now analysed in `Illuminate\Support\Collection`'s own scope — where reaching for its protected internals is perfectly valid.

Since `reportUnmatchedIgnoredErrors` is enabled by default, the two now-unmatched patterns fail the run.

This PR fixes it by removing them.