### PR TITLE
[6.x] Resolve `@statamic/cms` types under legacy module resolution

### DIFF
--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -38,5 +38,16 @@
         "./vite-plugin": {
             "default": "./src/vite-plugin/index.js"
         }
+    },
+    "main": "./src/index.js",
+    "types": "./types/bootstrap/cms/index.d.ts",
+    "typesVersions": {
+        "*": {
+            "ui": ["./types/bootstrap/cms/ui.d.ts"],
+            "api": ["./types/bootstrap/cms/api.d.ts"],
+            "bard": ["./types/bootstrap/cms/bard.d.ts"],
+            "save-pipeline": ["./types/bootstrap/cms/save-pipeline.d.ts"],
+            "inertia": ["./types/bootstrap/cms/inertia.d.ts"]
+        }
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where importing from `@statamic/cms` subpaths in an addon shows as unresolved in some editors, with a warning like "Cannot find module `@statamic/cms/api` or its corresponding type declarations".

This was happening because the package only declares its subpath types through the `exports` map. Editors running node10-style `moduleResolution` (which is still PhpStorm's default in a lot of setups) ignore `exports` entirely, so they'd find no type declarations — even while reporting that the `.d.ts` file exists and can't be reached under the current setting.

This PR fixes it by adding `typesVersions`, plus root `main`/`types` fields, as a downlevel fallback pointing at the same declaration files. The `exports` map is untouched, and modern resolvers (Vite, `node16`, `bundler`) continue to use it and ignore what's been added.

Worth noting the `main` field also means pre-`exports` bundlers can now resolve the root `@statamic/cms` import. That's a side effect rather than a goal — subpath imports still won't resolve on those tools, since `typesVersions` redirects types only, not the JS.