### PR TITLE
[6.x] Fix moved nav items reappearing after reordering children

### DIFF
--- a/src/CP/Navigation/NavBuilder.php
+++ b/src/CP/Navigation/NavBuilder.php
@@ -20,6 +20,7 @@ class NavBuilder
     protected $itemsKeyedById = null;
     protected $withHidden = false;
     protected $itemsWithChildrenClosures = [];
+    protected $itemsRemovedFromChildren = [];
     protected $sections = [];
     protected $sectionsEmptiedByAuthorization = [];
     protected $sectionsOriginalItemIds = [];
@@ -736,6 +737,7 @@ class NavBuilder
     protected function userModifyItemChildren($item, $childrenOverrides, $section, $reorder)
     {
         $itemChildren = collect($item->original()->resolveChildren()->children())
+            ->reject(fn ($child) => in_array($child->id(), $this->itemsRemovedFromChildren))
             ->each(fn ($item, $index) => $item->order($index + 1000))
             ->keyBy
             ->id();
@@ -883,6 +885,8 @@ class NavBuilder
         if (! $parent) {
             return;
         }
+
+        $this->itemsRemovedFromChildren[] = $item->id();
 
         if ($this->urlsUnresolvedChildren->has($parent->id())) {
             $this->urlsUnresolvedChildren[$parent->id()] = collect($this->urlsUnresolvedChildren[$parent->id()])

--- a/tests/CP/Navigation/NavPreferencesTest.php
+++ b/tests/CP/Navigation/NavPreferencesTest.php
@@ -1129,6 +1129,63 @@ class NavPreferencesTest extends TestCase
     }
 
     #[Test]
+    public function it_doesnt_show_moved_child_items_in_original_parent_when_reordering_remaining_children()
+    {
+        Facades\Collection::make('events')->title('Events')->save();
+
+        $nav = $this->buildNavWithPreferences([
+            'content' => [
+                'reorder' => true,
+                'items' => [
+                    'content::collections::pages' => '@move',
+                    'content::collections' => [
+                        'action' => '@modify',
+                        'reorder' => true,
+                        'children' => [
+                            'content::collections::events' => '@inherit',
+                            'content::collections::articles' => '@inherit',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $contentItems = $nav->get('Content')->keyBy->display();
+
+        $this->assertEquals(['Pages', 'Collections', 'Navigation', 'Taxonomies', 'Assets', 'Globals'], $contentItems->keys()->all());
+        $this->assertEquals(['Events', 'Articles'], $contentItems->get('Collections')->children()->map->display()->all());
+
+        Request::swap(Request::create('http://localhost/cp/collections/pages'));
+
+        $this->assertTrue($contentItems->get('Pages')->isActive());
+        $this->assertFalse($contentItems->get('Collections')->isActive());
+    }
+
+    #[Test]
+    public function it_doesnt_show_hidden_child_items_in_original_parent_when_reordering_remaining_children()
+    {
+        Facades\Collection::make('events')->title('Events')->save();
+
+        $nav = $this->buildNavWithPreferences([
+            'content' => [
+                'items' => [
+                    'content::collections::pages' => '@hide',
+                    'content::collections' => [
+                        'action' => '@modify',
+                        'reorder' => true,
+                        'children' => [
+                            'content::collections::events' => '@inherit',
+                            'content::collections::articles' => '@inherit',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(['Events', 'Articles'], $nav->get('Content')->keyBy->display()->get('Collections')->children()->map->display()->all());
+    }
+
+    #[Test]
     public function it_can_move_child_items_into_another_items_children()
     {
         $nav = $this->buildNavWithPreferences([


### PR DESCRIPTION
This pull request fixes an issue where a nav item moved out of its parent (like a collection moved to the top level of a section) would reappear under its original parent when the remaining children were reordered, resulting in the item being displayed twice. Clicking the moved item would also incorrectly highlight the original parent, since the resurrected child still matched the current URL. The same thing happened with hidden child items.

This was happening because when applying `@modify` preferences with reordered children, `NavBuilder` rebuilds the item's children from its original state — a snapshot taken before preferences are applied — which resurrects any children that earlier `@move` or `@hide` preferences had removed.

This PR fixes it by keeping track of items removed from their parent's children while preferences are applied, and excluding them when children are rebuilt from the original state.

Fixes #10831