### PR TITLE
[6.x] Authorize tree endpoints

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -18,6 +18,8 @@ class CollectionTreeController extends CpController
 {
     public function index(Request $request, Collection $collection)
     {
+        $this->authorize('view', $collection, trans('You are not authorized to view this collection.'));
+
         $site = $request->site ?? Site::selected()->handle();
 
         $pages = (new TreeBuilder)->buildForController([

--- a/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
@@ -11,6 +11,8 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Structures\TreeBuilder;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class NavigationTreeController extends CpController
 {
     private $data;
@@ -21,6 +23,8 @@ class NavigationTreeController extends CpController
         $nav = Nav::find($handle);
 
         $site = $request->site ?? Site::selected()->handle();
+
+        $this->authorize('view', $nav->in($site), __('You are not authorized to view navs.'));
 
         $nav->in($site)->ensureBranchIds();
 

--- a/tests/Feature/Collections/ViewCollectionTreeTest.php
+++ b/tests/Feature/Collections/ViewCollectionTreeTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Collections;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ViewCollectionTreeTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_shows_the_tree()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection();
+
+        $response = $this
+            ->actingAs($user)
+            ->index($collection)
+            ->assertOk();
+
+        $this->assertEquals(['e1', 'e2'], collect($response->json('pages'))->map->entry->all());
+    }
+
+    #[Test]
+    public function it_denies_access_if_you_dont_have_permission_to_view_the_collection()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection();
+
+        $this
+            ->actingAs($user)
+            ->index($collection)
+            ->assertForbidden();
+    }
+
+    private function createStructuredCollection()
+    {
+        $collection = tap(Collection::make('test')->routes('{parent_uri}/{slug}'))->save();
+
+        EntryFactory::id('e1')->collection($collection)->slug('a')->create();
+        EntryFactory::id('e2')->collection($collection)->slug('b')->create();
+
+        $collection->structureContents(['root' => false])->save();
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'e1'],
+            ['entry' => 'e2'],
+        ])->save();
+
+        return $collection;
+    }
+
+    private function index($collection)
+    {
+        return $this->getJson(cp_route('collections.tree.index', $collection->handle()));
+    }
+}

--- a/tests/Feature/Navigation/ViewNavigationTreeTest.php
+++ b/tests/Feature/Navigation/ViewNavigationTreeTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature\Navigation;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Nav;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ViewNavigationTreeTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_shows_the_tree()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test nav']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $nav = $this->createNavWithTree();
+
+        $response = $this
+            ->actingAs($user)
+            ->index($nav)
+            ->assertOk();
+
+        $this->assertEquals(['One', 'Two'], collect($response->json('pages'))->map->title->all());
+    }
+
+    #[Test]
+    public function it_denies_access_if_you_dont_have_permission_to_view_the_nav()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $nav = $this->createNavWithTree();
+
+        $this
+            ->actingAs($user)
+            ->index($nav)
+            ->assertForbidden();
+    }
+
+    private function createNavWithTree()
+    {
+        $nav = tap(Nav::make('test'))->save();
+
+        $nav->makeTree('en', [
+            ['id' => 'id1', 'title' => 'One', 'url' => 'http://example.com/one'],
+            ['id' => 'id2', 'title' => 'Two', 'url' => 'http://example.com/two'],
+        ])->save();
+
+        return $nav;
+    }
+
+    private function index($nav)
+    {
+        return $this->getJson(cp_route('navigation.tree.index', $nav->handle()));
+    }
+}


### PR DESCRIPTION
This pull request fixes missing authorization checks on the collection and navigation tree endpoints.