### PR TITLE
[6.x] Fix static cache urls map race conditions under concurrent requests

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -25,6 +25,7 @@ return [
     'cache_utility_image_cache_description' => 'The image cache stores copies of all transformed and resized images.',
     'cache_utility_stache_description' => 'The Stache is Statamic\'s content store that functions much like a database. It is generated automatically from the content files.',
     'cache_utility_static_cache_description' => 'Static pages bypass Statamic completely and are rendered directly from the server for maximum performance.',
+    'cache_utility_static_cache_invalidate_urls_locked' => 'Could not invalidate URLs because the cache was locked by another process. Please try again.',
     'choose_entry_localization_deletion_behavior' => 'Choose the action you wish to perform on the localized entries.',
     'collection_configure_date_behavior_private' => 'Private - Hidden from listings, URLs return 404',
     'collection_configure_date_behavior_public' => 'Public - Always visible',

--- a/src/Http/Controllers/CP/Utilities/CacheController.php
+++ b/src/Http/Controllers/CP/Utilities/CacheController.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Http\Controllers\CP\Utilities;
 
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
 use Inertia\Inertia;
@@ -133,7 +134,11 @@ class CacheController extends CpController
             ...$prefixedRelativeUrls,
         ];
 
-        app(Cacher::class)->invalidateUrls($urls);
+        try {
+            app(Cacher::class)->invalidateUrls($urls);
+        } catch (LockTimeoutException $e) {
+            return back()->withError(__('Could not invalidate URLs because the cache was locked by another process. Please try again.'));
+        }
 
         return back()->withSuccess(__('Invalidated URLs in the Static Cache.'));
     }

--- a/src/Http/Controllers/CP/Utilities/CacheController.php
+++ b/src/Http/Controllers/CP/Utilities/CacheController.php
@@ -137,7 +137,7 @@ class CacheController extends CpController
         try {
             app(Cacher::class)->invalidateUrls($urls);
         } catch (LockTimeoutException $e) {
-            return back()->withError(__('Could not invalidate URLs because the cache was locked by another process. Please try again.'));
+            return back()->withError(__('statamic::messages.cache_utility_static_cache_invalidate_urls_locked'));
         }
 
         return back()->withSuccess(__('Invalidated URLs in the Static Cache.'));

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -9,6 +9,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Statamic\Console\Commands\StaticWarmJob;
+use Statamic\Events\UrlInvalidated;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\StaticCaching\Cacher;
@@ -39,10 +40,10 @@ abstract class AbstractCacher implements Cacher
     private $config;
 
     /**
-     * Lock keys currently held by this instance, so nested withLock() calls for
-     * the same key (e.g. forgetUrl() called from within a batched invalidateUrls()
-     * loop that already holds the domain's urls lock) don't try to re-acquire a
-     * lock against themselves and deadlock until LOCK_WAIT expires.
+     * Lock keys currently held by this instance, so nested withLock() calls
+     * for the same key (e.g. forgetUrl() called from code already holding the
+     * domain's urls lock) don't try to re-acquire a lock against themselves
+     * and deadlock until LOCK_WAIT expires.
      *
      * @var array<string, bool>
      */
@@ -180,7 +181,9 @@ abstract class AbstractCacher implements Cacher
     public function flushUrls()
     {
         $this->getDomains()->each(function ($domain) {
-            $this->cache->forget($this->getUrlsCacheKey($domain));
+            $this->withLock($this->getUrlsLockKey($domain), function () use ($domain) {
+                $this->cache->forget($this->getUrlsCacheKey($domain));
+            });
         });
 
         $this->cache->forget($this->normalizeKey('domains'));
@@ -266,31 +269,37 @@ abstract class AbstractCacher implements Cacher
     }
 
     /**
+     * Invalidate a URL.
+     *
+     * @param  string  $url
+     * @param  string|null  $domain
+     * @return void
+     */
+    public function invalidateUrl($url, $domain = null)
+    {
+        // For CLI contexts where Site::current()->url() may return the wrong
+        // domain causing getUrls() to look under the wrong cache key.
+        if ($domain === null) {
+            [$url, $domain] = $this->getPathAndDomain($url);
+        }
+
+        $this->invalidatePathsForDomain([$url], $domain);
+    }
+
+    /**
      * Invalidate a wildcard URL.
      *
      * @param  string  $wildcard
      */
     protected function invalidateWildcardUrl($wildcard)
     {
-        // Remove the asterisk
-        $wildcard = substr($wildcard, 0, -1);
+        [, $domain] = $this->getPathAndDomain(substr($wildcard, 0, -1));
 
-        [$wildcard, $domain] = $this->getPathAndDomain($wildcard);
-
-        $this->getUrls($domain)->filter(function ($url) use ($wildcard) {
-            return Str::startsWith($url, $wildcard);
-        })->each(function ($url) use ($domain) {
-            $this->invalidateUrl($url, $domain);
-        });
+        $this->invalidatePathsForDomain([$wildcard], $domain);
     }
 
     /**
      * Invalidate multiple URLs.
-     *
-     * Grouped by domain and run under a single lock per domain, so a large
-     * batch doesn't acquire and release the domain's urls lock once per URL
-     * (each acquisition able to block up to LOCK_WAIT) and instead holds it
-     * once for the whole domain's batch.
      *
      * @param  array  $urls
      * @return void
@@ -299,18 +308,73 @@ abstract class AbstractCacher implements Cacher
     {
         collect($urls)
             ->groupBy(fn ($url) => $this->resolveDomainForInvalidation($url))
-            ->each(function ($urlsForDomain, $domain) {
-                $this->withLock($this->getUrlsLockKey($domain), function () use ($urlsForDomain) {
-                    $urlsForDomain->each(function ($url) {
-                        if (Str::contains($url, '*')) {
-                            $this->invalidateWildcardUrl($url);
-                        } else {
-                            $this->invalidateUrl(...$this->getPathAndDomain($url));
-                        }
-                    });
-                });
-            });
+            ->each(fn ($urlsForDomain, $domain) => $this->invalidatePathsForDomain($urlsForDomain->all(), $domain));
     }
+
+    /**
+     * Invalidate a set of paths (and trailing-* wildcards) for a single domain.
+     *
+     * Two phases, so the urls lock is only held for map bookkeeping and never
+     * for driver cleanup (file deletes, cache forgets) or event listeners:
+     *
+     * 1. Under the domain's urls lock: resolve which map entries match, remove
+     *    them, and persist the map in a single write.
+     * 2. After releasing the lock: driver cleanup and UrlInvalidated events.
+     *
+     * A page cached concurrently with phase two can at worst leave a map entry
+     * whose cached copy was just deleted, which is self-healing: the next
+     * request re-renders and re-caches under the same key. The reverse - a
+     * cached copy the map doesn't know about - cannot happen.
+     *
+     * @param  array  $urls
+     * @param  string|null  $domain
+     * @return void
+     */
+    protected function invalidatePathsForDomain($urls, $domain)
+    {
+        $paths = collect($urls)->map(function ($url) {
+            $wildcard = Str::contains($url, '*');
+
+            [$path] = $this->getPathAndDomain($wildcard ? substr($url, 0, -1) : $url);
+
+            return ['path' => $path, 'wildcard' => $wildcard];
+        });
+
+        $invalidated = $this->withLock($this->getUrlsLockKey($domain), function () use ($paths, $domain) {
+            $urls = $this->getUrls($domain);
+
+            $invalidated = $urls->filter(fn ($value) => $paths->contains(fn ($path) => $path['wildcard']
+                ? Str::startsWith($value, $path['path'])
+                : ($value === $path['path'] || Str::startsWith($value, $path['path'].'?'))));
+
+            if ($invalidated->isNotEmpty()) {
+                $this->cache->forever($this->getUrlsCacheKey($domain), $urls->diffKeys($invalidated)->all());
+            }
+
+            return $invalidated;
+        });
+
+        $this->cleanupInvalidatedUrls($invalidated, $paths, $domain);
+
+        $paths->each(function ($path) use ($invalidated, $domain) {
+            $path['wildcard']
+                ? $invalidated
+                    ->filter(fn ($value) => Str::startsWith($value, $path['path']))
+                    ->each(fn ($value) => UrlInvalidated::dispatch($value, $domain))
+                : UrlInvalidated::dispatch($path['path'], $domain);
+        });
+    }
+
+    /**
+     * Clean up the driver's stored copies of invalidated pages. Runs after the
+     * urls lock has been released.
+     *
+     * @param  \Illuminate\Support\Collection  $invalidated  The removed entries, keyed by their urls map key.
+     * @param  \Illuminate\Support\Collection  $paths  The ['path' => string, 'wildcard' => bool] entries the invalidation was requested with.
+     * @param  string|null  $domain
+     * @return void
+     */
+    abstract protected function cleanupInvalidatedUrls($invalidated, $paths, $domain);
 
     /**
      * Resolve the domain an invalidation entry belongs to, the same way

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -38,6 +38,16 @@ abstract class AbstractCacher implements Cacher
      */
     private $config;
 
