### PR TITLE
[5.x] Fix markdown tests

### DIFF
--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -254,7 +254,7 @@ EOT, $markdown);
 <h2><a id="content-alfa-bravo" href="#content-alfa-bravo" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Alfa Bravo</h2>
 <h2><a id="content-charlie-delta" href="#content-charlie-delta" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Charlie Delta</h2>
 EOT,
-            str_replace(' tabindex="-1"', '', rtrim(Markdown::withHeadingPermalinks()->parse($markdown)))
+            rtrim(Markdown::withHeadingPermalinks()->parse($markdown))
         );
     }
 
@@ -294,7 +294,7 @@ EOT;
         // and without the tabindex attribute because it's only added in 2.9.2 and later.
         $this->assertEquals(
             str($expected)->replace("\n", ''),
-            str(Markdown::withTableOfContents()->parse($markdown))->trim()->replace("\n", '')->replace(' tabindex="-1"', '')
+            str(Markdown::withTableOfContents()->parse($markdown))->trim()->replace("\n", '')
         );
     }
 }

--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -249,11 +249,12 @@ EOT;
 <h2>Charlie Delta</h2>
 EOT, $markdown);
 
+        // Make assertion without the tabindex attribute because it's only added in commonmark 2.9.2 and later.
         $this->assertEquals(<<<'EOT'
 <h2><a id="content-alfa-bravo" href="#content-alfa-bravo" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Alfa Bravo</h2>
 <h2><a id="content-charlie-delta" href="#content-charlie-delta" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Charlie Delta</h2>
 EOT,
-            rtrim(Markdown::withHeadingPermalinks()->parse($markdown))
+            str_replace(' tabindex="-1"', '', rtrim(Markdown::withHeadingPermalinks()->parse($markdown)))
         );
     }
 
@@ -289,10 +290,11 @@ EOT, $markdown);
 <p>Baz qux.</p>
 EOT;
 
-        // Make assertion without newlines because they differ between versions of commonmark.
+        // Make assertion without newlines because they differ between versions of commonmark,
+        // and without the tabindex attribute because it's only added in 2.9.2 and later.
         $this->assertEquals(
             str($expected)->replace("\n", ''),
-            str(Markdown::withTableOfContents()->parse($markdown))->trim()->replace("\n", '')
+            str(Markdown::withTableOfContents()->parse($markdown))->trim()->replace("\n", '')->replace(' tabindex="-1"', '')
         );
     }
 }

--- a/tests/Markdown/MarkdownTest.php
+++ b/tests/Markdown/MarkdownTest.php
@@ -254,7 +254,7 @@ EOT, $markdown);
 <h2><a id="content-alfa-bravo" href="#content-alfa-bravo" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Alfa Bravo</h2>
 <h2><a id="content-charlie-delta" href="#content-charlie-delta" class="heading-permalink" aria-hidden="true" title="Permalink">¶</a>Charlie Delta</h2>
 EOT,
-            rtrim(Markdown::withHeadingPermalinks()->parse($markdown))
+            str_replace(' tabindex="-1"', '', rtrim(Markdown::withHeadingPermalinks()->parse($markdown)))
         );
     }
 
@@ -294,7 +294,7 @@ EOT;
         // and without the tabindex attribute because it's only added in 2.9.2 and later.
         $this->assertEquals(
             str($expected)->replace("\n", ''),
-            str(Markdown::withTableOfContents()->parse($markdown))->trim()->replace("\n", '')
+            str(Markdown::withTableOfContents()->parse($markdown))->trim()->replace("\n", '')->replace(' tabindex="-1"', '')
         );
     }
 }


### PR DESCRIPTION
commonmark 2.9.2 adds `tabindex="-1"` to heading permalinks, so that a permalink rendered with `aria-hidden="true"` isn't left in the keyboard tab order. The markdown tests assert against hardcoded permalink markup, so they started failing as soon as 2.9.2 was released.

Rather than hardcoding the new markup, the assertions now strip the attribute before comparing, in the same spirit as the existing newline normalization in the table of contents test. That keeps the tests passing on both 2.9.2 and 2.9.0, which is what `prefer-lowest` currently resolves to. I didn't want to bump the requirement to an hours-old release on 5.x.

This is targeting 5.x even though it's in security-only status, because CI runs would fail.
