### PR TITLE
[6.x] Reset memoized Stache state between jobs instead of disabling it process-wide

### DIFF
--- a/src/Assets/AssetContainer.php
+++ b/src/Assets/AssetContainer.php
@@ -27,7 +27,6 @@ use Statamic\Facades\Pattern;
 use Statamic\Facades\Search;
 use Statamic\Facades\Stache;
 use Statamic\Facades\URL;
-use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
@@ -345,7 +344,7 @@ class AssetContainer implements Arrayable, ArrayAccess, AssetContainerContract, 
 
     public function contents()
     {
-        return Blink::onceIf(! Statamic::isWorker(), 'asset-listing-cache-'.$this->handle(), function () {
+        return Blink::once('asset-listing-cache-'.$this->handle(), function () {
             return app(AssetContainerContents::class)->container($this);
         });
     }

--- a/src/Assets/AssetContainerContents.php
+++ b/src/Assets/AssetContainerContents.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use League\Flysystem\DirectoryListing;
 use Statamic\Facades\Stache;
-use Statamic\Statamic;
 use Statamic\Support\Str;
 
 class AssetContainerContents
@@ -31,7 +30,7 @@ class AssetContainerContents
      */
     public function all()
     {
-        if ($this->files && ! Statamic::isWorker()) {
+        if ($this->files) {
             return $this->files;
         }
 
@@ -209,7 +208,7 @@ class AssetContainerContents
 
     public function filteredFilesIn($folder, $recursive)
     {
-        if (isset($this->filteredFiles[$key = $folder.($recursive ? '-recursive' : '')]) && ! Statamic::isWorker()) {
+        if (isset($this->filteredFiles[$key = $folder.($recursive ? '-recursive' : '')])) {
             return $this->filteredFiles[$key];
         }
 
@@ -239,7 +238,7 @@ class AssetContainerContents
 
     public function filteredDirectoriesIn($folder, $recursive)
     {
-        if (isset($this->filteredDirectories[$key = $folder.($recursive ? '-recursive' : '')]) && ! Statamic::isWorker()) {
+        if (isset($this->filteredDirectories[$key = $folder.($recursive ? '-recursive' : '')])) {
             return $this->filteredDirectories[$key];
         }
 
@@ -296,10 +295,6 @@ class AssetContainerContents
         }
 
         $files = $this->all()->put($path, $metadata);
-
-        if (Statamic::isWorker()) {
-            $this->cacheStore()->put($this->key(), $files, $this->ttl());
-        }
 
         $this->filteredFiles = null;
         $this->filteredDirectories = null;

--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -3,7 +3,6 @@
 namespace Statamic\Stache\Indexes;
 
 use Statamic\Facades\Stache;
-use Statamic\Statamic;
 
 abstract class Index
 {
@@ -66,16 +65,11 @@ abstract class Index
         }
 
         $loadingKey = $this->store->key().'/'.$this->name;
-        $currentlyLoadingThis = in_array($loadingKey, static::$loadingStack);
 
         static::$loadingStack[] = $loadingKey;
 
         try {
             $this->loaded = true;
-
-            if (Statamic::isWorker() && ! $currentlyLoadingThis) {
-                $this->loaded = false;
-            }
 
             debugbar()->addMessage("Loading index: {$loadingKey}", 'stache');
 
@@ -161,6 +155,11 @@ abstract class Index
         $this->items = null;
 
         Stache::cacheStore()->forget($this->cacheKey());
+    }
+
+    public function resetMemoizedState()
+    {
+        $this->loaded = false;
     }
 
     /** @deprecated */

--- a/src/Stache/Indexes/Index.php
+++ b/src/Stache/Indexes/Index.php
@@ -160,6 +160,7 @@ abstract class Index
     public function resetMemoizedState()
     {
         $this->loaded = false;
+        $this->items = null;
     }
 
     /** @deprecated */

--- a/src/Stache/ServiceProvider.php
+++ b/src/Stache/ServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace Statamic\Stache;
 
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 use Statamic\Assets\QueryBuilder as AssetQueryBuilder;
 use Statamic\Facades\File;
 use Statamic\Facades\Site;
 use Statamic\Stache\Query\EntryQueryBuilder;
 use Statamic\Stache\Query\SubmissionQueryBuilder;
+use Statamic\Statamic;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\Store\FlockStore;
 
@@ -45,6 +48,8 @@ class ServiceProvider extends LaravelServiceProvider
         $stache->sites(Site::all()->keys()->all());
 
         $this->registerStores($stache);
+
+        $this->resetMemoizedStateBetweenJobs($stache);
     }
 
     private function registerStores($stache)
@@ -68,6 +73,19 @@ class ServiceProvider extends LaravelServiceProvider
         });
 
         $stache->registerStores($stores->all());
+    }
+
+    private function resetMemoizedStateBetweenJobs($stache)
+    {
+        Event::listen(JobProcessing::class, function () use ($stache) {
+            if (! Statamic::isWorker()) {
+                return;
+            }
+
+            $stache->stores()->each->resetMemoizedState();
+
+            $this->app->make('stache.indexes')->each->resetMemoizedState();
+        });
     }
 
     private function locks()

--- a/src/Stache/Stores/AggregateStore.php
+++ b/src/Stache/Stores/AggregateStore.php
@@ -87,6 +87,13 @@ abstract class AggregateStore extends Store
         $this->discoverStores()->each->warm();
     }
 
+    public function resetMemoizedState()
+    {
+        parent::resetMemoizedState();
+
+        $this->stores->each->resetMemoizedState();
+    }
+
     public function paths()
     {
         return $this->discoverStores()->flatMap(function ($store) {

--- a/src/Stache/Stores/ContainerAssetsStore.php
+++ b/src/Stache/Stores/ContainerAssetsStore.php
@@ -4,7 +4,6 @@ namespace Statamic\Stache\Stores;
 
 use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Stache;
-use Statamic\Statamic;
 use Statamic\Support\Str;
 
 class ContainerAssetsStore extends ChildStore
@@ -54,7 +53,7 @@ class ContainerAssetsStore extends ChildStore
 
     public function paths()
     {
-        if ($this->paths && ! Statamic::isWorker()) {
+        if ($this->paths) {
             return $this->paths;
         }
 

--- a/src/Stache/Stores/Store.php
+++ b/src/Stache/Stores/Store.php
@@ -9,7 +9,6 @@ use Statamic\Facades\Stache;
 use Statamic\Stache\Exceptions\DuplicateKeyException;
 use Statamic\Stache\Indexes;
 use Statamic\Stache\Indexes\Index;
-use Statamic\Statamic;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -299,7 +298,7 @@ abstract class Store
     {
         $this->handleFileChanges();
 
-        if ($this->paths && ! Statamic::isWorker()) {
+        if ($this->paths) {
             return $this->paths;
         }
 
@@ -376,6 +375,11 @@ abstract class Store
     {
         $this->paths = null;
         Stache::cacheStore()->forget($this->pathsCacheKey());
+    }
+
+    public function resetMemoizedState()
+    {
+        $this->paths = null;
     }
 
     protected function pathsCacheKey()

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Facade;
-use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\DirectoryAttributes;
 use League\Flysystem\DirectoryListing;
@@ -34,7 +33,6 @@ use Statamic\Facades\File;
 use Statamic\Fields\Blueprint;
 use Statamic\Filesystem\Filesystem;
 use Statamic\Filesystem\FlysystemAdapter;
-use Tests\Fakes\FakeArtisanRequest;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -603,8 +601,6 @@ class AssetContainerTest extends TestCase
 
         $container = (new AssetContainer)->handle('test')->disk('test');
 
-        Request::swap(new FakeArtisanRequest('queue:listen'));
-
         $expected = ['one.jpg', 'two.jpg'];
         $this->assertEquals($expected, $container->files()->all());
         $this->assertEquals(1, $cacheHits);
@@ -738,8 +734,6 @@ class AssetContainerTest extends TestCase
 
         $container = (new AssetContainer)->handle('test')->disk('test');
 
-        Request::swap(new FakeArtisanRequest('queue:listen'));
-
         $expected = ['one', 'two'];
         $this->assertEquals($expected, $container->folders()->all());
         $this->assertEquals(1, $cacheHits);
@@ -771,8 +765,6 @@ class AssetContainerTest extends TestCase
         ]));
 
         $container = (new AssetContainer)->handle('test')->disk('test');
-
-        Request::swap(new FakeArtisanRequest('queue:work'));
 
         // First job populates the instance's $metaFiles cache. metaFilesIn() has no
         // memoization guard of its own, so if contents() reused the same instance

--- a/tests/Assets/AssetContainerTest.php
+++ b/tests/Assets/AssetContainerTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\DirectoryAttributes;
@@ -581,7 +582,7 @@ class AssetContainerTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_files_from_the_cache_every_time_if_running_in_a_queue_worker()
+    public function it_still_only_gets_the_files_from_the_cache_once_per_job_if_running_in_a_queue_worker()
     {
         $cacheKey = 'asset-list-contents-test';
 
@@ -607,6 +608,14 @@ class AssetContainerTest extends TestCase
         $expected = ['one.jpg', 'two.jpg'];
         $this->assertEquals($expected, $container->files()->all());
         $this->assertEquals(1, $cacheHits);
+        $this->assertEquals($expected, $container->files()->all());
+        $this->assertEquals(1, $cacheHits);
+
+        // Laravel's real queue worker daemon loop clears resolved facade instances
+        // before every job it processes, which resets the Blink-backed
+        // AssetContainerContents instance behind the `contents()` call.
+        Facade::clearResolvedInstances();
+
         $this->assertEquals($expected, $container->files()->all());
         $this->assertEquals(2, $cacheHits);
     }
@@ -709,7 +718,7 @@ class AssetContainerTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_folders_from_the_cache_and_blink_every_time_if_running_in_a_queue_worker()
+    public function it_still_only_gets_the_folders_from_the_cache_and_blink_once_per_job_if_running_in_a_queue_worker()
     {
         $cacheKey = 'asset-list-contents-test';
 
@@ -735,11 +744,20 @@ class AssetContainerTest extends TestCase
         $this->assertEquals($expected, $container->folders()->all());
         $this->assertEquals(1, $cacheHits);
         $this->assertEquals($expected, $container->folders()->all());
-        $this->assertEquals(2, $cacheHits);
+        $this->assertEquals(1, $cacheHits);
 
+        // Still within the same job (resolved facade instances haven't been cleared),
+        // a freshly newed up container reuses the same Blink-cached contents.
         $anotherInstanceOfTheContainer = (new AssetContainer)->handle('test')->disk('test');
         $this->assertEquals($expected, $anotherInstanceOfTheContainer->folders()->all());
-        $this->assertEquals(3, $cacheHits);
+        $this->assertEquals(1, $cacheHits);
+
+        // Laravel's real queue worker daemon loop clears resolved facade instances
+        // before every job it processes, which resets the Blink-backed contents cache.
+        Facade::clearResolvedInstances();
+
+        $this->assertEquals($expected, $container->folders()->all());
+        $this->assertEquals(2, $cacheHits);
     }
 
     #[Test]
@@ -757,8 +775,11 @@ class AssetContainerTest extends TestCase
         Request::swap(new FakeArtisanRequest('queue:work'));
 
         // First job populates the instance's $metaFiles cache. metaFilesIn() has no
-        // isWorker() guard, so if contents() reused the same instance across jobs
-        // the filtered result would stick around and bleed into the next job.
+        // memoization guard of its own, so if contents() reused the same instance
+        // across jobs the filtered result would stick around and bleed into the
+        // next job. In real usage, Laravel's queue worker daemon loop clears
+        // resolved facade instances before every job it processes, which resets
+        // the Blink-backed instance behind `contents()` at each job boundary.
         $this->assertEquals(
             ['.meta/a.txt.yaml'],
             $container->contents()->metaFilesIn('/', true)->keys()->all()
@@ -771,6 +792,10 @@ class AssetContainerTest extends TestCase
             'b.txt' => ['type' => 'file', 'path' => 'b.txt', 'dirname' => ''],
             '.meta/b.txt.yaml' => ['type' => 'file', 'path' => '.meta/b.txt.yaml', 'dirname' => '.meta'],
         ]));
+
+        // Simulate the job boundary: Laravel clears resolved facade instances
+        // before every job.
+        Facade::clearResolvedInstances();
 
         $this->assertEquals(
             ['.meta/a.txt.yaml', '.meta/b.txt.yaml'],

--- a/tests/Stache/ServiceProviderTest.php
+++ b/tests/Stache/ServiceProviderTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Stache;
+
+use Illuminate\Cache\Events\CacheHit;
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Request;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Stache;
+use Statamic\Stache\Stores\Store;
+use Tests\Fakes\FakeArtisanRequest;
+use Tests\TestCase;
+
+class ServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function it_resets_memoized_store_and_index_state_between_jobs_when_running_in_a_worker()
+    {
+        $store = (new ServiceProviderTestStore)->directory('/path/to/directory');
+        Stache::registerStore($store);
+
+        $pathsCacheKey = "stache::indexes::{$store->key()}::path";
+        $idIndexCacheKey = "stache::indexes::{$store->key()}::id";
+
+        Cache::put($pathsCacheKey, ['foo', 'bar']);
+        Cache::put($idIndexCacheKey, ['alfa' => 'alfa.md']);
+
+        $hits = collect();
+        Event::listen(CacheHit::class, function ($event) use (&$hits) {
+            $hits->push($event->key);
+        });
+
+        Request::swap(new FakeArtisanRequest('queue:work'));
+
+        // Memoize both the store's paths and one of its indexes.
+        $store->paths();
+        $store->index('id');
+        $store->paths();
+        $store->index('id');
+        $this->assertEquals(1, $hits->filter(fn ($key) => $key === $pathsCacheKey)->count());
+        $this->assertEquals(1, $hits->filter(fn ($key) => $key === $idIndexCacheKey)->count());
+
+        // Simulate the worker's daemon loop moving on to its next job. This is what
+        // actually fires the `JobProcessing` listener registered by the Stache
+        // service provider, as opposed to calling `resetMemoizedState()` directly.
+        Event::dispatch(new JobProcessing('sync', $this->fakeJob()));
+
+        // Both should be re-fetched from the cache store now that the job boundary has passed.
+        $store->paths();
+        $store->index('id');
+        $this->assertEquals(2, $hits->filter(fn ($key) => $key === $pathsCacheKey)->count());
+        $this->assertEquals(2, $hits->filter(fn ($key) => $key === $idIndexCacheKey)->count());
+    }
+
+    #[Test]
+    public function it_does_not_reset_memoized_state_for_jobs_processed_outside_a_worker()
+    {
+        // `Illuminate\Queue\SyncQueue` also fires `JobProcessing` for jobs dispatched
+        // synchronously during an ordinary web request, so the listener must stay a
+        // no-op outside of an actual `queue:*`/`horizon:*` worker process.
+        $store = (new ServiceProviderTestStore)->directory('/path/to/directory');
+        Stache::registerStore($store);
+
+        $pathsCacheKey = "stache::indexes::{$store->key()}::path";
+
+        Cache::put($pathsCacheKey, ['foo', 'bar']);
+
+        $hits = 0;
+        Event::listen(CacheHit::class, function ($event) use (&$hits, $pathsCacheKey) {
+            if ($event->key === $pathsCacheKey) {
+                $hits++;
+            }
+        });
+
+        $store->paths();
+        $this->assertEquals(1, $hits);
+
+        Event::dispatch(new JobProcessing('sync', $this->fakeJob()));
+
+        $store->paths();
+        $this->assertEquals(1, $hits);
+    }
+
+    private function fakeJob(): Job
+    {
+        $job = Mockery::mock(Job::class);
+        $job->shouldReceive('payload')->andReturn([]);
+
+        return $job;
+    }
+}
+
+class ServiceProviderTestStore extends Store
+{
+    public function getItem($key)
+    {
+    }
+
+    public function getItemValues($keys, $valueIndex, $keyIndex)
+    {
+    }
+
+    public function key()
+    {
+        return 'service-provider-test-store';
+    }
+}

--- a/tests/Stache/StoreTest.php
+++ b/tests/Stache/StoreTest.php
@@ -64,7 +64,7 @@ class StoreTest extends TestCase
     }
 
     #[Test]
-    public function it_gets_the_paths_from_the_cache_every_time_if_running_in_a_queue_worker()
+    public function it_still_only_gets_the_paths_from_the_cache_once_per_job_if_running_in_a_queue_worker()
     {
         $store = $this->store->directory('/path/to/directory');
         $cacheKey = "stache::indexes::{$store->key()}::path";
@@ -83,6 +83,33 @@ class StoreTest extends TestCase
         $expected = collect(['foo', 'bar']);
         $this->assertEquals($expected, $store->paths());
         $this->assertEquals(1, $cacheHits);
+        $this->assertEquals($expected, $store->paths());
+        $this->assertEquals(1, $cacheHits);
+    }
+
+    #[Test]
+    public function it_gets_the_paths_from_the_cache_again_after_memoized_state_is_reset_between_jobs()
+    {
+        $store = $this->store->directory('/path/to/directory');
+        $cacheKey = "stache::indexes::{$store->key()}::path";
+
+        Cache::put($cacheKey, ['foo', 'bar']);
+
+        $cacheHits = 0;
+        Event::listen(CacheHit::class, function ($event) use (&$cacheHits, $cacheKey) {
+            if ($event->key === $cacheKey) {
+                $cacheHits++;
+            }
+        });
+
+        Request::swap(new FakeArtisanRequest('queue:listen'));
+
+        $expected = collect(['foo', 'bar']);
+        $this->assertEquals($expected, $store->paths());
+        $this->assertEquals(1, $cacheHits);
+
+        $store->resetMemoizedState();
+
         $this->assertEquals($expected, $store->paths());
         $this->assertEquals(2, $cacheHits);
     }

--- a/tests/Stache/StoreTest.php
+++ b/tests/Stache/StoreTest.php
@@ -5,11 +5,9 @@ namespace Tests\Stache;
 use Illuminate\Cache\Events\CacheHit;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Request;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Stache\Stache;
 use Statamic\Stache\Stores\Store;
-use Tests\Fakes\FakeArtisanRequest;
 use Tests\TestCase;
 
 class StoreTest extends TestCase
@@ -78,8 +76,6 @@ class StoreTest extends TestCase
             }
         });
 
