### PR TITLE
[6.x] Encode asset URLs

### DIFF
--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -417,7 +417,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             return null;
         }
 
-        return URL::assemble($this->container()->url(), $this->path());
+        return URL::assemble($this->container()->url(), URL::encode($this->path()));
     }
 
     public function absoluteUrl()
@@ -426,7 +426,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             return null;
         }
 
-        return URL::assemble($this->container()->absoluteUrl(), $this->path());
+        return URL::assemble($this->container()->absoluteUrl(), URL::encode($this->path()));
     }
 
     public function thumbnailUrl($preset = null)

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -417,7 +417,7 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             return null;
         }
 
-        return URL::assemble($this->container()->url(), URL::encode($this->path()));
+        return URL::assemble($this->container()->url(), $this->encodedPath());
     }
 
     public function absoluteUrl()
@@ -426,7 +426,12 @@ class Asset implements Arrayable, ArrayAccess, AssetContract, Augmentable, Conta
             return null;
         }
 
-        return URL::assemble($this->container()->absoluteUrl(), URL::encode($this->path()));
+        return URL::assemble($this->container()->absoluteUrl(), $this->encodedPath());
+    }
+
+    private function encodedPath()
+    {
+        return implode('/', array_map('rawurlencode', explode('/', $this->path())));
     }
 
     public function thumbnailUrl($preset = null)

--- a/src/Assets/AssetRepository.php
+++ b/src/Assets/AssetRepository.php
@@ -59,7 +59,7 @@ class AssetRepository implements Contract
             $url = $siteUrl.$url;
         }
 
-        $path = Str::after($url, $containerUrl);
+        $path = rawurldecode(Str::after($url, $containerUrl));
 
         return $container->asset($path);
     }

--- a/tests/Assets/AssetRepositoryTest.php
+++ b/tests/Assets/AssetRepositoryTest.php
@@ -5,6 +5,7 @@ namespace Tests\Assets;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Assets\AssetRepository;
 use Statamic\Contracts\Assets\Asset as AssetContract;
@@ -107,20 +108,29 @@ EOT;
     }
 
     #[Test]
-    public function it_finds_assets_by_an_encoded_url()
+    #[DataProvider('encodedUrlProvider')]
+    public function it_finds_assets_by_an_encoded_url($path, $expectedUrl)
     {
         Storage::fake('test', ['url' => 'test']);
-        Storage::disk('test')->put('foo/Dún Laoghaire_18 2.jpg', UploadedFile::fake()->image('bar.jpg')->getContent());
+        Storage::disk('test')->put($path, UploadedFile::fake()->image('bar.jpg')->getContent());
 
         $container = tap(AssetContainer::make('test_container')->disk('test'))->save();
-        $asset = tap($container->makeAsset('foo/Dún Laoghaire_18 2.jpg'))->save();
+        $asset = tap($container->makeAsset($path))->save();
 
-        $this->assertEquals('/test/foo/D%C3%BAn%20Laoghaire_18%202.jpg', $asset->url());
+        $this->assertEquals($expectedUrl, $asset->url());
 
         $found = Asset::findByUrl($asset->url());
 
         $this->assertInstanceOf(AssetContract::class, $found);
         $this->assertEquals($asset->id(), $found->id());
+    }
+
+    public static function encodedUrlProvider()
+    {
+        return [
+            'spaces and accents' => ['foo/Dún Laoghaire_18 2.jpg', '/test/foo/D%C3%BAn%20Laoghaire_18%202.jpg'],
+            'literal percent sequences' => ['foo/photo%20one.jpg', '/test/foo/photo%2520one.jpg'],
+        ];
     }
 
     #[Test]

--- a/tests/Assets/AssetRepositoryTest.php
+++ b/tests/Assets/AssetRepositoryTest.php
@@ -107,6 +107,23 @@ EOT;
     }
 
     #[Test]
