### PR TITLE
[6.x] Parse Antlers enabled fields in Blade templates

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\View\View;
 use Statamic\Contracts\View\Antlers\Parser as ParserContract;
 use Statamic\Facades\Site;
+use Statamic\Fields\Value;
 use Statamic\Statamic;
 use Statamic\View\Antlers\Engine;
 use Statamic\View\Antlers\Language\Analyzers\NodeTypeAnalyzer;
@@ -22,6 +23,7 @@ use Statamic\View\Antlers\Language\Runtime\Tracing\TraceManager;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 use Statamic\View\Blade\AntlersBladePrecompiler;
 use Statamic\View\Blade\StatamicTagCompiler;
+use Statamic\View\Blade\ValueEchoHandler;
 use Statamic\View\Cascade;
 use Statamic\View\Debugbar\AntlersProfiler\PerformanceCollector;
 use Statamic\View\Debugbar\AntlersProfiler\PerformanceTracer;
@@ -434,6 +436,8 @@ PHP;
         Blade::precompiler(function ($content) {
             return AntlersBladePrecompiler::compile($content);
         });
+
+        Blade::stringable(Value::class, [ValueEchoHandler::class, 'handle']);
 
         View::macro('withoutExtractions', function () {
             if ($this->getEngine() instanceof Engine) {

--- a/src/View/Blade/ValueEchoHandler.php
+++ b/src/View/Blade/ValueEchoHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Statamic\View\Blade;
+
+use Statamic\Facades\Antlers;
+use Statamic\Facades\Cascade;
+use Statamic\Fields\Value;
+use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
+
+class ValueEchoHandler
+{
+    public static function handle(Value $value): mixed
+    {
+        if (! $value->shouldParseAntlers()) {
+            return $value;
+        }
+
+        $data = Cascade::toArray() ?: Cascade::hydrate()->toArray();
+
+        $wasEvaluatingUserData = GlobalRuntimeState::$isEvaluatingUserData;
+        GlobalRuntimeState::$isEvaluatingUserData = true;
+        GlobalRuntimeState::$userContentEvalState = [$value, null];
+
+        try {
+            return $value->antlersValue(Antlers::parser(), $data);
+        } finally {
+            GlobalRuntimeState::$userContentEvalState = null;
+            GlobalRuntimeState::$isEvaluatingUserData = $wasEvaluatingUserData;
+        }
+    }
+}

--- a/tests/View/Blade/AntlersValueTest.php
+++ b/tests/View/Blade/AntlersValueTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\View\Blade;
+
+use Illuminate\Support\Facades\Blade;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Cascade;
+use Statamic\Fields\Field;
+use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Markdown;
+use Statamic\Fieldtypes\Textarea;
+use Tests\TestCase;
+
+class AntlersValueTest extends TestCase
+{
+    #[Test]
+    public function it_parses_antlers_in_a_value_when_the_field_has_antlers_enabled()
+    {
+        Cascade::set('name', 'World');
+
+        $value = $this->value(new Textarea, 'Hello {{ name }}', ['antlers' => true]);
+
+        $this->assertSame('Hello World', Blade::render('{!! $text !!}', ['text' => $value]));
+    }
+
+    #[Test]
+    public function it_doesnt_parse_antlers_in_a_value_when_the_field_has_antlers_disabled()
+    {
+        Cascade::set('name', 'World');
+
+        $value = $this->value(new Textarea, 'Hello {{ name }}', ['antlers' => false]);
+
+        $this->assertSame('Hello {{ name }}', Blade::render('{!! $text !!}', ['text' => $value]));
+    }
+
+    #[Test]
+    public function it_parses_antlers_before_augmenting_a_markdown_value()
+    {
+        Cascade::set('name', 'World');
+
+        $value = $this->value(new Markdown, '# Hello {{ name }}', ['antlers' => true]);
+
+        $this->assertSame("<h1>Hello World</h1>\n", Blade::render('{!! $text !!}', ['text' => $value]));
+    }
+
+    #[Test]
+    public function it_escapes_parsed_antlers_in_an_escaped_echo()
+    {
+        Cascade::set('name', '<b>World</b>');
+
+        $value = $this->value(new Textarea, 'Hello {{ name }}', ['antlers' => true]);
+
+        $this->assertSame('Hello &lt;b&gt;World&lt;/b&gt;', Blade::render('{{ $text }}', ['text' => $value]));
+    }
+
+    private function value($fieldtype, $raw, array $config)
+    {
+        return new Value($raw, 'text', $fieldtype->setField(new Field('text', $config)));
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where fields with the "Parse Antlers" option enabled wouldn't have their Antlers parsed when rendered in a Blade template.

This was happening because Antlers enabled fields are only ever parsed by the Antlers runtime, which calls `Value::antlersValue()` when it comes across one. Blade doesn't know anything about that, so echoing a `Value` falls through to `__toString()` and returns the augmented value with the Antlers left as-is.

This PR fixes it by registering a Blade echo handler for `Value` objects, which parses Antlers enabled fields using the cascade as their context. The same user content sandboxing the Antlers runtime applies is used here, so guarded tags and modifiers behave identically in both templating languages. Values without the option enabled are returned untouched.

Worth noting: Blade only picks up echo handlers when a view is compiled, so sites will need to run `php artisan view:clear` after upgrading before they'll see the fix.

Fixes #8430