### PR TITLE
[6.x] Remove stale @param from wildcard() docblocks

### DIFF
--- a/src/Tags/Can.php
+++ b/src/Tags/Can.php
@@ -11,7 +11,6 @@ class Can extends Tags
      * Maps to {{ can:[permission] }}.
      *
      * @param  string  $method
-     * @param  array  $args
      * @return string|void
      */
     public function wildcard($method)

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -25,7 +25,6 @@ class Glide extends Tags
      * Where `field` is the variable containing the image ID
      *
      * @param  string  $method
-     * @param  array  $args
      * @return string
      */
     public function wildcard($method)

--- a/src/Tags/In.php
+++ b/src/Tags/In.php
@@ -11,7 +11,6 @@ class In extends Tags
      * Maps to {{ in:[group] }}.
      *
      * @param  string  $method
-     * @param  array  $args
      * @return string|void
      */
     public function wildcard($method)

--- a/src/Tags/Is.php
+++ b/src/Tags/Is.php
@@ -11,7 +11,6 @@ class Is extends Tags
      * Maps to {{ is:[role] }}.
      *
      * @param  string  $method
-     * @param  array  $args
      * @return string|void
      */
     public function wildcard($method)

--- a/src/Tags/ParentTags.php
+++ b/src/Tags/ParentTags.php
@@ -19,7 +19,6 @@ class ParentTags extends Tags
      * Gets a specified field value from the parent.
      *
      * @param  string  $method
-     * @param  array  $args
      * @return mixed
      */
     public function wildcard($method)

--- a/src/Tags/Theme.php
+++ b/src/Tags/Theme.php
@@ -17,7 +17,6 @@ class Theme extends Tags
      * eg. {{ theme:img }}, {{ theme:svg }}, etc.
      *
      * @param  string  $method  Tag part
-     * @param  array  $arguments  Unused
      * @return string
      */
     public function wildcard($method)


### PR DESCRIPTION
Six `wildcard()` docblocks document a second parameter the method does not take.

| Where | Documented | Actual |
|---|---|---|
| `src/Tags/In.php:10` | `array $args` | `wildcard($method)` |
| `src/Tags/Can.php:10` | `array $args` | `wildcard($method)` |
| `src/Tags/Is.php:10` | `array $args` | `wildcard($method)` |
| `src/Tags/Glide.php:22` | `array $args` | `wildcard($method)` |
| `src/Tags/ParentTags.php:16` | `array $args` | `wildcard($method)` |
| `src/Tags/Theme.php:13` | `array $arguments` `Unused` | `wildcard($method)` |

`Tags::__call()` dispatches with a single argument:

```php
return $this->{$this->wildcardMethod}($this->method);
```

and all 35 `wildcard()` implementations in `src/` declare one parameter, so there
is nothing for the second tag to describe. `Theme` already carried the note
`Unused` on its copy.

Removed those six lines. Comments only — no signature, call site, or behaviour is
touched, so no test covers it.

---

While looking at this I noticed a further 21 `@param` tags elsewhere in `src/`
whose names don't match their signatures — mostly parameters that were renamed
(`Support/Arr.php` `removeNullValues`, `Assets/AssetFolder.php` `rename`,
`Console/Processes/Process.php` `withoutLoggingErrors`, and others). They're a
different kind of change from this one, so I left them out. Happy to send them
separately if you want them.
