### PR TITLE
[6.x] Bundle Control Panel icons into a single chunk

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -44,7 +44,16 @@ export default defineConfig(({ mode, command }) => {
             },
         },
         build: {
-            minify: isProdBuild
+            minify: isProdBuild,
+            rollupOptions: {
+                output: {
+                    advancedChunks: {
+                        groups: [
+                            { name: 'icons', test: /resources[\\/]svg[\\/]icons[\\/].*\.svg/ },
+                        ],
+                    },
+                },
+            },
         },
         test: {
             projects: [


### PR DESCRIPTION
This pull request fixes an issue where the Control Panel makes far more HTTP requests than it needs to, which can trip Cloudflare rate limiting rules — like the ones enabled by default on Laravel Cloud.

This was happening because the icon registry loads icons with `import.meta.glob`, which emits one lazily-loaded chunk per icon. Since `Icon.vue` awaits a separate loader for each one, every distinct icon rendered on a page was its own request. The nav alone accounts for around 20 of them, on every page.

It wasn't a problem in v5 because the nav was rendered in Blade with its icons inlined server-side, and much less of the Control Panel was Vue.

This PR fixes it by grouping the icons into a single chunk. The chunk is still lazily loaded, so the icons stay out of the entry bundle, but they arrive in one request and are cached from then on.

The build now emits 143 assets instead of 690. Measured against a sandbox site with a cold cache:

| Page | Before | After |
| --- | --- | --- |
| Dashboard | 51 | 24 |
| Collections | 53 | 25 |
| Asset browser | 62 | 27 |

Helps with #14711