### PR TITLE
[5.x] Improve permission handling on tree endpoints

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -526,7 +526,9 @@ class Entries extends Relationship
             ? Collection::findByHandle($this->getConfiguredCollections()[0])
             : null;
 
-        if (! $collection || ! $collection->hasStructure()) {
+        // Without permission to view the collection, the tree endpoint would reject the
+        // request, so don't offer the tree at all. The selector falls back to the list.
+        if (! $collection || ! $collection->hasStructure() || ! User::current()?->can('view', $collection)) {
             return parent::preload();
         }
 

--- a/src/Http/Controllers/CP/Collections/CollectionTreeController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionTreeController.php
@@ -12,16 +12,20 @@ use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Structures\TreeBuilder;
 use Statamic\Support\Arr;
 
+use function Statamic\trans as __;
+
 class CollectionTreeController extends CpController
 {
     public function index(Request $request, Collection $collection)
     {
-        $site = $request->site ?? Site::selected()->handle();
+        abort_unless($site = Site::get($request->site ?? Site::selected()->handle()), 404);
+
+        $this->authorize('viewInSite', [$collection, $site], __('You are not authorized to view this collection.'));
 
         $pages = (new TreeBuilder)->buildForController([
             'structure' => $collection->structure(),
             'include_home' => true,
-            'site' => $site,
+            'site' => $site->handle(),
         ]);
 
         return ['pages' => $pages];
@@ -29,12 +33,14 @@ class CollectionTreeController extends CpController
 
     public function update(Request $request, $collection)
     {
-        $this->authorize('reorder', $collection);
+        abort_unless($site = Site::get($request->site ?? Site::selected()->handle()), 404);
+
+        $this->authorize('reorderInSite', [$collection, $site]);
 
         $contents = $this->toTree($request->pages);
 
         $structure = $collection->structure();
-        $tree = $structure->in($request->site);
+        $tree = $structure->in($site->handle());
 
         // Clone the tree and add the submitted contents into it so we can
         // validate URI uniqueness without affecting the real object in memory.
@@ -44,7 +50,7 @@ class CollectionTreeController extends CpController
 
         // Validate the tree, which will add any missing entries or throw an exception
         // if somehow the root would end up having child pages, which isn't allowed.
-        $contents = $structure->validateTree($contents, $request->site);
+        $contents = $structure->validateTree($contents, $site->handle());
 
         return [
             'saved' => $tree->tree($contents)->save(),

--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -3,12 +3,14 @@
 namespace Statamic\Http\Controllers\CP\Collections;
 
 use Illuminate\Http\Request;
+use Statamic\Facades\Site;
 use Statamic\Http\Controllers\CP\CpController;
 
 class ReorderEntriesController extends CpController
 {
     public function __invoke(Request $request, $collection)
     {
+        // Checked up front so an unauthorized user is denied before seeing any validation feedback.
         $this->authorize('reorder', $collection);
 
         $request->validate([
@@ -18,7 +20,11 @@ class ReorderEntriesController extends CpController
             'site' => 'required',
         ]);
 
-        $tree = $collection->structure()->in($request->site);
+        abort_unless($site = Site::get($request->site), 404);
+
+        $this->authorize('reorderInSite', [$collection, $site]);
+
+        $tree = $collection->structure()->in($site->handle());
 
         $contents = collect($tree->tree())->keyBy('entry');
 

--- a/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationTreeController.php
@@ -18,11 +18,15 @@ class NavigationTreeController extends CpController
 
     public function index(Request $request, $handle)
     {
-        $nav = Nav::find($handle);
+        abort_unless($nav = Nav::find($handle), 404);
 
         $site = $request->site ?? Site::selected()->handle();
 
-        $nav->in($site)->ensureBranchIds();
+        abort_unless($tree = $nav->in($site), 404);
+
+        $this->authorize('view', $tree, __('You are not authorized to view navs.'));
+
+        $tree->ensureBranchIds();
 
         $pages = (new TreeBuilder)->buildForController([
             'structure' => $nav,

--- a/src/Policies/CollectionPolicy.php
+++ b/src/Policies/CollectionPolicy.php
@@ -3,7 +3,9 @@
 namespace Statamic\Policies;
 
 use Statamic\Facades\Collection;
+use Statamic\Facades\Site as Sites;
 use Statamic\Facades\User;
+use Statamic\Sites\Site;
 
 class CollectionPolicy
 {
@@ -49,6 +51,15 @@ class CollectionPolicy
             && $this->userCanAccessAnySite($user, $collection->sites());
     }
 
+    // `view` only requires access to *any* of the collection's sites, which is the right
+    // question for "should this appear in the CP at all". When a request names a site,
+    // that site is the one that needs checking.
+    public function viewInSite($user, $collection, $site)
+    {
+        return $this->view($user, $collection)
+            && $this->userCanAccessGivenSite($user, $site);
+    }
+
     public function edit($user, $collection)
     {
         // handled by before()
@@ -69,5 +80,20 @@ class CollectionPolicy
         $user = User::fromUser($user);
 
         return $collection->hasStructure() && $user->hasPermission("reorder {$collection->handle()} entries");
+    }
+
+    public function reorderInSite($user, $collection, $site)
+    {
+        return $this->reorder($user, $collection)
+            && $this->userCanAccessGivenSite($user, $site);
+    }
+
+    private function userCanAccessGivenSite($user, $site)
+    {
+        if (! $site instanceof Site) {
+            $site = Sites::get($site);
+        }
+
+        return $site ? $this->userCanAccessSite(User::fromUser($user), $site) : false;
     }
 }

--- a/tests/Feature/Collections/UpdateCollectionTreeTest.php
+++ b/tests/Feature/Collections/UpdateCollectionTreeTest.php
@@ -200,6 +200,70 @@ class UpdateCollectionTreeTest extends TestCase
             ->assertForbidden();
     }
 
+    #[Test]
+    public function it_denies_access_to_a_site_you_cannot_access()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'view test entries', 'reorder test entries', 'access en site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $collection = tap(Collection::make('test')->sites(['en', 'fr'])->routes('{parent_uri}/{slug}'))->save();
+        EntryFactory::id('fr1')->collection($collection)->locale('fr')->slug('a')->create();
+        EntryFactory::id('fr2')->collection($collection)->locale('fr')->slug('b')->create();
+        $collection->structureContents(['root' => false])->save();
+        $collection->structure()->in('en')->tree([])->save();
+        $collection->structure()->in('fr')->tree([['entry' => 'fr1'], ['entry' => 'fr2']])->save();
+
+        $this
+            ->actingAs($user)
+            ->update($collection, ['site' => 'fr', 'pages' => [
+                ['id' => 'fr2', 'children' => []],
+                ['id' => 'fr1', 'children' => []],
+            ]])
+            ->assertForbidden();
+
+        $this->assertEquals(
+            ['fr1', 'fr2'],
+            collect(Collection::findByHandle('test')->structure()->in('fr')->tree())->pluck('entry')->all()
+        );
+    }
+
+    #[Test]
+    public function configure_collections_can_update_any_site()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'configure collections']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $collection = tap(Collection::make('test')->sites(['en', 'fr'])->routes('{parent_uri}/{slug}'))->save();
+        EntryFactory::id('fr1')->collection($collection)->locale('fr')->slug('a')->create();
+        EntryFactory::id('fr2')->collection($collection)->locale('fr')->slug('b')->create();
+        $collection->structureContents(['root' => false])->save();
+        $collection->structure()->in('en')->tree([])->save();
+        $collection->structure()->in('fr')->tree([['entry' => 'fr1'], ['entry' => 'fr2']])->save();
+
+        $this
+            ->actingAs($user)
+            ->update($collection, ['site' => 'fr', 'pages' => [
+                ['id' => 'fr2', 'children' => []],
+                ['id' => 'fr1', 'children' => []],
+            ]])
+            ->assertOk();
+
+        $this->assertEquals(
+            ['fr2', 'fr1'],
+            collect(Collection::findByHandle('test')->structure()->in('fr')->tree())->pluck('entry')->all()
+        );
+    }
+
     public function update($collection, $payload = [])
     {
         $validParams = [

--- a/tests/Feature/Collections/ViewCollectionTreeTest.php
+++ b/tests/Feature/Collections/ViewCollectionTreeTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\Collections;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ViewCollectionTreeTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_shows_the_tree()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection();
+
+        $response = $this
+            ->actingAs($user)
+            ->index($collection)
+            ->assertOk();
+
+        $this->assertEquals(['e1', 'e2'], collect($response->json('pages'))->map->entry->all());
+    }
+
+    #[Test]
+    public function it_denies_access_if_you_dont_have_permission_to_view_the_collection()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection();
+
+        $this
+            ->actingAs($user)
+            ->index($collection)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_shows_the_tree_for_a_site_you_can_access()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'view test entries', 'access en site', 'access fr site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection(['en', 'fr']);
+
+        $response = $this
+            ->actingAs($user)
+            ->index($collection, 'fr')
+            ->assertOk();
+
+        $this->assertEquals(['fr1'], collect($response->json('pages'))->map->entry->all());
+    }
+
+    #[Test]
+    public function it_denies_access_to_a_site_you_cannot_access()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'view test entries', 'access en site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection(['en', 'fr']);
+
+        $this
+            ->actingAs($user)
+            ->index($collection, 'fr')
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function configure_collections_can_view_any_site()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'configure collections']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection(['en', 'fr']);
+
+        $response = $this
+            ->actingAs($user)
+            ->index($collection, 'fr')
+            ->assertOk();
+
+        $this->assertEquals(['fr1'], collect($response->json('pages'))->map->entry->all());
+    }
+
+    #[Test]
+    public function it_404s_when_the_site_doesnt_exist()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = $this->createStructuredCollection();
+
+        $this
+            ->actingAs($user)
+            ->index($collection, 'nope')
+            ->assertNotFound();
+    }
+
+    private function createStructuredCollection($sites = ['en'])
+    {
+        $collection = tap(Collection::make('test')->sites($sites)->routes('{parent_uri}/{slug}'))->save();
+
+        EntryFactory::id('e1')->collection($collection)->locale('en')->slug('a')->create();
+        EntryFactory::id('e2')->collection($collection)->locale('en')->slug('b')->create();
+
+        $collection->structureContents(['root' => false])->save();
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'e1'],
+            ['entry' => 'e2'],
+        ])->save();
+
+        if (in_array('fr', $sites)) {
+            EntryFactory::id('fr1')->collection($collection)->locale('fr')->slug('c')->create();
+
+            $collection->structure()->in('fr')->tree([
+                ['entry' => 'fr1'],
+            ])->save();
+        }
+
+        return $collection;
+    }
+
+    private function index($collection, $site = null)
+    {
+        $url = cp_route('collections.tree.index', $collection->handle());
+
+        if ($site) {
+            $url .= '?site='.$site;
+        }
+
+        return $this->getJson($url);
+    }
+}

