### PR TITLE
[6.x] Some CSS rendering performance optimisations

### DIFF
--- a/resources/css/components/assets.css
+++ b/resources/css/components/assets.css
@@ -132,6 +132,8 @@
 
 .asset-tile {
     @apply relative flex min-w-0 cursor-pointer flex-col items-center justify-between rounded-lg outline outline-gray-300 dark:outline-gray-700;
+    /* Localize selection/hover layout work; avoid paint so selection outlines aren't clipped. */
+    contain: layout;
 
     > button {
         /* Shift the focus outline offset slightly to account for the grey border. Target direct descendents so we don't target inner buttons like the three-dot menu. */

--- a/resources/css/components/blueprints.css
+++ b/resources/css/components/blueprints.css
@@ -42,8 +42,3 @@
         @apply bg-white;
     }
 }
-
-.fieldtype-list {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-}

--- a/resources/css/components/page-tree.css
+++ b/resources/css/components/page-tree.css
@@ -18,6 +18,11 @@
     .page-tree-branch {
         @apply relative rounded-xl bg-white text-xs shadow;
         @apply dark:bg-gray-800;
+        /* Skip layout/paint for off-screen branches.
+          - content-visibility already applies containment while rendering / skipped
+        */
+        content-visibility: auto;
+        contain-intrinsic-size: auto 44px;
     }
 
     .page-move {

--- a/resources/css/components/stacks.css
+++ b/resources/css/components/stacks.css
@@ -36,6 +36,11 @@
     }
 
     .stack-content {
+        /* Isolate stack layout from the rest of the CP.
+          - layout-only: no paint/size
+          - keeps shadows, focus rings, and portaled menus intact
+        */
+        contain: layout;
         @apply relative h-[calc(100svh-1rem)];
     }
 

--- a/resources/css/elements/tables.css
+++ b/resources/css/elements/tables.css
@@ -69,6 +69,11 @@
     tbody {
         @apply text-sm shadow-sm-b rounded-xl outline-none;
 
+        > tr {
+            /* Localize row updates; layout-only so cell focus rings / shadows aren't clipped. */
+            contain: layout;
+        }
+
         tr {
             &:last-child {
                 @apply border-none;

--- a/resources/js/components/fields/FieldtypeSelector.vue
+++ b/resources/js/components/fields/FieldtypeSelector.vue
@@ -28,7 +28,7 @@
                             <ui-description :text="group.description" />
                         </ui-panel-header>
                         <div class="grid grid-cols-[repeat(auto-fill,minmax(180px,1fr))] gap-1.5">
-                        <div v-for="fieldtype in group.fieldtypes" :key="fieldtype.handle">
+                        <div v-for="fieldtype in group.fieldtypes" :key="fieldtype.handle" class="contain-layout">
                             <button
                                 class="flex items-center gap-2 w-full px-3 py-2.5 group bg-white dark:bg-gray-850 shadow-ui-sm rounded-xl border border-gray-200 dark:border-x-0 dark:border-b-0 dark:border-gray-700 cursor-pointer"
                                 type="button"


### PR DESCRIPTION
## Description of the Problem

Parts of the CP are self-contained UI “islands” (stacks, asset tiles, listing rows, page-tree branches, fieldtype picker cards). Without CSS containment, small updates inside those islands can force the browser to reconsider layout for much larger parts of the page.

This may bet be noticeable in normal use, but we can make small/cheap changes here to optimise things for the browser.

## What this PR Does

Uses CSS's `containment` and `content-visibility` properties to isolate browser rendering.

This is low-risk CSS rendering isolation.

- **contain:** layout on stacks, asset tiles, listing table rows, and fieldtype picker cards — keeps internal layout work local without clipping shadows, outlines, or menus.
- **content-visibility:** auto (+ intrinsic size) on page-tree branches — skips layout/paint for off-screen rows
- Removes a dead .fieldtype-list rule (grid now lives in FieldtypeSelector.vue)

I've intentionally avoided paint/content containment and content-visibility on parts of the CP that are variable-height such as the publish form, where there's a risk of increasing cumulative layout shift (CLS) and clipping.

## How to Reproduce

1. **Stacks** — open an asset editor or relationship browse stack; interact inside it
2. **Asset tiles** — `/cp/assets` grid; select tiles, open menus
3. **Page tree** — `/cp/nav/default/edit` (expand all, scroll, drag) or a structured collection tree
4. **Listing rows** — `/cp/collections/pages` (or any index); hover/select rows
5. **Fieldtype picker** — edit a blueprint → Add Field

Expect little visible change when the CPU is idle. Worth checking for clipped shadows/outlines, jumpy scroll on large trees, and drag-and-drop still feeling correct on the nav/page tree.