### PR TITLE
[6.x] Fix @param names that do not match the signatures

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1019,7 +1019,6 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
     /**
      * Get the blueprint.
      *
-     * @param  string|null  $blueprint
      * @return \Statamic\Fields\Blueprint
      */
     public function blueprint()

--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -529,7 +529,7 @@ class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, 
     /**
      * The specific glide presets to be used when warming glide image cache on upload.
      *
-     * @param  array|null  $presets
+     * @param  array|null  $preset
      * @return array|null|$this
      */
     public function warmPresets($preset = null)

--- a/src/Assets/AssetFolder.php
+++ b/src/Assets/AssetFolder.php
@@ -165,7 +165,7 @@ class AssetFolder implements Arrayable, ContainsQueryableValues, Contract
     /**
      * Rename the folder.
      *
-     * @param  string  $filename
+     * @param  string  $name
      * @return AssetFolder
      *
      * @throws \Exception

--- a/src/Auth/File/User.php
+++ b/src/Auth/File/User.php
@@ -140,7 +140,7 @@ class User extends BaseUser
     /**
      * Set the token value for the "remember me" session.
      *
-     * @param  string  $value
+     * @param  string  $token
      * @return void
      */
     public function setRememberToken($token)

--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -34,7 +34,6 @@ class NavBuilder
      * Instantiate nav builder.
      *
      * @param  array  $items
