### PR TITLE
[6.x] Fall back to default site on password-protected sites

### DIFF
--- a/src/Auth/Protect/Protectors/Password/Controller.php
+++ b/src/Auth/Protect/Protectors/Password/Controller.php
@@ -19,7 +19,7 @@ class Controller extends BaseController
     public function show()
     {
         if ($this->tokenData = session('statamic:protect:password.tokens.'.request('token'))) {
-            $site = Site::findByUrl($this->getUrl());
+            $site = Site::findByUrl($this->getUrl()) ?? Site::default();
             $data = Data::find($this->tokenData['reference']);
 
             app()->setLocale($site->lang());

--- a/tests/Auth/Protect/PasswordProtectionTest.php
+++ b/tests/Auth/Protect/PasswordProtectionTest.php
@@ -109,6 +109,35 @@ class PasswordProtectionTest extends PageProtectionTestCase
     }
 
     #[Test]
+    public function password_form_falls_back_to_default_site_when_url_doesnt_match_a_site()
+    {
+        $this->viewShouldReturnRendered('statamic::auth.protect.password', '');
+
+        $this->setSites([
+            'en' => ['name' => 'EN', 'locale' => 'en_US', 'lang' => 'en', 'url' => 'http://localhost/en/'],
+            'fr' => ['name' => 'FR', 'locale' => 'fr_FR', 'lang' => 'fr', 'url' => 'http://localhost/fr/'],
+        ]);
+
+        config(['statamic.protect.default' => 'password-scheme']);
+        config(['statamic.protect.schemes.password-scheme' => [
+            'driver' => 'password',
+            'allowed' => ['test'],
+        ]]);
+
+        Token::shouldReceive('generate')->andReturn('test-token');
+
+        $this
+            ->get('/')
+            ->assertRedirect('http://localhost/!/protect/password?token=test-token');
+
+        $this
+            ->get('/!/protect/password?token=test-token')
+            ->assertOk();
+
+        $this->assertEquals('en', app()->getLocale());
+    }
+
+    #[Test]
     public function custom_password_form_url_is_unprotected()
     {
         $this->viewShouldReturnRendered('password-entry', 'Password form template');


### PR DESCRIPTION
Fix an error where accessing the root URL `/` on a multi-site with all prefixed sites (`/en`, `/fr`) would lead to an exception. This follows the same pattern used in other areas, e.g. user login or password requests: fall back to the default site if the current site cannot be identified by the request URL. 

Closes #15085 