### PR TITLE
[6.x] Fix page tree border radius

### DIFF
--- a/resources/css/components/page-tree.css
+++ b/resources/css/components/page-tree.css
@@ -61,7 +61,7 @@
             @apply mt-8 pt-1 bg-gray-200/45 dark:bg-gray-950 rounded-t-2xl;
         }
         &:has(+ .tree-node .is-section),
-        &:last-child {
+        &:nth-last-child(1 of .tree-node) {
             @apply pb-1 rounded-b-2xl;
         }
         &:has(.is-top-level-section-placeholder) {


### PR DESCRIPTION
## Description of the Problem

the `:last-child` selector was broken in because `tree_aria_instructions` were added to the end of the page-tree (https://github.com/statamic/cms/pull/14499)

This caused the border-radius of the last section to break.

See the bottom left border of the users section here

<img width="3420" height="2146" alt="2026-08-11 at 14 08 54@2x" src="https://github.com/user-attachments/assets/c4246f22-00d5-44e2-8cea-a46437687806" />

## What this PR Does

Makes the selector less brittle

## How to Reproduce

1. Go to `/cp/nav/default/edit` and observe the last section border-radius