### PR TITLE
[6.x] Resolve delete redirects from the configured CP route

### DIFF
--- a/resources/js/pages/taxonomies/Show.vue
+++ b/resources/js/pages/taxonomies/Show.vue
@@ -115,7 +115,7 @@ export default {
             ref="deleter"
             :resource-title="taxonomyTitle"
             :route="deleteUrl"
-            redirect="/cp/taxonomies"
+            :redirect="cp_url('taxonomies')"
         />
 
         <Listing

--- a/resources/js/pages/user-groups/Show.vue
+++ b/resources/js/pages/user-groups/Show.vue
@@ -75,7 +75,7 @@ function handleDelete() {
             ref="deleter"
             :resource-title="group.title"
             :route="group.deleteUrl"
-            redirect="/cp/user-groups"
+            :redirect="cp_url('user-groups')"
         />
     </div>
 </template>


### PR DESCRIPTION
The delete action in the taxonomy and user-group detail views hardcoded its redirect to `/cp/...`. On sites that set a custom `CP_ROUTE`, that path no longer exists, so deleting either resource ends on a 404.

Both views now build the redirect with `cp_url()`, the same helper used everywhere else in the panel, so it follows whatever CP route is configured.

Fixes #15106