--- a/tests/Feature/Entries/ReorderEntriesTest.php
+++ b/tests/Feature/Entries/ReorderEntriesTest.php
@@ -144,6 +144,37 @@ class ReorderEntriesTest extends TestCase
         $this->assertEquals(7, Entry::find(7)->order());
     }
 
+    #[Test]
+    public function it_denies_access_to_a_site_you_cannot_access()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->collection->sites(['en', 'fr'])->save();
+        $this->structure->makeTree('fr')->save();
+
+        EntryFactory::id('fr1')->collection('test')->locale('fr')->slug('a')->create();
+        EntryFactory::id('fr2')->collection('test')->locale('fr')->slug('b')->create();
+        $this->structure->in('fr')->tree([['entry' => 'fr1'], ['entry' => 'fr2']])->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view test entries', 'reorder test entries', 'access en site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $this
+            ->from('/original')
+            ->actingAs($user)
+            ->reorder(['site' => 'fr', 'ids' => ['fr2', 'fr1'], 'page' => 1, 'perPage' => 10])
+            ->assertRedirect('/original')
+            ->assertSessionHas('error');
+
+        $this->assertEquals(
+            ['fr1', 'fr2'],
+            collect($this->structure->in('fr')->tree())->pluck('entry')->all()
+        );
+    }
+
     private function reorder($payload)
     {
         return $this->post(cp_route('collections.entries.reorder', 'test'), array_merge(['site' => 'en'], $payload));

--- a/tests/Feature/Navigation/ViewNavigationTreeTest.php
+++ b/tests/Feature/Navigation/ViewNavigationTreeTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Tests\Feature\Navigation;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Nav;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class ViewNavigationTreeTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function it_shows_the_tree()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test nav']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $nav = $this->createNavWithTree();
+
+        $response = $this
+            ->actingAs($user)
+            ->index($nav)
+            ->assertOk();
+
+        $this->assertEquals(['One', 'Two'], collect($response->json('pages'))->map->title->all());
+    }
+
+    #[Test]
+    public function it_denies_access_if_you_dont_have_permission_to_view_the_nav()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $nav = $this->createNavWithTree();
+
+        $this
+            ->actingAs($user)
+            ->index($nav)
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_shows_the_tree_for_a_site_you_can_access()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'view test nav', 'access en site', 'access fr site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $nav = $this->createNavWithTree();
+
+        $response = $this
+            ->actingAs($user)
+            ->index($nav, 'fr')
+            ->assertOk();
+
+        $this->assertEquals(['Un'], collect($response->json('pages'))->map->title->all());
+    }
+
+    #[Test]
+    public function it_denies_access_to_a_site_you_cannot_access()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'view test nav', 'access en site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $nav = $this->createNavWithTree();
+
+        $this
+            ->actingAs($user)
+            ->index($nav, 'fr')
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function it_404s_when_the_nav_doesnt_exist()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test nav']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $this->createNavWithTree();
+
+        $this
+            ->actingAs($user)
+            ->getJson(cp_route('navigation.tree.index', 'nope'))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function it_404s_when_the_nav_has_no_tree_for_the_site()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $this->setTestRoles(['test' => ['access cp', 'view test nav', 'access en site', 'access fr site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $nav = tap(Nav::make('test'))->save();
+        $nav->makeTree('en', [['id' => 'id1', 'title' => 'One', 'url' => 'http://example.com/one']])->save();
+
+        $this
+            ->actingAs($user)
+            ->index($nav, 'fr')
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function super_users_get_a_404_rather_than_a_403_when_the_nav_has_no_tree_for_the_site()
+    {
+        $this->setSites([
+            'en' => ['url' => '/', 'locale' => 'en_US'],
+            'fr' => ['url' => '/fr', 'locale' => 'fr_FR'],
+        ]);
+
+        $user = tap(User::make()->makeSuper())->save();
+
+        $nav = tap(Nav::make('test'))->save();
+        $nav->makeTree('en', [['id' => 'id1', 'title' => 'One', 'url' => 'http://example.com/one']])->save();
+
+        $this
+            ->actingAs($user)
+            ->index($nav, 'fr')
+            ->assertNotFound();
+    }
+
+    private function createNavWithTree()
+    {
+        $nav = tap(Nav::make('test'))->save();
+
+        $nav->makeTree('en', [
+            ['id' => 'id1', 'title' => 'One', 'url' => 'http://example.com/one'],
+            ['id' => 'id2', 'title' => 'Two', 'url' => 'http://example.com/two'],
+        ])->save();
+
+        $nav->makeTree('fr', [
+            ['id' => 'id3', 'title' => 'Un', 'url' => 'http://example.com/un'],
+        ])->save();
+
+        return $nav;
+    }
+
+    private function index($nav, $site = null)
+    {
+        $url = cp_route('navigation.tree.index', $nav->handle());
+
+        if ($site) {
+            $url .= '?site='.$site;
+        }
+
+        return $this->getJson($url);
+    }
+}

--- a/tests/Fieldtypes/EntriesPreloadTest.php
+++ b/tests/Fieldtypes/EntriesPreloadTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Entries;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class EntriesPreloadTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $collection = tap(Facades\Collection::make('pages')->routes('{parent_uri}/{slug}'))->save();
+
+        EntryFactory::id('e1')->collection($collection)->slug('a')->create();
+
+        $collection->structureContents(['root' => false])->save();
+        $collection->structure()->in('en')->tree([['entry' => 'e1']])->save();
+    }
+
+    #[Test]
+    public function it_preloads_the_tree_when_you_can_view_the_collection()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view pages entries']]);
+        $user = tap(Facades\User::make()->assignRole('test'))->save();
+
+        $this->actingAs($user);
+
+        $this->assertArrayHasKey('tree', $this->fieldtype()->preload());
+    }
+
+    #[Test]
+    public function it_doesnt_preload_the_tree_when_you_cant_view_the_collection()
+    {
+        $this->setTestRoles(['test' => ['access cp']]);
+        $user = tap(Facades\User::make()->assignRole('test'))->save();
+
+        $this->actingAs($user);
+
+        $this->assertArrayNotHasKey('tree', $this->fieldtype()->preload());
+    }
+
+    private function fieldtype()
+    {
+        return (new Entries)->setField(new Field('test', [
+            'type' => 'entries',
+            'collections' => ['pages'],
+        ]));
+    }
+}


### PR DESCRIPTION
Brings the collection and navigation tree endpoints in line with the screens that use them — they now check the same permissions as those screens, including which sites the user has access to.

The per-site part is done with two new `CollectionPolicy` abilities, `viewInSite` and `reorderInSite`, which build on the existing `view` and `reorder` rather than replacing them. That leaves `view`/`reorder` untouched everywhere else, and means a custom policy extending ours still gets a say.

Also tidies up some missing-resource handling, so an unknown nav or site gives a 404 rather than an error, and the entries fieldtype no longer offers a tree for a collection the user can't view — the selector falls back to the list, same as the change on 6.x.