### PR TITLE
[6.x] Stop tests depending on other tests having run first

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,4 +21,5 @@ phpstan.dist.neon export-ignore
 phpunit.bat export-ignore
 phpunit.dist.xml export-ignore
 SECURITY.md export-ignore
+testbench.yaml export-ignore
 translator export-ignore

--- a/testbench.yaml
+++ b/testbench.yaml
@@ -1,0 +1,44 @@
+# Everything the test suite is known to write into the testbench skeleton
+# (vendor/orchestra/testbench-core/laravel). Tests/TestCase clears these once per
+# process before snapshotting the skeleton, so a suite run never inherits leftovers
+# from a previous one. It's also what `vendor/bin/testbench package:purge-skeleton`
+# removes.
+purge:
+    directories:
+        - addons
+        - app/Actions
+        - app/Dictionaries
+        - app/Fieldtypes
+        - app/Modifiers
+        - app/Scopes
+        - app/Tags
+        - app/Widgets
+        - config/statamic
+        - public/diskimgroot
+        - public/glide
+        - public/imgcache
+        - public/static
+        - public/testimages
+        - public/vendor
+        - resources/addons
+        - resources/blueprints
+        - resources/content
+        - resources/css
+        - resources/dictionaries
+        - resources/fieldsets
+        - resources/forms
+        - resources/js
+        - resources/users
+        - storage/framework/testing/disks
+        - storage/statamic
+    files:
+        - app/Providers/AppServiceProvider.php
+        - composer.json.bak
+        - composer.lock
+        - package.json
+        - public/*.jpg
+        - resources/*.svg
+        - resources/preferences.yaml
+        - resources/sites.yaml
+        - storage/logs/*.log
+        - vite-cp.config.js

--- a/tests/Actions/DuplicateFormTest.php
+++ b/tests/Actions/DuplicateFormTest.php
@@ -7,11 +7,13 @@ use Statamic\Actions\DuplicateForm;
 use Statamic\Facades\Form;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
 class DuplicateFormTest extends TestCase
 {
     use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
 
     public function setUp(): void
     {

--- a/tests/Antlers/ParserTestCase.php
+++ b/tests/Antlers/ParserTestCase.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Antlers;
 
+use Statamic\Contracts\View\Antlers\Parser as ParserContract;
 use Statamic\Facades\YAML;
 use Statamic\Fields\Blueprint;
 use Statamic\Fields\BlueprintRepository;
@@ -46,6 +47,14 @@ class ParserTestCase extends TestCase
         parent::setUp();
 
         GlobalRuntimeState::resetGlobalState();
+
+        // The guarded/allowed path lists on GlobalRuntimeState are only populated as a side
+        // effect of resolving the real parser, and resetGlobalState() doesn't clear them. The
+        // tests here build their own parsers, so without this they'd run against whatever the
+        // last test to resolve one happened to leave behind - or against empty lists, which
+        // silently drop every modifier in user content, if nothing has resolved one yet.
+        app(ParserContract::class);
+
         GlobalRuntimeState::$throwErrorOnAccessViolation = false;
         GlobalRuntimeState::$allowPhpInContent = false;
         GlobalRuntimeState::$allowMethodsInContent = false;

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2112,6 +2112,10 @@ class AssetTest extends TestCase
 
         $this->container->sourcePreset('small');
 
+        // Glide only creates its temp directory when it actually processes an image, so
+        // create it up front. Otherwise there'd be nothing for the assertion below to check.
+        app('files')->makeDirectory($glideDir = storage_path('statamic/glide/tmp'), 0777, true, true);
+
         $asset = (new Asset)->container($this->container)->path("path/to/file.{$extension}")->syncOriginal();
 
         Facades\AssetContainer::shouldReceive('findByHandle')->with('test_container')->andReturn($this->container);
@@ -2123,7 +2127,6 @@ class AssetTest extends TestCase
         $return = $asset->upload(UploadedFile::fake()->createWithContent("file.{$extension}", '<svg width="20" height="30"></svg>'));
 
         $this->assertEquals($asset, $return);
-        $this->assertDirectoryExists($glideDir = storage_path('statamic/glide/tmp'));
         $this->assertEmpty(app('files')->allFiles($glideDir)); // no temp files
         Storage::disk('test')->assertExists("path/to/file.{$extension}");
         $this->assertEquals("path/to/file.{$extension}", $asset->path());

--- a/tests/CP/Navigation/NavTest.php
+++ b/tests/CP/Navigation/NavTest.php
@@ -27,9 +27,6 @@ class NavTest extends TestCase
 
         Route::any('wordpress-importer', ['as' => 'statamic.cp.wordpress-importer.index']);
         Route::any('security-droids', ['as' => 'statamic.cp.security-droids.index']);
-
-        // TODO: Other tests are leaving behind forms without titles that are causing failures here?
-        Facades\Form::shouldReceive('all')->andReturn(collect());
     }
 
     #[Test]

--- a/tests/Console/Commands/MakeAddonTest.php
+++ b/tests/Console/Commands/MakeAddonTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Console\Commands;
 
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Process;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
@@ -18,6 +19,10 @@ class MakeAddonTest extends TestCase
         parent::setUp();
 
         $this->markTestSkippedInWindows();
+
+        // Without this, the addon's `npm install` runs for real. Since the testbench app
+        // has no package.json, npm walks up and installs against this repo's own one.
+        Process::fake();
 
         $this->files = app(Filesystem::class);
         $this->fakeSuccessfulComposerRequire();

--- a/tests/Feature/Blueprints/ViewBlueprintListingTest.php
+++ b/tests/Feature/Blueprints/ViewBlueprintListingTest.php
@@ -51,6 +51,8 @@ class ViewBlueprintListingTest extends TestCase
 
         Facades\Blueprint::addNamespace($namespace, 'resources/content/'.$namespace);
 
+        $this->createBlueprint($namespace, $handle)->save();
+
         $this
             ->actingAs($user)
             ->get(cp_route('blueprints.additional.edit', [$namespace, $handle]))
@@ -58,8 +60,8 @@ class ViewBlueprintListingTest extends TestCase
             ->assertInertia(fn ($page) => $page->component('blueprints/Edit'));
     }
 
-    private function createBlueprint($handle)
+    private function createBlueprint($namespace, $handle)
     {
-        return tap(new Blueprint)->setHandle($handle);
+        return tap(new Blueprint)->setHandle($handle)->setNamespace($namespace);
     }
 }

--- a/tests/Modifiers/ArrayAccessType.php
+++ b/tests/Modifiers/ArrayAccessType.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use ArrayAccess;
+
+class ArrayAccessType implements ArrayAccess
+{
+    private $data;
+
+    public function __construct($data)
+    {
+        $this->data = $data;
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        return $this->data[$offset];
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetExists($offset)
+    {
+        return isset($this->data[$offset]);
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetSet($offset, $value)
+    {
+        //
+    }
+
+    #[\ReturnTypeWillChange]
+    public function offsetUnset($offset)
+    {
+        //
+    }
+}

--- a/tests/Modifiers/Item.php
+++ b/tests/Modifiers/Item.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Data\ContainsData;
+use Statamic\Support\Traits\FluentlyGetsAndSets;
+
+// Represents an object that doesn't have origins and therefore wouldn't have a "value" method.
+// So a "get" method would need to be used. e.g. a form Submission.
+class Item
+{
+    use ContainsData, FluentlyGetsAndSets;
+
+    public function __construct($data)
+    {
+        $this->data($data);
+    }
+}

--- a/tests/Modifiers/ItemWithOrigin.php
+++ b/tests/Modifiers/ItemWithOrigin.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Modifiers;
+
+use Statamic\Data\ContainsData;
+use Statamic\Data\HasOrigin;
+use Statamic\Support\Traits\FluentlyGetsAndSets;
+
+// Represents an object that could have an origin and therefore a "value" method. e.g. an Entry.
+class ItemWithOrigin
+{
+    use ContainsData, FluentlyGetsAndSets, HasOrigin;
+
+    public function __construct($data, $origin = null)
+    {
+        $this->data($data);
+        $this->origin = $origin;
+    }
+
+    public function origin($origin = null)
+    {
+        // Bypass the logic to load the origin. Just use what was passed in.
+        return $this->origin;
+    }
+
+    public function getOriginByString($origin)
+    {
+        // Required by trait
+    }
+}

--- a/tests/Modifiers/PluckTest.php
+++ b/tests/Modifiers/PluckTest.php
@@ -2,16 +2,12 @@
 
 namespace Tests\Modifiers;
 
-use ArrayAccess;
 use Illuminate\Support\Collection;
 use Mockery;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\Query\Builder;
-use Statamic\Data\ContainsData;
-use Statamic\Data\HasOrigin;
 use Statamic\Entries\EntryCollection;
 use Statamic\Modifiers\Modify;
-use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Tests\TestCase;
 
 class PluckTest extends TestCase
@@ -166,74 +162,5 @@ class PluckTest extends TestCase
     private function modify($value, $key)
     {
         return Modify::value($value)->pluck([$key])->fetch();
-    }
-}
-
-// Represents an object that doesn't have origins and therefore wouldn't have a "value" method.
-// So a "get" method would need to be used. e.g. a form Submission.
-class Item
-{
-    use ContainsData, FluentlyGetsAndSets;
-
-    public function __construct($data)
-    {
-        $this->data($data);
-    }
-}
-
-// Represents an object that could have an origin and therefore a "value" method. e.g. an Entry.
-class ItemWithOrigin
-{
-    use ContainsData, FluentlyGetsAndSets, HasOrigin;
-
-    public function __construct($data, $origin = null)
-    {
-        $this->data($data);
-        $this->origin = $origin;
-    }
-
-    public function origin($origin = null)
-    {
-        // Bypass the logic to load the origin. Just use what was passed in.
-        return $this->origin;
-    }
-
-    public function getOriginByString($origin)
-    {
-        // Required by trait
-    }
-}
-
-class ArrayAccessType implements ArrayAccess
-{
-    private $data;
-
-    public function __construct($data)
-    {
-        $this->data = $data;
-    }
-
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
-    {
-        return $this->data[$offset];
-    }
-
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
-    {
-        return isset($this->data[$offset]);
-    }
-
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
-    {
-        //
-    }
-
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
-    {
-        //
     }
 }

--- a/tests/RestoresTestbenchSkeleton.php
+++ b/tests/RestoresTestbenchSkeleton.php
@@ -10,13 +10,17 @@ use function Orchestra\Testbench\default_skeleton_path;
 
 trait RestoresTestbenchSkeleton
 {
+    use DeletesDirectories;
+
     /**
-     * The skeleton's contents before any test in this process had a chance to touch it,
-     * keyed by path relative to the skeleton root so lookups are hash based.
+     * The set of paths, relative to the skeleton root, that existed before any test in this
+     * process had a chance to touch it. Paths are keys so lookups are hash based.
      */
     private static ?array $skeletonSnapshot = null;
 
     private static ?string $skeletonPath = null;
