### PR TITLE
[6.x] Respect collection permissions in the navigation page selector

### DIFF
--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -97,9 +97,13 @@ class NavigationController extends CpController
 
         $collectionTree = null;
 
-        if ($nav->collections()->count() === 1 && $nav->collections()->first()->hasStructure()) {
-            $collection = $nav->collections()->first();
-
+        // Don't offer a tree for a collection the user isn't allowed to view.
+        // The selector falls back to the list.
+        if (
+            $nav->collections()->count() === 1
+            && ($collection = $nav->collections()->first())->hasStructure()
+            && User::current()->can('view', $collection)
+        ) {
             $collectionBlueprints = $collection
                 ->entryBlueprints()
                 ->reject->hidden()

--- a/tests/Feature/Navigation/ViewNavigationTest.php
+++ b/tests/Feature/Navigation/ViewNavigationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Navigation;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ViewNavigationTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_provides_the_collection_tree_when_you_can_view_the_collection()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test nav', 'view pages entries']]);
+        $user = tap(Facades\User::make()->assignRole('test'))->save();
+        $nav = $this->createNavLinkedToStructuredCollection();
+
+        $this
+            ->actingAs($user)
+            ->visitShow($nav)
+            ->assertSuccessful()
+            ->assertInertia(fn ($page) => $page
+                ->component('navigation/Show')
+                ->where('collectionTree.title', 'Pages')
+            );
+    }
+
+    #[Test]
+    public function it_doesnt_provide_the_collection_tree_when_you_cant_view_the_collection()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test nav']]);
+        $user = tap(Facades\User::make()->assignRole('test'))->save();
+        $nav = $this->createNavLinkedToStructuredCollection();
+
+        $this
+            ->actingAs($user)
+            ->visitShow($nav)
+            ->assertSuccessful()
+            ->assertInertia(fn ($page) => $page
+                ->component('navigation/Show')
+                ->where('collectionTree', null)
+            );
+    }
+
+    private function createNavLinkedToStructuredCollection()
+    {
+        $collection = tap(Facades\Collection::make('pages')->title('Pages')->routes('{parent_uri}/{slug}'))->save();
+
+        EntryFactory::id('e1')->collection($collection)->slug('a')->create();
+
+        $collection->structureContents(['root' => false])->save();
+        $collection->structure()->in('en')->tree([['entry' => 'e1']])->save();
+
+        $nav = tap(Facades\Nav::make('test')->collections(['pages']))->save();
+        $nav->makeTree('en', [['id' => 'id1', 'title' => 'One', 'url' => 'http://example.com/one']])->save();
+
+        return $nav;
+    }
+
+    private function visitShow($nav)
+    {
+        return $this->get(cp_route('navigation.show', $nav->handle()));
+    }
+}


### PR DESCRIPTION
When a navigation is linked to a single structured collection, its page selector offers a tree view of that collection alongside the list. The tree was being offered regardless of whether the user has permission to view that collection.

Now it's only included when they do, and the selector falls back to the list.

Also drops a duplicated `$nav->collections()->first()` call while I was in there.