### PR TITLE
[6.x] Keep marked and DOMPurify out of the front-end helpers bundle

### DIFF
--- a/resources/js/bootstrap/globals.js
+++ b/resources/js/bootstrap/globals.js
@@ -3,6 +3,8 @@ import { nanoid as uid } from 'nanoid';
 import PreviewHtml from '../components/fieldtypes/replicator/PreviewHtml';
 import renderMarkdown from '@/util/markdown.js';
 
+export { data_get } from '@/util/data_get.js';
+
 export function cp_url(url) {
     url = Statamic.$config.get('cpUrl') + '/' + url;
     return tidy_url(url);
@@ -27,13 +29,6 @@ export function relative_url(url) {
 
 export function dd(args) {
     console.log(args);
-}
-
-export function data_get(obj, path, fallback = null) {
-    // Source: https://stackoverflow.com/a/22129960
-    var properties = Array.isArray(path) ? path : path.split('.');
-    var value = properties.reduce((prev, curr) => prev && prev[curr], obj);
-    return value !== undefined ? value : fallback;
 }
 
 export function data_set(obj, path, value) {

--- a/resources/js/components/field-conditions/Validator.js
+++ b/resources/js/components/field-conditions/Validator.js
@@ -1,7 +1,7 @@
 import Converter from './Converter.js';
 import ParentResolver from './ParentResolver.js';
 import { KEYS } from './Constants.js';
-import { data_get } from '../../bootstrap/globals.js';
+import { data_get } from '../../util/data_get.js';
 import { isObject, intersection } from 'lodash-es';
 
 const NUMBER_SPECIFIC_COMPARISONS = ['>', '>=', '<', '<='];

--- a/resources/js/util/data_get.js
+++ b/resources/js/util/data_get.js
@@ -1,0 +1,6 @@
+export function data_get(obj, path, fallback = null) {
+    // Source: https://stackoverflow.com/a/22129960
+    var properties = Array.isArray(path) ? path : path.split('.');
+    var value = properties.reduce((prev, curr) => prev && prev[curr], obj);
+    return value !== undefined ? value : fallback;
+}


### PR DESCRIPTION
The front-end `helpers.js` bundle ships all of `marked` and `dompurify`. It only exposes `$conditions` and `$passkeys`, and neither of those paths renders Markdown or sanitizes HTML, so every visitor downloads two libraries the page can never call.

They arrive through a single import. `field-conditions/Validator.js` takes `data_get` from `bootstrap/globals.js`, and `globals.js` also imports `util/markdown.js`, which brings in both. Neither library declares `sideEffects: false` and both instantiate at module scope, so the bundler has to keep them.

This moves `data_get` into its own module and points `Validator.js` there. `globals.js` re-exports it, so nothing else needed touching. The built file drops from 99,546 bytes to 28,190 (30,692 to 8,411 gzipped) with the same two exports intact.

Fixes #15173