### PR TITLE
[6.x] Update `extraValues` state in `PublishContainer` when prop is updated

### DIFF
--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -151,6 +151,11 @@ watch(
 );
 
 watch(
+    () => props.extraValues,
+    (newExtraValues) => extraValues.value = newExtraValues,
+);
+
+watch(
     () => props.meta,
     (newMeta) => meta.value = newMeta,
 );


### PR DESCRIPTION
This pull request ensures the `extraValues` state in the `PublishContainer` component is updated when the prop is updated.

This fixes something I ran into where updating the prop's value in my component didn't update it in the container's internal state.