### PR TITLE
[6.x] Use standard console output helpers in commands

### DIFF
--- a/src/Console/Commands/InstallSsg.php
+++ b/src/Console/Commands/InstallSsg.php
@@ -49,7 +49,7 @@ class InstallSsg extends Command
             'Installing the statamic/ssg package...'
         );
 
-        $this->checkLine('Installed statamic/ssg package');
+        $this->components->info('Installed statamic/ssg package');
 
         if (confirm('Would you like to publish the config file?')) {
             spin(
@@ -65,7 +65,7 @@ class InstallSsg extends Command
                 message: 'Publishing the config file...'
             );
 
-            $this->checkLine('Config file published. You can find it at config/statamic/ssg.php');
+            $this->components->info('Config file published. You can find it at config/statamic/ssg.php');
         }
 
         if (
@@ -78,7 +78,7 @@ class InstallSsg extends Command
                 'Installing the spatie/fork package...'
             );
 
-            $this->checkLine('Installed spatie/fork package');
+            $this->components->info('Installed spatie/fork package');
         }
     }
 }

--- a/src/Console/Commands/LicenseSet.php
+++ b/src/Console/Commands/LicenseSet.php
@@ -45,7 +45,7 @@ class LicenseSet extends Command
 
         LicenseSetEvent::dispatch();
 
-        $this->checkInfo('Statamic license key set successfully.');
+        $this->components->info('Statamic license key set successfully.');
     }
 
     /**

--- a/src/Console/Commands/ProEnable.php
+++ b/src/Console/Commands/ProEnable.php
@@ -8,6 +8,8 @@ use Statamic\Console\EnhancesCommands;
 use Statamic\Console\RunsInPlease;
 use Statamic\Support\Str;
 
+use function Laravel\Prompts\text;
+
 class ProEnable extends Command
 {
     use ConfirmableTrait, EnhancesCommands, RunsInPlease;
@@ -39,20 +41,20 @@ class ProEnable extends Command
             return;
         }
 
-        $this->checkInfo('Statamic Pro successfully enabled in .env file!');
+        $this->components->info('Statamic Pro successfully enabled in .env file!');
         $this->promptToSetLicenseKey();
 
         if ($this->option('update-config') && $this->updateConfig()) {
-            $this->checkInfo('Statamic editions config successfully updated to reference .env var!');
+            $this->components->info('Statamic editions config successfully updated to reference .env var!');
         }
 
         if ($this->option('update-config') && ! $this->isConfigReferencingEnv()) {
-            $this->crossLine('Could not reliably update editions config to reference .env var!');
-            $this->comment(PHP_EOL.'For this setting to take effect, please modify your [config/statamic/editions.php] as follows:');
+            $this->components->error('Could not reliably update editions config to reference .env var!');
+            $this->line('For this setting to take effect, please modify your [config/statamic/editions.php] as follows:');
             $this->line("'pro' => env('STATAMIC_PRO_ENABLED', false)");
         } elseif (! $this->isConfigReferencingEnv()) {
-            $this->crossLine('Statamic editions config not currently referencing .env var!');
-            $this->comment('Please re-run this command with the `--update-config` option.');
+            $this->components->error('Statamic editions config not currently referencing .env var!');
+            $this->line('Please re-run this command with the `--update-config` option.');
         } else {
             config()->set('statamic.editions.pro', true);
         }
@@ -127,10 +129,13 @@ class ProEnable extends Command
             return;
         }
 
-        $licenseKey = trim((string) $this->ask('If you have a Statamic license key, paste it now (leave blank to add later)'));
+        $licenseKey = trim(text(
+            label: 'If you have a Statamic license key, paste it now',
+            hint: 'Leave blank to add later.',
+        ));
 
         if ($licenseKey === '') {
-            $this->comment('Add `STATAMIC_LICENSE_KEY=...` to your `.env` before or when your site goes live.');
+            $this->components->warn('Add `STATAMIC_LICENSE_KEY=...` to your `.env` before or when your site goes live.');
 
             return;
         }
@@ -141,7 +146,7 @@ class ProEnable extends Command
             $this->appendLicenseKeyToEnv($licenseKey);
         }
 
-        $this->checkInfo('Statamic license key saved in .env file.');
+        $this->components->info('Statamic license key saved in .env file.');
     }
 
     /**

--- a/src/Console/Commands/StacheDoctor.php
+++ b/src/Console/Commands/StacheDoctor.php
@@ -44,13 +44,9 @@ class StacheDoctor extends Command
             return;
         }
 
-        if (! $this->hasDuplicateIds) {
-            $this->output->newLine();
-        }
-
         $missing->each(function ($item, $key) {
-            $this->line("<fg=red>[✗]</> Unconfigured indexes in <comment>{$key}</comment>");
-            $this->output->listing($item->all());
+            $this->components->warn("Unconfigured indexes in [{$key}]:");
+            $this->components->bulletList($item->all());
         });
     }
 
@@ -73,7 +69,7 @@ class StacheDoctor extends Command
         $this->hasDuplicateIds = $duplicates->isNotEmpty();
 
         if (! $this->hasDuplicateIds) {
-            $this->components->info('No duplicate IDs detected.');
+            $this->components->success('No duplicate IDs detected.');
 
             return;
         }
@@ -81,7 +77,7 @@ class StacheDoctor extends Command
         $duplicates->flatMap(function ($duplicates) {
             return $duplicates;
         })->each(function ($paths, $id) {
-            $this->line("<fg=red>[✗]</> Duplicate ID <comment>$id</comment>");
+            $this->components->error("Duplicate ID [{$id}]:");
 
             $this->output->listing(collect($paths)->map(function ($path) {
                 return Str::after($path, base_path().'/');

--- a/src/Console/Commands/StacheDoctor.php
+++ b/src/Console/Commands/StacheDoctor.php
@@ -37,7 +37,7 @@ class StacheDoctor extends Command
         });
 
         if ($missing->isEmpty()) {
-            $this->checkLine('No unconfigured indexes.');
+            $this->components->info('No unconfigured indexes.');
             $this->output->text('Indexes are created on demand through regular site usage.');
             $this->output->text('You could consider trying again after browsing your site.');
 
@@ -73,7 +73,7 @@ class StacheDoctor extends Command
         $this->hasDuplicateIds = $duplicates->isNotEmpty();
 
         if (! $this->hasDuplicateIds) {
-            $this->checkLine('No duplicate IDs detected.');
+            $this->components->info('No duplicate IDs detected.');
 
             return;
         }

--- a/src/Console/EnhancesCommands.php
+++ b/src/Console/EnhancesCommands.php
@@ -14,19 +14,4 @@ trait EnhancesCommands
 
         return parent::run($input, $output);
     }
-
-    public function checkLine($message)
-    {
-        $this->line("<info>[✓]</info> $message");
-    }
-
-    public function checkInfo($message)
-    {
-        $this->info("[✓] $message");
-    }
-
-    public function crossLine($message)
-    {
-        $this->line("<fg=red>[✗]</> $message");
-    }
 }

--- a/src/Console/EnhancesCommands.php
+++ b/src/Console/EnhancesCommands.php
@@ -14,4 +14,22 @@ trait EnhancesCommands
 
         return parent::run($input, $output);
     }
+
+    /** @deprecated Use $this->components->info() instead. */
+    public function checkLine($message)
+    {
+        $this->line("<info>[✓]</info> $message");
+    }
+
+    /** @deprecated Use $this->components->info() instead. */
+    public function checkInfo($message)
+    {
+        $this->info("[✓] $message");
+    }
+
+    /** @deprecated Use $this->components->error() instead. */
+    public function crossLine($message)
+    {
+        $this->line("<fg=red>[✗]</> $message");
+    }
 }

