### PR TITLE
[6.x] Fix ensuring config on fields from imported fieldsets

### DIFF
--- a/src/Fields/Blueprint.php
+++ b/src/Fields/Blueprint.php
@@ -632,6 +632,12 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, ContainsQueryabl
             return $this;
         }
 
+        // A field from an imported fieldset can't be removed on its
+        // own, since it would take the rest of the fieldset with it.
+        if (isset($fields[$handle]['import'])) {
+            return $this;
+        }
+
         $fieldKey = $fields[$handle]['fieldIndex'];
         $sectionIndex = $fields[$handle]['sectionIndex'];
 
@@ -644,10 +650,18 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, ContainsQueryabl
     private function getTabFields($tab)
     {
         return collect($this->contents['tabs'][$tab]['sections'])->flatMap(function ($section, $sectionIndex) {
-            return collect($section['fields'] ?? [])->map(function ($field, $fieldIndex) use ($sectionIndex) {
-                return $field + ['fieldIndex' => $fieldIndex, 'sectionIndex' => $sectionIndex];
+            return collect($section['fields'] ?? [])->flatMap(function ($field, $fieldIndex) use ($sectionIndex) {
+                $indexes = ['fieldIndex' => $fieldIndex, 'sectionIndex' => $sectionIndex];
+
+                // An imported fieldset is a single entry in the contents, but may
+                // contain any number of fields, each pointing back at the import.
+                if (isset($field['import'])) {
+                    return (new Fields([$field]))->all()->map(fn () => $field + $indexes)->all();
+                }
+
+                return [$field['handle'] => $field + $indexes];
             });
-        })->keyBy('handle');
+        });
     }
 
     protected function ensureFieldInTabHasConfig($handle, $tab, $config)
@@ -669,10 +683,13 @@ class Blueprint implements Arrayable, ArrayAccess, Augmentable, ContainsQueryabl
 
         $field = $this->contents['tabs'][$tab]['sections'][$sectionKey]['fields'][$fieldKey];
 
-        $fieldValue = Arr::get($field, 'field');
-        $isImportedField = is_string($fieldValue);
-
-        if ($isImportedField) {
+        if (isset($field['import'])) {
+            // An import keeps its overrides in a `config` array keyed by the
+            // field handles within the fieldset, before any prefix is applied.
+            $importedHandle = Str::after($handle, $field['prefix'] ?? '');
+            $existingConfig = Arr::get($field, "config.{$importedHandle}", []);
+            $this->contents['tabs'][$tab]['sections'][$sectionKey]['fields'][$fieldKey]['config'][$importedHandle] = array_merge($existingConfig, $config);
+        } elseif (is_string(Arr::get($field, 'field'))) {
             $existingConfig = Arr::get($field, 'config', []);
             $this->contents['tabs'][$tab]['sections'][$sectionKey]['fields'][$fieldKey]['config'] = array_merge($existingConfig, $config);
         } else {

--- a/tests/Feature/Entries/CreateEntryTest.php
+++ b/tests/Feature/Entries/CreateEntryTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Feature\Entries;
 
+use Facades\Statamic\Fields\BlueprintRepository;
+use Facades\Statamic\Fields\FieldsetRepository;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
+use Statamic\Facades\Fieldset;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -88,5 +92,41 @@ class CreateEntryTest extends TestCase
             ->get(cp_route('collections.entries.create', ['test', 'en']))
             ->assertOk()
             ->assertInertia(fn ($page) => $page->where('canManagePublishState', true));
+    }
+
+    #[Test]
+    public function the_author_field_is_read_only_when_it_comes_from_an_imported_fieldset()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $collection = tap(Collection::make('test'))->save();
+
+        FieldsetRepository::partialMock();
+        FieldsetRepository::shouldReceive('find')->with('author')->andReturn(
+            Fieldset::make('author')->setContents(['fields' => [
+                ['handle' => 'author', 'field' => ['type' => 'users', 'max_items' => 1]],
+            ]])
+        );
+
+        $blueprint = Blueprint::make('test')->setContents(['tabs' => [
+            'main' => ['sections' => [['fields' => [['import' => 'author']]]]],
+        ]]);
+
+        BlueprintRepository::partialMock();
+        BlueprintRepository::shouldReceive('in')
+            ->with('collections/'.$collection->handle())
+            ->andReturn(collect([$blueprint]));
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('collections.entries.create', ['test', 'en']))
+            ->assertOk()
+            ->assertInertia(function ($page) {
+                $fields = collect($page->toArray()['props']['blueprint']['tabs'])
+                    ->flatMap(fn ($tab) => collect($tab['sections'])->flatMap(fn ($section) => $section['fields']))
+                    ->keyBy('handle');
+
+                $this->assertEquals('read_only', $fields['author']['visibility']);
+            });
     }
 }

