### PR TITLE
[6.x] Fix Combobox trigger classes not reacting to prop changes

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -85,7 +85,7 @@ const wrapperAttrs = computed(() => {
     return rest;
 });
 
-const triggerClasses = cva({
+const triggerClasses = computed(() => cva({
     base: 'w-full flex items-center justify-between antialiased cursor-pointer',
     variants: {
         variant: {
@@ -117,7 +117,7 @@ const triggerClasses = cva({
     'discrete-focus-outline': props.discreteFocusOutline,
     readOnly: props.readOnly,
     disabled: props.disabled,
-});
+}));
 
 const itemClasses = cva({
     base: [


### PR DESCRIPTION
This pull request fixes an issue where the `Combobox` component's disabled styling wouldn't apply or unapply when the `disabled` prop changed after the initial render.

This was happening because `triggerClasses` invoked the `cva` factory immediately during `setup`, rather than inside a `computed`. The `variant`, `size`, `readOnly` and `disabled` props were read once and baked into a static string, so any subsequent change to them was never reflected in the class list.

This PR fixes it by wrapping `triggerClasses` in a `computed`, matching how `Input.vue` and `Button.vue` already build their classes.