### PR TITLE
[6.x] Use the fieldtype's config() when building the publish array

### DIFF
--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -438,7 +438,7 @@ class Field implements Arrayable
     {
         $fieldtype = $this->fieldtype();
 
-        $fields = $fieldtype->configFields()->addValues($this->config);
+        $fields = $fieldtype->configFields()->addValues($fieldtype->config());
 
         return array_merge(
             self::commonFieldOptions()->all()->map->defaultValue()->all(),

--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -362,9 +362,12 @@ abstract class Fieldtype implements Arrayable
             return $fallback;
         }
 
+        $fieldConfig = $this->field->config();
+
         $config = $this->configFields()->all()
+            ->reject(fn ($field, $handle) => array_key_exists($handle, $fieldConfig))
             ->map->defaultValue()
-            ->merge($this->field->config());
+            ->merge($fieldConfig);
 
         return $key
             ? ($config->get($key) ?? $fallback)

--- a/tests/Fields/FieldTest.php
+++ b/tests/Fields/FieldTest.php
@@ -358,6 +358,32 @@ class FieldTest extends TestCase
     }
 
     #[Test]
+    public function the_publish_array_uses_config_provided_by_the_fieldtype()
+    {
+        FieldtypeRepository::partialMock();
+
+        FieldtypeRepository::shouldReceive('find')
+            ->with('example')
+            ->andReturn(new class extends Fieldtype
+            {
+                protected $configFields = [
+                    'options' => ['type' => 'array'],
+                ];
+
+                public function config(?string $key = null, $fallback = null)
+                {
+                    $config = array_merge(parent::config(), ['options' => ['one' => 'One', 'two' => 'Two']]);
+
+                    return $key ? ($config[$key] ?? $fallback) : $config;
+                }
+            });
+
+        $field = new Field('test', ['type' => 'example']);
+
+        $this->assertSame(['one' => 'One', 'two' => 'Two'], $field->toPublishArray()['options']);
+    }
+
+    #[Test]
     public function it_gets_the_value()
     {
         $field = (new Field('test', ['type' => 'fieldtype']));

--- a/tests/Fields/FieldtypeTest.php
+++ b/tests/Fields/FieldtypeTest.php
@@ -545,6 +545,32 @@ class FieldtypeTest extends TestCase
     }
 
     #[Test]
+    public function it_only_computes_default_values_for_config_fields_missing_from_the_raw_config()
+    {
+        FieldtypeWithCountedDefaultValue::$timesDefaultValueWasComputed = 0;
+
+        (new FieldtypeWithCountedDefaultValue)::register();
+
+        $fieldtype = (new TestFieldtypeWithCountedConfigField)->setField(new Field('test', [
+            'alfa' => 'explicitly set',
+        ]));
+
+        $this->assertEquals([
+            'alfa' => 'explicitly set',
+        ], $fieldtype->config());
+
+        $this->assertSame(0, FieldtypeWithCountedDefaultValue::$timesDefaultValueWasComputed);
+
+        $fieldtype = (new TestFieldtypeWithCountedConfigField)->setField(new Field('test', []));
+
+        $this->assertEquals([
+            'alfa' => 'default!',
+        ], $fieldtype->config());
+
+        $this->assertSame(1, FieldtypeWithCountedDefaultValue::$timesDefaultValueWasComputed);
+    }
+
+    #[Test]
     #[Group('graphql')]
     public function it_gets_the_graphql_type_of_string_by_default()
     {
@@ -742,6 +768,29 @@ class TestFieldtypeWithConfigFields extends Fieldtype
             'default' => ['hotel!'],
         ],
     ];
+}
+
+class TestFieldtypeWithCountedConfigField extends Fieldtype
+{
+    protected $configFields = [
+        'alfa' => [
+            'type' => 'counted_default',
+        ],
+    ];
+}
+
+class FieldtypeWithCountedDefaultValue extends Fieldtype
+{
+    protected static $handle = 'counted_default';
+
+    public static $timesDefaultValueWasComputed = 0;
+
+    public function defaultValue()
+    {
+        static::$timesDefaultValueWasComputed++;
+
+        return 'default!';
+    }
 }
 
 class TestMultiWordFieldtype extends Fieldtype

--- a/tests/Fieldtypes/SetsTest.php
+++ b/tests/Fieldtypes/SetsTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Fieldtypes;
 
+use Facades\Statamic\Fields\FieldtypeRepository;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Icon;
 use Statamic\Facades\Path;
 use Statamic\Fields\ConfigField;
 use Statamic\Fields\Field;
+use Statamic\Fields\Fieldtype;
 use Statamic\Fieldtypes\Sets;
 use Statamic\Statamic;
 use Tests\TestCase;
@@ -368,6 +370,43 @@ class SetsTest extends TestCase
         ]));
 
         $this->assertEquals([], $field->preProcess()->value());
+    }
+
+    #[Test]
+    public function it_preprocesses_for_config_using_config_provided_by_the_set_fieldtypes()
+    {
+        FieldtypeRepository::partialMock();
+
+        FieldtypeRepository::shouldReceive('find')
+            ->with('example')
+            ->andReturn(new class extends Fieldtype
+            {
+                protected $configFields = [
+                    'options' => ['type' => 'array'],
+                ];
+
+                public function config(?string $key = null, $fallback = null)
+                {
+                    $config = array_merge(parent::config(), ['options' => ['one' => 'One', 'two' => 'Two']]);
+
+                    return $key ? ($config[$key] ?? $fallback) : $config;
+                }
+            });
+
+        $field = (new ConfigField('test', [
+            'type' => 'sets',
+        ]))->setValue([
+            'one' => [
+                'fields' => [
+                    ['handle' => 'field_one', 'field' => ['type' => 'example']],
+                ],
+            ],
+        ]);
+
+        $this->assertSame(
+            ['one' => 'One', 'two' => 'Two'],
+            $field->preProcess()->value()[0]['sets'][0]['fields'][0]['options']
+        );
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where a fieldtype overriding `config()` never had that config reach its Vue component.

This was happening because `Field::preProcessedConfig()` populated the config fields from the field's raw YAML config, rather than asking the fieldtype for its config. It meant `$this->config('placeholder')` in PHP and `config.placeholder` in Vue could disagree for the same field.

This PR fixes it by passing `$fieldtype->config()` into `addValues()` when building the publish array.

Worth noting the original issue describes a custom select fieldtype with dynamic options, which already works today — select options travel to the CP through `preload()`, which does respect `config()` overrides. The inconsistency only remains for fieldtypes whose Vue component reads a config key directly (`config.placeholder`, `config.character_limit`, etc.), which is what this PR addresses.

Fixes #2882