### PR TITLE
[6.x] Allow revisions to be referenced by something other than their timestamp

### DIFF
--- a/resources/js/components/revision-history/History.vue
+++ b/resources/js/components/revision-history/History.vue
@@ -15,7 +15,7 @@
                     <div class="absolute inset-y-0 left-6 top-3 border-l-1 border-gray-400 dark:border-gray-600 border-dashed" />
                     <revision
                         v-for="(revision, index) in group.revisions"
-                        :key="revision.date"
+                        :key="revision.reference"
                         :revision="revision"
                         :restore-url="restoreUrl"
                         :reference="reference"

--- a/resources/js/components/revision-history/Restore.vue
+++ b/resources/js/components/revision-history/Restore.vue
@@ -38,7 +38,7 @@ export default {
     methods: {
         restore() {
             const payload = {
-                revision: this.revision.date,
+                revision: this.revision.reference,
             };
 
             this.$axios.post(this.url, payload).then((response) => {

--- a/src/Contracts/Revisions/Revision.php
+++ b/src/Contracts/Revisions/Revision.php
@@ -6,6 +6,9 @@ interface Revision
 {
     public function id();
 
+    // TODO: Uncomment for v7
+    // public function reference();
+
     public function message($message = null);
 
     public function attributes($attributes = null);

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -22,7 +22,7 @@ class EntryRevisionsController extends CpController
             ->each(fn ($revision) => $revision->attribute('item_url', cp_route('collections.entries.revisions.show', [
                 'collection' => $collection,
                 'entry' => $entry->id(),
-                'revision' => $revision->date()->timestamp,
+                'revision' => $revision->reference(),
             ])))
             ->prepend($this->workingCopy($entry))
             ->filter();

--- a/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
+++ b/src/Http/Controllers/CP/Collections/RestoreEntryRevisionController.php
@@ -19,8 +19,7 @@ class RestoreEntryRevisionController extends CpController
 
         /** @var $target Revision */
         if (! $target = $entry->revision($request->revision)) {
-            dd('no such revision', $request->revision);
-            // todo: handle invalid revision reference
+            abort(404, "Revision [{$request->revision}] not found.");
         }
 
         if ($entry->published()) {

--- a/src/Revisions/Revision.php
+++ b/src/Revisions/Revision.php
@@ -33,7 +33,12 @@ class Revision implements Arrayable, ContainsQueryableValues, Contract
 
     public function id()
     {
-        return $this->key.'/'.($this->isWorkingCopy() ? 'working' : $this->date()->timestamp);
+        return $this->key.'/'.$this->reference();
+    }
+
+    public function reference()
+    {
+        return $this->isWorkingCopy() ? 'working' : (string) $this->date()->timestamp;
     }
 
     public function user($user = null)
@@ -97,7 +102,7 @@ class Revision implements Arrayable, ContainsQueryableValues, Contract
         return vsprintf('%s/%s/%s.yaml', [
             Revisions::directory(),
             $this->key(),
-            $this->isWorkingCopy() ? 'working' : $this->date()->timestamp,
+            $this->reference(),
         ]);
     }
 
@@ -126,6 +131,7 @@ class Revision implements Arrayable, ContainsQueryableValues, Contract
 
         return [
             'id' => $this->id(),
+            'reference' => $this->reference(),
             'action' => $this->action,
             'date' => $this->date()->timestamp,
             'user' => $user,

--- a/src/Revisions/RevisionRepository.php
+++ b/src/Revisions/RevisionRepository.php
@@ -36,7 +36,7 @@ class RevisionRepository implements Contract
             ->where('key', $key)
             ->where('action', '!=', 'working')
             ->get()
-            ->keyBy(fn ($revision) => $revision->date()->timestamp);
+            ->keyBy(fn ($revision) => $revision->reference());
     }
 
     public function findWorkingCopyByKey($key)

--- a/tests/Feature/Entries/EntryRevisionsTest.php
+++ b/tests/Feature/Entries/EntryRevisionsTest.php
@@ -6,9 +6,11 @@ use Facades\Statamic\Fields\BlueprintRepository;
 use Facades\Tests\Factories\EntryFactory;
 use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Contracts\Revisions\Revision as RevisionContract;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Folder;
+use Statamic\Facades\Revision as Revisions;
 use Statamic\Facades\User;
 use Statamic\Fields\Blueprint;
 use Statamic\Revisions\Revision;
@@ -535,6 +537,52 @@ class EntryRevisionsTest extends TestCase
         $this->assertCount(1, $entry->revisions());
     }
 
+    #[Test]
+    public function it_restores_a_revision_referenced_by_something_other_than_its_timestamp()
+    {
+        $this->app->bind(RevisionContract::class, RevisionWithCustomReference::class);
+
+        $this->setTestBlueprint('test', ['foo' => ['type' => 'text']]);
+        $this->setTestRoles(['test' => ['access cp', 'view blog entries', 'edit blog entries']]);
+        $user = User::make()->id('user-1')->assignRole('test')->save();
+
+        tap(Revisions::make()
+            ->key('collections/blog/en/123')
+            ->date(Carbon::createFromTimestamp('1553546421', config('app.timezone')))
+            ->attributes([
+                'published' => true,
+                'slug' => 'existing-slug',
+                'data' => ['foo' => 'existing foo'],
+            ]))->save();
+
+        $entry = EntryFactory::id('123')
+            ->slug('test')
+            ->collection('blog')
+            ->published(false)
+            ->data([
+                'blueprint' => 'test',
+                'title' => 'Title',
+                'foo' => 'bar',
+            ])->create();
+
+        $this
+            ->actingAs($user)
+            ->get($entry->revisionsUrl())
+            ->assertOk()
+            ->assertJsonPath('0.revisions.0.reference', 'uuid-1553546421')
+            ->assertJsonPath('0.revisions.0.attributes.item_url', 'http://localhost/cp/collections/blog/entries/123/revisions/uuid-1553546421');
+
+        $this
+            ->actingAs($user)
+            ->restore($entry, ['revision' => 'uuid-1553546421'])
+            ->assertOk()
+            ->assertSessionHas('success');
+
+        $entry = Entry::find($entry->id());
+        $this->assertEquals('existing-slug', $entry->slug());
+        $this->assertEquals('existing foo', $entry->get('foo'));
+    }
+
     private function publish($entry, $payload)
     {
         return $this->post($entry->publishUrl(), $payload);
@@ -757,5 +805,13 @@ class EntryRevisionsTest extends TestCase
         BlueprintRepository::partialMock();
         BlueprintRepository::shouldReceive('find')->with('test')->andReturn($blueprint);
         BlueprintRepository::shouldReceive('in')->with('collections/blog')->andReturn(collect(['test' => $blueprint]));
+    }
+}
+
+class RevisionWithCustomReference extends Revision
+{
+    public function reference()
+    {
+        return $this->isWorkingCopy() ? 'working' : 'uuid-'.$this->date()->timestamp;
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where revisions could only ever be referenced by their date timestamp, which meant custom revision implementations had no way of identifying revisions by anything else.

This was happening because the timestamp was hardcoded in a few places: the payload sent when restoring a revision, the `item_url` used to preview one, and the keys `RevisionRepository::whereKey()` returns its collection with.

This PR fixes it by introducing a `reference()` method on `Revision`, which is now used as the identifier in each of those places. It defaults to the revision's timestamp (or `working` for working copies) so nothing changes out of the box, but it can be overridden to return a UUID, or whatever else makes sense.

`reference()` hasn't been added to the `Statamic\Contracts\Revisions\Revision` contract, since that would break implementations which don't extend `Statamic\Revisions\Revision`. It's been left commented out with a note to add it in v7.

This PR also replaces a leftover `dd()` in `RestoreEntryRevisionController` with a 404, and switches the revision history's `v-for` key over to `reference()` — two revisions saved in the same second would previously have shared a key.

Fixes #6026