### PR TITLE
[6.x] Return the fallback when reading a file from a disk that throws

### DIFF
--- a/src/Filesystem/AbstractAdapter.php
+++ b/src/Filesystem/AbstractAdapter.php
@@ -3,6 +3,7 @@
 namespace Statamic\Filesystem;
 
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use League\Flysystem\UnableToReadFile;
 use Statamic\Support\FileCollection;
 use Statamic\Support\Str;
 
@@ -12,7 +13,7 @@ abstract class AbstractAdapter implements Filesystem
     {
         try {
             return $this->filesystem->get($this->normalizePath($path)) ?: $fallback;
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException|UnableToReadFile $e) {
             return $fallback;
         }
     }

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -839,6 +839,33 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    public function it_generates_meta_on_demand_if_it_doesnt_exist_on_a_disk_that_throws_exceptions()
+    {
+        Storage::fake('test', ['throw' => true]);
+
+        $file = UploadedFile::fake()->image('image.jpg', 30, 60); // creates a 723 byte image
+        Storage::disk('test')->putFileAs('foo', $file, 'image.jpg');
+        $realFilePath = Storage::disk('test')->path('foo/image.jpg');
+        touch($realFilePath, $timestamp = Carbon::parse('2021-02-22 09:41:42')->timestamp);
+
+        $container = Facades\AssetContainer::make('test')->disk('test');
+        $asset = (new Asset)->container($container)->path('foo/image.jpg');
+
+        $meta = [
+            'data' => [],
+            'size' => 723,
+            'last_modified' => $timestamp,
+            'width' => 30,
+            'height' => 60,
+            'mime_type' => 'image/jpeg',
+            'duration' => null,
+        ];
+
+        $this->assertEquals($meta, $asset->meta());
+        $this->assertEquals($meta, YAML::parse(Storage::disk('test')->get('foo/.meta/image.jpg.yaml')));
+    }
+
+    #[Test]
     public function it_generates_meta_on_demand_if_a_required_value_is_missing()
     {
         Storage::fake('test');

--- a/tests/Assets/AssetTest.php
+++ b/tests/Assets/AssetTest.php
@@ -866,6 +866,23 @@ class AssetTest extends TestCase
     }
 
     #[Test]
+    public function it_uploads_to_a_disk_that_throws_exceptions_while_the_last_modified_index_is_in_use()
+    {
+        Storage::fake('test', ['throw' => true]);
+
+        $container = Facades\AssetContainer::make('test')->disk('test')->save();
+
+        Facades\Stache::store('assets::test')->cacheIndexUsage('last_modified');
+
+        $asset = $container->makeAsset('image.jpg');
+
+        $asset->upload(UploadedFile::fake()->image('image.jpg', 30, 60));
+
+        $this->assertTrue(Storage::disk('test')->exists('.meta/image.jpg.yaml'));
+        $this->assertNotNull($asset->lastModified());
+    }
+
+    #[Test]
     public function it_generates_meta_on_demand_if_a_required_value_is_missing()
     {
         Storage::fake('test');

--- a/tests/Filesystem/FlysystemAdapterTest.php
+++ b/tests/Filesystem/FlysystemAdapterTest.php
@@ -42,6 +42,18 @@ class FlysystemAdapterTest extends TestCase
     }
 
     #[Test]
+    public function gets_fallback_if_file_doesnt_exist_on_a_disk_that_throws_exceptions()
+    {
+        $adapter = new FlysystemAdapter(Storage::build([
+            'driver' => 'local',
+            'root' => $this->tempDir,
+            'throw' => true,
+        ]));
+
+        $this->assertEquals('Hello World', $adapter->get('filename.txt', 'Hello World'));
+    }
+
+    #[Test]
     public function it_normalizes_relative_paths()
     {
         $this->assertEquals('bar.txt', $this->adapter->normalizePath('bar.txt'));


### PR DESCRIPTION
This pull request fixes an issue where a missing asset meta file would break the asset browser on any disk configured with `'throw' => true`, with `Unable to read file from location: .meta/example.jpg.yaml`.

This was happening because `Statamic\Filesystem\AbstractAdapter::get()` only caught `Illuminate\Contracts\Filesystem\FileNotFoundException`, which `Storage` disks stopped throwing in Laravel 9. 

On a disk with `throw` enabled, Laravel rethrows `League\Flysystem\UnableToReadFile` instead, so the exception escaped `get()` rather than returning the fallback. `Asset::meta()` relies on that fallback to know it needs to generate a missing meta file, so meta was never generated and the whole listing went down. It's not S3-specific — it affects any disk with `throw` enabled, which is why it's also been reported on SFTP.

This PR fixes it by catching `UnableToReadFile` as well. The `FileNotFoundException` catch has to stay: `AbstractAdapter` is shared by `FlysystemAdapter`, which wraps a `Storage` disk, and `FilesystemAdapter`, which wraps `Illuminate\Filesystem\Filesystem` — and the latter still throws it today.

There are two routes to the same failed read, and this PR covers both with tests:
- Browsing assets that never had meta (uploaded directly to the disk) hits it via `Asset::meta()`
- Uploading while the `last_modified` index is in use hits it via the indexer, which calls `lastModified()` during `$store->save()` — before `AssetRepository::save()` writes the meta file.

Fixes #8641
Fixes #11961
Related: #11966
