### PR TITLE
[5.x] Harden SVG sanitization

### DIFF
--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -58,7 +58,7 @@ abstract class Uploader
     {
         $stream = fopen($sourcePath, 'r');
 
-        if (config('statamic.assets.svg_sanitization_on_upload', true) && Str::endsWith($destinationPath, '.svg')) {
+        if (config('statamic.assets.svg_sanitization_on_upload', true) && Str::of($destinationPath)->lower()->endsWith('.svg')) {
             $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
             $stream = $sanitizer->sanitize($svg = stream_get_contents($stream), [
                 'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),

--- a/src/Assets/Uploader.php
+++ b/src/Assets/Uploader.php
@@ -58,7 +58,7 @@ abstract class Uploader
     {
         $stream = fopen($sourcePath, 'r');
 
-        if (config('statamic.assets.svg_sanitization_on_upload', true) && Str::of($destinationPath)->lower()->endsWith('.svg')) {
+        if (config('statamic.assets.svg_sanitization_on_upload', true) && trim(strtolower(pathinfo($destinationPath, PATHINFO_EXTENSION))) === 'svg') {
             $sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
             $stream = $sanitizer->sanitize($svg = stream_get_contents($stream), [
                 'remove-xml-tags' => ! Str::startsWith($svg, '<?xml'),

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -42,10 +42,11 @@ use Statamic\Support\Arr;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
+use Tests\WindowsHelpers;
 
 class AssetTest extends TestCase
 {
-    use PreventSavingStacheItemsToDisk;
+    use PreventSavingStacheItemsToDisk, WindowsHelpers;
 
     private $container;
 
@@ -1961,6 +1962,10 @@ class AssetTest extends TestCase
     #[DataProvider('unnormalizedSvgExtensionProvider')]
     public function it_sanitizes_svgs_on_upload_regardless_of_how_the_extension_is_written($extension)
     {
+        if (trim($extension) !== $extension) {
+            $this->markTestSkippedInWindows('Windows does not allow filenames with trailing whitespace.');
+        }
+
         Event::fake();
 
         // Disable filename lowercasing so the uppercase extension actually

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1958,8 +1958,8 @@ class AssetTest extends TestCase
     }
 
     #[Test]
-    #[DataProvider('svgExtensionCaseProvider')]
-    public function it_sanitizes_svgs_on_upload_regardless_of_extension_case($extension)
+    #[DataProvider('unnormalizedSvgExtensionProvider')]
+    public function it_sanitizes_svgs_on_upload_regardless_of_how_the_extension_is_written($extension)
     {
         Event::fake();
 
@@ -1985,11 +1985,13 @@ class AssetTest extends TestCase
         $this->assertStringNotContainsString('</script>', $asset->contents());
     }
 
-    public static function svgExtensionCaseProvider()
+    public static function unnormalizedSvgExtensionProvider()
     {
         return [
             'uppercase' => ['SVG'],
             'mixed case' => ['Svg'],
+            'trailing whitespace' => ['svg '],
+            'uppercase with trailing whitespace' => ['SVG '],
         ];
     }
 

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -1957,6 +1957,42 @@ class AssetTest extends TestCase
         $this->assertStringContainsString('</script>', $asset->contents());
     }
 
+    #[Test]
+    #[DataProvider('svgExtensionCaseProvider')]
+    public function it_sanitizes_svgs_on_upload_regardless_of_extension_case($extension)
+    {
+        Event::fake();
+
+        // Disable filename lowercasing so the uppercase extension actually
+        // reaches the disk, otherwise it'd be normalized before we could
+        // prove the sanitization check itself is case insensitive.
+        config()->set('statamic.assets.lowercase', false);
+
+        $asset = (new Asset)->container($this->container)->path($path = "path/to/asset.{$extension}")->syncOriginal();
+
+        Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
+        Storage::disk('test')->assertMissing($path);
+
+        $return = $asset->upload(UploadedFile::fake()->createWithContent("asset.{$extension}", '<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" width="500" height="500"><script type="text/javascript">alert(`Bad stuff could go in here.`);</script></svg>'));
+
+        $this->assertEquals($asset, $return);
+        Storage::disk('test')->assertExists($path);
+        $this->assertEquals($path, $asset->path());
+
+        // Ensure the inline scripts were stripped out.
+        $this->assertStringNotContainsString('<script', $asset->contents());
+        $this->assertStringNotContainsString('Bad stuff could go in here.', $asset->contents());
+        $this->assertStringNotContainsString('</script>', $asset->contents());
+    }
+
+    public static function svgExtensionCaseProvider()
+    {
+        return [
+            'uppercase' => ['SVG'],
+            'mixed case' => ['Svg'],
+        ];
+    }
+
     public static function nonGlideableFileExtensionsProvider()
     {
         return [

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -76,6 +76,42 @@ class FilesTest extends TestCase
         }
     }
 
+    #[Test]
+    #[DataProvider('svgExtensionCaseProvider')]
+    public function it_sanitizes_svgs_on_upload_regardless_of_extension_case($extension)
+    {
+        Date::setTestNow(Date::createFromTimestamp(1671484636, config('app.timezone')));
+
+        $disk = Storage::fake('local');
+
+        $file = UploadedFile::fake()->createWithContent("test.{$extension}", '<?xml version="1.0" encoding="UTF-8" standalone="no"?><svg xmlns="http://www.w3.org/2000/svg" width="500" height="500"><script type="text/javascript">alert(`Bad stuff could go in here.`);</script></svg>');
+
+        $this
+            ->actingAs(tap(User::make()->makeSuper())->save())
+            ->post('/cp/fieldtypes/files/upload', ['file' => $file])
+            ->assertOk()
+            ->assertJson([
+                'data' => [
+                    'id' => $path = "1671484636/test.{$extension}",
+                ],
+            ]);
+
+        $contents = $disk->get('statamic/file-uploads/'.$path);
+
+        // Ensure the inline scripts were stripped out.
+        $this->assertStringNotContainsString('<script', $contents);
+        $this->assertStringNotContainsString('Bad stuff could go in here.', $contents);
+        $this->assertStringNotContainsString('</script>', $contents);
+    }
+
+    public static function svgExtensionCaseProvider()
+    {
+        return [
+            'uppercase' => ['SVG'],
+            'mixed case' => ['Svg'],
+        ];
+    }
+
     public static function uploadProvider()
     {
         return [

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -77,8 +77,8 @@ class FilesTest extends TestCase
     }
 
     #[Test]
-    #[DataProvider('svgExtensionCaseProvider')]
-    public function it_sanitizes_svgs_on_upload_regardless_of_extension_case($extension)
+    #[DataProvider('unnormalizedSvgExtensionProvider')]
+    public function it_sanitizes_svgs_on_upload_regardless_of_how_the_extension_is_written($extension)
     {
         Date::setTestNow(Date::createFromTimestamp(1671484636, config('app.timezone')));
 
@@ -104,11 +104,13 @@ class FilesTest extends TestCase
         $this->assertStringNotContainsString('</script>', $contents);
     }
 
-    public static function svgExtensionCaseProvider()
+    public static function unnormalizedSvgExtensionProvider()
     {
         return [
             'uppercase' => ['SVG'],
             'mixed case' => ['Svg'],
+            'trailing whitespace' => ['svg '],
+            'uppercase with trailing whitespace' => ['SVG '],
         ];
     }
 

--- a/tests/Feature/Fieldtypes/FilesTest.php
+++ b/tests/Feature/Fieldtypes/FilesTest.php
@@ -11,10 +11,11 @@ use Statamic\Assets\AssetContainer;
 use Statamic\Facades\User;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
+use Tests\WindowsHelpers;
 
 class FilesTest extends TestCase
 {
-    use PreventSavingStacheItemsToDisk;
+    use PreventSavingStacheItemsToDisk, WindowsHelpers;
 
     public function setUp(): void
     {
@@ -80,6 +81,10 @@ class FilesTest extends TestCase
     #[DataProvider('unnormalizedSvgExtensionProvider')]
     public function it_sanitizes_svgs_on_upload_regardless_of_how_the_extension_is_written($extension)
     {
+        if (trim($extension) !== $extension) {
+            $this->markTestSkippedInWindows('Windows does not allow filenames with trailing whitespace.');
+        }
+
         Date::setTestNow(Date::createFromTimestamp(1671484636, config('app.timezone')));
 
         $disk = Storage::fake('local');


### PR DESCRIPTION
Aligns the SVG sanitization check on upload with the extension normalization already used elsewhere.

Replaces #15095