--- a/tests/Fields/BlueprintTest.php
+++ b/tests/Fields/BlueprintTest.php
@@ -931,6 +931,88 @@ class BlueprintTest extends TestCase
     // todo: duplicate or tweak above test but make the target field not in the first section.
 
     #[Test]
+    public function it_ensures_a_field_within_an_imported_fieldset_has_config()
+    {
+        FieldsetRepository::shouldReceive('find')->with('the_partial')->andReturn(
+            (new Fieldset)->setContents(['fields' => [
+                [
+                    'handle' => 'author',
+                    'field' => ['type' => 'users', 'do_not_touch_other_config' => true],
+                ],
+                [
+                    'handle' => 'the_field',
+                    'field' => ['type' => 'text'],
+                ],
+            ]])
+        );
+
+        $blueprint = (new Blueprint)->setContents(['tabs' => [
+            'tab_one' => [
+                'sections' => [
+                    [
+                        'fields' => [
+                            ['handle' => 'title', 'field' => ['type' => 'text']],
+                        ],
+                    ],
+                    [
+                        'fields' => [
+                            ['import' => 'the_partial'],
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+
+        $fields = $blueprint
+            ->ensureFieldHasConfig('author', ['visibility' => 'read_only'])
+            ->fields();
+
+        $this->assertEquals(['type' => 'text'], $fields->get('title')->config());
+        $this->assertEquals(['type' => 'text'], $fields->get('the_field')->config());
+
+        $this->assertEquals([
+            'type' => 'users',
+            'do_not_touch_other_config' => true,
+            'visibility' => 'read_only',
+        ], $fields->get('author')->config());
+    }
+
+    #[Test]
+    public function it_ensures_a_prefixed_field_within_an_imported_fieldset_has_config()
+    {
+        FieldsetRepository::shouldReceive('find')->with('the_partial')->andReturn(
+            (new Fieldset)->setContents(['fields' => [
+                [
+                    'handle' => 'author',
+                    'field' => ['type' => 'users', 'do_not_touch_other_config' => true],
+                ],
+            ]])
+        );
+
+        $blueprint = (new Blueprint)->setContents(['tabs' => [
+            'tab_one' => [
+                'sections' => [
+                    [
+                        'fields' => [
+                            ['import' => 'the_partial', 'prefix' => 'prefixed_'],
+                        ],
+                    ],
+                ],
+            ],
+        ]]);
+
+        $fields = $blueprint
+            ->ensureFieldHasConfig('prefixed_author', ['visibility' => 'read_only'])
+            ->fields();
+
+        $this->assertEquals([
+            'type' => 'users',
+            'do_not_touch_other_config' => true,
+            'visibility' => 'read_only',
+        ], $fields->get('prefixed_author')->config());
+    }
+
+    #[Test]
     public function it_can_ensure_an_deferred_ensured_field_has_specific_config()
     {
         $blueprint = (new Blueprint)->setContents(['tabs' => [
@@ -1445,6 +1527,39 @@ class BlueprintTest extends TestCase
         $this->assertTrue($blueprint->hasField('two'));
         $this->assertFalse($blueprint->hasField('three'));
         $this->assertTrue($blueprint->hasField('four'));
+    }
+
+    #[Test]
+    public function it_leaves_fields_within_an_imported_fieldset_alone_when_removing_a_field()
+    {
+        FieldsetRepository::shouldReceive('find')->with('the_partial')->andReturn(
+            (new Fieldset)->setContents(['fields' => [
+                ['handle' => 'two', 'field' => ['type' => 'text']],
+                ['handle' => 'three', 'field' => ['type' => 'text']],
+            ]])
+        );
+
+        $blueprint = (new Blueprint)->setHandle('test')->setContents([
+            'title' => 'Test',
+            'tabs' => [
+                'tab_one' => [
+                    'sections' => [
+                        [
+                            'fields' => [
+                                ['handle' => 'one', 'field' => ['type' => 'text']],
+                                ['import' => 'the_partial'],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $blueprint->removeField('one')->removeField('two');
+
+        $this->assertFalse($blueprint->hasField('one'));
+        $this->assertTrue($blueprint->hasField('two'));
+        $this->assertTrue($blueprint->hasField('three'));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where a user without the "edit other authors entries" permission would get an `Undefined array key "author"` error when creating or editing an entry, if the blueprint's `author` field came from an imported fieldset.

This was happening because `getTabFields` built its lookup from the raw blueprint contents using `keyBy('handle')`. An `import:` row has no `handle`, so the fields inside an imported fieldset were invisible to the lookup, while `hasFieldInTab` resolves imports and reported them as present. `ensureFieldHasConfig` trusted the latter, then indexed into the former.

This PR fixes it by resolving `import:` rows into their fields, and writing the override into the import's `config` array, keyed by the field's handle within the fieldset. That's the same shape `ensureField` already produces for imports.

This PR also stops `removeField` erroring on a field from an imported fieldset. It can't be removed on its own, since the only entry in the contents is the whole fieldset, so it's left in place.

Fixes #8805
Related: #8803