### PR TITLE
[6.x] Don't navigate between assets when typing in a field

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -381,13 +381,25 @@ export default {
         },
 
         keydown(event) {
-            if ((event.metaKey || event.ctrlKey) && event.key === 'ArrowLeft') {
+            if (!event.metaKey && !event.ctrlKey) return;
+
+            if (this.isEditingText(event.target)) return;
+
+            if (event.key === 'ArrowLeft') {
                 this.navigateToPreviousAsset();
             }
 
-            if ((event.metaKey || event.ctrlKey) && event.key === 'ArrowRight') {
+            if (event.key === 'ArrowRight') {
                 this.navigateToNextAsset();
             }
+        },
+
+        isEditingText(element) {
+            if (!element) return false;
+
+            const tag = element.tagName;
+
+            return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || element.isContentEditable;
         },
 
         navigateToPreviousAsset() {

--- a/resources/js/tests/components/assets/Editor.test.js
+++ b/resources/js/tests/components/assets/Editor.test.js
@@ -1,41 +1,48 @@
 import { expect, test, vi } from 'vitest';
 import Editor from '@/components/assets/Editor/Editor.vue';
 
-function keydown(key, target) {
+function keydown(key, target, modifier) {
     const component = {
         navigateToPreviousAsset: vi.fn(),
         navigateToNextAsset: vi.fn(),
         isEditingText: Editor.methods.isEditingText,
     };
 
-    Editor.methods.keydown.call(component, { key, ctrlKey: true, metaKey: false, target });
+    Editor.methods.keydown.call(component, { key, ctrlKey: false, metaKey: false, target, [modifier]: true });
 
     return component;
 }
 
-test('ctrl + arrow keys navigate between assets', () => {
+test.each([['ctrlKey'], ['metaKey']])('%s + arrow keys navigate between assets', (modifier) => {
     const target = document.createElement('div');
 
-    expect(keydown('ArrowLeft', target).navigateToPreviousAsset).toHaveBeenCalled();
-    expect(keydown('ArrowRight', target).navigateToNextAsset).toHaveBeenCalled();
+    expect(keydown('ArrowLeft', target, modifier).navigateToPreviousAsset).toHaveBeenCalled();
+    expect(keydown('ArrowRight', target, modifier).navigateToNextAsset).toHaveBeenCalled();
 });
 
-test.each([['input'], ['textarea'], ['select']])(
-    'ctrl + arrow keys do not navigate between assets when focused on a %s',
-    (tag) => {
-        const target = document.createElement(tag);
+test.each([
+    ['ctrlKey', 'input'],
+    ['ctrlKey', 'textarea'],
+    ['ctrlKey', 'select'],
+    ['metaKey', 'input'],
+    ['metaKey', 'textarea'],
+    ['metaKey', 'select'],
+])('%s + arrow keys do not navigate between assets when focused on a %s', (modifier, tag) => {
+    const target = document.createElement(tag);
 
-        expect(keydown('ArrowLeft', target).navigateToPreviousAsset).not.toHaveBeenCalled();
-        expect(keydown('ArrowRight', target).navigateToNextAsset).not.toHaveBeenCalled();
+    expect(keydown('ArrowLeft', target, modifier).navigateToPreviousAsset).not.toHaveBeenCalled();
+    expect(keydown('ArrowRight', target, modifier).navigateToNextAsset).not.toHaveBeenCalled();
+});
+
+test.each([['ctrlKey'], ['metaKey']])(
+    '%s + arrow keys do not navigate between assets when focused on a contenteditable element',
+    (modifier) => {
+        const target = document.createElement('div');
+
+        // jsdom doesn't implement isContentEditable.
+        Object.defineProperty(target, 'isContentEditable', { value: true });
+
+        expect(keydown('ArrowLeft', target, modifier).navigateToPreviousAsset).not.toHaveBeenCalled();
+        expect(keydown('ArrowRight', target, modifier).navigateToNextAsset).not.toHaveBeenCalled();
     },
 );
-
-test('ctrl + arrow keys do not navigate between assets when focused on a contenteditable element', () => {
-    const target = document.createElement('div');
-
-    // jsdom doesn't implement isContentEditable.
-    Object.defineProperty(target, 'isContentEditable', { value: true });
-
-    expect(keydown('ArrowLeft', target).navigateToPreviousAsset).not.toHaveBeenCalled();
-    expect(keydown('ArrowRight', target).navigateToNextAsset).not.toHaveBeenCalled();
-});

--- a/resources/js/tests/components/assets/Editor.test.js
+++ b/resources/js/tests/components/assets/Editor.test.js
@@ -1,0 +1,41 @@
+import { expect, test, vi } from 'vitest';
+import Editor from '@/components/assets/Editor/Editor.vue';
+
+function keydown(key, target) {
+    const component = {
+        navigateToPreviousAsset: vi.fn(),
+        navigateToNextAsset: vi.fn(),
+        isEditingText: Editor.methods.isEditingText,
+    };
+
+    Editor.methods.keydown.call(component, { key, ctrlKey: true, metaKey: false, target });
+
+    return component;
+}
+
+test('ctrl + arrow keys navigate between assets', () => {
+    const target = document.createElement('div');
+
+    expect(keydown('ArrowLeft', target).navigateToPreviousAsset).toHaveBeenCalled();
+    expect(keydown('ArrowRight', target).navigateToNextAsset).toHaveBeenCalled();
+});
+
+test.each([['input'], ['textarea'], ['select']])(
+    'ctrl + arrow keys do not navigate between assets when focused on a %s',
+    (tag) => {
+        const target = document.createElement(tag);
+
+        expect(keydown('ArrowLeft', target).navigateToPreviousAsset).not.toHaveBeenCalled();
+        expect(keydown('ArrowRight', target).navigateToNextAsset).not.toHaveBeenCalled();
+    },
+);
+
+test('ctrl + arrow keys do not navigate between assets when focused on a contenteditable element', () => {
+    const target = document.createElement('div');
+
+    // jsdom doesn't implement isContentEditable.
+    Object.defineProperty(target, 'isContentEditable', { value: true });
+
+    expect(keydown('ArrowLeft', target).navigateToPreviousAsset).not.toHaveBeenCalled();
+    expect(keydown('ArrowRight', target).navigateToNextAsset).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
This pull request fixes an issue where using `Ctrl + Left/Right` (or `Cmd + Left/Right` on macOS) to move the cursor a word at a time in the Alt Text field would navigate to the previous/next asset instead.

This was happening because the asset editor's `keydown` handler is bound to `window` and never checked where focus was, so the shortcut fired even while typing in a field.

This PR fixes it by ignoring the shortcut when the event target is an `input`, `textarea`, `select` or contenteditable element.

Fixes #15104