### PR TITLE
[6.x] - Fix typo in Dutch translation for 'Move to Folder'

### DIFF
--- a/lang/nl.json
+++ b/lang/nl.json
@@ -721,7 +721,7 @@
     "Move": "Verplaats",
     "Move Asset|Move :count Assets": "Verplaats asset|Verplaats :count assets",
     "Move Folder|Move :count Folders": "Verplaats map|Verplaats :count mappen",
-    "Move to Folder": "Verplaat naar map",
+    "Move to Folder": "Verplaats naar map",
     "Moved Item": "Verplaatste Item",
     "Multi-Site": "Multisite",
     "Multiple": "Meerdere",


### PR DESCRIPTION
Fix the typo "**Verplaat** naar map", which should be "**Verplaats** naar map"