### PR TITLE
[6.x] Fix Checkbox & Radio label click capturing and useId prop binding

### DIFF
--- a/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
+++ b/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
@@ -4,6 +4,7 @@
             <Checkbox
                 v-for="(option, index) in options"
                 :disabled="config.disabled"
+                :id="`${id}_${index}`"
                 :key="index"
                 :label="option.label || option.value"
                 :read-only="isReadOnly"

--- a/resources/js/components/fieldtypes/RadioFieldtype.vue
+++ b/resources/js/components/fieldtypes/RadioFieldtype.vue
@@ -3,6 +3,7 @@
         <Radio
             v-for="(option, index) in options"
             :disabled="config.disabled"
+            :id="`${id}_${index}`"
             :key="index"
             :label="option.label || option.value"
             :read-only="isReadOnly"

--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { CheckboxIndicator, CheckboxRoot, useId } from 'reka-ui';
-import { computed, useAttrs } from 'vue';
+import { CheckboxIndicator, CheckboxRoot } from 'reka-ui';
+import { computed, useAttrs, useId } from 'vue';
 import { cva } from 'cva';
 import { twMerge } from 'tailwind-merge';
 import { injectCheckboxContext } from './Group.vue';
@@ -10,6 +10,8 @@ defineOptions({ inheritAttrs: false });
 const attrs = useAttrs();
 
 const props = defineProps({
+    /** Optional ID for the checkbox input */
+    id: { type: String, default: () => useId() },
     /** Controls the vertical alignment of the checkbox with its label. Options: `start`, `center` */
     align: { type: String, default: 'start', validator: (value) => ['start', 'center'].includes(value) },
     /** Description text to display below the label */
@@ -36,8 +38,6 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue', 'keydown']);
 
 const { appearance } = injectCheckboxContext() ?? { appearance: computed(() => 'default') };
-
-const id = useId();
 
 const handleKeydown = (event) => {
     emit('keydown', event);
@@ -97,7 +97,7 @@ const conditionalProps = computed(() => {
 
     // Only add aria-describedby if description exists AND it's not a solo checkbox
     if (props.description && !props.solo) {
-        props_obj['aria-describedby'] = `${id}-description`;
+        props_obj['aria-describedby'] = `${props.id}-description`;
     }
 
     if (props.solo && (props.label || props.value)) {
@@ -112,7 +112,7 @@ const conditionalProps = computed(() => {
     <div :class="containerClasses" data-ui-checkbox-item>
         <CheckboxRoot
             :disabled="readOnly || disabled"
-            :id
+            :id="props.id"
             :name="name"
             :value="value"
             v-bind="conditionalProps"
@@ -132,10 +132,10 @@ const conditionalProps = computed(() => {
             </span>
         </CheckboxRoot>
         <div class="flex flex-col" v-if="!solo">
-            <label class="text-sm font-normal antialiased cursor-pointer dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
+            <label class="text-sm font-normal antialiased cursor-pointer dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="props.id">
                 <slot>{{ label || value }}</slot>
             </label>
-            <p v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500 dark:text-gray-200">{{ description }}</p>
+            <p v-if="description" :id="`${props.id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500 dark:text-gray-200">{{ description }}</p>
         </div>
     </div>
 </template>

--- a/resources/js/components/ui/Radio/Item.vue
+++ b/resources/js/components/ui/Radio/Item.vue
@@ -4,6 +4,8 @@ import { RadioGroupIndicator, RadioGroupItem } from 'reka-ui';
 import { injectRadioContext } from './Group.vue';
 
 const props = defineProps({
+    /** Optional ID for the radio button */
+    id: { type: String, default: () => useId() },
     /** Description text to display below the label */
     description: { type: String, default: null },
     disabled: { type: Boolean, default: false },
@@ -15,8 +17,6 @@ const props = defineProps({
 });
 
 const { appearance } = injectRadioContext() ?? { appearance: computed(() => 'default') };
-
-const id = useId();
 </script>
 
 <template>
@@ -26,10 +26,10 @@ const id = useId();
         data-ui-radio-item
     >
         <RadioGroupItem
-            :id
+            :id="props.id"
             :value="value"
             :disabled="readOnly || disabled"
-            :aria-describedby="description ? `${id}-description` : undefined"
+            :aria-describedby="description ? `${props.id}-description` : undefined"
             class="
                 shadow-ui-xs mt-0.5 size-4 cursor-default rounded-full
                 focus:focus-outline border border-gray-400/75 bg-white with-contrast:border-gray-100
@@ -48,10 +48,10 @@ const id = useId();
             />
         </RadioGroupItem>
         <div class="flex flex-col" :class="{ 'opacity-50': disabled }">
-            <label class="text-sm font-normal antialiased cursor-pointer dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="id">
+            <label class="text-sm font-normal antialiased cursor-pointer dark:text-gray-200 before:absolute before:inset-0 before:content-['']" :for="props.id">
                 <slot>{{ label || value }}</slot>
             </label>
-            <span v-if="description" :id="`${id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500">{{ description }}</span>
+            <span v-if="description" :id="`${props.id}-description`" class="mt-0.5 block text-xs leading-snug text-gray-500">{{ description }}</span>
         </div>
     </div>
 </template>

--- a/resources/js/tests/components/CheckboxItem.test.js
+++ b/resources/js/tests/components/CheckboxItem.test.js
@@ -1,0 +1,32 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+import Checkbox from '@/components/ui/Checkbox/Item.vue';
+
+test('the label targets the auto-generated id when no id prop is given', () => {
+    const wrapper = mount(Checkbox, {
+        props: { label: 'Subscribe' },
+    });
+
+    const id = wrapper.find('[role="checkbox"]').attributes('id');
+
+    expect(id).toBeTruthy();
+    expect(wrapper.find('label').attributes('for')).toBe(id);
+});
+
+test('a custom id prop is honored on the control and the label', () => {
+    const wrapper = mount(Checkbox, {
+        props: { label: 'Subscribe', id: 'custom-checkbox-id' },
+    });
+
+    expect(wrapper.find('[role="checkbox"]').attributes('id')).toBe('custom-checkbox-id');
+    expect(wrapper.find('label').attributes('for')).toBe('custom-checkbox-id');
+});
+
+test('aria-describedby and the description element share the custom id', () => {
+    const wrapper = mount(Checkbox, {
+        props: { label: 'Subscribe', id: 'custom-checkbox-id', description: 'Receive occasional emails' },
+    });
+
+    expect(wrapper.find('[role="checkbox"]').attributes('aria-describedby')).toBe('custom-checkbox-id-description');
+    expect(wrapper.find('p').attributes('id')).toBe('custom-checkbox-id-description');
+});

--- a/resources/js/tests/components/RadioItem.test.js
+++ b/resources/js/tests/components/RadioItem.test.js
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+import { h } from 'vue';
+import RadioGroup from '@/components/ui/Radio/Group.vue';
+import Radio from '@/components/ui/Radio/Item.vue';
+
+// RadioGroupItem requires a RadioGroupRoot ancestor for its reka-ui context injection.
+function mountRadio(props) {
+    return mount(RadioGroup, {
+        slots: {
+            default: () => h(Radio, { label: 'Yes', value: 'yes', ...props }),
+        },
+    });
+}
+
+test('the label targets the auto-generated id when no id prop is given', () => {
+    const wrapper = mountRadio({});
+
+    const id = wrapper.find('[role="radio"]').attributes('id');
+
+    expect(id).toBeTruthy();
+    expect(wrapper.find('label').attributes('for')).toBe(id);
+});
+
+test('a custom id prop is honored on the control and the label', () => {
+    const wrapper = mountRadio({ id: 'custom-radio-id' });
+
+    expect(wrapper.find('[role="radio"]').attributes('id')).toBe('custom-radio-id');
+    expect(wrapper.find('label').attributes('for')).toBe('custom-radio-id');
+});
+
+test('aria-describedby and the description element share the custom id', () => {
+    const wrapper = mountRadio({ id: 'custom-radio-id', description: 'This cannot be undone' });
+
+    expect(wrapper.find('[role="radio"]').attributes('aria-describedby')).toBe('custom-radio-id-description');
+    expect(wrapper.find('span').attributes('id')).toBe('custom-radio-id-description');
+});


### PR DESCRIPTION
### Summary

Fixes `useId` and `id` prop binding in `Checkbox/Item.vue` and `Radio/Item.vue`:
1. **`useId` & Prop Binding Flaw:** `Checkbox/Item.vue` and `Radio/Item.vue` called `useId()` internally as a fixed local variable (`const id = useId()`) instead of exposing an `id` prop. `Checkbox/Item.vue` also imported `useId` from `reka-ui` rather than Vue. Passing a custom `id` prop was ignored, breaking accessibility customization, causing duplicate or mismatched ID target bindings across items, and failing to align with Statamic's standard UI component design pattern (`id: { type: String, default: () => useId() }`).
2. **Preserved Full-Item Click Target (#14821):** Restores proper ID matching between `<label :for="props.id">` and `<CheckboxRoot :id="props.id">` / `<RadioGroupItem :id="props.id">`, ensuring that the intended `before:absolute before:inset-0` full-item click overlay (which makes descriptions and chip paddings clickable) targets the correct control without misfiring or triggering adjacent components.

---

### Reproduction

1. Render `<CheckboxItem id="custom-id">` or `<RadioItem id="custom-id">`.
2. **Observed Behavior:** The component ignored `props.id` and used an internal auto-generated ID. Because `reka-ui`'s `useId` / missing prop binding generated mismatched or non-unique IDs across fieldsets, clicking a label or its full-item overlay triggered wrong input controls or ignored explicit ID overrides.
3. **Expected Behavior:** The component accepts an explicit `id` prop, falling back to Vue's native `useId()` when omitted, and cleanly links `<label :for>` to the input element.

**Minimal Reproduction Repository:**
https://github.com/ibrokemycomputer/statamic-input-error-poc

---

### Root Cause

`const id = useId()` was defined directly in `<script setup>` scope without exposing an `id` prop, preventing overrides. Additionally, `Checkbox/Item.vue` imported `useId` from `reka-ui` instead of `'vue'`, creating ID generation inconsistencies across Statamic's component library.

---

### Solution

**Standardized `useId` & Added `id` Prop:**
- Imported `useId` from `'vue'` across both components.
- Added `id: { type: String, default: () => useId() }` to `defineProps`.
- Updated template bindings to use `props.id` for `:id` on `<CheckboxRoot>` / `<RadioGroupItem>`, `:for` on `<label>`, and `:id` on `<p>`/`<span>` description elements.
- Retained `before:absolute before:inset-0 before:content-['']` on `<label>` so the entire item box (including descriptions and chip padding) remains clickable as intended in PR #14821.

---

### Changes

- `resources/js/components/ui/Checkbox/Item.vue`
  - Swapped `reka-ui` `useId` import for Vue's native `useId`.
  - Added `id: { type: String, default: () => useId() }` prop.
  - Updated `:id`, `:for`, and `aria-describedby` template bindings to use `props.id`.

- `resources/js/components/ui/Radio/Item.vue`
  - Imported `useId` from `'vue'`.
  - Added `id: { type: String, default: () => useId() }` prop.
  - Updated `:id`, `:for`, and `aria-describedby` template bindings to use `props.id`.
