### PR TITLE
[6.x] Fix `uri` index for new entries in orderable collections

### DIFF
--- a/src/Stache/Stores/CollectionEntriesStore.php
+++ b/src/Stache/Stores/CollectionEntriesStore.php
@@ -160,13 +160,13 @@ class CollectionEntriesStore extends ChildStore
     {
         $indexes = collect([
             'slug',
-            'uri',
             'collectionHandle',
             'published',
             'title',
             'site' => Indexes\Site::class,
             'origin' => Indexes\Origin::class,
             'parent' => Indexes\Parents::class,
+            'uri',
         ]);
 
         if (! $collection = Collection::findByHandle($this->childKey())) {

--- a/tests/Stache/OrderableEntryUriTest.php
+++ b/tests/Stache/OrderableEntryUriTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Stache;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blink;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class OrderableEntryUriTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $collection = Collection::make('vehicles')
+            ->routes('/vehicles/{slug}')
+            ->structureContents(['max_depth' => 1]);
+        $collection->save();
+    }
+
+    private function simulateNewRequest(): void
+    {
+        Blink::flush();
+        Stache::stores()->each->resetMemoizedState();
+        app('stache.indexes')->each->resetMemoizedState();
+    }
+
+    #[Test]
+    public function entries_have_uris_and_orders_after_being_saved()
+    {
+        Entry::make()->collection('vehicles')->slug('car')->data(['title' => 'Car'])->save();
+
+        $this->simulateNewRequest();
+
+        Entry::make()->collection('vehicles')->slug('bus')->data(['title' => 'Bus'])->save();
+
+        $this->simulateNewRequest();
+
+        $this->assertNotNull($car = Entry::findByUri('/vehicles/car'));
+        $this->assertNotNull($bus = Entry::findByUri('/vehicles/bus'));
+        $this->assertEquals(1, $car->order());
+        $this->assertEquals(2, $bus->order());
+    }
+}


### PR DESCRIPTION
This pull request fixes an issue where new entries in an orderable collection (a structure with a `max_depth` of 1) would 404 on the front end until they were saved a second time.

This was happening because `uri` was being updated before `collectionHandle` and `site` in `CollectionEntriesStore::storeIndexes()`. Entries in orderable collections never get written to the tree file, so `CollectionStructure::validateTree()` reconciles the tree by querying the collection's entries. At the point the `uri` index was updated, the entry being saved wasn't yet visible to that query, so no page was found for it and `null` got cached as its uri. Saving a second time worked because the entry was in the other indexes by then.

This PR fixes it by moving `uri` after the indexes that query relies on, alongside `parent`, which is resolved from the structure too. This also fixes the `order` index, which was landing on `1` for every new entry.

Fixes #11534