+    /**
+     * Lock keys currently held by this instance, so nested withLock() calls for
+     * the same key (e.g. forgetUrl() called from within a batched invalidateUrls()
+     * loop that already holds the domain's urls lock) don't try to re-acquire a
+     * lock against themselves and deadlock until LOCK_WAIT expires.
+     *
+     * @var array<string, bool>
+     */
+    private $heldLocks = [];
+
     public function __construct(Repository $cache, $config)
     {
         $this->cache = $cache;
@@ -227,11 +237,23 @@ abstract class AbstractCacher implements Cacher
      */
     protected function withLock(string $key, \Closure $callback)
     {
+        if (isset($this->heldLocks[$key])) {
+            return $callback();
+        }
+
         if (! $this->cache->getStore() instanceof LockProvider) {
             return $callback();
         }
 
-        return $this->cache->lock($key, static::LOCK_TIMEOUT)->block(static::LOCK_WAIT, $callback);
+        return $this->cache->lock($key, static::LOCK_TIMEOUT)->block(static::LOCK_WAIT, function () use ($key, $callback) {
+            $this->heldLocks[$key] = true;
+
+            try {
+                return $callback();
+            } finally {
+                unset($this->heldLocks[$key]);
+            }
+        });
     }
 
     /**
@@ -265,18 +287,46 @@ abstract class AbstractCacher implements Cacher
     /**
      * Invalidate multiple URLs.
      *
+     * Grouped by domain and run under a single lock per domain, so a large
+     * batch doesn't acquire and release the domain's urls lock once per URL
+     * (each acquisition able to block up to LOCK_WAIT) and instead holds it
+     * once for the whole domain's batch.
+     *
      * @param  array  $urls
      * @return void
      */
     public function invalidateUrls($urls)
     {
-        collect($urls)->each(function ($url) {
-            if (Str::contains($url, '*')) {
-                $this->invalidateWildcardUrl($url);
-            } else {
-                $this->invalidateUrl(...$this->getPathAndDomain($url));
-            }
-        });
+        collect($urls)
+            ->groupBy(fn ($url) => $this->resolveDomainForInvalidation($url))
+            ->each(function ($urlsForDomain, $domain) {
+                $this->withLock($this->getUrlsLockKey($domain), function () use ($urlsForDomain) {
+                    $urlsForDomain->each(function ($url) {
+                        if (Str::contains($url, '*')) {
+                            $this->invalidateWildcardUrl($url);
+                        } else {
+                            $this->invalidateUrl(...$this->getPathAndDomain($url));
+                        }
+                    });
+                });
+            });
+    }
+
+    /**
+     * Resolve the domain an invalidation entry belongs to, the same way
+     * invalidateUrl()/invalidateWildcardUrl() would internally, so entries can
+     * be grouped by domain before either is called.
+     *
+     * @param  string  $url
+     * @return string
+     */
+    protected function resolveDomainForInvalidation($url)
+    {
+        $url = Str::contains($url, '*') ? substr($url, 0, -1) : $url;
+
+        [, $domain] = $this->getPathAndDomain($url);
+
+        return $domain;
     }
 
     /**

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -3,6 +3,7 @@
 namespace Statamic\StaticCaching\Cachers;
 
 use GuzzleHttp\Psr7\Request as GuzzleRequest;
+use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -17,6 +18,16 @@ use Statamic\Support\Str;
 
 abstract class AbstractCacher implements Cacher
 {
+    /**
+     * Seconds until a held lock auto-expires, as a crash safety net.
+     */
+    protected const LOCK_TIMEOUT = 10;
+
+    /**
+     * Seconds a caller will wait to acquire a lock before giving up.
+     */
+    protected const LOCK_WAIT = 5;
+
     /**
      * @var Repository
      */
@@ -125,13 +136,17 @@ abstract class AbstractCacher implements Cacher
      */
     public function cacheDomain($domain = null)
     {
-        $domains = $this->getDomains();
+        $domain = $domain ?? $this->getBaseUrl();
 
-        if (! $domains->contains($domain = $domain ?? $this->getBaseUrl())) {
-            $domains->push($domain);
-        }
+        $this->withLock($this->normalizeKey('domains:lock'), function () use ($domain) {
+            $domains = $this->getDomains();
 
-        $this->cache->forever($this->normalizeKey('domains'), $domains->all());
+            if (! $domains->contains($domain)) {
+                $domains->push($domain);
+            }
+
+            $this->cache->forever($this->normalizeKey('domains'), $domains->all());
+        });
     }
 
     /**
@@ -174,13 +189,15 @@ abstract class AbstractCacher implements Cacher
 
         $this->cacheDomain($domain);
 
-        $urls = $this->getUrls($domain);
+        $this->withLock($this->getUrlsLockKey($domain), function () use ($key, $url, $domain) {
+            $urls = $this->getUrls($domain);
 
-        $url = Str::removeLeft($url, $domain);
+            $url = Str::removeLeft($url, $domain);
 
-        $urls->put($key, $url);
+            $urls->put($key, $url);
 
-        $this->cache->forever($this->getUrlsCacheKey($domain), $urls->all());
+            $this->cache->forever($this->getUrlsCacheKey($domain), $urls->all());
+        });
     }
 
     /**
@@ -191,11 +208,39 @@ abstract class AbstractCacher implements Cacher
      */
     public function forgetUrl($key, $domain = null)
     {
-        $urls = $this->getUrls($domain);
+        $this->withLock($this->getUrlsLockKey($domain), function () use ($key, $domain) {
+            $urls = $this->getUrls($domain);
 
-        $urls->forget($key);
+            $urls->forget($key);
 
-        $this->cache->forever($this->getUrlsCacheKey($domain), $urls->all());
+            $this->cache->forever($this->getUrlsCacheKey($domain), $urls->all());
+        });
+    }
+
+    /**
+     * Run a callback while holding an exclusive lock for the given key, if the
+     * configured cache store supports locking. Falls back to running the
+     * callback unprotected if it doesn't, so cache stores without lock
+     * support (e.g. some third-party addons) don't hard crash.
+     *
+     * @return mixed
+     */
+    protected function withLock(string $key, \Closure $callback)
+    {
+        if (! $this->cache->getStore() instanceof LockProvider) {
+            return $callback();
+        }
+
+        return $this->cache->lock($key, static::LOCK_TIMEOUT)->block(static::LOCK_WAIT, $callback);
+    }
+
+    /**
+     * @param  string|null  $domain
+     * @return string
+     */
+    protected function getUrlsLockKey($domain = null)
+    {
+        return $this->getUrlsCacheKey($domain).':lock';
     }
 
     /**

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Support\Facades\Event;
-use Statamic\Events\UrlInvalidated;
 use Statamic\StaticCaching\Page;
 
 class ApplicationCacher extends AbstractCacher
@@ -106,38 +105,34 @@ class ApplicationCacher extends AbstractCacher
      */
     public function flush()
     {
-        $this->getDomains()->each(function ($domain) {
-            $this->getUrls($domain)->keys()->each(function ($key) {
-                $this->cache->forget($this->normalizeKey('responses:'.$key));
+        // Capture each domain's response keys and wipe its map under the urls
+        // lock, so a page cached mid-flush can't end up as a stored response
+        // the map doesn't know about. The responses are forgotten afterwards.
+        $keys = $this->getDomains()->flatMap(function ($domain) {
+            return $this->withLock($this->getUrlsLockKey($domain), function () use ($domain) {
+                $keys = $this->getUrls($domain)->keys();
+
+                $this->cache->forget($this->getUrlsCacheKey($domain));
+
+                return $keys;
             });
         });
 
-        $this->flushUrls();
+        $this->cache->forget($this->normalizeKey('domains'));
+
+        $keys->each(fn ($key) => $this->cache->forget($this->normalizeKey('responses:'.$key)));
     }
 
     /**
-     * Invalidate a URL.
+     * Forget the stored responses for invalidated urls map entries.
      *
-     * @param  string  $url
+     * @param  \Illuminate\Support\Collection  $invalidated
+     * @param  \Illuminate\Support\Collection  $paths
      * @param  string|null  $domain
      * @return void
      */
-    public function invalidateUrl($url, $domain = null)
+    protected function cleanupInvalidatedUrls($invalidated, $paths, $domain)
     {
-        // For CLI contexts where Site::current()->url() may return the wrong
-        // domain causing getUrls() to look under the wrong cache key.
-        if ($domain === null) {
-            [$url, $domain] = $this->getPathAndDomain($url);
-        }
-
-        $this
-            ->getUrls($domain)
-            ->filter(fn ($value) => $value === $url || str_starts_with($value, $url.'?'))
-            ->each(function ($value, $key) use ($domain) {
-                $this->cache->forget($this->normalizeKey('responses:'.$key));
-                $this->forgetUrl($key, $domain);
-            });
-
-        UrlInvalidated::dispatch($url, $domain);
+        $invalidated->keys()->each(fn ($key) => $this->cache->forget($this->normalizeKey('responses:'.$key)));
     }
 }

--- a/src/StaticCaching/Cachers/ApplicationCacher.php
+++ b/src/StaticCaching/Cachers/ApplicationCacher.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\StaticCaching\Cachers;
 
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Events\ResponsePrepared;
 use Illuminate\Support\Facades\Event;
@@ -38,8 +39,14 @@ class ApplicationCacher extends AbstractCacher
         // and other URL characters wouldn't work as a cache key.
         $key = $this->makeHash($url);
 
-        // Keep track of the URL and key the response content is about to be stored within.
-        $this->cacheUrl($key, ...$this->getPathAndDomain($url));
+        try {
+            // Keep track of the URL and key the response content is about to be stored within.
+            $this->cacheUrl($key, ...$this->getPathAndDomain($url));
+        } catch (LockTimeoutException $e) {
+            // The URL couldn't be recorded in the urls map, so don't store the
+            // response either. The response will just go out uncached.
+            return;
+        }
 
         $key = $this->normalizeKey('responses:'.$key);
         $value = $this->normalizeContent($content);

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\StaticCaching\Cachers;
 
+use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -81,7 +82,14 @@ class FileCacher extends AbstractCacher
             return;
         }
 
-        $this->cacheUrl($this->makeHash($url), ...$this->getPathAndDomain($url));
+        try {
+            $this->cacheUrl($this->makeHash($url), ...$this->getPathAndDomain($url));
+        } catch (LockTimeoutException $e) {
+            // The URL couldn't be recorded in the urls map. Remove the written
+            // file so it isn't served while being invisible to invalidation,
+            // and let the response go out uncached.
+            $this->writer->delete($path);
+        }
     }
 
     public function preventLoggingRewriteWarning()

--- a/src/StaticCaching/Cachers/FileCacher.php
+++ b/src/StaticCaching/Cachers/FileCacher.php
@@ -7,7 +7,6 @@ use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\LazyCollection;
-use Statamic\Events\UrlInvalidated;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Facades\Site;
@@ -127,38 +126,45 @@ class FileCacher extends AbstractCacher
      */
     public function flush()
     {
+        // Wipe the urls map before deleting files, so a page cached mid-flush
+        // can't end up as a file the map doesn't know about.
+        $this->flushUrls();
+
         foreach ($this->getCachePaths() as $path) {
             $this->writer->flush($path);
         }
-
-        $this->flushUrls();
     }
 
     /**
-     * Invalidate a URL.
+     * Delete the static files for invalidated urls map entries.
      *
-     * @param  string  $url
+     * @param  \Illuminate\Support\Collection  $invalidated
+     * @param  \Illuminate\Support\Collection  $paths
+     * @param  string|null  $domain
      * @return void
      */
-    public function invalidateUrl($url, $domain = null)
+    protected function cleanupInvalidatedUrls($invalidated, $paths, $domain)
     {
-        $site = optional(Site::findByUrl($domain.$url))->handle();
+        $invalidated->each(function ($value) use ($domain) {
+            $site = optional(Site::findByUrl($domain.$value))->handle();
 
-        $this
-            ->getUrls($domain)
-            ->filter(fn ($value) => $value === $url || str_starts_with($value, $url.'?'))
-            ->each(function ($value, $key) use ($site, $domain) {
-                $this->writer->delete($this->getFilePath($domain.$value, $site));
-                $this->forgetUrl($key, $domain);
+            $this->writer->delete($this->getFilePath($domain.$value, $site));
+        });
+
+        // Also delete file variants that aren't tracked in the urls map,
+        // e.g. pagination pages written alongside the base url.
+        $paths
+            ->flatMap(fn ($path) => $path['wildcard']
+                ? $invalidated->filter(fn ($value) => Str::startsWith($value, $path['path']))->values()
+                : [$path['path']])
+            ->groupBy(fn ($prefix) => optional(Site::findByUrl($domain.$prefix))->handle() ?? '')
+            ->each(function ($prefixes, $site) {
+                $this->getFiles($site === '' ? null : $site)
+                    ->filter(fn ($file) => $prefixes->contains(fn ($prefix) => str_starts_with($file, $prefix.'_')))
+                    ->each(function ($file, $path) {
+                        $this->writer->delete($path);
+                    });
             });
-
-        $this->getFiles($site)
-            ->filter(fn ($file) => str_starts_with($file, $url.'_'))
-            ->each(function ($file, $path) {
-                $this->writer->delete($path);
-            });
-
-        UrlInvalidated::dispatch($url, $domain);
     }
 
     /**

--- a/tests/StaticCaching/CacherConcurrencyTest.php
+++ b/tests/StaticCaching/CacherConcurrencyTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\File;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Events\UrlInvalidated;
 use Statamic\StaticCaching\Cachers\AbstractCacher;
 use Statamic\StaticCaching\Cachers\ApplicationCacher;
 use Statamic\StaticCaching\Cachers\FileCacher;
@@ -122,10 +123,9 @@ class CacherConcurrencyTest extends TestCase
             'two' => '/two',
             'three' => '/three',
         ]);
-        $cache->shouldReceive('forever')->withArgs(fn ($key) => $key === $urlsKey);
+        // One lock, one map write for the whole batch - not one per URL.
+        $cache->shouldReceive('forever')->once()->withArgs(fn ($key) => $key === $urlsKey);
 
-        // The whole point of the fix: one lock covers the entire batch, not
-        // one acquisition per URL.
         $cache->shouldReceive('lock')
             ->once()
             ->withArgs(fn ($key) => $key === $lockKey)
@@ -245,6 +245,94 @@ class CacherConcurrencyTest extends TestCase
         $this->assertFileDoesNotExist($cacher->getFilePath('http://localhost/about'));
     }
 
+    #[Test]
+    public function urls_lock_is_released_before_invalidation_cleanup_and_events_run()
+    {
+        $cache = app(Repository::class);
+        $writer = Mockery::spy(Writer::class);
+
+        $cacher = new FileCacher($writer, $cache, [
+            'base_url' => 'http://example.com',
+            'path' => $this->cachePath(),
+            'locale' => 'en',
+        ]);
+
+        $cache->forever('static-cache:'.md5('http://example.com').'.urls', ['one' => '/one']);
+
+        $lockKey = 'static-cache:'.md5('http://example.com').'.urls:lock';
+
+        // If invalidation still held the urls lock while dispatching events,
+        // this listener wouldn't be able to acquire it - and neither would a
+        // visitor request trying to cache a page during a long cleanup.
+        $lockWasFree = null;
+        Event::listen(UrlInvalidated::class, function () use ($cache, $lockKey, &$lockWasFree) {
+            $lock = $cache->lock($lockKey, 10);
+
+            if ($lockWasFree = $lock->get()) {
+                $lock->release();
+            }
+        });
+
+        $cacher->invalidateUrls(['/one']);
+
+        $this->assertTrue($lockWasFree, 'The urls lock should be released before cleanup and events run.');
+        $this->assertSame([], $cacher->getUrls('http://example.com')->all());
+    }
+
+    #[Test]
+    public function file_cacher_flush_wipes_the_urls_map_before_deleting_files()
+    {
+        $cache = app(Repository::class);
+        $urlsKey = 'static-cache:'.md5('http://example.com').'.urls';
+
+        $cache->forever('static-cache:domains', ['http://example.com']);
+        $cache->forever($urlsKey, ['one' => '/one']);
+
+        // If files were deleted first, a request re-rendering one of them could
+        // write a fresh file whose map entry is then wiped - an orphan. Map
+        // first means the worst case is a map entry without a file, which the
+        // next request heals by re-caching under the same key.
+        $writer = Mockery::mock(Writer::class);
+        $writer->shouldReceive('flush')->once()->andReturnUsing(function () use ($cache, $urlsKey) {
+            $this->assertNull($cache->get($urlsKey), 'The urls map should be wiped before files are deleted.');
+        });
+
+        $cacher = new FileCacher($writer, $cache, [
+            'base_url' => 'http://example.com',
+            'path' => $this->cachePath(),
+            'locale' => 'en',
+        ]);
+
+        $cacher->flush();
+
+        $this->assertNull($cache->get($urlsKey));
+        $this->assertNull($cache->get('static-cache:domains'));
+    }
+
+    #[Test]
+    public function application_cacher_flush_wipes_the_urls_map_before_forgetting_responses()
+    {
+        $urlsKey = 'static-cache:'.md5('http://example.com').'.urls';
+
+        $store = Mockery::mock(\Illuminate\Contracts\Cache\LockProvider::class, \Illuminate\Contracts\Cache\Store::class);
+        $lock = Mockery::mock(\Illuminate\Contracts\Cache\Lock::class);
+        $lock->shouldReceive('block')->andReturnUsing(fn ($seconds, $callback) => $callback());
+
+        $cache = Mockery::mock(\Illuminate\Contracts\Cache\Repository::class);
+        $cache->shouldReceive('getStore')->andReturn($store);
+        $cache->shouldReceive('lock')->andReturn($lock);
+        $cache->shouldReceive('get')->with('static-cache:domains', [])->andReturn(['http://example.com']);
+        $cache->shouldReceive('get')->with($urlsKey, [])->andReturn(['one' => '/one']);
+
+        $cache->shouldReceive('forget')->with($urlsKey)->once()->ordered();
+        $cache->shouldReceive('forget')->with('static-cache:domains')->once()->ordered();
+        $cache->shouldReceive('forget')->with('static-cache:responses:one')->once()->ordered();
+
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+
+        $cacher->flush();
+    }
+
     private function cachePath()
     {
         return storage_path('framework/testing/static-cache-concurrency');
@@ -265,10 +353,8 @@ class CacherConcurrencyTest extends TestCase
     }
 
     /**
-     * A minimal concrete AbstractCacher whose invalidateUrl() mirrors the real
-     * FileCacher/ApplicationCacher pattern of looking up matching urls map
-     * entries and calling forgetUrl() per match, so tests can exercise the
-     * real nested-lock path (invalidateUrls() -> invalidateUrl() -> forgetUrl()).
+     * A minimal concrete AbstractCacher with no driver-side storage, so tests
+     * can exercise the shared two-phase invalidation path directly.
      */
     private function concreteCacher($cache, $config = [])
     {
@@ -286,15 +372,8 @@ class CacherConcurrencyTest extends TestCase
             {
             }
 
-            public function invalidateUrl($url, $domain = null)
+            protected function cleanupInvalidatedUrls($invalidated, $paths, $domain)
             {
-                $domain = $domain ?? $this->getBaseUrl();
-
-                $this->getUrls($domain)
-                    ->filter(fn ($value) => $value === $url)
-                    ->each(function ($value, $key) use ($domain) {
-                        $this->forgetUrl($key, $domain);
-                    });
             }
         };
     }

--- a/tests/StaticCaching/CacherConcurrencyTest.php
+++ b/tests/StaticCaching/CacherConcurrencyTest.php
@@ -4,6 +4,7 @@ namespace Tests\StaticCaching;
 
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\LockTimeoutException;
+use Illuminate\Http\Request;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\StaticCaching\Cachers\AbstractCacher;
@@ -89,8 +90,107 @@ class CacherConcurrencyTest extends TestCase
         $this->assertTrue(true);
     }
 
+    #[Test]
+    public function invalidate_urls_only_acquires_the_domain_lock_once_for_a_multi_url_batch()
+    {
+        $lockKey = 'static-cache:'.md5('http://example.com').'.urls:lock';
+        $urlsKey = 'static-cache:'.md5('http://example.com').'.urls';
+
+        $store = Mockery::mock(\Illuminate\Contracts\Cache\LockProvider::class, \Illuminate\Contracts\Cache\Store::class);
+        $lock = Mockery::mock(\Illuminate\Contracts\Cache\Lock::class);
+
+        $cache = Mockery::mock(\Illuminate\Contracts\Cache\Repository::class);
+        $cache->shouldReceive('getStore')->andReturn($store);
+        $cache->shouldReceive('get')->with($urlsKey, [])->andReturn([
+            'one' => '/one',
+            'two' => '/two',
+            'three' => '/three',
+        ]);
+        $cache->shouldReceive('forever')->withArgs(fn ($key) => $key === $urlsKey);
+
+        // The whole point of the fix: one lock covers the entire batch, not
+        // one acquisition per URL.
+        $cache->shouldReceive('lock')
+            ->once()
+            ->withArgs(fn ($key) => $key === $lockKey)
+            ->andReturn($lock);
+        $lock->shouldReceive('block')->once()->andReturnUsing(fn ($seconds, $callback) => $callback());
+
+        $cacher = $this->concreteCacher($cache, ['base_url' => 'http://example.com']);
+
+        $cacher->invalidateUrls(['/one', '/two', '/three']);
+    }
+
+    #[Test]
+    public function invalidate_urls_throws_once_for_the_whole_batch_when_the_domain_lock_is_contended()
+    {
+        $cache = app(Repository::class);
+        $cacher = $this->concreteCacher($cache, ['base_url' => 'http://example.com']);
+
+        $urlsKey = 'static-cache:'.md5('http://example.com').'.urls';
+        $cache->forever($urlsKey, [
+            'one' => '/one',
+            'two' => '/two',
+            'three' => '/three',
+        ]);
+
+        $lockKey = 'static-cache:'.md5('http://example.com').'.urls:lock';
+        $externalLock = $cache->lock($lockKey, 10);
+        $this->assertTrue($externalLock->get());
+
+        try {
+            $this->expectException(LockTimeoutException::class);
+
+            $cacher->invalidateUrls(['/one', '/two', '/three']);
+        } finally {
+            $externalLock->forceRelease();
+        }
+
+        // Nothing should have been removed since the batch never acquired the lock.
+        $this->assertSame([
+            'one' => '/one',
+            'two' => '/two',
+            'three' => '/three',
+        ], $cache->get($urlsKey));
+    }
+
     private function cacher($cache, $config = [])
     {
         return Mockery::mock(AbstractCacher::class, [$cache, $config])->makePartial();
+    }
+
+    /**
+     * A minimal concrete AbstractCacher whose invalidateUrl() mirrors the real
+     * FileCacher/ApplicationCacher pattern of looking up matching urls map
+     * entries and calling forgetUrl() per match, so tests can exercise the
+     * real nested-lock path (invalidateUrls() -> invalidateUrl() -> forgetUrl()).
+     */
+    private function concreteCacher($cache, $config = [])
+    {
+        return new class($cache, $config) extends AbstractCacher
+        {
+            public function cachePage(Request $request, $content)
+            {
+            }
+
+            public function getCachedPage(Request $request)
+            {
+            }
+
+            public function flush()
+            {
+            }
+
+            public function invalidateUrl($url, $domain = null)
+            {
+                $domain = $domain ?? $this->getBaseUrl();
+
+                $this->getUrls($domain)
+                    ->filter(fn ($value) => $value === $url)
+                    ->each(function ($value, $key) use ($domain) {
+                        $this->forgetUrl($key, $domain);
+                    });
+            }
+        };
     }
 }

--- a/tests/StaticCaching/CacherConcurrencyTest.php
+++ b/tests/StaticCaching/CacherConcurrencyTest.php
@@ -5,13 +5,29 @@ namespace Tests\StaticCaching;
 use Illuminate\Cache\Repository;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Events\ResponsePrepared;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\File;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\StaticCaching\Cachers\AbstractCacher;
+use Statamic\StaticCaching\Cachers\ApplicationCacher;
+use Statamic\StaticCaching\Cachers\FileCacher;
+use Statamic\StaticCaching\Cachers\Writer;
+use Statamic\StaticCaching\Middleware\Cache as CacheMiddleware;
+use Statamic\StaticCaching\NoCache\Session;
 use Tests\TestCase;
 
 class CacherConcurrencyTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        File::deleteDirectory($this->cachePath());
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function cache_url_is_blocked_while_another_process_holds_the_urls_lock_for_the_domain()
     {
@@ -152,6 +168,95 @@ class CacherConcurrencyTest extends TestCase
             'two' => '/two',
             'three' => '/three',
         ], $cache->get($urlsKey));
