### PR TITLE
[6.x] Fall back to the default site when sites.yaml is empty

### DIFF
--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -130,9 +130,11 @@ class Sites
 
     protected function getSavedSites()
     {
-        return File::exists($sitesPath = $this->path())
+        $sites = File::exists($sitesPath = $this->path())
             ? YAML::file($sitesPath)->parse()
-            : $this->getFallbackConfig();
+            : [];
+
+        return $sites ?: $this->getFallbackConfig();
     }
 
     protected function getFallbackConfig()

--- a/tests/Sites/SitesConfigTest.php
+++ b/tests/Sites/SitesConfigTest.php
@@ -84,6 +84,19 @@ class SitesConfigTest extends TestCase
     }
 
     #[Test]
+    public function it_gets_default_site_with_empty_yaml()
+    {
+        File::put($this->yamlPath, '');
+
+        // Ensure new sites instance in container, so that it attempts to read the empty yaml file
+        Site::swap(new Sites);
+
+        $this->assertCount(1, Site::all());
+        $this->assertSame('default', Site::default()->handle());
+        $this->assertSame('default', Site::current()->handle());
+    }
+
+    #[Test]
     public function it_sets_sites_at_runtime()
     {
         Site::setSites([


### PR DESCRIPTION
Deploying with the zero downtime setup fails during `composer install` with `Call to a member function handle() on null` in `StaticCacheManager`.

The static cache manager builds its driver config from `Site::current()->handle()`. `Site::current()` falls back to the first site, and returns null when there aren't any. `Sites` only falls back to the built-in default site when `resources/sites.yaml` is missing, so a file that exists but is empty leaves you with zero sites and that error. I can't confirm that's what the file looked like on the reporter's server, but the zero downtime guide does have you share `resources/sites.yaml` between releases, which is an easy way for it to end up blank on a first deploy.

An empty sites file now falls back to the default site, same as a missing one.

Fixes #15134