### PR TITLE
[6.x] Share taggable additions across entries

### DIFF
--- a/lang/en/fieldtypes.php
+++ b/lang/en/fieldtypes.php
@@ -173,7 +173,7 @@ return [
     'select.config.options' => 'Set the keys and their optional labels.',
     'select.config.placeholder' => 'Set placeholder text.',
     'select.config.searchable' => 'Enable searching through possible options.',
-    'select.config.taggable' => 'Allow adding new options in addition to pre-defined options.',
+    'select.config.taggable' => 'Allow adding new options in addition to pre-defined ones. Additions become available on other entries.',
     'select.title' => 'Select',
     'sites.title' => 'Sites',
     'slug.config.from' => 'Target field to create a slug from.',

--- a/lang/et/fieldtypes.php
+++ b/lang/et/fieldtypes.php
@@ -158,7 +158,6 @@ return [
     'select.config.multiple' => 'Luba mitut valikut.',
     'select.config.options' => 'Määra võtmed ja nende valikulised sildid.',
     'select.config.placeholder' => 'Määra kohatäite tekst.',
-    'select.config.push_tags' => 'Lisa äsja loodud sildid valikute loendisse.',
     'select.config.searchable' => 'Luba võimalike valikute otsimist.',
     'select.config.taggable' => 'Luba lisaks eelnevalt määratletud valikutele uute valikute lisamist.',
     'select.title' => 'Valik',

--- a/lang/vi/fieldtypes.php
+++ b/lang/vi/fieldtypes.php
@@ -155,7 +155,6 @@ return [
     'select.config.multiple' => 'Cho phép chọn nhiều tùy chọn.',
     'select.config.options' => 'Đặt các khóa và nhãn tùy chọn.',
     'select.config.placeholder' => 'Đặt văn bản giữ chỗ.',
-    'select.config.push_tags' => 'Thêm thẻ mới tạo vào danh sách tùy chọn.',
     'select.config.searchable' => 'Cho phép tìm kiếm thông qua các tùy chọn có thể.',
     'select.config.taggable' => 'Cho phép thêm các tùy chọn mới ngoài các tùy chọn được xác định trước',
     'select.title' => 'Chọn',

--- a/src/Fieldtypes/Select.php
+++ b/src/Fieldtypes/Select.php
@@ -2,6 +2,11 @@
 
 namespace Statamic\Fieldtypes;
 
+use Illuminate\Support\Collection as IlluminateCollection;
+use Statamic\Contracts\Entries\Collection as CollectionContract;
+use Statamic\Contracts\Entries\Entry as EntryContract;
+use Statamic\Facades\Blink;
+use Statamic\Facades\Entry;
 use Statamic\Fields\Fieldtype;
 
 use function Statamic\trans as __;
@@ -14,6 +19,67 @@ class Select extends Fieldtype
     protected $keywords = ['select', 'option', 'choice', 'dropdown', 'list'];
     protected $selectableInForms = true;
     protected $indexComponent = 'tags';
+
+    public function preload(): array
+    {
+        $options = $this->getOptions();
+
+        if (! $this->config('taggable')) {
+            return ['options' => $options];
+        }
+
+        $existing = collect($options)->pluck('value');
+
+        $discovered = $this->discoverOptionsFromEntries()
+            ->reject(fn ($value) => $existing->contains($value))
+            ->map(fn ($value) => ['value' => $value, 'label' => $value])
+            ->values()
+            ->all();
+
+        return ['options' => array_merge($options, $discovered)];
+    }
+
+    protected function discoverOptionsFromEntries(): IlluminateCollection
+    {
+        $field = $this->field();
+
+        if (! $field || $field->parentField()) {
+            return collect();
+        }
+
+        $collection = $this->collectionHandleFromParent();
+
+        if (! $collection) {
+            return collect();
+        }
+
+        $handle = $field->handle();
+
+        return Blink::once("select-options-{$collection}-{$handle}", function () use ($collection, $handle) {
+            return Entry::query()
+                ->where('collection', $collection)
+                ->pluck($handle)
+                ->flatten()
+                ->filter(fn ($value) => ! is_null($value) && $value !== '')
+                ->unique()
+                ->values();
+        });
+    }
+
+    protected function collectionHandleFromParent(): ?string
+    {
+        $parent = $this->field()?->parent();
+
+        if ($parent instanceof EntryContract) {
+            return $parent->collectionHandle();
+        }
+
+        if ($parent instanceof CollectionContract) {
+            return $parent->handle();
+        }
+
+        return null;
+    }
 
     protected function configFieldItems(): array
     {

--- a/tests/Fieldtypes/SelectTest.php
+++ b/tests/Fieldtypes/SelectTest.php
@@ -3,21 +3,35 @@
 namespace Tests\Fieldtypes;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
+use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Validation\ValidationException;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Select;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class SelectTest extends TestCase
 {
     use CastsBooleansTests, CastsMultipleBooleansTests, HasSelectOptionsTests, LabeledValueTests, MultipleLabeledValueTests;
+    use PreventSavingStacheItemsToDisk;
 
-    private function field($config)
+    private function field($config, $parent = null, $parentField = null)
     {
         $ft = new Select;
 
-        return $ft->setField(new Field('test', array_merge($config, ['type' => $ft->handle()])));
+        $field = new Field('test', array_merge($config, ['type' => $ft->handle()]));
+
+        if ($parent) {
+            $field->setParent($parent);
+        }
+
+        if ($parentField) {
+            $field->setParentField($parentField);
+        }
+
+        return $ft->setField($field);
     }
 
     #[Test]
@@ -82,5 +96,116 @@ class SelectTest extends TestCase
         // If we've made it this far, it means we've passed validation
         // (otherwise an exception would be thrown).
         $this->assertTrue(true);
+    }
+
+    #[Test]
+    public function it_does_not_discover_options_from_entries_when_taggable_is_disabled()
+    {
+        $collection = tap(Collection::make('products'))->save();
+
+        EntryFactory::collection($collection)->slug('one')->data(['test' => 'custom'])->create();
+
+        $field = $this->field([
+            'options' => ['one' => 'One'],
+            'taggable' => false,
+        ], $collection);
+
+        $this->assertSame([
+            ['value' => 'one', 'label' => 'One'],
+        ], $field->preload()['options']);
+    }
+
+    #[Test]
+    public function it_discovers_options_from_entries_when_taggable_is_enabled()
+    {
+        $collection = tap(Collection::make('products'))->save();
+
+        EntryFactory::collection($collection)->slug('one')->data(['test' => 'custom'])->create();
+        EntryFactory::collection($collection)->slug('two')->data(['test' => 'another'])->create();
+        EntryFactory::collection($collection)->slug('three')->data(['test' => 'custom'])->create();
+        EntryFactory::collection($collection)->slug('four')->data(['test' => 'one'])->create();
+
+        $field = $this->field([
+            'options' => ['one' => 'One'],
+            'taggable' => true,
+        ], $collection);
+
+        $this->assertSame([
+            ['value' => 'one', 'label' => 'One'],
+            ['value' => 'custom', 'label' => 'custom'],
+            ['value' => 'another', 'label' => 'another'],
+        ], $field->preload()['options']);
+    }
+
+    #[Test]
+    public function it_flattens_multiple_select_values_when_discovering_options()
+    {
+        $collection = tap(Collection::make('products'))->save();
+
+        EntryFactory::collection($collection)->slug('one')->data(['test' => ['alpha', 'beta']])->create();
+        EntryFactory::collection($collection)->slug('two')->data(['test' => ['beta', 'gamma']])->create();
+
+        $field = $this->field([
+            'options' => ['alpha' => 'Alpha'],
+            'taggable' => true,
+            'multiple' => true,
+        ], $collection);
+
+        $this->assertSame([
+            ['value' => 'alpha', 'label' => 'Alpha'],
+            ['value' => 'beta', 'label' => 'beta'],
+            ['value' => 'gamma', 'label' => 'gamma'],
+        ], $field->preload()['options']);
+    }
+
+    #[Test]
+    public function it_discovers_options_when_parent_is_an_entry()
+    {
+        $collection = tap(Collection::make('products'))->save();
+
+        EntryFactory::collection($collection)->slug('one')->data(['test' => 'custom'])->create();
+        $parent = EntryFactory::collection($collection)->slug('editing')->data(['test' => 'one'])->create();
+
+        $field = $this->field([
+            'options' => ['one' => 'One'],
+            'taggable' => true,
+        ], $parent);
+
+        $this->assertSame([
+            ['value' => 'one', 'label' => 'One'],
+            ['value' => 'custom', 'label' => 'custom'],
+        ], $field->preload()['options']);
+    }
+
+    #[Test]
+    public function it_does_not_discover_options_without_a_collection_parent()
+    {
+        $field = $this->field([
+            'options' => ['one' => 'One'],
+            'taggable' => true,
+        ]);
+
+        $this->assertSame([
+            ['value' => 'one', 'label' => 'One'],
+        ], $field->preload()['options']);
+    }
+
+    #[Test]
+    public function it_does_not_discover_options_for_nested_fields()
+    {
+        $collection = tap(Collection::make('products'))->save();
+
+        EntryFactory::collection($collection)->slug('one')->data(['test' => 'custom'])->create();
+
+        $parentField = new Field('replicator', ['type' => 'replicator']);
+
+        $field = $this->field([
+            'options' => ['one' => 'One'],
+            'taggable' => true,
+        ], $collection, $parentField);
+
+        $this->assertSame([
+            ['value' => 'one', 'label' => 'One'],
+        ], $field->preload()['options']);
     }
 }

--- a/tests/__fixtures__/blueprints/article.yaml
+++ b/tests/__fixtures__/blueprints/article.yaml
@@ -264,7 +264,6 @@ tabs:
           clearable: false
           searchable: true
           taggable: false
-          push_tags: false
           cast_booleans: false
           display: 'Select Field'
           type: select
@@ -531,7 +530,6 @@ tabs:
                     clearable: false
                     searchable: true
                     taggable: false
-                    push_tags: false
                     cast_booleans: false
                     display: 'Select Field'
                     type: select
@@ -824,7 +822,6 @@ tabs:
                     clearable: false
                     searchable: true
                     taggable: false
-                    push_tags: false
                     cast_booleans: false
                     display: 'Select Field'
                     type: select


### PR DESCRIPTION
Preload distinct collection values and add to existing options when `taggable: true`.