### PR TITLE
[6.x] Forms 2: Show option dropdown when adding logic against Image Choice fields

### DIFF
--- a/resources/js/components/field-conditions/Condition.vue
+++ b/resources/js/components/field-conditions/Condition.vue
@@ -58,7 +58,7 @@ const isToggleField = (field) => ['toggle', 'revealer', 'yes_no'].includes(field
 const showValueToggle = computed(() => isToggleField(selectedField.value) && ['equals', 'not', '===', '!=='].includes(props.condition.operator));
 
 const showValueDropdown = computed(() => {
-    const optionTypes = ['button_group', 'checkboxes', 'radio', 'select', 'dropdown', 'multi_choice', 'ranking'];
+    const optionTypes = ['button_group', 'checkboxes', 'radio', 'select', 'dropdown', 'multi_choice', 'ranking', 'image_choice'];
     return optionTypes.includes(selectedField.value?.config?.type) && ['equals', 'not', '===', '!=='].includes(props.condition.operator);
 });
 

--- a/resources/js/components/fieldtypes/HasInputOptions.js
+++ b/resources/js/components/fieldtypes/HasInputOptions.js
@@ -17,10 +17,10 @@ export default {
                     let valueKey = 'value';
                     let labelKey = 'label';
 
-                    // Support both {key: '', value: ''} and {value: '', label: ''} formats.
+                    // Support {key: '', value: ''}, {key: '', label: ''}, and {value: '', label: ''} formats.
                     if (option.hasOwnProperty('key')) {
                         valueKey = 'key';
-                        labelKey = 'value';
+                        labelKey = option.hasOwnProperty('value') ? 'value' : 'label';
                     }
 
                     return {

--- a/resources/js/tests/NormalizeInputOptions.test.js
+++ b/resources/js/tests/NormalizeInputOptions.test.js
@@ -54,3 +54,15 @@ it('normalizes input options with array of objects with key value keys', () => {
         { value: 'two', label: 'Two' },
     ]);
 });
+
+it('normalizes input options with array of objects with key label keys', () => {
+    expect(
+        normalizeInputOptions([
+            { key: 'one', label: 'One', image: 'one.jpg' },
+            { key: 'two', label: 'Two', image: 'two.jpg' },
+        ]),
+    ).toEqual([
+        { value: 'one', label: 'Uno' },
+        { value: 'two', label: 'Two' },
+    ]);
+});


### PR DESCRIPTION
This pull request adds support for showing Image Choice options in a dropdown when configuring field conditions, matching the existing behaviour for Select, Checkboxes, Radio, and other option-based fieldtypes.

This PR also fixes `normalizeInputOptions` to correctly read the `label` key when normalizing option objects that use a `{key, label}` shape (like Image Choice) rather than the `{key, value}` shape used by Select/Checkboxes/Radio.