### PR TITLE
[6.x] Exclude private ($__) variables from cache context to resolve serialization exception 

### DIFF
--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -29,7 +29,19 @@ abstract class Region
     protected function filterContext(array $context)
     {
         $context = collect($context)
-            ->reject(fn ($value, $key) => in_array($key, ['__env', 'app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor']))
+            ->reject(function ($value, $key) {
+                return str_starts_with((string) $key, '__')
+                    || in_array($key, [
+                        'app',
+                        'errors',
+                        'resolve',
+                        'resolveComponentsUsing',
+                        'forgetComponentsResolver',
+                        'forgetFactory',
+                        'flushCache',
+                        'constructor',
+                    ], true);
+            })
             ->map(function ($value, $key) {
                 if ($value instanceof InvokableComponentVariable) {
                     return $value->resolveDisplayableValue();

--- a/src/StaticCaching/NoCache/Region.php
+++ b/src/StaticCaching/NoCache/Region.php
@@ -29,19 +29,8 @@ abstract class Region
     protected function filterContext(array $context)
     {
         $context = collect($context)
-            ->reject(function ($value, $key) {
-                return str_starts_with((string) $key, '__')
-                    || in_array($key, [
-                        'app',
-                        'errors',
-                        'resolve',
-                        'resolveComponentsUsing',
-                        'forgetComponentsResolver',
-                        'forgetFactory',
-                        'flushCache',
-                        'constructor',
-                    ], true);
-            })
+            ->reject(fn ($value, $key) => str_starts_with((string) $key, '__'))
+            ->reject(fn ($value, $key) => in_array($key, ['app', 'errors', 'resolve', 'resolveComponentsUsing', 'forgetComponentsResolver', 'forgetFactory', 'flushCache', 'constructor']))
             ->map(function ($value, $key) {
                 if ($value instanceof InvokableComponentVariable) {
                     return $value->resolveDisplayableValue();

--- a/tests/StaticCaching/NoCacheSessionTest.php
+++ b/tests/StaticCaching/NoCacheSessionTest.php
@@ -49,6 +49,22 @@ class NoCacheSessionTest extends TestCase
     }
 
     #[Test]
+    public function when_pushing_a_region_it_will_filter_out_private_variables()
+    {
+        $session = new Session('/');
+
+        $region = $session->pushRegion('', [
+            'foo' => 'bar',
+            '__env' => 'env value',
+            '__blaze' => fn () => 'a closure',
+        ], '');
+
+        $this->assertEquals([
+            'foo' => 'bar',
+        ], $region->context());
+    }
+
+    #[Test]
     public function it_gets_the_fragment_data()
     {
         // fragment data should be the context,


### PR DESCRIPTION
When using `@blaze` in a Blade-based Statamic site, using the `nocache` tag or directive would result in an exception:
```
Serialization of 'Closure' is not allowed
```

Within the NoCache Region `filterContext` method, explicit context properties were removed, plus `__env`.

Blaze adds a `__blaze` which includes a closure - this is what is causing the exception to be thrown.

This PR keeps the same rejection, but instead of just `__env`, excludes any private variables (i.e. those prefixed with `__`).

If this feels too heavy-handed, another approach would be to revert to what it was, but add `__blaze` to the list too.

However, the challenge with this approach is that if future updates introduce new private variables with the same closure behaviour, the issue will re-occur.

So while the "exclude any private variable" is very wide, it also covers other internals being excluded (i.e. if things within Blaze, Blade, Livewire, etc, evolve).