+    }
+
+    #[Test]
+    public function file_cacher_removes_the_written_file_when_the_urls_lock_is_contended()
+    {
+        $cache = app(Repository::class);
+        $cacher = $this->fileCacher($cache, 'http://example.com');
+
+        $lockKey = 'static-cache:'.md5('http://example.com').'.urls:lock';
+        $externalLock = $cache->lock($lockKey, 10);
+        $this->assertTrue($externalLock->get());
+
+        try {
+            $cacher->cachePage(Request::create('http://example.com/about'), '<html>hello</html>');
+        } finally {
+            $externalLock->forceRelease();
+        }
+
+        // The page couldn't be recorded in the urls map, so the written file
+        // must be removed. Otherwise it would be served forever but invisible
+        // to invalidation - the exact orphaned state the locking prevents.
+        $this->assertFileDoesNotExist($cacher->getFilePath('http://example.com/about'));
+        $this->assertNull($cache->get('static-cache:'.md5('http://example.com').'.urls'));
+    }
+
+    #[Test]
+    public function application_cacher_skips_caching_the_response_when_the_urls_lock_is_contended()
+    {
+        $cache = app(Repository::class);
+        $cacher = new ApplicationCacher($cache, ['base_url' => 'http://example.com']);
+
+        $lockKey = 'static-cache:'.md5('http://example.com').'.urls:lock';
+        $externalLock = $cache->lock($lockKey, 10);
+        $this->assertTrue($externalLock->get());
+
+        try {
+            $cacher->cachePage($request = Request::create('http://example.com/about'), '<html>hello</html>');
+        } finally {
+            $externalLock->forceRelease();
+        }
+
+        // The response listener should never have been registered, so preparing
+        // a response must not store the page either.
+        Event::dispatch(new ResponsePrepared($request, new Response('<html>hello</html>')));
+
+        $this->assertNull($cache->get('static-cache:responses:'.md5('http://example.com/about')));
+        $this->assertNull($cache->get('static-cache:'.md5('http://example.com').'.urls'));
+    }
+
+    #[Test]
+    public function middleware_serves_the_rendered_response_uncached_when_the_urls_lock_is_contended()
+    {
+        $cache = app(Repository::class);
+        $cacher = $this->fileCacher($cache, 'http://localhost');
+
+        $middleware = new CacheMiddleware($cacher, app(Session::class));
+
+        $lockKey = 'static-cache:'.md5('http://localhost').'.urls:lock';
+        $externalLock = $cache->lock($lockKey, 10);
+        $this->assertTrue($externalLock->get());
+
+        try {
+            $response = $middleware->handle(
+                Request::create('http://localhost/about'),
+                fn () => new Response('<h1>Hello</h1>')
+            );
+        } finally {
+            $externalLock->forceRelease();
+        }
+
+        // The page rendered fine and should reach the visitor, not be discarded
+        // in favor of a 503 refresh response just because it couldn't be cached.
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('<h1>Hello</h1>', $response->getContent());
+        $this->assertFileDoesNotExist($cacher->getFilePath('http://localhost/about'));
+    }
+
+    private function cachePath()
+    {
+        return storage_path('framework/testing/static-cache-concurrency');
+    }
+
+    private function fileCacher($cache, $baseUrl)
+    {
+        return new FileCacher(new Writer, $cache, [
+            'base_url' => $baseUrl,
+            'path' => $this->cachePath(),
+            'locale' => 'en',
+        ]);
     }
 
     private function cacher($cache, $config = [])

