### PR TITLE
[6.x] Fix Eloquent user data setting roles and groups as model attributes

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -52,7 +52,7 @@ class User extends BaseUser
             return collect(Arr::except($data, ['id', 'email']));
         }
 
-        foreach ($data as $key => $value) {
+        foreach (Arr::except($data, ['roles', 'groups']) as $key => $value) {
             $this->set($key, $value);
         }
 

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -351,6 +351,20 @@ class EloquentUserTest extends TestCase
     }
 
     #[Test]
+    public function data_does_not_set_roles_and_groups_as_model_attributes()
+    {
+        $user = $this->user();
+
+        $user->data($user->data()->merge(['name' => 'Updated Name'])->all());
+
+        $attributes = $user->model()->getAttributes();
+
+        $this->assertArrayNotHasKey('roles', $attributes);
+        $this->assertArrayNotHasKey('groups', $attributes);
+        $this->assertEquals('Updated Name', $attributes['name']);
+    }
+
+    #[Test]
     #[Group('passkeys')]
     public function it_gets_passkeys()
     {


### PR DESCRIPTION
Running `php please migrate-dates-to-utc` on a site with Eloquent users fails with `SQLSTATE[42S22]: Column not found: 1054 Unknown column 'roles' in 'field list'`.

The command reads a user's data, converts the date fields, then writes the whole array back through `data()`. The getter injects `roles` and `groups` from their relationship tables, but the setter passes every key through `set()`, which assigns them straight to the Eloquent model, so the save tries to write columns that don't exist. `merge()` was fixed the same way in #14526, and `UsersController` already strips both keys before calling `data()`.

The same crash happens anywhere else data is round-tripped through the setter, such as renaming an asset, which goes through `AssetReferenceUpdater`.

Fixes #15124
