### PR TITLE
[6.x] Prevent blueprint field rows from overflowing

### DIFF
--- a/resources/js/components/blueprints/RegularField.vue
+++ b/resources/js/components/blueprints/RegularField.vue
@@ -1,21 +1,21 @@
 <template>
-    <ui-card class="py-0.75! px-2! field-grid-item blueprint-section-field" :class="widthClass">
+    <ui-card class="py-0.75! px-2! field-grid-item blueprint-section-field @container" :class="widthClass">
         <div class="flex items-center gap-2">
-            <ui-icon name="handles" class="blueprint-drag-handle size-4 cursor-grab text-gray-300 dark:text-gray-600" />
-            <div class="flex flex-1 items-center justify-between">
-                <div class="flex flex-1 items-center py-2">
+            <ui-icon name="handles" class="blueprint-drag-handle size-4 shrink-0 cursor-grab text-gray-300 dark:text-gray-600" />
+            <div class="flex min-w-0 flex-1 items-center justify-between gap-2">
+                <div class="flex min-w-0 flex-1 items-center py-2">
                     <ui-icon
-                        class="size-4 me-2 text-gray-500 dark:text-gray-400"
+                        class="size-4 shrink-0 me-2 text-gray-500 dark:text-gray-400"
                         :name="field.icon"
                         v-tooltip="tooltipText"
                     />
-                    <div class="flex items-center gap-2">
-                        <button class="cursor-pointer overflow-hidden text-ellipsis text-sm hover:text-ui-accent-text text-start" type="button" v-text="__(labelText)" @click="$emit('edit')" />
-                        <ui-icon v-if="isReferenceField" name="link" class="text-gray-400" />
-                        <span v-if="isReferenceField" class="text-gray-500 font-mono text-2xs cursor-help" v-text="__('Field')" v-tooltip="__('Imported from: :reference', { reference: field.field_reference })" />
+                    <div class="flex min-w-0 items-center gap-2">
+                        <button class="cursor-pointer truncate text-sm hover:text-ui-accent-text text-start" type="button" v-text="__(labelText)" @click="$emit('edit')" />
+                        <ui-icon v-if="isReferenceField" name="link" class="shrink-0 text-gray-400 cursor-help" v-tooltip="referenceTooltipText" />
+                        <span v-if="isReferenceField" class="shrink-0 text-gray-500 font-mono text-2xs cursor-help @max-2xs:hidden" v-text="__('Field')" v-tooltip="referenceTooltipText" />
                     </div>
                 </div>
-                <div class="flex items-center gap-2">
+                <div class="flex shrink-0 items-center gap-2">
                     <width-selector v-if="!isHidden" v-model="width" />
 
                     <div
@@ -95,6 +95,10 @@ export default {
 
         isInlineField() {
             return !this.isReferenceField;
+        },
+
+        referenceTooltipText() {
+            return __('Imported from: :reference', { reference: this.field.field_reference });
         },
 
         fieldConfig() {


### PR DESCRIPTION
This pull request fixes an issue where fields in the blueprint/fieldset builder could overflow their card, with the name wrapping onto multiple lines and the width selector and action buttons spilling outside the row.

This was happening because the field row is a flex row where nothing was allowed to shrink. Without `min-w-0` on the left-hand side, the name couldn't shrink below its min-content width (so the existing `text-ellipsis` never kicked in), and without `shrink-0` on the right-hand side, the width selector got squashed instead.

This PR fixes it by letting the name truncate and keeping the controls at their natural size. On narrow fields (25%), the card is now a container, so the `Field` label next to linked fields is hidden to leave room for the name itself — its tooltip has moved onto the link icon so the reference is still discoverable.

## Before

<img width="922" height="389" alt="CleanShot 2026-08-05 at 09 38 48" src="https://github.com/user-attachments/assets/a0f943b1-ffc3-4783-bf8d-2625c761c808" />


## After

<img width="901" height="284" alt="CleanShot 2026-08-05 at 09 37 38" src="https://github.com/user-attachments/assets/c8d657aa-2708-47db-90fa-3353b20f8874" />


---

Fixes #15117