### PR TITLE
[6.x] Allow unique rule validation messages to be overridden at the app level

### DIFF
--- a/src/Rules/UniqueEntryValue.php
+++ b/src/Rules/UniqueEntryValue.php
@@ -4,6 +4,7 @@ namespace Statamic\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Lang;
 use Statamic\Facades\Entry;
 
 class UniqueEntryValue implements ValidationRule
@@ -44,6 +45,10 @@ class UniqueEntryValue implements ValidationRule
             return;
         }
 
-        $fail('statamic::validation.unique_entry_value')->translate();
+        $key = Lang::has('validation.unique_entry_value')
+            ? 'validation.unique_entry_value'
+            : 'statamic::validation.unique_entry_value';
+
+        $fail($key)->translate();
     }
 }

--- a/src/Rules/UniqueFormHandle.php
+++ b/src/Rules/UniqueFormHandle.php
@@ -4,6 +4,7 @@ namespace Statamic\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Lang;
 use Statamic\Facades\Form;
 
 class UniqueFormHandle implements ValidationRule
@@ -11,7 +12,11 @@ class UniqueFormHandle implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         if (Form::find($value)) {
-            $fail('statamic::validation.unique_form_handle')->translate();
+            $key = Lang::has('validation.unique_form_handle')
+                ? 'validation.unique_form_handle'
+                : 'statamic::validation.unique_form_handle';
+
+            $fail($key)->translate();
         }
     }
 }

--- a/src/Rules/UniqueTermValue.php
+++ b/src/Rules/UniqueTermValue.php
@@ -4,6 +4,7 @@ namespace Statamic\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Lang;
 use Statamic\Facades\Term;
 
 class UniqueTermValue implements ValidationRule
@@ -44,6 +45,10 @@ class UniqueTermValue implements ValidationRule
             return;
         }
 
-        $fail('statamic::validation.unique_term_value')->translate();
+        $key = Lang::has('validation.unique_term_value')
+            ? 'validation.unique_term_value'
+            : 'statamic::validation.unique_term_value';
+
+        $fail($key)->translate();
     }
 }

--- a/src/Rules/UniqueUserValue.php
+++ b/src/Rules/UniqueUserValue.php
@@ -4,6 +4,7 @@ namespace Statamic\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Lang;
 use Statamic\Facades\User;
 
 class UniqueUserValue implements ValidationRule
@@ -35,6 +36,10 @@ class UniqueUserValue implements ValidationRule
             return;
         }
 
-        $fail('statamic::validation.unique_user_value')->translate();
+        $key = Lang::has('validation.unique_user_value')
+            ? 'validation.unique_user_value'
+            : 'statamic::validation.unique_user_value';
+
+        $fail($key)->translate();
     }
 }

--- a/tests/Validation/UniqueEntryValueTest.php
+++ b/tests/Validation/UniqueEntryValueTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Validation;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Rules\UniqueEntryValue;
@@ -82,5 +83,27 @@ class UniqueEntryValueTest extends TestCase
             ['slug' => 'foo'],
             ['slug' => new UniqueEntryValue(collection: 'collection-one', site: 'site-two')]
         )->passes());
+    }
+
+    #[Test]
+    public function it_uses_the_app_translation_when_one_exists()
+    {
+        EntryFactory::id('123')->slug('foo')->collection('collection-one')->create();
+
+        $validator = Validator::make(
+            ['slug' => 'foo'],
+            ['slug' => new UniqueEntryValue]
+        );
+
+        $this->assertEquals('This value has already been taken.', $validator->errors()->first('slug'));
+
+        Lang::addLines(['validation.unique_entry_value' => 'This slug has already been taken.'], 'en');
+
+        $validator = Validator::make(
+            ['slug' => 'foo'],
+            ['slug' => new UniqueEntryValue]
+        );
+
+        $this->assertEquals('This slug has already been taken.', $validator->errors()->first('slug'));
     }
 }

