### PR TITLE
[6.x] Add min and max validation rules when configured as zero

### DIFF
--- a/src/Fieldtypes/Floatval.php
+++ b/src/Fieldtypes/Floatval.php
@@ -90,11 +90,11 @@ class Floatval extends Fieldtype
     {
         $rules = ['numeric'];
 
-        if ($min = $this->config('min')) {
+        if (! is_null($min = $this->config('min'))) {
             $rules[] = 'min:'.$min;
         }
 
-        if ($max = $this->config('max')) {
+        if (! is_null($max = $this->config('max'))) {
             $rules[] = 'max:'.$max;
         }
 

--- a/src/Fieldtypes/Integer.php
+++ b/src/Fieldtypes/Integer.php
@@ -94,11 +94,11 @@ class Integer extends Fieldtype
     {
         $rules = ['integer'];
 
-        if ($min = $this->config('min')) {
+        if (! is_null($min = $this->config('min'))) {
             $rules[] = 'min:'.$min;
         }
 
-        if ($max = $this->config('max')) {
+        if (! is_null($max = $this->config('max'))) {
             $rules[] = 'max:'.$max;
         }
 

--- a/tests/Fieldtypes/FloatvalTest.php
+++ b/tests/Fieldtypes/FloatvalTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\ConfigFields;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Floatval;
+use Tests\TestCase;
+
+class FloatvalTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('configValueProvider')]
+    public function it_pre_processes_config_values($value, $expected)
+    {
+        $fields = (new ConfigFields([
+            ['handle' => 'max', 'field' => ['type' => 'float']],
+        ]))->addValues(['max' => $value]);
+
+        $this->assertSame($expected, $fields->preProcess()->values()->get('max'));
+    }
+
+    public static function configValueProvider()
+    {
+        return [
+            'float' => [5.5, 5.5],
+            'numeric string' => ['5.5', 5.5],
+            'zero' => [0, 0.0],
+            'null' => [null, null],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('rulesProvider')]
+    public function it_adds_min_and_max_rules($config, $expected)
+    {
+        $field = (new Floatval)->setField(new Field('test', array_merge([
+            'type' => 'float',
+        ], $config)));
+
+        $this->assertSame($expected, $field->rules());
+    }
+
+    public static function rulesProvider()
+    {
+        return [
+            'min and max' => [['min' => 1.5, 'max' => 10.5], ['numeric', 'min:1.5', 'max:10.5']],
+            'zeroes' => [['min' => 0, 'max' => 0], ['numeric', 'min:0', 'max:0']],
+            'nulls' => [['min' => null, 'max' => null], ['numeric']],
+            'not configured' => [[], ['numeric']],
+        ];
+    }
+}

--- a/tests/Fieldtypes/IntegerTest.php
+++ b/tests/Fieldtypes/IntegerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\ConfigFields;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Integer;
+use Tests\TestCase;
+
+class IntegerTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('configValueProvider')]
+    public function it_pre_processes_config_values($value, $expected)
+    {
+        $fields = (new ConfigFields([
+            ['handle' => 'max', 'field' => ['type' => 'integer']],
+        ]))->addValues(['max' => $value]);
+
+        $this->assertSame($expected, $fields->preProcess()->values()->get('max'));
+    }
+
+    public static function configValueProvider()
+    {
+        return [
+            'integer' => [5, 5],
+            'numeric string' => ['5', 5],
+            'zero' => [0, 0],
+            'null' => [null, null],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('rulesProvider')]
+    public function it_adds_min_and_max_rules($config, $expected)
+    {
+        $field = (new Integer)->setField(new Field('test', array_merge([
+            'type' => 'integer',
+        ], $config)));
+
+        $this->assertSame($expected, $field->rules());
+    }
+
+    public static function rulesProvider()
+    {
+        return [
+            'min and max' => [['min' => 1, 'max' => 10], ['integer', 'min:1', 'max:10']],
+            'zeroes' => [['min' => 0, 'max' => 0], ['integer', 'min:0', 'max:0']],
+            'nulls' => [['min' => null, 'max' => null], ['integer']],
+            'not configured' => [[], ['integer']],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where a `min` or `max` of `0` on the Integer and Float fieldtypes was silently ignored, so the value never got validated.

This was happening because `Integer::rules()` and `Floatval::rules()` used truthy checks (`if ($min = $this->config('min'))`), which treat a configured `0` as unset. Since #12395 made Min, Max and Step user-facing config fields on both fieldtypes, it became easy to hit — setting Min to `0` to prevent negative numbers did nothing at all.

This PR fixes it by checking for `null` instead of truthiness.

Related: #8932
Caused by #12395