+
+    private static ?string $skeletonRealPath = null;
 
     private static bool $skeletonPurged = false;
 
@@ -59,7 +63,7 @@ trait RestoresTestbenchSkeleton
         }
 
         foreach ($expand($purge['directories']) as $directory) {
-            $files->deleteDirectory($directory);
+            $this->deleteDirectory($directory);
         }
     }
 
@@ -70,6 +74,7 @@ trait RestoresTestbenchSkeleton
         }
 
         self::$skeletonPath = $this->app->basePath();
+        self::$skeletonRealPath = realpath(self::$skeletonPath) ?: self::$skeletonPath;
         self::$skeletonSnapshot = $this->scanTestbenchSkeleton();
     }
 
@@ -84,10 +89,14 @@ trait RestoresTestbenchSkeleton
         // Deepest first, so directories are empty by the time we get to them.
         uksort($added, fn ($a, $b) => substr_count($b, '/') <=> substr_count($a, '/'));
 
-        foreach ($added as $path => $isDir) {
+        foreach ($added as $path => $ignored) {
             $absolute = self::$skeletonPath.'/'.$path;
 
-            $isDir ? @rmdir($absolute) : @unlink($absolute);
+            // Same reasoning as DeletesDirectories: never ask whether the path is a file, a
+            // directory or a link, because a junction gives contradictory answers. unlink()
+            // takes files and file links, rmdir() takes empty directories, directory links
+            // and junctions without following them.
+            @unlink($absolute) || @rmdir($absolute);
         }
     }
 
