### PR TITLE
[6.x] Improve performance of data reference updates

### DIFF
--- a/src/Data/DataReferenceUpdater.php
+++ b/src/Data/DataReferenceUpdater.php
@@ -69,6 +69,10 @@ abstract class DataReferenceUpdater
         $this->originalValue = $originalValue;
         $this->newValue = $newValue;
 
+        if (! $this->itemMayContainReferences()) {
+            return false;
+        }
+
         $this->recursivelyUpdateFields($this->getTopLevelFields());
 
         if ($this->updated) {
@@ -76,6 +80,27 @@ abstract class DataReferenceUpdater
         }
 
         return (bool) $this->updated;
+    }
+
+    protected function itemMayContainReferences()
+    {
+        if (! is_string($this->originalValue) || $this->originalValue === '') {
+            return true;
+        }
+
+        try {
+            $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+            if (! is_string($data = json_encode($this->item->data()->all(), $flags))) {
+                return true;
+            }
+
+            $needle = substr(json_encode($this->originalValue, $flags), 1, -1);
+
+            return str_contains($data, $needle);
+        } catch (\Throwable $e) {
+            return true;
+        }
     }
 
     /**

--- a/tests/Data/DataReferenceUpdaterTest.php
+++ b/tests/Data/DataReferenceUpdaterTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Data;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Assets\AssetReferenceUpdater;
+use Statamic\Facades\Blueprint;
+use Tests\TestCase;
+
+class DataReferenceUpdaterTest extends TestCase
+{
+    private function makeItem(array $data)
+    {
+        return new class($data)
+        {
+            public $blueprintResolved = false;
+
+            public function __construct(private $data)
+            {
+                $this->data = collect($data);
+            }
+
+            public function data()
+            {
+                return $this->data;
+            }
+
+            public function blueprint()
+            {
+                $this->blueprintResolved = true;
+
+                return Blueprint::makeFromFields([]);
+            }
+
+            public function save()
+            {
+                //
+            }
+        };
+    }
+
+    #[Test]
+    public function it_skips_blueprint_traversal_when_data_cannot_contain_the_original_value()
+    {
+        $item = $this->makeItem(['hero' => 'unrelated.jpg']);
+
+        $updated = AssetReferenceUpdater::item($item)
+            ->filterByContainer('assets')
+            ->updateReferences('img/hoff.jpg', 'img/new-hoff.jpg');
+
+        $this->assertFalse($updated);
+        $this->assertFalse($item->blueprintResolved);
+    }
+
+    #[Test]
+    public function it_traverses_blueprint_when_data_contains_the_original_value()
+    {
+        $item = $this->makeItem(['hero' => 'img/hoff.jpg']);
+
+        AssetReferenceUpdater::item($item)
+            ->filterByContainer('assets')
+            ->updateReferences('img/hoff.jpg', 'img/new-hoff.jpg');
+
+        $this->assertTrue($item->blueprintResolved);
+    }
+
+    #[Test]
+    public function it_traverses_blueprint_when_original_value_appears_within_a_larger_string()
+    {
+        $item = $this->makeItem(['content' => '[link](statamic://asset::assets::img/hoff.jpg)']);
+
+        AssetReferenceUpdater::item($item)
+            ->filterByContainer('assets')
+            ->updateReferences('img/hoff.jpg', 'img/new-hoff.jpg');
+
+        $this->assertTrue($item->blueprintResolved);
+    }
+
+    #[Test]
+    public function it_traverses_blueprint_when_original_value_contains_non_ascii_characters()
+    {
+        $item = $this->makeItem(['hero' => 'img/föö-bär.jpg']);
+
+        AssetReferenceUpdater::item($item)
+            ->filterByContainer('assets')
+            ->updateReferences('img/föö-bär.jpg', 'img/new.jpg');
+
+        $this->assertTrue($item->blueprintResolved);
+    }
+
+    #[Test]
+    public function it_traverses_blueprint_when_original_value_contains_json_special_characters()
+    {
+        $item = $this->makeItem(['hero' => 'img/we"ird\\file.jpg']);
+
+        AssetReferenceUpdater::item($item)
+            ->filterByContainer('assets')
+            ->updateReferences('img/we"ird\\file.jpg', 'img/new.jpg');
+
+        $this->assertTrue($item->blueprintResolved);
+    }
+
+    #[Test]
+    public function it_traverses_blueprint_when_json_encoding_data_throws()
+    {
+        $throwing = new class implements \JsonSerializable
+        {
+            public function jsonSerialize(): mixed
+            {
+                throw new \Exception('Cannot be serialized.');
+            }
+        };
+
+        $item = $this->makeItem(['object' => $throwing, 'hero' => 'unrelated.jpg']);
+
+        AssetReferenceUpdater::item($item)
+            ->filterByContainer('assets')
+            ->updateReferences('img/hoff.jpg', 'img/new-hoff.jpg');
+
+        $this->assertTrue($item->blueprintResolved);
+    }
+
+    #[Test]
+    public function it_traverses_blueprint_when_data_cannot_be_json_encoded()
+    {
+        $item = $this->makeItem(['broken' => "\xB1\x31", 'hero' => 'unrelated.jpg']);
+
+        AssetReferenceUpdater::item($item)
+            ->filterByContainer('assets')
+            ->updateReferences('img/hoff.jpg', 'img/new-hoff.jpg');
+
+        $this->assertTrue($item->blueprintResolved);
+    }
+}


### PR DESCRIPTION
### TLDR

Speed up asset & term reference updates with a cheap string check on each item's raw data, performed before resolving the blueprint and iterating over any fields.

3x faster in benchmarks + memory stays flat.

### The problem

On larger sites (20k+ entries) the `UpdateAssetReferences` / `UpdateTermReferences` jobs regularly exceed queue worker timeouts and memory limits. Once a job exceeds the timeout it gets discarded and the references silently never get updated :(

The listener already iterates lazily over items, so that part is efficient. The expensive part is that for every item it resolves the blueprint and instantiates all fields to figure out which fields could realistically hold a reference. On an asset rename, 99% of items don't reference the asset at all, but they all pay the full cost of resolving the blueprint.

### The fix

An early exit in `DataReferenceUpdater`: json-encode the item's raw data, check if the resulting string contains the value being replaced, and bail before touching the blueprint if it's not found.

### Is it safe?

This sounds too dumb to be correct, I thought, but it works out because the updater itself never augments anything: it reads and writes raw stored data, i.e. the blueprint is only used to decide which keys to look at. Every replacement path requires the old value to appear verbatim in the data: assets compare using `===`, including in Bard, markdown searches exact `statamic://` urls. So if the old value isn't a substring of the encoded data, there is nothing the updater could ever rewrite.

### Numbers

The more complex the blueprints, the bigger the speedup, since the skipped work grows while the string check stays constant. Tge production site in question went from exceeding a 128MB memory limit to finishing within it.

| Entries | Before | After |
|---|---|---|
| 2,000 | 701 ms | 244 ms |
| 5,000 | 1,704 ms | 568 ms |

### On Eloquent

On Eloquent sites there's an even better early exit available: a `where` on the `data` column before hydrating anything. We run that in production with a subclassed listener and it's really effective but tied directly to the Eloquent driver using the `data` column setup. The check in this PR is driver agnostic. It runs on hydrated data, so flat files, a data column or hoisted columns all behave the same.
