### PR TITLE
[6.x] Fix CP nav breaking when a form has no title

### DIFF
--- a/src/CP/Navigation/Nav.php
+++ b/src/CP/Navigation/Nav.php
@@ -26,7 +26,9 @@ class Nav
      */
     public function create($name)
     {
-        $item = (new NavItem)->display($name);
+        $item = new NavItem;
+
+        $item->display($name);
 
         $this->items[] = $item;
 

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -75,7 +75,12 @@ class Form implements Arrayable, Augmentable, ContainsQueryableValues, FormContr
      */
     public function title($title = null)
     {
-        return $this->fluentlyGetOrSet('title')->args(func_get_args());
+        return $this
+            ->fluentlyGetOrSet('title')
+            ->getter(function ($title) {
+                return $title ?? ucfirst($this->handle);
+            })
+            ->args(func_get_args());
     }
 
     /**

--- a/tests/CP/Navigation/CoreNavTest.php
+++ b/tests/CP/Navigation/CoreNavTest.php
@@ -221,6 +221,18 @@ class CoreNavTest extends TestCase
         $this->assertEqualsCanonicalizing($expected, $actual);
     }
 
+    #[Test]
+    public function it_builds_the_nav_when_a_form_has_no_title()
+    {
+        Facades\Form::make('contact_us')->save();
+
+        $this->actingAs(tap(User::make()->makeSuper())->save());
+
+        $forms = $this->build()->get('Tools')->keyBy->display()->get('Forms');
+
+        $this->assertEquals(['Contact_us'], $forms->children()->map->display()->all());
+    }
+
     protected function build()
     {
         return Nav::build()->pluck('items', 'display');

--- a/tests/CP/Navigation/NavTest.php
+++ b/tests/CP/Navigation/NavTest.php
@@ -70,6 +70,26 @@ class NavTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_the_nav_item_when_created_without_a_display_name()
+    {
+        $item = Nav::create(null);
+
+        $this->assertInstanceOf(NavItem::class, $item);
+        $this->assertNull($item->display());
+        $this->assertEquals([$item], Nav::items());
+    }
+
+    #[Test]
+    public function it_returns_the_nav_item_when_created_without_a_display_name_using_the_item_alias()
+    {
+        $item = Nav::item(null);
+
+        $this->assertInstanceOf(NavItem::class, $item);
+        $this->assertNull($item->display());
+        $this->assertEquals([$item], Nav::items());
+    }
+
+    #[Test]
     public function it_can_create_a_nav_item_with_a_more_custom_config()
     {
         Gate::policy(DroidsClass::class, DroidsPolicy::class);

--- a/tests/Forms/FormTest.php
+++ b/tests/Forms/FormTest.php
@@ -11,6 +11,7 @@ use Statamic\Events\FormDeleted;
 use Statamic\Events\FormDeleting;
 use Statamic\Events\FormSaved;
 use Statamic\Events\FormSaving;
+use Statamic\Facades\File;
 use Statamic\Facades\Form;
 use Statamic\Fields\Blueprint;
 use Tests\TestCase;
@@ -22,6 +23,28 @@ class FormTest extends TestCase
         parent::setUp();
 
         Form::all()->each->delete();
+    }
+
+    #[Test]
+    public function it_falls_back_to_the_handle_for_the_title()
+    {
+        $form = Form::make('contact_us');
+
+        $this->assertEquals('Contact_us', $form->title());
+
+        $form->title('Contact Us');
+
+        $this->assertEquals('Contact Us', $form->title());
+    }
+
+    #[Test]
+    public function it_doesnt_save_the_fallback_title()
+    {
+        $form = Form::make('contact_us');
+
+        $form->save();
+
+        $this->assertStringNotContainsString('title', File::get($form->path()));
     }
 
     #[Test]


### PR DESCRIPTION
Fixes two independent bugs that could take down the entire Control Panel nav.

**`Nav::create()` returned null when given a null display name**

`NavItem::display()` is a fluent get-or-set, so passing null means "get". Chaining `create()` off it returned the current display (null) rather than the item, and pushed that null into the registered items — corrupting the list for everything downstream. `Nav::item()` is an alias, so it had the same problem.

The item is now constructed and `display()` called as a statement, so the item is always returned. `display()`'s fluent get-or-set semantics are unchanged.

**A form with no title crashed the nav**

`Form::title()` was the only titled entity without a fallback, so a form whose YAML has no title returned null. Combined with the above, `CoreNav` died with `Call to a member function url() on null` — one malformed form took out the whole nav.

`Form::title()` now falls back to the humanized handle, matching collections, taxonomies, asset containers, globals, roles, and user groups. `save()` writes the raw property, so the fallback is never persisted to YAML.