--- a/tests/StaticCaching/CacherConcurrencyTest.php
+++ b/tests/StaticCaching/CacherConcurrencyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\StaticCaching;
+
+use Illuminate\Cache\Repository;
+use Illuminate\Contracts\Cache\LockTimeoutException;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\StaticCaching\Cachers\AbstractCacher;
+use Tests\TestCase;
+
+class CacherConcurrencyTest extends TestCase
+{
+    #[Test]
+    public function cache_url_is_blocked_while_another_process_holds_the_urls_lock_for_the_domain()
+    {
+        $cache = app(Repository::class);
+        $cacher = $this->cacher($cache, ['base_url' => 'http://example.com']);
+
+        $lockKey = 'static-cache:'.md5('http://example.com').'.urls:lock';
+        $externalLock = $cache->lock($lockKey, 10);
+        $this->assertTrue($externalLock->get());
+
+        try {
+            $this->expectException(LockTimeoutException::class);
+
+            $cacher->cacheUrl('one', '/one');
+        } finally {
+            $externalLock->forceRelease();
+        }
+    }
+
+    #[Test]
+    public function forget_url_and_cache_url_share_the_same_lock_for_a_domain()
+    {
+        $cache = app(Repository::class);
+        $cacher = $this->cacher($cache, ['base_url' => 'http://example.com']);
+
+        $cache->forever('static-cache:'.md5('http://example.com').'.urls', [
+            'one' => '/one',
+        ]);
+
+        $lockKey = 'static-cache:'.md5('http://example.com').'.urls:lock';
+        $externalLock = $cache->lock($lockKey, 10);
+        $this->assertTrue($externalLock->get());
+
+        try {
+            $this->expectException(LockTimeoutException::class);
+
+            $cacher->forgetUrl('one');
+        } finally {
+            $externalLock->forceRelease();
+        }
+    }
+
+    #[Test]
+    public function cache_domain_has_its_own_independent_lock_from_the_urls_map()
+    {
+        $cache = app(Repository::class);
+        $cacher = $this->cacher($cache, ['base_url' => 'http://example.com']);
+
+        $externalLock = $cache->lock('static-cache:domains:lock', 10);
+        $this->assertTrue($externalLock->get());
+
+        try {
+            $this->expectException(LockTimeoutException::class);
+
+            $cacher->cacheUrl('one', '/one');
+        } finally {
+            $externalLock->forceRelease();
+        }
+    }
+
+    #[Test]
+    public function it_falls_back_to_unlocked_behavior_when_the_cache_store_does_not_support_locking()
+    {
+        $store = Mockery::mock(\Illuminate\Contracts\Cache\Store::class);
+
+        $cache = Mockery::mock(\Illuminate\Contracts\Cache\Repository::class);
+        $cache->shouldReceive('getStore')->andReturn($store);
+        $cache->shouldReceive('get')->andReturn([]);
+        $cache->shouldReceive('forever');
+        $cache->shouldNotReceive('lock');
+
+        $cacher = $this->cacher($cache, ['base_url' => 'http://example.com']);
+
+        $cacher->cacheUrl('one', '/one');
+
+        $this->assertTrue(true);
+    }
+
+    private function cacher($cache, $config = [])
+    {
+        return Mockery::mock(AbstractCacher::class, [$cache, $config])->makePartial();
+    }
+}