--- a/tests/Console/Commands/ProEnableTest.php
+++ b/tests/Console/Commands/ProEnableTest.php
@@ -63,7 +63,7 @@ ENV;
 
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', '');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', '');
 
         $this->assertTrue(Statamic::pro());
         $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
@@ -87,7 +87,7 @@ ENV);
 
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', '');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', '');
 
         $this->assertTrue(Statamic::pro());
         $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
@@ -109,7 +109,7 @@ ENV);
 
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', '');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', '');
 
         $this->assertEquals(<<<'ENV'
 APP_NAME=Statamic
@@ -140,7 +140,7 @@ EDITIONS);
 
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', '')
+            ->expectsQuestion('If you have a Statamic license key, paste it now', '')
             ->expectsOutput('Please re-run this command with the `--update-config` option.');
 
         // Though it should still update .env
@@ -186,7 +186,7 @@ EDITIONS);
 
         $this
             ->artisan('statamic:pro:enable', ['--update-config' => true])
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', '');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', '');
 
         $this->assertTrue(Statamic::pro());
         $this->assertEquals($this->defaultEditionsContents, $this->files->get($this->editionsPath));
@@ -219,8 +219,8 @@ EDITIONS);
 
         $this
             ->artisan('statamic:pro:enable', ['--update-config' => true])
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', '')
-            ->expectsOutput(PHP_EOL.'For this setting to take effect, please modify your [config/statamic/editions.php] as follows:')
+            ->expectsQuestion('If you have a Statamic license key, paste it now', '')
+            ->expectsOutput('For this setting to take effect, please modify your [config/statamic/editions.php] as follows:')
             ->expectsOutput("'pro' => env('STATAMIC_PRO_ENABLED', false)");
 
         // Though it should still update .env
@@ -239,7 +239,7 @@ ENV, $this->files->get($this->envPath));
     {
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', 'test-license-key');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', 'test-license-key');
 
         $this->assertEquals(<<<'ENV'
 APP_NAME=Statamic
@@ -259,7 +259,7 @@ ENV);
 
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', 'test-license-key');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', 'test-license-key');
 
         $this->assertEquals(<<<'ENV'
 APP_NAME=Statamic
@@ -279,7 +279,7 @@ ENV);
 
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', 'test-license-key');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', 'test-license-key');
 
         $this->assertEquals(<<<'ENV'
 APP_NAME=Statamic
@@ -293,8 +293,8 @@ ENV, $this->files->get($this->envPath));
     {
         $this
             ->artisan('statamic:pro:enable')
-            ->expectsQuestion('If you have a Statamic license key, paste it now (leave blank to add later)', '')
-            ->expectsOutput('Add `STATAMIC_LICENSE_KEY=...` to your `.env` before or when your site goes live.');
+            ->expectsQuestion('If you have a Statamic license key, paste it now', '')
+            ->expectsOutputToContain('Add `STATAMIC_LICENSE_KEY=...` to your `.env` before or when your site goes live.');
     }
 
     #[Test]


### PR DESCRIPTION
This pull request replaces the custom `checkInfo`/`crossLine`/`checkLine` helper methods on `EnhancesCommands` with the standard `$this->components->info()`/`error()`/`warn()` output, matching the convention already used elsewhere (e.g. `Multisite`, `MakeUser`).

This PR also switches the license key prompt in `ProEnable` over to Laravel Prompts' `text()`, consistent with other interactive commands.

It also updates a couple of other commands.