### PR TITLE
[6.x] Deprecate the `theme` tag

### DIFF
--- a/src/Tags/Theme.php
+++ b/src/Tags/Theme.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Path;
 use Statamic\Facades\URL;
 use Statamic\Support\Str;
 
+/** @deprecated Will be removed in v7. Use the vite or mix tags instead. */
 class Theme extends Tags
 {
     /**


### PR DESCRIPTION
This pull request deprecates the `theme` tag ahead of its removal in the next major version. The `vite` or `mix` tags should be used instead.