+    public function it_finds_assets_by_an_encoded_url()
+    {
+        Storage::fake('test', ['url' => 'test']);
+        Storage::disk('test')->put('foo/Dún Laoghaire_18 2.jpg', UploadedFile::fake()->image('bar.jpg')->getContent());
+
+        $container = tap(AssetContainer::make('test_container')->disk('test'))->save();
+        $asset = tap($container->makeAsset('foo/Dún Laoghaire_18 2.jpg'))->save();
+
+        $this->assertEquals('/test/foo/D%C3%BAn%20Laoghaire_18%202.jpg', $asset->url());
+
+        $found = Asset::findByUrl($asset->url());
+
+        $this->assertInstanceOf(AssetContract::class, $found);
+        $this->assertEquals($asset->id(), $found->id());
+    }
+
+    #[Test]
     public function it_finds_assets_by_id_when_the_path_contains_windows_separators()
     {
         Storage::fake('test');

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2376,6 +2376,31 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('urlEncodingProvider')]
+    public function it_encodes_the_url($path, $expected)
+    {
+        $container = $this->mock(AssetContainer::class);
+        $container->shouldReceive('private')->andReturnFalse();
+        $container->shouldReceive('url')->andReturn('http://example.com/container');
+        $container->shouldReceive('absoluteUrl')->andReturn('http://example.com/container');
+        $asset = (new Asset)->container($container)->path($path);
+
+        $this->assertEquals('http://example.com/container'.$expected, $asset->url());
+        $this->assertEquals('http://example.com/container'.$expected, $asset->absoluteUrl());
+        $this->assertEquals('http://example.com/container'.$expected, (string) $asset);
+    }
+
+    public static function urlEncodingProvider()
+    {
+        return [
+            'nothing to encode' => ['path/to/test.txt', '/path/to/test.txt'],
+            'spaces' => ['path/to/Image X - Whatever_17.jpg', '/path/to/Image%20X%20-%20Whatever_17.jpg'],
+            'accents' => ['path/to/Dún Laoghaire_18 2.jpg', '/path/to/D%C3%BAn%20Laoghaire_18%202.jpg'],
+            'spaces in folders' => ['path to/my folder/test.txt', '/path%20to/my%20folder/test.txt'],
+        ];
+    }
+
+    #[Test]
     public function there_is_no_url_for_a_private_asset()
     {
         $container = $this->mock(AssetContainer::class);

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -2397,6 +2397,7 @@ class AssetTest extends TestCase
             'spaces' => ['path/to/Image X - Whatever_17.jpg', '/path/to/Image%20X%20-%20Whatever_17.jpg'],
             'accents' => ['path/to/Dún Laoghaire_18 2.jpg', '/path/to/D%C3%BAn%20Laoghaire_18%202.jpg'],
             'spaces in folders' => ['path to/my folder/test.txt', '/path%20to/my%20folder/test.txt'],
+            'literal percent sequences' => ['path/to/photo%20one.jpg', '/path/to/photo%2520one.jpg'],
         ];
     }
 


### PR DESCRIPTION
This pull request fixes an issue where asset URLs weren't encoded, so filenames containing spaces or accented characters produced invalid URLs.

This was happening because `Asset::url()` and `Asset::absoluteUrl()` assembled the URL from the raw path, leaving characters like `ú` and spaces untouched. An asset called `Dún Laoghaire_18 2.jpg` came back as `https://ams3.digitaloceanspaces.com/mywebsite/Dún Laoghaire_18 2.jpg`, which `Str::isUrl()` doesn't consider a URL. Browsers percent-encode a raw `src` attribute for you, so images still rendered — the breakage only showed up server-side, where passing the URL into something like the `Glide` tag would send it down the wrong branch.

This PR fixes it by encoding each path segment with `rawurlencode()` when assembling both URLs, and decoding the path in `AssetRepository::findByUrl()` so encoded URLs resolve back to their asset. Since encoding and decoding are exact inverses, filenames containing literal percent sequences round trip correctly too — a file named `photo%20one.jpg` gets the URL `photo%2520one.jpg`. That does mean any old unencoded URLs to such files stored in content will no longer resolve via `findByUrl()`, which is inherent to encoding the URLs at all.

Fixes #5593
