### PR TITLE
[6.x] Fix count() TypeError when entries collections config is a string

### DIFF
--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -516,7 +516,7 @@ class Entries extends Relationship
 
     public function relationshipQueryBuilder()
     {
-        $collections = $this->config('collections');
+        $collections = $this->getConfiguredCollections();
 
         return Entry::query()
             ->when($collections, fn ($query) => $query->whereIn('collection', $collections));

--- a/src/Fieldtypes/Entries.php
+++ b/src/Fieldtypes/Entries.php
@@ -470,7 +470,7 @@ class Entries extends Relationship
     {
         return empty($collections = $this->config('collections'))
             ? Collection::handles()->all()
-            : $collections;
+            : Arr::wrap($collections);
     }
 
     public function toGqlType()

--- a/src/Fieldtypes/Link/EntryLinkType.php
+++ b/src/Fieldtypes/Link/EntryLinkType.php
@@ -7,6 +7,7 @@ use Statamic\Facades;
 use Statamic\Facades\Blink;
 use Statamic\Facades\Site;
 use Statamic\Fields\Field;
+use Statamic\Support\Arr;
 
 use function Statamic\trans as __;
 
@@ -80,6 +81,6 @@ class EntryLinkType extends LinkType
             });
         }
 
-        return $collections;
+        return Arr::wrap($collections);
     }
 }

--- a/src/Query/Scopes/Filters/Collection.php
+++ b/src/Query/Scopes/Filters/Collection.php
@@ -6,6 +6,7 @@ use Statamic\Exceptions\AuthorizationException;
 use Statamic\Facades;
 use Statamic\Facades\User;
 use Statamic\Query\Scopes\Filter;
+use Statamic\Support\Arr;
 
 use function Statamic\trans as __;
 
@@ -45,7 +46,7 @@ class Collection extends Filter
 
     public function visibleTo($key)
     {
-        return $key === 'entries-fieldtype' && count($this->context['collections']) > 1;
+        return $key === 'entries-fieldtype' && count(Arr::wrap($this->context['collections'] ?? [])) > 1;
     }
 
     protected function options()

--- a/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
+++ b/tests/Feature/Fieldtypes/RelationshipFieldtypeTest.php
@@ -97,6 +97,47 @@ class RelationshipFieldtypeTest extends TestCase
     }
 
     #[Test]
+    public function it_gets_selection_filters_for_multiple_collections()
+    {
+        Collection::make('pages')->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'view test entries', 'view pages entries']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $config = base64_encode(json_encode([
+            'type' => 'entries',
+            'collections' => ['test', 'pages'],
+        ]));
+
+        $handles = collect($this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship/filters?config={$config}")
+            ->assertOk()
+            ->json())
+            ->pluck('handle');
+
+        $this->assertTrue($handles->contains('collection'));
+    }
+
+    #[Test]
+    public function it_gets_selection_filters_when_collections_config_is_a_string()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'view test entries']]);
+        $user = User::make()->assignRole('test')->save();
+
+        // Single collection configs are often stored as a plain string in YAML.
+        $config = base64_encode(json_encode([
+            'type' => 'entries',
+            'collections' => 'test',
+        ]));
+
+        $this
+            ->actingAs($user)
+            ->getJson("/cp/fieldtypes/relationship/filters?config={$config}")
+            ->assertOk();
+    }
+
+    #[Test]
     public function it_limits_access_to_entries_from_collections_the_user_can_view()
     {
         Collection::make('pages')->save();

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -11,6 +11,7 @@ use Statamic\Facades;
 use Statamic\Fields\ArrayableString;
 use Statamic\Fields\Field;
 use Statamic\Fieldtypes\Link;
+use Statamic\Fieldtypes\Link\EntryLinkType;
 use Statamic\Fieldtypes\Link\LinkType;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -101,6 +102,20 @@ class LinkTest extends TestCase
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertNull($augmented->value());
         $this->assertEquals(['url' => null], $augmented->toArray());
+    }
+
+    #[Test]
+    public function it_wraps_a_string_collections_config_into_an_array_for_the_entry_link_type()
+    {
+        // A hand-authored blueprint may set `collections: pages` (a string) rather than
+        // `collections: [pages]`. Building the nested entries fieldtype config used to
+        // return that string as-is, which broke the `array` return type on collections()
+        // and crashed as soon as the link field's "entry" type was rendered (e.g. opening
+        // "Link to Entry" in a nav item).
+        $field = new Field('test', ['type' => 'link', 'collections' => 'pages']);
+        $config = (new EntryLinkType)->fieldtype($field);
+
+        $this->assertEquals(['pages'], $config['collections']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- Opening **Link to Entry** in a nav (or any entries relationship selector) hit `count(): Argument #1 ($value) must be of type Countable|array, string given` when `collections` was a string
- Wrap collections in `Arr::wrap()` in the Collection filter and `Entries::getConfiguredCollections()` so string YAML configs (`collections: pages`) don't blow up on PHP 8
- Add regression tests for multi-collection filters and string collections config

_From Discord: https://discord.com/channels/489818810157891584/1537065384119894146_