### PR TITLE
[6.x] Fix GitProcessTest failing when run from a nested directory

### DIFF
--- a/tests/Git/GitProcessTest.php
+++ b/tests/Git/GitProcessTest.php
@@ -66,8 +66,8 @@ class GitProcessTest extends TestCase
         $this->assertTrue(Git::create($this->basePath('temp/content/taxonomies'))->isRepo());
         $this->assertTrue(Git::create($this->basePath('temp/assets'))->isRepo());
 
-        // Traversing up from the app would land inside this repo when running from a
-        // worktree, so use the system temp directory, which is never in a repo.
+        // Traversing up from the app would land inside a repo whenever this checkout is
+        // nested within one (e.g. a Claude worktree), so use the system temp directory.
         $notARepoPath = Path::resolve(sys_get_temp_dir().'/statamic-not-a-repo-'.uniqid());
 
         $this->createTempDirectory($notARepoPath);

--- a/tests/Git/GitProcessTest.php
+++ b/tests/Git/GitProcessTest.php
@@ -66,9 +66,17 @@ class GitProcessTest extends TestCase
         $this->assertTrue(Git::create($this->basePath('temp/content/taxonomies'))->isRepo());
         $this->assertTrue(Git::create($this->basePath('temp/assets'))->isRepo());
 
-        $notARepoPath = Path::resolve(base_path('../../../../..'));
+        // Traversing up from the app would land inside this repo when running from a
+        // worktree, so use the system temp directory, which is never in a repo.
+        $notARepoPath = Path::resolve(sys_get_temp_dir().'/statamic-not-a-repo-'.uniqid());
 
-        $this->assertFalse(Git::create($notARepoPath)->isRepo());
+        $this->createTempDirectory($notARepoPath);
+
+        try {
+            $this->assertFalse(Git::create($notARepoPath)->isRepo());
+        } finally {
+            $this->deleteTempDirectory($notARepoPath);
+        }
     }
 
     #[Group('integration')]


### PR DESCRIPTION
This pull request fixes `GitProcessTest::it_can_check_if_folder_is_in_git_repo` failing whenever the test suite is run from a nested directory (for example a claude-managed worktree which lives in `.claude/worktrees`) rather than a plain checkout. Nothing in the shipped code is affected — the bad assumption lives entirely in the test, so this is just noise for anyone developing in a worktree, and it passes in CI either way.

This is annoying because everytime an AI agent runs tests inside a worktree, it gets that error and has to burn tokens and time figuring out that it's a non-issue.

The test needs a path that isn't inside a git repo, and it obtained one by walking five directories up from the testbench app (`base_path('../../../../..')`). That relies on where the checkout happens to live. From a normal checkout it lands somewhere harmless outside the repo, but a nested directory it lands back *inside* the repo, so `isRepo()` returned `true` and the assertion failed.

This PR fixes it by creating a throwaway directory in the system temp directory and asserting against that instead, which doesn't depend on the location of the checkout.