### PR TITLE
[6.x] Serve HEAD requests from the static cache

### DIFF
--- a/src/StaticCaching/Middleware/Cache.php
+++ b/src/StaticCaching/Middleware/Cache.php
@@ -185,7 +185,7 @@ class Cache
 
     private function canBeCached($request)
     {
-        if ($request->method() !== 'GET') {
+        if (! in_array($request->method(), ['GET', 'HEAD'])) {
             return false;
         }
 

--- a/tests/StaticCaching/HalfMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/HalfMeasureStaticCachingTest.php
@@ -70,6 +70,57 @@ class HalfMeasureStaticCachingTest extends TestCase
     }
 
     #[Test]
+    public function it_serves_head_requests_from_the_cache()
+    {
+        app()->instance('example_count', 0);
+
+        (new class extends \Statamic\Tags\Tags
+        {
+            public static $handle = 'example_count';
+
+            public function index()
+            {
+                $count = app('example_count');
+                $count++;
+                app()->instance('example_count', $count);
+
+                return $count;
+            }
+        })::register();
+
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('default', '{{ example_count }}');
+
+        $this->createPage('about');
+
+        $this->get('/about')->assertOk()->assertSee('1');
+
+        $this->head('/about')->assertNoContent(200);
+
+        $this->assertEquals(1, app('example_count'));
+    }
+
+    #[Test]
+    public function it_doesnt_statically_cache_head_requests()
+    {
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('default', '<h1>{{ title }}</h1>');
+
+        $page = $this->createPage('about', ['with' => ['title' => 'The About Page']]);
+
+        $this->head('/about')->assertNoContent(200);
+
+        $page
+            ->set('title', 'Updated title')
+            ->saveQuietly(); // Save quietly to prevent the invalidator from clearing the statically cached page.
+
+        $this
+            ->get('/about')
+            ->assertOk()
+            ->assertSee('<h1>Updated title</h1>', false);
+    }
+
+    #[Test]
     public function it_performs_replacements()
     {
         Carbon::setTestNow(Carbon::parse('2019-01-01'));


### PR DESCRIPTION
The static caching middleware only ever reads the cache for GET requests, so a HEAD request to a page that's already cached runs the whole render pipeline anyway. Symfony then throws the body away when it prepares the response, so all that work is wasted. Uptime monitors, crawlers and link checkers tend to use HEAD, and on a half measure site they end up an order of magnitude slower than the equivalent GET.

Laravel routes HEAD requests through the matching GET route, and the cacher keys pages by URL, so a HEAD request can just be served the response that GET already cached. This lets `canBeCached()` through for HEAD as well.

Writes are untouched. `shouldBeCached()` still only allows GET, so a HEAD miss renders as before without populating the cache with an emptied response.

Fixes #15165