### PR TITLE
[6.x] Use a unique temporary path when reading image attributes

### DIFF
--- a/src/Imaging/Attributes.php
+++ b/src/Imaging/Attributes.php
@@ -15,25 +15,24 @@ class Attributes
     public function from(FilesystemAdapter $source, string $path)
     {
         if ($source->getAdapter() instanceof LocalFilesystemAdapter) {
-            $this->cacheDisk = $source;
+            $fullPath = $source->path($path);
         } else {
+            $temporaryPath = Str::random(32).'.'.pathinfo($path, PATHINFO_EXTENSION);
+
             $manager = $this->mountManager($source->getDriver(), $this->cacheDisk()->getDriver());
+            $manager->copy("source://{$path}", "cache://{$temporaryPath}", ['visibility' => 'private']);
 
-            if ($manager->has($destination = "cache://{$path}")) {
-                $manager->delete($destination);
-            }
-
-            $manager->copy("source://{$path}", $destination, ['visibility' => 'private']);
+            $fullPath = $this->cacheDisk()->path($temporaryPath);
         }
 
         $svg = Str::endsWith($path, '.svg');
 
         try {
-            $attributes = $svg ? $this->svgAttributes($path) : $this->imageAttributes($path);
+            $attributes = $svg ? $this->svgAttributes($fullPath) : $this->imageAttributes($fullPath);
         } catch (\Exception $e) {
             $attributes = $svg ? $this->defaultSvgAttributes() : [];
         } finally {
-            isset($manager) && $manager->delete($destination);
+            isset($temporaryPath) && $this->cacheDisk()->delete($temporaryPath);
         }
 
         return $attributes;
@@ -41,13 +40,11 @@ class Attributes
 
     private function imageAttributes(string $path)
     {
-        $fullPath = $this->prefixPath($path);
-
-        if (! file_exists($fullPath)) {
+        if (! file_exists($path)) {
             return ['width' => 0, 'height' => 0];
         }
 
-        $size = @getimagesize($fullPath);
+        $size = @getimagesize($path);
 
         if ($size === false) {
             return ['width' => 0, 'height' => 0];
@@ -56,7 +53,7 @@ class Attributes
         [$width, $height] = $size;
 
         if (function_exists('exif_read_data')) {
-            $exif = @exif_read_data($fullPath);
+            $exif = @exif_read_data($path);
             $orientation = $exif['Orientation'] ?? 1;
 
             if (in_array($orientation, [5, 6, 7, 8])) {
@@ -69,7 +66,7 @@ class Attributes
 
     private function svgAttributes(string $path)
     {
-        $svg = simplexml_load_file($this->prefixPath($path));
+        $svg = simplexml_load_file($path);
 
         if ($svg['width'] && $svg['height']
             && is_numeric((string) $svg['width'])
@@ -99,14 +96,9 @@ class Attributes
 
     private function cacheDisk()
     {
-        return $this->cacheDisk ?: $this->cacheDisk = Storage::build([
+        return $this->cacheDisk ??= Storage::build([
             'driver' => 'local',
             'root' => storage_path('statamic/attributes-cache'),
         ]);
-    }
-
-    private function prefixPath($path)
-    {
-        return $this->cacheDisk()->path($path);
     }
 }

--- a/tests/Imaging/AttributesTest.php
+++ b/tests/Imaging/AttributesTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Imaging;
+
+use Facades\Statamic\Imaging\Attributes;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\Config;
+use League\Flysystem\Filesystem;
+use League\Flysystem\FilesystemAdapter as FlysystemAdapter;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\File;
+use Tests\TestCase;
+
+class AttributesTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        File::delete($this->cachePath());
+
+        Storage::extend('non-local', function ($app, $config) {
+            $adapter = new NonLocalAdapter(new LocalFilesystemAdapter($config['root']));
+
+            return new FilesystemAdapter(new Filesystem($adapter), $adapter, $config);
+        });
+    }
+
+    public function tearDown(): void
+    {
+        File::delete($this->cachePath());
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_gets_attributes_from_a_local_disk()
+    {
+        $disk = $this->disk('local');
+        $disk->putFileAs('foo', UploadedFile::fake()->image('bar.jpg', 30, 60), 'bar.jpg');
+
+        $this->assertEquals(['width' => 30, 'height' => 60], Attributes::from($disk, 'foo/bar.jpg'));
+        $this->assertEmpty(File::getFilesRecursively($this->cachePath()));
+    }
+
+    #[Test]
+    public function it_gets_attributes_from_a_non_local_disk()
+    {
+        $disk = $this->disk('non-local');
+        $disk->putFileAs('foo', UploadedFile::fake()->image('bar.jpg', 30, 60), 'bar.jpg');
+
+        $this->assertEquals(['width' => 30, 'height' => 60], Attributes::from($disk, 'foo/bar.jpg'));
+        $this->assertEmpty(File::getFilesRecursively($this->cachePath()));
+    }
+
+    #[Test]
+    public function it_gets_attributes_of_an_svg_on_a_non_local_disk()
+    {
+        $disk = $this->disk('non-local');
+        $disk->put('foo/bar.svg', '<svg xmlns="http://www.w3.org/2000/svg" width="45" height="90"></svg>');
+
+        $this->assertEquals(['width' => 45.0, 'height' => 90.0], Attributes::from($disk, 'foo/bar.svg'));
+    }
+
+    #[Test]
+    public function it_does_not_touch_temporary_files_belonging_to_other_requests()
+    {
+        $disk = $this->disk('non-local');
+        $disk->putFileAs('foo', UploadedFile::fake()->image('bar.jpg', 30, 60), 'bar.jpg');
+
+        $cache = Storage::build(['driver' => 'local', 'root' => $this->cachePath()]);
+        $cache->put('foo/bar.jpg', 'another request is using this');
+
+        $this->assertEquals(['width' => 30, 'height' => 60], Attributes::from($disk, 'foo/bar.jpg'));
+        $this->assertSame('another request is using this', $cache->get('foo/bar.jpg'));
+    }
+
+    #[Test]
+    public function it_does_not_use_a_local_source_disk_as_the_temporary_cache_disk()
+    {
+        $local = $this->disk('local');
+        $local->putFileAs('foo', UploadedFile::fake()->image('bar.jpg', 30, 60), 'bar.jpg');
+        $local->put('baz/qux.jpg', 'this file has nothing to do with the non-local disk');
+
+        Attributes::from($local, 'foo/bar.jpg');
+
+        $nonLocal = $this->disk('non-local');
+        $nonLocal->putFileAs('baz', UploadedFile::fake()->image('qux.jpg', 120, 240), 'qux.jpg');
+
+        $this->assertEquals(['width' => 120, 'height' => 240], Attributes::from($nonLocal, 'baz/qux.jpg'));
+        $this->assertSame('this file has nothing to do with the non-local disk', $local->get('baz/qux.jpg'));
+    }
+
+    private function disk(string $driver): FilesystemAdapter
+    {
+        $root = storage_path('statamic/test-'.$driver);
+
+        File::delete($root);
+
+        return Storage::build(['driver' => $driver, 'root' => $root]);
+    }
+
+    private function cachePath(): string
+    {
+        return storage_path('statamic/attributes-cache');
+    }
+}
+
+class NonLocalAdapter implements FlysystemAdapter
+{
+    public function __construct(private FlysystemAdapter $adapter)
+    {
+    }
+
+    public function fileExists(string $path): bool
+    {
+        return $this->adapter->fileExists($path);
+    }
+
+    public function directoryExists(string $path): bool
+    {
+        return $this->adapter->directoryExists($path);
+    }
+
+    public function write(string $path, string $contents, Config $config): void
+    {
+        $this->adapter->write($path, $contents, $config);
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->adapter->writeStream($path, $contents, $config);
+    }
+
+    public function read(string $path): string
+    {
+        return $this->adapter->read($path);
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->adapter->readStream($path);
+    }
+
+    public function delete(string $path): void
+    {
+        $this->adapter->delete($path);
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        $this->adapter->deleteDirectory($path);
+    }
+
+    public function createDirectory(string $path, Config $config): void
+    {
+        $this->adapter->createDirectory($path, $config);
+    }
+
+    public function setVisibility(string $path, string $visibility): void
+    {
+        $this->adapter->setVisibility($path, $visibility);
+    }
+
+    public function visibility(string $path): \League\Flysystem\FileAttributes
+    {
+        return $this->adapter->visibility($path);
+    }
+
+    public function mimeType(string $path): \League\Flysystem\FileAttributes
+    {
+        return $this->adapter->mimeType($path);
+    }
+
+    public function lastModified(string $path): \League\Flysystem\FileAttributes
+    {
+        return $this->adapter->lastModified($path);
+    }
+
+    public function fileSize(string $path): \League\Flysystem\FileAttributes
+    {
+        return $this->adapter->fileSize($path);
+    }
+
+    public function listContents(string $path, bool $deep): iterable
+    {
+        return $this->adapter->listContents($path, $deep);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->move($source, $destination, $config);
+    }
+
+    public function copy(string $source, string $destination, Config $config): void
+    {
+        $this->adapter->copy($source, $destination, $config);
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where reading image attributes from a non-local disk could throw `Unable to delete file located at: cache://...`, or return `0x0` dimensions.

This was happening because `Imaging\Attributes` copies files off non-local disks into a temporary local disk so their dimensions can be read locally, and the destination was the source path itself. Every request reading attributes for the same file used the same temporary path, so concurrent requests would clobber and delete each other's copy. It also left an empty directory tree behind on every call.

This PR fixes it by copying to a unique filename per call, and by deleting through the disk (which doesn't throw) rather than the mount manager.

This PR also fixes an issue where those temporary copies could be written into the site's asset container. Since #7887, the local disk shortcut assigned the source disk to `$cacheDisk`, which is memoized for the lifetime of the request because `Attributes` is resolved through a real-time facade. Once anything had read attributes off a local disk, every later non-local read copied into *that* disk instead of the temporary one.

Fixes #7437
Caused by #7887