### PR TITLE
[6.x] Fix save button hanging forever when a save hook fails

### DIFF
--- a/resources/js/components/ui/Publish/SavePipeline.js
+++ b/resources/js/components/ui/Publish/SavePipeline.js
@@ -27,10 +27,7 @@ export class Pipeline {
             try {
                 return await step.handle(payload);
             } catch (error) {
-                if (error instanceof PipelineStopped) {
-                    new Stopped().handle(payload);
-                    throw error;
-                }
+                new Stopped().handle(payload);
                 throw error;
             }
         }, initialPromise);
@@ -112,7 +109,7 @@ export class BeforeSaveHooks extends Step {
     }
     handle(payload) {
         return new Promise((resolve, reject) => {
-            return Statamic.$hooks.run(`${this.#prefix}.saving`, this.#hookPayload).then(() => resolve(payload));
+            return Statamic.$hooks.run(`${this.#prefix}.saving`, this.#hookPayload).then(() => resolve(payload), reject);
         });
     }
 }
@@ -132,7 +129,7 @@ export class AfterSaveHooks extends Step {
                     ...this.#hookPayload,
                     response,
                 })
-                .then(() => resolve(response));
+                .then(() => resolve(response), reject);
         });
     }
 }

--- a/resources/js/components/users/PublishForm.vue
+++ b/resources/js/components/users/PublishForm.vue
@@ -187,6 +187,12 @@ export default {
                     this.title = response.data.title;
 
                     this.$nextTick(() => this.$emit('saved', response));
+                })
+                .catch((e) => {
+                    if (!(e instanceof PipelineStopped)) {
+                        this.$toast.error(__('Something went wrong'));
+                        console.error(e);
+                    }
                 });
         },
 

--- a/resources/js/tests/components/ui/Publish/SavePipeline.test.js
+++ b/resources/js/tests/components/ui/Publish/SavePipeline.test.js
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { ref } from 'vue';
+import Hooks from '@/components/Hooks.js';
+import { AfterSaveHooks, BeforeSaveHooks, Pipeline, PipelineStopped } from '@/components/ui/Publish/SavePipeline.js';
+
+let saving;
+let errors;
+let container;
+
+// If a step leaves its promise unsettled the pipeline hangs, so fail fast rather than waiting for the suite timeout.
+function withTimeout(promise, ms = 1000) {
+    return Promise.race([
+        promise,
+        new Promise((resolve, reject) => setTimeout(() => reject(new Error('Pipeline never settled')), ms)),
+    ]);
+}
+
+function pipeline(steps) {
+    return withTimeout(new Pipeline().provide({ container, errors, saving }).through(steps));
+}
+
+function step() {
+    return { handle: vi.fn((payload) => payload) };
+}
+
+function throwingStep(error) {
+    return {
+        handle: () => {
+            throw error;
+        },
+    };
+}
+
+beforeEach(() => {
+    saving = ref(false);
+    errors = ref({});
+    container = ref({ saving: vi.fn(), saved: vi.fn() });
+    global.Statamic = { $hooks: new Hooks() };
+});
+
+test('it runs the steps and finishes', async () => {
+    const middle = step();
+
+    await pipeline([new BeforeSaveHooks('entry', {}), middle, new AfterSaveHooks('entry', {})]);
+
+    expect(middle.handle).toHaveBeenCalled();
+    expect(saving.value).toBe(false);
+    expect(container.value.saved).toHaveBeenCalled();
+});
+
+test('it passes the payload through the hooks', async () => {
+    const saved = vi.fn();
+
+    Statamic.$hooks.on('entry.saving', (resolve, reject, payload) => {
+        expect(payload).toEqual({ collection: 'pages' });
+        resolve();
+    });
+
+    Statamic.$hooks.on('entry.saved', (resolve, reject, payload) => {
+        saved(payload);
+        resolve();
+    });
+
+    await pipeline([
+        new BeforeSaveHooks('entry', { collection: 'pages' }),
+        { handle: () => 'the-response' },
+        new AfterSaveHooks('entry', { collection: 'pages' }),
+    ]);
+
+    expect(saved).toHaveBeenCalledWith({ collection: 'pages', response: 'the-response' });
+});
+
+describe('a rejecting hook', () => {
+    test('stops the pipeline when saving', async () => {
+        const next = step();
+        Statamic.$hooks.on('entry.saving', (resolve, reject) => reject(new Error('nope')));
+
+        await expect(pipeline([new BeforeSaveHooks('entry', {}), next])).rejects.toThrow('nope');
+
+        expect(next.handle).not.toHaveBeenCalled();
+        expect(saving.value).toBe(false);
+        expect(container.value.saved).not.toHaveBeenCalled();
+    });
+
+    test('stops the pipeline when saved', async () => {
+        Statamic.$hooks.on('entry.saved', (resolve, reject) => reject(new Error('nope')));
+
+        await expect(pipeline([new AfterSaveHooks('entry', {})])).rejects.toThrow('nope');
+
+        expect(saving.value).toBe(false);
+        expect(container.value.saved).not.toHaveBeenCalled();
+    });
+});
+
+describe('a throwing hook', () => {
+    test('stops the pipeline when saving', async () => {
+        Statamic.$hooks.on('entry.saving', () => {
+            throw new Error('nope');
+        });
+
+        await expect(pipeline([new BeforeSaveHooks('entry', {})])).rejects.toThrow('nope');
+
+        expect(saving.value).toBe(false);
+    });
+
+    test('stops the pipeline when saved', async () => {
+        Statamic.$hooks.on('entry.saved', () => {
+            throw new Error('nope');
+        });
+
+        await expect(pipeline([new AfterSaveHooks('entry', {})])).rejects.toThrow('nope');
+
+        expect(saving.value).toBe(false);
+    });
+});
+
+test('a stopped pipeline resets the saving state', async () => {
+    const next = step();
+
+    await expect(pipeline([throwingStep(new PipelineStopped()), next])).rejects.toThrow(PipelineStopped);
+
+    expect(next.handle).not.toHaveBeenCalled();
+    expect(saving.value).toBe(false);
+});
+
+test('a step that throws resets the saving state', async () => {
+    await expect(pipeline([throwingStep(new Error('nope'))])).rejects.toThrow('nope');
+
+    expect(saving.value).toBe(false);
+});


### PR DESCRIPTION
Fixes a bug where the Save button could spin forever, locking the form until a page reload — losing unsaved work.

`BeforeSaveHooks` and `AfterSaveHooks` wrapped the hook run in a promise but only wired up the fulfilment path. If a `saving` or `saved` hook rejected — or threw, which becomes a rejection — nothing ever called `resolve` or `reject`, so the promise never settled. The pipeline stalled mid-flight, `Finish` never ran, and the saving state stayed `true`. The only sign anything went wrong was an unhandled rejection in the console.

Since `saving` and `saved` are public extension points, a single throwing hook in an addon or in a site's own CP JS takes out saving entirely for that form.

The rejection is now propagated. `Pipeline.through()` also resets the saving state for any error, not just `PipelineStopped` — otherwise propagating the rejection would only have converted the hang into a different one.

Also added the missing `.catch` to the user publish form, the one publish form with no rejection handler at all.

To reproduce on `6.x`: register `Statamic.$hooks.on('entry.saving', (resolve, reject) => reject(new Error('boom')))` in your CP JS, then save an entry.