@@ -109,18 +118,37 @@ trait RestoresTestbenchSkeleton
                     continue;
                 }
 
-                $isDir = is_dir($absolute.'/'.$entry) && ! is_link($absolute.'/'.$entry);
-
-                if ($isDir) {
+                if ($this->isRealSkeletonDirectory($absolute.'/'.$entry)) {
                     $scan($path);
                 }
 
-                $paths[$path] = $isDir;
+                $paths[$path] = true;
             }
         };
 
         $scan('');
 
         return $paths;
+    }
+
+    /**
+     * Whether the scan may descend into a path. Recursing through a link would record its
+     * target's contents as skeleton paths, and the restore would then delete files that can
+     * live anywhere on disk, so anything we can't positively place inside the skeleton is
+     * left alone. Resolving the path is what settles it: a junction whose lstat mode makes
+     * is_dir() and is_link() disagree still resolves to wherever it points.
+     */
+    private function isRealSkeletonDirectory(string $path): bool
+    {
+        clearstatcache(true, $path);
+
+        if (is_link($path) || ! is_dir($path)) {
+            return false;
+        }
+
+        $resolved = realpath($path);
+
+        return $resolved !== false
+            && str_starts_with($resolved.DIRECTORY_SEPARATOR, self::$skeletonRealPath.DIRECTORY_SEPARATOR);
     }
 }