-     * @param  bool  $withHidden
      */
     public function __construct($items)
     {

--- a/src/Console/Commands/MakeWidget.php
+++ b/src/Console/Commands/MakeWidget.php
@@ -71,8 +71,6 @@ class MakeWidget extends GeneratorCommand
 
     /**
      * Generate the widget view file.
-     *
-     * @param  string  $addon
      */
     protected function generateWidgetView()
     {

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -161,7 +161,6 @@ class Process
     /**
      * Run callback without logging errors.
      *
-     * @param  Closure  $callback
      * @return mixed
      */
     public function withoutLoggingErrors(Closure $callback)

--- a/src/Console/Processes/Process.php
+++ b/src/Console/Processes/Process.php
@@ -161,7 +161,7 @@ class Process
     /**
      * Run callback without logging errors.
      *
-     * @param  Closure  $callable
+     * @param  Closure  $callback
      * @return mixed
      */
     public function withoutLoggingErrors(Closure $callback)

--- a/src/Contracts/Forms/Form.php
+++ b/src/Contracts/Forms/Form.php
@@ -9,7 +9,7 @@ interface Form extends Arrayable
     /**
      * Get or set the handle.
      *
-     * @param  string|null  $name
+     * @param  string|null  $handle
      * @return string
      */
     public function handle($handle = null);

--- a/src/Contracts/Forms/Submission.php
+++ b/src/Contracts/Forms/Submission.php
@@ -54,7 +54,7 @@ interface Submission extends Arrayable
     /**
      * Get a value of a field.
      *
-     * @param  string  $key
+     * @param  string  $field
      * @return mixed
      */
     public function get($field);
@@ -71,7 +71,6 @@ interface Submission extends Arrayable
     /**
      * Delete submission.
      *
-     * @param  string  $key
      * @return mixed
      */
     public function delete();

--- a/src/Contracts/View/Antlers/Parser.php
+++ b/src/Contracts/View/Antlers/Parser.php
@@ -60,7 +60,7 @@ interface Parser
      * array or object.
      *
      * @param  string  $key  Dot-notated key to find
-     * @param  array|object  $data  Array or object to search
+     * @param  array|object  $context  Array or object to search
      * @param  mixed  $default  Default value to use if not found
      * @return mixed
      */

--- a/src/Http/Controllers/CP/Updater/UpdateProductController.php
+++ b/src/Http/Controllers/CP/Updater/UpdateProductController.php
@@ -16,7 +16,7 @@ class UpdateProductController extends CpController
     /**
      * Show product updates overview.
      *
-     * @param  string  $slug
+     * @param  string  $marketplaceProductSlug
      */
     public function show($marketplaceProductSlug)
     {
@@ -65,7 +65,7 @@ class UpdateProductController extends CpController
     /**
      * Product changelog.
      *
-     * @param  string  $slug
+     * @param  string  $marketplaceProductSlug
      */
     public function changelog(Request $request, $marketplaceProductSlug)
     {

--- a/src/Http/Controllers/GlideController.php
+++ b/src/Http/Controllers/GlideController.php
@@ -82,7 +82,7 @@ class GlideController extends Controller
     /**
      * Generate a manipulated image by an asset reference.
      *
-     * @param  string  $ref
+     * @param  string  $encoded
      * @return mixed
      *
      * @throws \Exception

--- a/src/Imaging/GlideUrlBuilder.php
+++ b/src/Imaging/GlideUrlBuilder.php
@@ -25,7 +25,6 @@ class GlideUrlBuilder extends ImageUrlBuilder
      *
      * @param  \Statamic\Contracts\Assets\Asset|string  $item
      * @param  array  $params
-     * @param  string|null  $filename
      * @return string
      *
      * @throws \Exception

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1712,7 +1712,6 @@ class CoreModifiers extends Modifier
     /**
      * Generate an md5 hash of a value.
      *
-     * @param  $value
      * @return string
      */
     public function md5($value)

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -1196,7 +1196,9 @@ class CoreModifiers extends Modifier
     /**
      * Check if an item exists in an array using "dot" notation.
      *
-     * @param  $value
+     * @param  array  $haystack
+     * @param  array  $params
+     * @param  array  $context
      * @return bool
      */
     public function inArray($haystack, $params, $context)
@@ -1710,7 +1712,7 @@ class CoreModifiers extends Modifier
     /**
      * Generate an md5 hash of a value.
      *
-     * @param  $params
+     * @param  $value
      * @return string
      */
     public function md5($value)
@@ -2902,7 +2904,6 @@ class CoreModifiers extends Modifier
      * Converts a Carbon instance to a timestamp.
      *
      * @param  Carbon  $value
-     * @param  array  $params
      * @return int
      */
     public function timestamp($value)

--- a/src/StaticCaching/Cachers/AbstractCacher.php
+++ b/src/StaticCaching/Cachers/AbstractCacher.php
@@ -254,7 +254,7 @@ abstract class AbstractCacher implements Cacher
     /**
      * Refresh an individual URL.
      *
-     * @param  string  $path
+     * @param  string  $url
      * @param  string|null  $domain
      * @return void
      */

--- a/src/Support/Arr.php
+++ b/src/Support/Arr.php
@@ -220,7 +220,7 @@ class Arr
     /**
      * Get rid of null values. (Empty arrays, literal null values, and empty strings).
      *
-     * @param  array  $array
+     * @param  array  $data
      * @return array
      */
     public static function removeNullValues($data)


### PR DESCRIPTION
Follow-up to #15119, which you merged earlier — this is the batch I mentioned there.

Twenty `@param` tags name an argument the method does not take. Each was opened and read against its signature before changing.

**Renames the docblock did not follow**

| Where | Documented | Actual |
|---|---|---|
| `src/Support/Arr.php:220` `removeNullValues` | `$array` | `$data` |
| `src/Assets/AssetFolder.php:165` `rename` | `$filename` | `$name` |
| `src/Assets/AssetContainer.php:529` `warmPresets` | `$presets` | `$preset` |
| `src/Auth/File/User.php:140` `setRememberToken` | `$value` | `$token` |
| `src/Console/Processes/Process.php:161` `withoutLoggingErrors` | `$callable` | `$callback` |
| `src/Contracts/Forms/Submission.php:54` `get` | `$key` | `$field` |
| `src/Contracts/Forms/Form.php:9` `handle` | `$name` | `$handle` |
| `src/Contracts/View/Antlers/Parser.php:58` `getVariable` | `$data` | `$context` |
| `src/Http/Controllers/GlideController.php:82` `generateByAsset` | `$ref` | `$encoded` |
| `src/StaticCaching/Cachers/AbstractCacher.php:254` `refreshUrl` | `$path` | `$url` |
| `src/Modifiers/CoreModifiers.php:1710` `md5` | `$params` | `$value` |
| `src/Http/Controllers/CP/Updater/UpdateProductController.php:16` `show` | `$slug` | `$marketplaceProductSlug` |
| `src/Http/Controllers/CP/Updater/UpdateProductController.php:65` `changelog` | `$slug` | `$marketplaceProductSlug` |

**Tags for parameters that are not there at all**

| Where | Documented | Actual |
|---|---|---|
| `src/Assets/Asset.php:1019` `blueprint` | `string\|null $blueprint` | takes nothing |
| `src/Console/Commands/MakeWidget.php:72` `generateWidgetView` | `$addon` | takes nothing; `$addon` comes from `$this->argument('addon')` |
| `src/Contracts/Forms/Submission.php:71` `delete` | `$key` | takes nothing |
| `src/CP/Navigation/NavBuilder.php:33` `__construct` | `$withHidden` | only `$items` |
| `src/Imaging/GlideUrlBuilder.php:23` `build` | `$filename` | only `$item`, `$params` |
| `src/Modifiers/CoreModifiers.php:2901` `timestamp` | `$params` | only `$value` |

**One that was short rather than wrong**

`src/Modifiers/CoreModifiers.php:1196` `inArray` documented a single `$value` while the method takes `$haystack, $params, $context`. Filled it in following `contains()` in the same file, which has the identical signature and a complete block.

No signature, call site, or behaviour is touched.

## Left alone

`src/CP/Navigation/NavItem.php:570` `name(...$arguments)` documents `$name`. It is variadic, so documenting what it actually accepts looks deliberate rather than stale — that one is your call, not mine.
