### PR TITLE
[6.x] Added autocomplete attribute to confirm-password screen

### DIFF
--- a/resources/js/pages/auth/ConfirmPassword.vue
+++ b/resources/js/pages/auth/ConfirmPassword.vue
@@ -42,7 +42,7 @@ async function confirmWithPasskey() {
 
         <Form v-if="!isOnlyUsingPasskey" method="post" :action="submitUrl" class="flex flex-col gap-6" v-slot="{ errors }">
             <Field v-if="isConfirmingPassword" :label="__('Password')" :error="errors.password">
-                <Input name="password" type="password" viewable autofocus />
+                <Input name="password" type="password" autocomplete="current-password" viewable autofocus />
             </Field>
 
             <Field v-if="isUsingVerificationCode" :label="__('Verification Code')" :error="errors.verification_code">


### PR DESCRIPTION
The confirm-password screen doesn't have an autocomplete attribute on the password input, so password managers, eg, 1Password may not autofill it.

I added "current-password" as an attribute which is mentioned on [W3 docs](https://www.w3schools.com/tags/att_input_autocomplete.asp) (Tested the attribute in CodePen and 1PW picked up on the right attribute)

Closes #15102