-        Request::swap(new FakeArtisanRequest('queue:listen'));
-
         $expected = collect(['foo', 'bar']);
         $this->assertEquals($expected, $store->paths());
         $this->assertEquals(1, $cacheHits);
@@ -101,8 +97,6 @@ class StoreTest extends TestCase
                 $cacheHits++;
             }
         });
-
-        Request::swap(new FakeArtisanRequest('queue:listen'));
 
         $expected = collect(['foo', 'bar']);
         $this->assertEquals($expected, $store->paths());


### PR DESCRIPTION
## Cause

`Statamic::isWorker()` disables in-process memoization for the entire life of a queue worker process whenever the running command is `queue:*`/`horizon:*`, instead of just resetting that memoization between jobs. That means every single access within one job falls back to a cache-store round trip (or full disk listing) rather than reusing an already-computed value, making queued indexing dramatically slower per document than running the identical work synchronously.

Closes #15118.

## Approach

- `Store`/`ContainerAssetsStore`/`Index` are container singletons that persist for the whole worker process, so they genuinely need an explicit reset at job boundaries. Added a `resetMemoizedState()` method to each, invoked once per job via a new `JobProcessing` listener that's only active when `Statamic::isWorker()` is true (so synchronous dispatch is completely unaffected).
- `AssetContainer`/`AssetContainerContents` are Blink-facade-backed, and Laravel's real `queue:work` daemon loop already clears resolved facade instances before every job it processes — so their `isWorker()` gates were redundant (and actively harmful, since they disabled memoization *within* a job too) and were simply removed.
- A redundant eager cache-store write in `AssetContainerContents::add()` (made unnecessary by the caller always chaining `->save()` right after) was also removed.

## Real performance numbers

Measured on a sandbox app with a 17,000-file asset container, indexing a 100-entry chunk (`chunk_size` 100) where each entry references 4 assets:

| | per 100-doc job |
|---|---|
| Sync (`QUEUE_CONNECTION=sync`) | ~29ms/doc (2.9s total) |
| Queue worker, **before** this fix | ~2.0s/doc (**3m 20s** total) |
| Queue worker, **after** this fix | ~10ms/doc (**1s** total) |

That's a **~200x speedup** for the identical job, with the fixed worker now on par with (slightly faster than) sync — confirming the fix removes the bug's overhead without reintroducing cross-job staleness (covered by new tests around `resetMemoizedState()`).