--- a/tests/Validation/UniqueFormHandleTest.php
+++ b/tests/Validation/UniqueFormHandleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Validation;
+
+use Illuminate\Support\Facades\Lang;
+use Illuminate\Support\Facades\Validator;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Form;
+use Statamic\Rules\UniqueFormHandle;
+use Tests\TestCase;
+
+class UniqueFormHandleTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        Form::all()->each->delete();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_fails_when_theres_a_duplicate_form_handle()
+    {
+        Form::make('contact')->save();
+
+        $this->assertTrue(Validator::make(
+            ['handle' => 'contact'],
+            ['handle' => new UniqueFormHandle]
+        )->fails());
+
+        $this->assertTrue(Validator::make(
+            ['handle' => 'newsletter'],
+            ['handle' => new UniqueFormHandle]
+        )->passes());
+    }
+
+    #[Test]
+    public function it_uses_the_app_translation_when_one_exists()
+    {
+        Form::make('contact')->save();
+
+        $validator = Validator::make(
+            ['handle' => 'contact'],
+            ['handle' => new UniqueFormHandle]
+        );
+
+        $this->assertEquals('This value has already been taken.', $validator->errors()->first('handle'));
+
+        Lang::addLines(['validation.unique_form_handle' => 'This handle has already been taken.'], 'en');
+
+        $validator = Validator::make(
+            ['handle' => 'contact'],
+            ['handle' => new UniqueFormHandle]
+        );
+
+        $this->assertEquals('This handle has already been taken.', $validator->errors()->first('handle'));
+    }
+}

--- a/tests/Validation/UniqueTermValueTest.php
+++ b/tests/Validation/UniqueTermValueTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Validation;
 
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Taxonomy;
@@ -95,5 +96,29 @@ class UniqueTermValueTest extends TestCase
             ['slug' => 'foo'],
             ['slug' => new UniqueTermValue(taxonomy: 'taxonomy-one', site: 'site-two')]
         )->passes());
+    }
+
+    #[Test]
+    public function it_uses_the_app_translation_when_one_exists()
+    {
+        Taxonomy::make('taxonomy-one')->save();
+
+        Term::make()->slug('foo')->taxonomy('taxonomy-one')->data(['Foo'])->save();
+
+        $validator = Validator::make(
+            ['slug' => 'foo'],
+            ['slug' => new UniqueTermValue]
+        );
+
+        $this->assertEquals('This value has already been taken.', $validator->errors()->first('slug'));
+
+        Lang::addLines(['validation.unique_term_value' => 'This slug has already been taken.'], 'en');
+
+        $validator = Validator::make(
+            ['slug' => 'foo'],
+            ['slug' => new UniqueTermValue]
+        );
+
+        $this->assertEquals('This slug has already been taken.', $validator->errors()->first('slug'));
     }
 }

--- a/tests/Validation/UniqueUserValueTest.php
+++ b/tests/Validation/UniqueUserValueTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Validation;
 
+use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\Facades\Validator;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
@@ -49,5 +50,27 @@ class UniqueUserValueTest extends TestCase
             ['baz' => 'foo@bar.com'],
             ['baz' => new UniqueUserValue(column: 'email')]
         )->fails());
+    }
+
+    #[Test]
+    public function it_uses_the_app_translation_when_one_exists()
+    {
+        User::make()->email('foo@bar.com')->save();
+
+        $validator = Validator::make(
+            ['email' => 'foo@bar.com'],
+            ['email' => new UniqueUserValue]
+        );
+
+        $this->assertEquals('This value has already been taken.', $validator->errors()->first('email'));
+
+        Lang::addLines(['validation.unique_user_value' => 'This email has already been taken.'], 'en');
+
+        $validator = Validator::make(
+            ['email' => 'foo@bar.com'],
+            ['email' => new UniqueUserValue]
+        );
+
+        $this->assertEquals('This email has already been taken.', $validator->errors()->first('email'));
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where custom translations for the `unique_entry_value`, `unique_term_value`, `unique_user_value` and `unique_form_handle` validation rules, defined in an app's `lang/{locale}/validation.php` file, were being ignored.

This was happening because #9785 converted these rules from string-based rules (registered via `Validator::extend`) into class-based rules. String-based rules resolved their messages through Laravel's standard message lookup, which checks the app's `validation.php` file first, whereas the class-based rules translate the namespaced `statamic::validation.*` key directly, which can only be overridden in `lang/vendor/statamic/{locale}/validation.php`.

This PR fixes it by using the app-level translation when one exists, falling back to the `statamic::` namespaced translation otherwise.

Fixes #10819
Caused by #9785