### PR TITLE
[6.x] Fix Outpost rate limiting and tests

### DIFF
--- a/src/Licensing/Outpost.php
+++ b/src/Licensing/Outpost.php
@@ -199,7 +199,7 @@ class Outpost
 
     private function cacheAndReturnRateLimitResponse($e)
     {
-        $seconds = (int) $e->getResponse()->getHeader('Retry-After')[0];
+        $seconds = (int) Arr::first($e->getResponse()->getHeader('Retry-After')) ?: 300;
 
         return $this->cacheResponse(now()->addSeconds($seconds), ['error' => 429]);
     }

--- a/src/Testing/AddonTestCase.php
+++ b/src/Testing/AddonTestCase.php
@@ -101,6 +101,11 @@ abstract class AddonTestCase extends OrchestraTestCase
 
         $app['config']->set('statamic.users.repository', 'file');
 
+        $app['config']->set('cache.stores.outpost', [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/outpost-data'),
+        ]);
+
         $app['config']->set('statamic.stache.watcher', false);
         $app['config']->set('statamic.stache.stores.taxonomies.directory', $directory.'/../tests/__fixtures__/content/taxonomies');
         $app['config']->set('statamic.stache.stores.terms.directory', $directory.'/../tests/__fixtures__/content/taxonomies');

--- a/tests/Licensing/OutpostTest.php
+++ b/tests/Licensing/OutpostTest.php
@@ -250,6 +250,24 @@ class OutpostTest extends TestCase
     }
 
     #[Test]
+    public function it_caches_a_429_too_many_requests_error_for_five_minutes_when_theres_no_retry_after_header()
+    {
+        $outpost = $this->outpostWithErrorResponse(429);
+
+        $expectedResponse = [
+            'error' => 429,
+            'expiry' => now()->addMinutes(5)->timestamp,
+            'payload' => $outpost->payload(),
+        ];
+
+        $this->assertEquals($expectedResponse, $outpost->response());
+        Carbon::setTestNow(now()->addMinutes(5)->subSecond());
+        $this->assertCachedResponseEquals($expectedResponse);
+        Carbon::setTestNow(now()->addSeconds(1));
+        $this->assertResponseNotCached();
+    }
+
+    #[Test]
     public function it_caches_a_422_validation_error_for_an_hour()
     {
         $outpost = $this->outpostWithErrorResponse(422, [], [


### PR DESCRIPTION
This pull request fixes an issue where real requests would be sent to the Outpost when running an addon's test suite when testing Control Panel URLs.

This PR fixes it by configuring a fake cache store, like we do in our own tests. 

This PR also fixes an issue where the CP could throw `ErrorException: Undefined array key 0` when the Outpost rate limits a site. This was happening because `cacheAndReturnRateLimitResponse()` assumed the response always includes a `Retry-After` header, which isn't guaranteed. I've fixed it by falling back to five minutes when the header is missing or doesn't contain a number of seconds, matching the behaviour for other errors.