### PR TITLE
[6.x] Ensure fields into the first section of a tab instead of the last

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -281,8 +281,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, ContainsQueryabl
             }
         }
 
-        $targetSectionIndex = $existingField['section']
-            ?? ($prepend ? 0 : count($contents['tabs'][$tab]['sections'] ?? []) - 1);
+        $targetSectionIndex = $existingField['section'] ?? 0;
 
         $fields = collect($tabs[$tab]['sections'][$targetSectionIndex]['fields'] ?? [])->keyBy(function ($field) {
             return (isset($field['import'])) ? 'import:'.($field['prefix'] ?? null).$field['import'] : $field['handle'];
@@ -293,6 +292,7 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, ContainsQueryabl
                 $importKey = 'import:'.$importedField['partial'];
                 $field = $allFields->get($importKey);
                 $tab = $field['tab'];
+                $targetSectionIndex = $field['section'];
                 $fields = collect($tabs[$tab]['sections'][$targetSectionIndex]['fields'])->keyBy(function ($field) {
                     return (isset($field['import'])) ? 'import:'.($field['prefix'] ?? null).$field['import'] : $field['handle'];
                 });

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -783,12 +783,12 @@ class BlueprintTest extends TestCase
                     [
                         'fields' => [
                             ['handle' => 'existing_in_section_one', 'field' => ['type' => 'text']],
+                            ['handle' => 'new', 'field' => ['type' => 'textarea']],
                         ],
                     ],
                     [
                         'fields' => [
                             ['handle' => 'existing_in_section_two', 'field' => ['type' => 'text']],
-                            ['handle' => 'new', 'field' => ['type' => 'textarea']],
                         ],
                     ],
                 ],
@@ -1187,6 +1187,63 @@ class BlueprintTest extends TestCase
         $this->assertEquals(['tabs' => [
             'tab_one' => [
                 'sections' => [
+                    [
+                        'fields' => [
+                            [
+                                'import' => 'the_partial',
+                                'config' => [
+                                    'one' => ['foo' => 'bar'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]], $blueprint->contents());
+        $this->assertEquals(['type' => 'text', 'foo' => 'bar'], $blueprint->fields()->get('one')->config());
+    }
+
+    #[Test]
+    public function it_merges_config_overrides_when_ensuring_a_field_inside_an_imported_fieldset_in_a_later_section()
+    {
+        FieldsetRepository::shouldReceive('find')->with('the_partial')->andReturn(
+            (new Fieldset)->setContents(['fields' => [
+                [
+                    'handle' => 'one',
+                    'field' => ['type' => 'text'],
+                ],
+            ]])
+        );
+
+        $blueprint = (new Blueprint)->setContents(['tabs' => [
+            'tab_one' => [
+                'sections' => [
+                    [
+                        'fields' => [
+                            ['handle' => 'existing', 'field' => ['type' => 'text']],
+                        ],
+                    ],
+                    [
+                        'fields' => [
+                            ['import' => 'the_partial'],
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+
+        $return = $blueprint->ensureField('one', ['type' => 'textarea', 'foo' => 'bar']);
+
+        $this->assertEquals($blueprint, $return);
+        $this->assertTrue($blueprint->hasField('one'));
+        $this->assertEquals(['tabs' => [
+            'tab_one' => [
+                'sections' => [
+                    [
+                        'fields' => [
+                            ['handle' => 'existing', 'field' => ['type' => 'text']],
+                        ],
+                    ],
                     [
                         'fields' => [
                             [


### PR DESCRIPTION
When a blueprint tab has multiple sections, fields added at runtime via `ensureField()` get appended to the last section. The most visible casualty is the Super User toggle: add a new section to the user blueprint and the toggle jumps into it, away from the other user details.

Before the v4 tabs rewrite (#7746), ensured fields defaulted to the first section. This restores that behaviour: ensured fields that don't already exist in the blueprint now land at the end of the first section of the tab. Fields that already exist keep their position, and `ensureFieldPrepended()` still puts them at the top.

While in there, ensuring a field that lives inside an imported fieldset now writes the config override back to the section the import is actually in. Previously the override could end up as a duplicate import descriptor in a different section whenever the import wasn't in the fallback section.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="1280" height="1400" alt="statamic-13644-before" src="https://github.com/user-attachments/assets/2e943d17-6a60-4d08-815b-55e01c4a7e08" /></td>
<td><img width="1280" height="1400" alt="statamic-13644-after" src="https://github.com/user-attachments/assets/dee98262-abef-4001-8e90-94a632efc28c" /></td>
</tr>
</table>

Fixes #13644

🤖 Generated with [Claude Code](https://claude.com/claude-code)