### PR TITLE
[6.x] Harden SVG sanitization

### DIFF
--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -58,7 +58,7 @@ abstract class Uploader
     {
         $stream = fopen($sourcePath, 'r');
 
-        if (config('statamic.assets.svg_sanitization_on_upload', true) && Str::endsWith($destinationPath, '.svg')) {
+        if (config('statamic.assets.svg_sanitization_on_upload', true) && Str::of($destinationPath)->lower()->endsWith('.svg')) {
             $stream = Svg::sanitize(stream_get_contents($stream));
         }
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2089,6 +2089,33 @@ class AssetTest extends TestCase
         $this->assertStringContainsString('</script>', $asset->contents());
     }
 
+    #[Test]
+    public function it_sanitizes_svgs_on_upload_regardless_of_extension_case()
+    {
+        Event::fake();
+
+        // Disable filename lowercasing so the uppercase extension actually
+        // reaches the disk, otherwise it'd be normalized before we could
+        // prove the sanitization check itself is case insensitive.
+        config()->set('statamic.assets.lowercase', false);
+
+        $asset = (new Asset)->container($this->container)->path('path/to/asset.SVG')->syncOriginal();
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+        Storage::disk('test')->assertMissing('path/to/asset.SVG');
+
+        $return = $asset->upload(UploadedFile::fake()->createWithContent('asset.SVG', '<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" width="500" height="500"><script type="text/javascript">alert(`Bad stuff could go in here.`);</script></svg>'));
+
+        $this->assertEquals($asset, $return);
+        Storage::disk('test')->assertExists('path/to/asset.SVG');
+        $this->assertEquals('path/to/asset.SVG', $asset->path());
+
+        // Ensure the inline scripts were stripped out.
+        $this->assertStringNotContainsString('<script', $asset->contents());
+        $this->assertStringNotContainsString('Bad stuff could go in here.', $asset->contents());
+        $this->assertStringNotContainsString('</script>', $asset->contents());
+    }
+
     public static function nonGlideableFileExtensionsProvider()
     {
         return [

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -126,6 +126,32 @@ class FilesTest extends TestCase
     }
 
     #[Test]
+    public function it_sanitizes_svgs_on_upload_regardless_of_extension_case()
+    {
+        $disk = Storage::fake('local');
+
+        Date::setTestNow(Date::createFromTimestamp(1671484636, config('app.timezone')));
+
+        $file = UploadedFile::fake()->createWithContent('test.SVG', '<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" width="500" height="500"><script type="text/javascript">alert(`Bad stuff could go in here.`);</script></svg>');
+
+        $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->post('/cp/fieldtypes/files/upload', ['file' => $file])
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    'id' => $path = '1671484636/test.SVG',
+                ],
+            ]);
+
+        $contents = $disk->get('statamic/file-uploads/'.$path);
+
+        $this->assertStringNotContainsString('<script', $contents);
+        $this->assertStringNotContainsString('Bad stuff could go in here.', $contents);
+        $this->assertStringNotContainsString('</script>', $contents);
+    }
+
+    #[Test]
     public function it_replaces_dimensions_rule()
     {
         $replaced = $this->fieldtype(['validate' => ['dimensions:width=180,height=180']])->fieldRules();


### PR DESCRIPTION
This pull request fixes an issue where SVG sanitization was skipped for uppercase or mixed-case `.svg` extensions (e.g. `image.SVG`), since `Uploader::write()` checked the extension case-sensitively.

This PR fixes it by lowercasing the destination path before checking its extension.