--- a/tests/StaticCaching/CacherTest.php
+++ b/tests/StaticCaching/CacherTest.php
@@ -4,8 +4,10 @@ namespace Tests\StaticCaching;
 
 use Illuminate\Cache\Repository;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Event;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Events\UrlInvalidated;
 use Statamic\StaticCaching\Cachers\AbstractCacher;
 use Tests\TestCase;
 
@@ -238,6 +240,8 @@ class CacherTest extends TestCase
     #[Test]
     public function it_invalidates_urls()
     {
+        Event::fake();
+
         $cache = app(Repository::class);
 
         $this->setSites([
@@ -259,13 +263,6 @@ class CacherTest extends TestCase
 
         $cacher = $this->cacher();
 
-        $cacher->shouldReceive('invalidateUrl')->once()->with('/', 'http://example.com');
-        $cacher->shouldReceive('invalidateUrl')->twice()->with('/one', 'http://example.com');
-        $cacher->shouldReceive('invalidateUrl')->once()->with('/two', 'http://example.com');
-        $cacher->shouldReceive('invalidateUrl')->once()->with('/three', 'http://example.co.uk');
-        $cacher->shouldReceive('invalidateUrl')->times(3)->with('/blog/post', 'http://example.com');
-        $cacher->shouldReceive('invalidateUrl')->once()->with('/blog/post', 'http://example.co.uk');
-
         $cacher->invalidateUrls([
             '/',
             '/one',
@@ -277,6 +274,22 @@ class CacherTest extends TestCase
             'http://example.com/blog/*',
             'http://example.co.uk/blog/*',
         ]);
+
+        // Matching entries are removed from each domain's urls map.
+        $this->assertEquals(['blog' => '/blog', 'contact' => '/contact'], $cacher->getUrls('http://example.com')->all());
+        $this->assertEquals(['blog' => '/blog', 'contact' => '/contact'], $cacher->getUrls('http://example.co.uk')->all());
+
+        // An event fires for every requested path on its resolved domain, with
+        // wildcards expanding to the map entries they matched: '/' (1),
+        // '/one' and 'one' (2), '/two' (1), '/three' (1), and '/blog/post'
+        // once per wildcard on its domain (3 + 1).
+        Event::assertDispatchedTimes(UrlInvalidated::class, 9);
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/');
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/one');
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/two');
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.co.uk/three');
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/blog/post');
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.co.uk/blog/post');
     }
 
     private function cacher($config = [])

--- a/tests/StaticCaching/FileCacherTest.php
+++ b/tests/StaticCaching/FileCacherTest.php
@@ -346,6 +346,59 @@ class FileCacherTest extends TestCase
     }
 
     #[Test]
+    public function invalidating_multiple_urls_deletes_files_and_removes_entries_for_exact_and_wildcard_urls()
+    {
+        Event::fake();
+
+        $writer = \Mockery::spy(Writer::class);
+        $cache = app(Repository::class);
+        $cacher = $this->fileCacher(['base_url' => 'http://example.com'], $writer, $cache);
+
+        // Put it in the container so that the event can resolve it.
+        $this->instance(Cacher::class, $cacher);
+
+        $cache->forever($this->cacheKey('http://example.com'), [
+            'one' => '/one',
+            'oneqs' => '/one?foo=bar',
+            'blogone' => '/blog/one',
+            'blogtwo' => '/blog/two',
+            'other' => '/other',
+        ]);
+
+        $cacher->invalidateUrls(['/one', '/blog/*']);
+
+        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one'))->once();
+        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/one?foo=bar'))->once();
+        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/blog/one'))->once();
+        $writer->shouldHaveReceived('delete')->with($cacher->getFilePath('/blog/two'))->once();
+        $this->assertEquals(['other' => '/other'], $cacher->getUrls('http://example.com')->all());
+
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/one');
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/blog/one');
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/blog/two');
+    }
+
+    #[Test]
+    public function invalidating_urls_not_in_the_map_still_dispatches_events()
+    {
+        Event::fake();
+
+        $writer = \Mockery::spy(Writer::class);
+        $cache = app(Repository::class);
+        $cacher = $this->fileCacher(['base_url' => 'http://example.com'], $writer, $cache);
+
+        $this->instance(Cacher::class, $cacher);
+
+        $cacher->invalidateUrls(['/missing']);
+
+        $writer->shouldNotHaveReceived('delete');
+
+        // Listeners like CDN purgers rely on the event firing regardless of
+        // whether the url was tracked in the local map.
+        Event::assertDispatched(UrlInvalidated::class, fn ($event) => $event->url === 'http://example.com/missing');
+    }
+
+    #[Test]
     public function recaching_a_url_will_trigger_a_recache_job()
     {
         Queue::fake();


### PR DESCRIPTION
## The problem

The static cache keeps a `slug => path` urls map under **one cache key per domain** (`static-cache:{md5(domain)}.urls`). Every write to it was an unguarded read–modify–write:

```
 time │ Request A — caches /blog │  urls map (single key)  │ Request B — caches /about
──────┼──────────────────────────┼─────────────────────────┼──────────────────────────
  t1  │ read  ──────────────────►│ { }                     │
  t2  │                          │ { } ◄───────────────────│ read
  t3  │ write ──────────────────►│ { /blog }               │
  t4  │                          │ { /about } ◄────────────│ write
      │                          │      ▲                  │
      │                          │      └── /blog entry silently lost
```

The middleware's existing lock is **per-URL**, so two requests caching *different* URLs never contend — but they share the same map.

| after t4 | page on disk / in cache | in urls map | invalidation can find it? |
|---|:--:|:--:|:--:|
| `/about` | ✅ | ✅ | yes |
| `/blog` | ✅ | ❌ | **never — stale until a full cache clear** |

On high-traffic and load-balanced sites this happens routinely.

## The fix

**1. Serialize map writes with an atomic lock**

```
 cacheUrl · forgetUrl · cacheDomain · invalidate · flush
                      │
                      ▼
        ┌────────────────────────────────┐
        │ Cache::lock('<urls key>:lock') │  per domain, same store as the map
        └────────────────────────────────┘
                      │
             read → modify → write         serialized, no lost updates

 serving a cached page (reads) ──► no lock, unaffected
 store without LockProvider    ──► runs unlocked, exactly as before
```

Works on the file, redis, database, and array stores.

**2. Never leave an orphan on lock timeout**

```
 before │ render ─► write file ─► can't get lock ─► 503 refresh page, file left orphaned
 after  │ render ─► write file ─► can't get lock ─► undo the write ─► serve response uncached
```

`FileCacher` deletes the file it just wrote; `ApplicationCacher` skips storing the response. Either way the rendered response is still served.

**3. Hold the lock for map bookkeeping only**

```
 before — invalidating 500 urls
   lock ├─────────────────────────────────────────────────────────────────┤
        │ 500 × (read map · delete file · write map · dispatch event)     │
        └─ seconds under lock: visitors block, lock can expire mid-run ───┘

 after
   lock ├────┤
        │ resolve matches · one map write │
        └────┘──► unlocked: delete files · dispatch UrlInvalidated events
```

Lock holds are milliseconds regardless of batch size, so bulk invalidation (e.g. the CP "Invalidate URLs" utility) can no longer stall visitor requests, time out, or outlive the lock's expiry. Flushing wipes the urls map *before* deleting stored pages, so a page cached mid-flush can't become untracked. As a bonus, `FileCacher` runs its untracked-file scan once per batch instead of once per URL, and bulk invalidation writes the map once per domain instead of once per entry.

The worst remaining interleaving is a map entry whose cached copy was just deleted — self-healing, since the next request re-caches under the same key. The dangerous direction, a cached page invisible to the map, can no longer occur.

## Behavior notes

- The CP "Invalidate URLs" utility shows a friendly "cache was locked, try again" message instead of a 500 if the lock is genuinely contended.
- `UrlInvalidated` still fires for every requested URL (including ones not in the map), with wildcards expanding to the entries they matched — CDN-purger listeners are unaffected.
- On the database cache driver, locks use the `cache_locks` table, which upgraded apps without the default Laravel cache migration may need to add.

### One breaking change for custom cachers

Custom cachers extending `AbstractCacher` must now implement the `cleanupInvalidatedUrls()` hook, and `invalidateUrls()` no longer routes through `invalidateUrl()`. Deliberately abstract, so existing subclasses fail loudly instead of silently skipping their storage cleanup. Cachers implementing the `Cacher` interface directly are unaffected. (Happy to add hints for an upgrade-guide note.)

## Tests

Written test-first. Concurrency tests assert: the lock is shared per domain, batches acquire it once and write the map once, cleanup and events run *after* the lock is released, flush wipes the map before deleting pages, and a contended lock during page caching leaves no orphan while still serving the rendered response. Existing invalidation suites (query-string variants, multisite paths, wildcard expansion, event payloads) pass unchanged except `CacherTest::it_invalidates_urls`, which asserted the old internal routing and now asserts the same outcomes and event counts through the new path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
