### PR TITLE
[6.x] Regenerate Glide images when the cached file is missing

### DIFF
--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Imaging;
 
+use Closure;
 use Facades\Statamic\Imaging\ImageValidator;
 use Illuminate\Support\Facades\Storage;
 use League\Flysystem\Filesystem;
@@ -82,7 +83,7 @@ class ImageGenerator
      */
     public function generateByPath($path, array $params)
     {
-        return Glide::cacheStore()->rememberForever(
+        return $this->findOrGenerate(
             'path::'.$path.'::'.md5(json_encode($params)),
             fn () => $this->doGenerateByPath($path, $params)
         );
@@ -108,7 +109,7 @@ class ImageGenerator
      */
     public function generateByUrl($url, array $params)
     {
-        return Glide::cacheStore()->rememberForever(
+        return $this->findOrGenerate(
             'url::'.$url.'::'.md5(json_encode($params)),
             fn () => $this->doGenerateByUrl($url, $params)
         );
@@ -168,7 +169,7 @@ class ImageGenerator
             collect(Glide::cacheStore()->get($manifestCacheKey, []))->push($manipulationCacheKey)->unique()->all()
         );
 
-        return Glide::cacheStore()->rememberForever(
+        return $this->findOrGenerate(
             $manipulationCacheKey,
             fn () => $this->doGenerateByAsset($asset, $params)
         );
@@ -188,6 +189,19 @@ class ImageGenerator
         $this->server->setCachePathPrefix(self::assetCachePathPrefix($this->asset).'/'.$this->asset->folder());
 
         return $this->generate($this->asset->basename());
+    }
+
+    private function findOrGenerate(string $cacheKey, Closure $callback)
+    {
+        $store = Glide::cacheStore();
+
+        if (($path = $store->get($cacheKey)) && $this->server->getCache()->fileExists($path)) {
+            return $path;
+        }
+
+        $store->forget($cacheKey);
+
+        return $store->rememberForever($cacheKey, $callback);
     }
 
     public static function assetCacheManifestKey($asset)

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -99,6 +99,35 @@ class ImageGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function it_regenerates_an_image_by_asset_when_the_cached_file_is_missing()
+    {
+        Event::fake();
+
+        Storage::fake('test');
+        $file = UploadedFile::fake()->image('foo/hoff.jpg', 30, 60);
+        Storage::disk('test')->putFileAs('foo', $file, 'hoff.jpg');
+        $container = tap(AssetContainer::make('test_container')->disk('test'))->save();
+        $asset = tap($container->makeAsset('foo/hoff.jpg'))->save();
+
+        ImageValidator::shouldReceive('isValidImage')
+            ->andReturnTrue()
+            ->times(2); // Two manipulations should happen because the cached file gets deleted.
+
+        $path = $this->makeGenerator()->generateByAsset($asset, ['w' => 100, 'h' => 100]);
+
+        // Delete the generated file, but keep the cache store entry pointing to it.
+        Glide::cacheDisk()->delete($path);
+        $this->assertCount(0, $this->generatedImagePaths());
+
+        $regeneratedPath = $this->makeGenerator()->generateByAsset($asset, ['w' => 100, 'h' => 100]);
+
+        $this->assertEquals($path, $regeneratedPath);
+        $this->assertCount(1, $paths = $this->generatedImagePaths());
+        $this->assertContains($path, $paths);
+        Event::assertDispatchedTimes(GlideImageGenerated::class, 2);
+    }
+
+    #[Test]
     public function it_throws_unable_to_read_file_when_asset_is_not_a_valid_image()
     {
         Storage::fake('test');


### PR DESCRIPTION
This pull request fixes a long-standing issue where Glide would throw an `Unable to read file from location: containers/...` exception when a previously generated image no longer exists on the cache disk.

This was happening because the `ImageGenerator` remembers the path of every generated image forever in the `glide` cache store, but never checks the file still exists. Whenever the generated file went away without the cache entry going with it — a deployment wiping the cache directory, manual deletion, or changing the `image_manipulations.cache` config option (which changes the cache disk without invalidating the store) — the stale path was returned and anything reading it would throw. Depending on where that happened, this surfaced as a 500 when serving the image, or as exceptions from addons like Responsive Images.

This PR fixes it by treating a remembered path whose file is missing as a cache miss: the entry is forgotten and the image is regenerated.

Fixes #7350