### PR TITLE
[6.x] Make form email view fields clearable

### DIFF
--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -320,6 +320,7 @@ class FormsController extends CpController
                                     'display' => __('HTML view'),
                                     'instructions' => __('statamic::messages.form_configure_email_html_instructions'),
                                     'folder' => config('statamic.forms.email_view_folder'),
+                                    'clearable' => true,
                                 ],
                             ],
                             [
@@ -329,6 +330,7 @@ class FormsController extends CpController
                                     'display' => __('Text view'),
                                     'instructions' => __('statamic::messages.form_configure_email_text_instructions'),
                                     'folder' => config('statamic.forms.email_view_folder'),
+                                    'clearable' => true,
                                 ],
                             ],
                             [


### PR DESCRIPTION
Once an HTML or text view is picked for a form submission email, there's no way to unset it from the control panel. You have to edit the form's YAML file by hand.

The template fieldtype only shows a clear button when its `clearable` config is set, and the two view fields in the form's email grid never set it. The equivalent template fields on collections and taxonomies already do.

Fixes #15161