### PR TITLE
[6.x] Add config to disable `HandleEntrySchedule` job

### DIFF
--- a/config/system.php
+++ b/config/system.php
@@ -152,6 +152,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Handle Scheduled Entries
+    |--------------------------------------------------------------------------
+    |
+    | Process entries that have reached their scheduled publish date.
+    | Disabling this may cause the static cache and search indexes to fall
+    | out of sync.
+    |
+    */
+
+    'handle_scheduled_entries' => env('STATAMIC_HANDLE_SCHEDULED_ENTRIES', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Enable Cache Tags
     |--------------------------------------------------------------------------
     |

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -137,7 +137,9 @@ class AppServiceProvider extends ServiceProvider
 
         $this->registerElevatedSessionMacros();
 
-        $this->app->make(Schedule::class)->job(HandleEntrySchedule::class)->everyMinute();
+        if (config('statamic.system.handle_scheduled_entries')) {
+            $this->app->make(Schedule::class)->job(HandleEntrySchedule::class)->everyMinute();
+        }
     }
 
     public function register()

--- a/tests/Data/Entries/ScheduledEntriesTest.php
+++ b/tests/Data/Entries/ScheduledEntriesTest.php
@@ -4,10 +4,13 @@ namespace Tests\Data\Entries;
 
 use Carbon\Carbon;
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Console\Scheduling\Schedule;
+use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Entries\MinuteEntries;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
+use Statamic\Jobs\HandleEntrySchedule;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -90,5 +93,32 @@ class ScheduledEntriesTest extends TestCase
         $this->assertEquals(['07', '08', '09', '18'], $this->getEntryIdsForMinute('2023-09-13 12:14:00'));
         $this->assertEquals(['07', '08', '09', '18'], $this->getEntryIdsForMinute('2023-09-13 12:14:25'));
         $this->assertEquals(['22'], $this->getEntryIdsForMinute('2023-09-13 00:00:00'));
+    }
+
+    #[Test]
+    public function it_schedules_the_job_every_minute()
+    {
+        $events = $this->scheduledJobEvents();
+
+        $this->assertCount(1, $events);
+        $this->assertEquals('* * * * *', $events->first()->expression);
+    }
+
+    #[Test]
+    #[DefineEnvironment('disableHandlingOfScheduledEntries')]
+    public function it_doesnt_schedule_the_job_when_handling_scheduled_entries_is_disabled()
+    {
+        $this->assertCount(0, $this->scheduledJobEvents());
+    }
+
+    public function disableHandlingOfScheduledEntries($app)
+    {
+        $app['config']->set('statamic.system.handle_scheduled_entries', false);
+    }
+
+    private function scheduledJobEvents()
+    {
+        return collect($this->app->make(Schedule::class)->events())
+            ->filter(fn ($event) => $event->description === HandleEntrySchedule::class);
     }
 }


### PR DESCRIPTION
This pull request adds a `handle_scheduled_entries` config option, which allows the `HandleEntrySchedule` scheduled task to be disabled.

Statamic registers this scheduled job unconditionally, and runs it every minute:

```php
$this->app->make(Schedule::class)->job(HandleEntrySchedule::class)->everyMinute();
```

It's fine on traditional hosting, but becomes a problem on usage-billed platforms (like Laravel Cloud or Vapor) as it means the application's resources need to boot every 60 seconds to run the job, whether or not the site has a single scheduled entry.

This PR adds a config option so those sites can opt out:

```php
'handle_scheduled_entries' => env('STATAMIC_HANDLE_SCHEDULED_ENTRIES', true),
```

Disabling the job won't prevent entries from being published on time. `Entry::status()` derives `scheduled` from the entry's date on every read, so an entry goes live either way. The job only dispatches `EntryScheduleReached`, which invalidates the static cache and updates search indexes — so what you lose is those two staying in sync until something else touches the entry.

The original request asked for a configurable frequency rather than an on/off switch. I've gone with a boolean because the two aren't equivalent — `MinuteEntries` looks at exactly one minute, so running the task every fifteen minutes would skip fourteen of them rather than publishing late. Supporting a frequency means reworking the job to sweep the whole elapsed interval and persist its last run, which felt like more than this needed. A boolean can widen to accept a frequency later without a breaking change.

Closes statamic/ideas#1476