### PR TITLE
[6.x] Ability to set an id for the checkboxes and being unique

### DIFF
--- a/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
+++ b/resources/js/components/fieldtypes/CheckboxesFieldtype.vue
@@ -4,6 +4,7 @@
             <Checkbox
                 v-for="(option, index) in options"
                 :disabled="config.disabled"
+                :id="`${id}_${index}`"
                 :key="index"
                 :label="option.label || option.value"
                 :read-only="isReadOnly"

--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -16,6 +16,7 @@ const props = defineProps({
     description: { type: String, default: null },
     /** When `true`, disables the checkbox */
     disabled: { type: Boolean, default: false },
+    id: { type: String, default: null },
     /** When `true`, displays the checkbox in an indeterminate state (shows a dash) */
     indeterminate: { type: Boolean, default: false },
     /** Label text to display next to the checkbox */
@@ -37,7 +38,7 @@ const emit = defineEmits(['update:modelValue', 'keydown']);
 
 const { appearance } = injectCheckboxContext() ?? { appearance: computed(() => 'default') };
 
-const id = useId();
+const id = useId(props.id);
 
 const handleKeydown = (event) => {
     emit('keydown', event);


### PR DESCRIPTION
Made a small PR for fixing collisions between checkboxes. They sometimes had the same id, because useId was being generated automatically by Vue. This created names like "reka-v-52". With having multiple bard sets and widgets, this caused the checkboxes to unclickable and/or enable a totally other checkbox.

Not the id looks like "field_page_content_2_attrs_values_page_builder_6_card_rounded_corners_0"