### PR TITLE
[6.x] Don't save group-inherited roles as explicit roles

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -45,7 +45,7 @@ class User extends BaseUser
     {
         if (func_num_args() === 0) {
             $data = array_merge($this->model()->attributesToArray(), [
-                'roles' => $this->roles()->map->handle()->values()->all(),
+                'roles' => $this->explicitRoles()->map->handle()->values()->all(),
                 'groups' => $this->groups()->map->handle()->values()->all(),
             ]);
 
@@ -112,7 +112,7 @@ class User extends BaseUser
 
     protected function saveRoles()
     {
-        $roles = $this->roles()->map->id();
+        $roles = $this->explicitRoles()->map->id();
 
         (new Roles($this))->sync($roles);
     }

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -241,6 +241,24 @@ class EloquentUserTest extends TestCase
         $this->assertSame([$user->email(), $userTwo->email(), $userThree->email(), $userFour->email()], Facades\User::query()->whereGroupIn(['a', 'b'])->orWhereGroupIn(['c'])->get()->map->email()->all());
     }
 
+    #[Test]
+    public function it_doesnt_save_roles_inherited_from_groups_to_the_role_user_table()
+    {
+        $directRole = Facades\Role::make('direct');
+        $groupRole = Facades\Role::make('grouped');
+        $group = (new UserGroup)->handle('usergroup')->assignRole($groupRole);
+
+        Facades\Role::shouldReceive('find')->with('direct')->andReturn($directRole);
+        Facades\Role::shouldReceive('find')->with('grouped')->andReturn($groupRole);
+        Facades\UserGroup::shouldReceive('find')->with('usergroup')->andReturn($group);
+
+        $user = $this->createPermissible()->assignRole($directRole)->addToGroup($group);
+        $user->save();
+
+        $this->assertSame(['direct'], \DB::table(config('statamic.users.tables.role_user', 'role_user'))->where('user_id', $user->id())->pluck('role_id')->all());
+        $this->assertSame(['usergroup'], \DB::table(config('statamic.users.tables.group_user', 'group_user'))->where('user_id', $user->id())->pluck('group_id')->all());
+    }
+
     public function makeUser()
     {
         return (new EloquentUser)

--- a/tests/Auth/PermissibleContractTests.php
+++ b/tests/Auth/PermissibleContractTests.php
@@ -173,6 +173,27 @@ trait PermissibleContractTests
     }
 
     #[Test]
+    public function it_doesnt_treat_roles_inherited_from_groups_as_explicitly_assigned()
+    {
+        $directRole = RoleAPI::make('direct');
+        $groupRole = RoleAPI::make('grouped');
+        $group = (new UserGroup)->handle('usergroup')->assignRole($groupRole);
+
+        RoleAPI::shouldReceive('find')->with('direct')->andReturn($directRole);
+        RoleAPI::shouldReceive('find')->with('grouped')->andReturn($groupRole);
+        RoleAPI::shouldReceive('all')->andReturn(collect([$directRole, $groupRole]));
+        UserGroupAPI::shouldReceive('find')->with('usergroup')->andReturn($group);
+        UserGroupAPI::shouldReceive('all')->andReturn(collect([$group]));
+
+        $user = $this->createPermissible()->assignRole($directRole)->addToGroup($group);
+        $user->save();
+
+        $this->assertEquals(['direct', 'grouped'], $user->roles()->map->handle()->values()->all());
+        $this->assertEquals(['direct'], $user->explicitRoles()->map->handle()->values()->all());
+        $this->assertEquals(['direct'], $user->data()->get('roles'));
+    }
+
+    #[Test]
     public function it_gets_and_checks_permissions()
     {
         $directRole = RoleAPI::make('direct')->addPermission([


### PR DESCRIPTION
This pull request fixes an issue where roles inherited from a user group were saved against the user as though they'd been assigned directly, when using database-driven users. Removing the user from the group afterwards would leave those roles behind, orphaned in the `role_user` table.

This was happening because `Statamic\Auth\Eloquent\User` was using `roles()` in both `data()` and `saveRoles()`. That method merges the user's explicitly assigned roles with the roles they inherit from their groups, so the group's roles were rendered as checked in the Roles field, and were then written into `role_user` on save. The file driver isn't affected, since it only ever stores explicitly assigned handles.

This PR fixes it by using `explicitRoles()` in both places. `roles()` still merges group roles, so permissions are unaffected.

It's worth noting this doesn't clean up rows written by the previous behaviour — users already affected will keep their duplicated `role_user` rows until they're saved again with the Roles field corrected.

Fixes #15183