--- a/tests/RestoresTestbenchSkeleton.php
+++ b/tests/RestoresTestbenchSkeleton.php
@@ -22,8 +22,6 @@ trait RestoresTestbenchSkeleton
 
     private static ?string $skeletonRealPath = null;
 
-    private static bool $skeletonPurged = false;
-
     /**
      * Subtrees the framework owns and rebuilds on demand. Deleting these breaks
      * subsequent tests ("Please provide a valid cache path"), and walking them gets
@@ -38,18 +36,32 @@ trait RestoresTestbenchSkeleton
     ];
 
     /**
-     * The snapshot below only stops tests within a process from leaking into each other.
-     * A process starting against a skeleton dirtied by an earlier run would bake that dirt
-     * into its snapshot, so clear the known offenders before the app is ever booted.
+     * Runs once per process, before the first app is booted. Booting first would mean the
+     * directories the boot creates - a disk's root, say - were already there when the
+     * snapshot was taken, making them part of the baseline and invisible to the restore for
+     * the rest of the process.
      */
-    protected function purgeTestbenchSkeleton(): void
+    protected function prepareTestbenchSkeleton(): void
     {
-        if (self::$skeletonPurged) {
+        if (self::$skeletonSnapshot !== null) {
             return;
         }
 
-        self::$skeletonPurged = true;
+        self::$skeletonPath = default_skeleton_path();
+        self::$skeletonRealPath = realpath(self::$skeletonPath) ?: self::$skeletonPath;
 
+        $this->purgeTestbenchSkeleton();
+
+        self::$skeletonSnapshot = $this->scanTestbenchSkeleton();
+    }
+
+    /**
+     * The snapshot only stops tests within a process from leaking into each other. A process
+     * starting against a skeleton dirtied by an earlier run would bake that dirt into its
+     * snapshot, so clear the known offenders first.
+     */
+    private function purgeTestbenchSkeleton(): void
+    {
         $files = new Filesystem;
 
         $purge = Config::loadFromYaml(__DIR__.'/..')->getPurgeAttributes();
@@ -65,17 +77,6 @@ trait RestoresTestbenchSkeleton
         foreach ($expand($purge['directories']) as $directory) {
             $this->deleteDirectory($directory);
         }
-    }
-
-    protected function snapshotTestbenchSkeleton(): void
-    {
-        if (self::$skeletonSnapshot !== null) {
-            return;
-        }
-
-        self::$skeletonPath = $this->app->basePath();
-        self::$skeletonRealPath = realpath(self::$skeletonPath) ?: self::$skeletonPath;
-        self::$skeletonSnapshot = $this->scanTestbenchSkeleton();
     }
 
     protected function restoreTestbenchSkeleton(): void

--- a/tests/RestoresTestbenchSkeleton.php
+++ b/tests/RestoresTestbenchSkeleton.php
@@ -15,6 +15,9 @@ trait RestoresTestbenchSkeleton
     /**
      * The set of paths, relative to the skeleton root, that existed before any test in this
      * process had a chance to touch it. Paths are keys so lookups are hash based.
+     *
+     * Only paths a test adds get restored. A test that overwrites or deletes something the
+     * skeleton already shipped still affects the ones after it. Nothing does that today.
      */
     private static ?array $skeletonSnapshot = null;
 
@@ -23,9 +26,13 @@ trait RestoresTestbenchSkeleton
     private static ?string $skeletonRealPath = null;
 
     /**
-     * Subtrees the framework owns and rebuilds on demand. Deleting these breaks
-     * subsequent tests ("Please provide a valid cache path"), and walking them gets
-     * expensive once thousands of compiled views have piled up.
+     * Subtrees left alone because something else rebuilds them on demand. Deleting them breaks
+     * subsequent tests ("Please provide a valid cache path"), and walking storage/framework/views
+     * gets expensive once thousands of compiled views have piled up.
+     *
+     * Note bootstrap/cache isn't only the framework's: Statamic's addon manifest lands there as
+     * addons.php, so it survives a run and the next one starts with it. Empty in practice, but
+     * it sits outside the guarantee the rest of this trait makes.
      */
     private static array $skeletonExclusions = [
         'bootstrap/cache',

--- a/tests/RestoresTestbenchSkeleton.php
+++ b/tests/RestoresTestbenchSkeleton.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Orchestra\Testbench\Foundation\Config;
+
+use function Orchestra\Testbench\default_skeleton_path;
+
+trait RestoresTestbenchSkeleton
+{
+    /**
+     * The skeleton's contents before any test in this process had a chance to touch it,
+     * keyed by path relative to the skeleton root so lookups are hash based.
+     */
+    private static ?array $skeletonSnapshot = null;
+
+    private static ?string $skeletonPath = null;
+
+    private static bool $skeletonPurged = false;
+
+    /**
+     * Subtrees the framework owns and rebuilds on demand. Deleting these breaks
+     * subsequent tests ("Please provide a valid cache path"), and walking them gets
+     * expensive once thousands of compiled views have piled up.
+     */
+    private static array $skeletonExclusions = [
+        'bootstrap/cache',
+        'node_modules',
+        'storage/framework/cache',
+        'storage/framework/views',
+        'vendor',
+    ];
+
+    /**
+     * The snapshot below only stops tests within a process from leaking into each other.
+     * A process starting against a skeleton dirtied by an earlier run would bake that dirt
+     * into its snapshot, so clear the known offenders before the app is ever booted.
+     */
+    protected function purgeTestbenchSkeleton(): void
+    {
+        if (self::$skeletonPurged) {
+            return;
+        }
+
+        self::$skeletonPurged = true;
+
+        $files = new Filesystem;
+
+        $purge = Config::loadFromYaml(__DIR__.'/..')->getPurgeAttributes();
+
+        $expand = fn ($paths) => (new Collection($paths))
+            ->map(fn ($path) => default_skeleton_path().'/'.$path)
+            ->flatMap(fn ($path) => str_contains($path, '*') ? $files->glob($path) : [$path]);
+
+        foreach ($expand($purge['files']) as $file) {
+            $files->delete($file);
+        }
+
+        foreach ($expand($purge['directories']) as $directory) {
+            $files->deleteDirectory($directory);
+        }
+    }
+
+    protected function snapshotTestbenchSkeleton(): void
+    {
+        if (self::$skeletonSnapshot !== null) {
+            return;
+        }
+
+        self::$skeletonPath = $this->app->basePath();
+        self::$skeletonSnapshot = $this->scanTestbenchSkeleton();
+    }
+
+    protected function restoreTestbenchSkeleton(): void
+    {
+        if (self::$skeletonSnapshot === null) {
+            return;
+        }
+
+        $added = array_diff_key($this->scanTestbenchSkeleton(), self::$skeletonSnapshot);
+
+        // Deepest first, so directories are empty by the time we get to them.
+        uksort($added, fn ($a, $b) => substr_count($b, '/') <=> substr_count($a, '/'));
+
+        foreach ($added as $path => $isDir) {
+            $absolute = self::$skeletonPath.'/'.$path;
+
+            $isDir ? @rmdir($absolute) : @unlink($absolute);
+        }
+    }
+
+    private function scanTestbenchSkeleton(): array
+    {
+        $paths = [];
+
+        $scan = function ($relative) use (&$scan, &$paths) {
+            $absolute = self::$skeletonPath.($relative ? '/'.$relative : '');
+
+            foreach (scandir($absolute) ?: [] as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+
+                $path = $relative ? $relative.'/'.$entry : $entry;
+
+                if (in_array($path, self::$skeletonExclusions)) {
+                    continue;
+                }
+
+                $isDir = is_dir($absolute.'/'.$entry) && ! is_link($absolute.'/'.$entry);
+
+                if ($isDir) {
+                    $scan($path);
+                }
+
+                $paths[$path] = $isDir;
+            }
+        };
+
+        $scan('');
+
+        return $paths;
+    }
+}

--- a/tests/RestoresTestbenchSkeletonTest.php
+++ b/tests/RestoresTestbenchSkeletonTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\File;
+
+class RestoresTestbenchSkeletonTest extends TestCase
+{
+    private string $target;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->target = __DIR__.'/restores-testbench-skeleton-tmp';
+    }
+
+    public function tearDown(): void
+    {
+        $this->deleteDirectory($this->target);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_removes_files_and_directories_a_test_added()
+    {
+        File::put($file = base_path('added.html'), '');
+        File::put($nested = base_path('added-dir/nested/deep.html'), '');
+
+        $this->restoreTestbenchSkeleton();
+
+        clearstatcache();
+
+        $this->assertFileDoesNotExist($file);
+        $this->assertFileDoesNotExist($nested);
+        $this->assertDirectoryDoesNotExist(base_path('added-dir'));
+    }
+
+    #[Test]
+    public function it_removes_links_without_following_them()
+    {
+        File::put($this->target.'/kept.html', '');
+        File::put($targetFile = $this->target.'/kept-file.html', '');
+
+        app('files')->link($this->target, $linkedDir = base_path('linked-dir'));
+        app('files')->link($targetFile, $linkedFile = base_path('linked-file.html'));
+
+        $this->restoreTestbenchSkeleton();
+
+        clearstatcache();
+
+        $this->assertFalse(is_link($linkedDir));
+        $this->assertDirectoryDoesNotExist($linkedDir);
+        $this->assertFalse(is_link($linkedFile));
+        $this->assertFileDoesNotExist($linkedFile);
+
+        // If the scan had descended into the link, the restore would have deleted the
+        // target's contents along with it.
+        $this->assertFileExists($this->target.'/kept.html');
+        $this->assertFileExists($targetFile);
+    }
+}

--- a/tests/RestoresTestbenchSkeletonTest.php
+++ b/tests/RestoresTestbenchSkeletonTest.php
@@ -13,9 +13,12 @@ class RestoresTestbenchSkeletonTest extends TestCase
     {
         parent::setUp();
 
-        // Has to live outside the skeleton for the "doesn't follow links" assertions to mean
-        // anything, and outside the repo so this test doesn't do what the trait exists to stop.
-        $this->target = sys_get_temp_dir().'/restores-testbench-skeleton-tmp';
+        // Outside the skeleton, so descending into a link would be a genuine delete beyond it.
+        // Not in the repo's tracked tree, so this test doesn't do what the trait exists to stop.
+        // And on the same volume as the checkout: Filesystem::link() hard links the file case on
+        // Windows, and hard links can't cross volumes, so a temp dir on another drive wouldn't be
+        // linkable at all. dirname(base_path()) is the skeleton's parent, inside gitignored vendor.
+        $this->target = dirname(base_path()).'/restores-testbench-skeleton-tmp';
     }
 
     public function tearDown(): void
@@ -48,6 +51,12 @@ class RestoresTestbenchSkeletonTest extends TestCase
 
         app('files')->link($this->target, $linkedDir = base_path('linked-dir'));
         app('files')->link($targetFile, $linkedFile = base_path('linked-file.html'));
+
+        // Filesystem::link() shells out on Windows and throws away exec()'s result, so a link
+        // that never got created would leave every assertion below passing on a path that
+        // isn't there. Fail loudly instead of silently testing nothing.
+        $this->assertDirectoryExists($linkedDir);
+        $this->assertFileExists($linkedFile);
 
         $this->restoreTestbenchSkeleton();
 

--- a/tests/RestoresTestbenchSkeletonTest.php
+++ b/tests/RestoresTestbenchSkeletonTest.php
@@ -13,7 +13,9 @@ class RestoresTestbenchSkeletonTest extends TestCase
     {
         parent::setUp();
 
-        $this->target = __DIR__.'/restores-testbench-skeleton-tmp';
+        // Has to live outside the skeleton for the "doesn't follow links" assertions to mean
+        // anything, and outside the repo so this test doesn't do what the trait exists to stop.
+        $this->target = sys_get_temp_dir().'/restores-testbench-skeleton-tmp';
     }
 
     public function tearDown(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -12,7 +12,7 @@ use Statamic\Http\Middleware\CP\AuthenticateSession;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
-    use WindowsHelpers;
+    use RestoresTestbenchSkeleton, WindowsHelpers;
 
     protected $shouldFakeVersion = true;
     protected $shouldPreventNavBeingBuilt = true;
@@ -20,7 +20,11 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function setUp(): void
     {
+        $this->purgeTestbenchSkeleton();
+
         parent::setUp();
+
+        $this->snapshotTestbenchSkeleton();
 
         $this->withoutVite();
 
@@ -58,6 +62,8 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         }
 
         parent::tearDown();
+
+        $this->restoreTestbenchSkeleton();
     }
 
     protected function getPackageProviders($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -20,11 +20,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function setUp(): void
     {
-        $this->purgeTestbenchSkeleton();
+        $this->prepareTestbenchSkeleton();
 
         parent::setUp();
-
-        $this->snapshotTestbenchSkeleton();
 
         $this->withoutVite();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,9 +59,14 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             $this->deleteFakeStacheDirectory();
         }
 
-        parent::tearDown();
-
-        $this->restoreTestbenchSkeleton();
+        // Mockery verifies its expectations inside parent::tearDown() and throws when they
+        // aren't met, which would otherwise skip the restore and leak the failing test's files
+        // into the next one - right when you're already trying to work out what went wrong.
+        try {
+            parent::tearDown();
+        } finally {
+            $this->restoreTestbenchSkeleton();
+        }
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
## Cause

Our tests aren't isolated from each other. The suite runs as a single process, so every test file gets loaded, every static stays set, and every file a test writes into the testbench app is still sitting there for the next test. That hides two kinds of coupling.

**Tests that leak.** The testbench app at `vendor/orchestra/testbench-core/laravel` is created once and lives for the whole process. A sweep of all 984 test files found **198 leave files behind** — ~50 into `resources/`, `config/`, `addons/` and `public/`, 69 into `storage/statamic/`, 34 leaving `Storage::fake` residue, 29 leaving `laravel.log`. Two also wrote into the repo itself: `MakeAddonTest` rewrote the root `package-lock.json`, and `DuplicateFormTest` wrote `tests/__fixtures__/users/.yaml`.

**Tests that depend on those leaks.** Six files only pass because something else ran first:

- `SelectTest` uses helper classes declared at the bottom of `PluckTest.php`, so it needs that file loaded into the same process.
- `ViewBlueprintListingTest` asserts a custom namespace blueprint can be edited without ever creating one — `StoreCustomBlueprintTest` had left one in the skeleton.
- `AssetTest`'s non-glideable upload test asserts `storage/statamic/glide/tmp` exists, but glide only creates it when it actually processes an image. It was inheriting the directory from an earlier test in the file.
- `NavTest` mocked `Form::all()` away entirely, with a TODO guessing that other tests were leaving behind forms *without titles*. It was simpler than that: any leftover form at all adds children to the Forms nav item and breaks the assertions.
- `BardFieldtypeTest`, `MarkdownFieldtypeTest` and `PreparserTest` need Antlers' guarded/allowed path lists on `GlobalRuntimeState`, which are only populated as a side effect of resolving the parser out of the container. `resetGlobalState()` doesn't clear them, so `ParserTestCase` — which builds its parsers by hand — ran against whatever the last test to resolve one left behind. Starting a process with them empty silently drops every modifier in user content, so `{{ now format="Y" }}` rendered a full datetime and a preparsed `| upper` did nothing.

This matters now because it blocks splitting the suite across processes, and it has already broken a sharded CI run. (#15140) A leftover `resources/forms/*.yaml` containing `{}` has no title, so `CoreNav` calls `Nav::item(null)`, gets `null` back, and `tests/CP/Navigation/CoreNavTest.php` dies with `Call to a member function url() on null`. In the single-process suite it's masked by lucky ordering.

## Approach

Give every test a defined starting state rather than patching 198 tests to tidy up after themselves — the same idea as `RefreshDatabase`, applied to the other shared mutable state a test can reach.

`Tests\RestoresTestbenchSkeleton`, used by `Tests\TestCase`:

- Snapshots the skeleton once per process, before the first app boots. Snapshotting after the boot would make whatever that boot created — a filesystem disk's root directory, say — part of the baseline, and invisible to the restore for the rest of the process.
- Deletes anything new after each test, deepest first.
- Prunes `bootstrap/cache`, `storage/framework/{cache,views}`, `vendor` and `node_modules` from the walk. The framework owns those — deleting them breaks every subsequent test with *"Please provide a valid cache path"* — and walking compiled views gets expensive.

Deleting inside the skeleton follows `DeletesDirectories` from #15145: never ask whether a path is a file, a directory or a link, because a Windows junction reports an lstat mode that makes `is_dir()` and `is_link()` contradict each other. The scan is the part that really matters — it used that same answer to decide whether to recurse, so a junction claiming to be a directory would have had its target's contents recorded as skeleton paths, and the restore would then have deleted files from wherever it pointed. It now descends only into paths that resolve to somewhere inside the skeleton. Nothing links into the skeleton today, so this is latent rather than an active bug.

A process starting against an already dirty skeleton would bake that dirt into its snapshot, so a new `testbench.yaml` declares the paths our tests are known to write and those are cleared before the first app boot. That's testbench's own `purge` config, so `vendor/bin/testbench package:purge-skeleton` cleans up after us too.

The individual tests are then made self-sufficient:

- **`MakeAddonTest`** — making an addon with a fieldtype runs `npm install` from the testbench app's base path. That app has no `package.json`, so npm walks up and installs against ours. Now fakes the process, as the other commands that trigger this already do.
- **`DuplicateFormTest`** — the users it makes have no id, so saving them writes `.yaml`. Now points the stache stores at the throwaway directory.
- **`ViewBlueprintListingTest`** — creates the blueprint it's asserting against.
- **`AssetTest`** — creates glide's temp directory up front and keeps the assertion that nothing lands in it.
- **`PluckTest`** — `Item`, `ItemWithOrigin` and `ArrayAccessType` move into their own files. `Tests\` is autoloaded from `tests/`, so that's all they needed.
- **`NavTest`** — the `Form::all()` mock and its TODO are gone.
- **`ParserTestCase`** — resolves the real parser in `setUp`, so the Antlers runtime configuration comes from config every time instead of from whichever sibling happened to run first.

Worth calling out that `ViewBlueprintListingTest` and `AssetTest` started *failing* when the skeleton restore landed. They were green only on leaked state.

## Results

| | before | after |
|---|---|---|
| Full suite | 9990 tests, 29900 assertions, 4:24 | 9998 tests, 29918 assertions, **4:06** |
| Test files leaving the skeleton dirty | **198** of 984 | **0** |
| Test files writing into the repo | **2** | **0** |
| Test files failing when run on their own | **5** | **0** |

The suite got faster rather than slower, though the margin is smaller than it was before the snapshot moved ahead of the boot — those boot artifacts are now recreated per test rather than once. The extra tests are the ones that came in with 6.x, plus coverage for the deletion behaviour above; the redundant `assertDirectoryExists` came out of `AssetTest`'s 4 data sets. (`AssetTest` isn't in the isolation count — it passed as a whole file and only broke once tests stopped sharing state *within* a file.)

A full run now leaves the skeleton byte for byte as it found it.

Also verified directly: planting a `resources/forms/test.yaml` containing `{}` in the skeleton no longer breaks `CoreNavTest`.

Two product bugs this turned up — `Nav::create()` returning `null` for a null display name, and a title-less form crashing the CP nav — are deliberately out of scope and will get their own PR (#15144)

**Note that all of this allows the test suite to work in _shards_ only. Running in parallel still won't work because the clean ups could remove files other active tests are expecting.**
