### PR TITLE
[6.x] Export Inertia's `usePage` composable via `@statamic/cms/inertia`

### DIFF
--- a/packages/cms/src/inertia.js
+++ b/packages/cms/src/inertia.js
@@ -6,5 +6,6 @@ export const {
     toggleArchitecturalBackground,
     useArchitecturalBackground,
     useForm,
+    usePage,
     usePoll,
 } = __STATAMIC__.inertia;

--- a/resources/js/bootstrap/cms/inertia.js
+++ b/resources/js/bootstrap/cms/inertia.js
@@ -3,6 +3,7 @@ export {
     Link,
     router,
     useForm,
+    usePage,
     usePoll,
 } from '@inertiajs/vue3';
 

--- a/resources/js/tests/Package.test.js
+++ b/resources/js/tests/Package.test.js
@@ -88,6 +88,7 @@ it('exports inertia', async () => {
         'toggleArchitecturalBackground',
         'useArchitecturalBackground',
         'useForm',
+        'usePage',
         'usePoll',
     ];
 


### PR DESCRIPTION
This pull request exports Inertia's [`usePage`](https://inertiajs.com/docs/v3/data-props/shared-data#accessing-shared-data) composable via `@statamic/cms/inertia`. 

I'm using the `usePage` composable in Forms Pro to access some of Statamic's shared data (notably the `cmsName`). 

I _could_ export the `useStatamicPageProps` function instead but thought the generalised method might be more useful for other addon developers (in case you want to access data outwith the `_statamic` object).