### PR TITLE
[6.x] Hydrate cascade for error views rendered outside Statamic's exception stack

### DIFF
--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -137,6 +137,8 @@ class AppServiceProvider extends ServiceProvider
 
         $this->registerElevatedSessionMacros();
 
+        $this->registerCascadeHydrationForErrorViews();
+
         if (config('statamic.system.handle_scheduled_entries')) {
             $this->app->make(Schedule::class)->job(HandleEntrySchedule::class)->everyMinute();
         }
@@ -347,6 +349,44 @@ class AppServiceProvider extends ServiceProvider
             : $sites->take(3)->map->name()->join(', ').', and '.($sites->count() - 3).' more';
 
         return $sites->count().' ('.$summary.')';
+    }
+
+    // Statamic's own exceptions hydrate the cascade themselves via RendersHttpExceptions::contents().
+    // A generic HTTP exception thrown outside Statamic's stack (e.g. Livewire's default 404) never
+    // goes through that path, so the error template's globals would be unresolved. This closes that gap.
+    private function registerCascadeHydrationForErrorViews()
+    {
+        $handler = $this->app->make(\Illuminate\Contracts\Debug\ExceptionHandler::class);
+
+        if (! method_exists($handler, 'renderable')) {
+            return;
+        }
+
+        $handler->renderable(
+            function (\Symfony\Component\HttpKernel\Exception\HttpExceptionInterface $e, Request $request) {
+                if ($request->expectsJson() || Statamic::isCpRoute() || Statamic::isApiRoute()) {
+                    return null;
+                }
+
+                $status = $e->getStatusCode();
+
+                if (! view()->exists('errors.'.$status)) {
+                    return null;
+                }
+
+                Facades\Cascade::hydrated(function ($cascade) use ($status) {
+                    $cascade->set('response_code', $status);
+                });
+
+                $layouts = collect(['errors.layout', 'layouts.layout', config('statamic.system.layout', 'layout'), 'statamic::blank']);
+                $layout = $layouts->filter()->first(fn ($layout) => view()->exists($layout));
+
+                return response(
+                    $this->app->make(\Statamic\View\View::class)->template('errors.'.$status)->layout($layout)->render(),
+                    $status
+                );
+            }
+        );
     }
 
     private function registerElevatedSessionMacros()

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Route;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Auth\Protect\ProtectorManager;
@@ -17,9 +18,11 @@ use Statamic\Events\ResponseCreated;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Cascade;
 use Statamic\Facades\Collection;
+use Statamic\Facades\GlobalSet;
 use Statamic\Facades\User;
 use Statamic\Tags\Tags;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException as SymfonyNotFoundHttpException;
 
 class FrontendTest extends TestCase
 {
@@ -696,6 +699,27 @@ class FrontendTest extends TestCase
         $this->assertEquals(404, Cascade::get('response_code'));
 
         // todo: test cascade vars are in the debugbar
+    }
+
+    #[Test]
+    public function it_hydrates_the_cascade_for_a_404_thrown_outside_of_statamics_own_exception_stack()
+    {
+        // Simulates something like Livewire's default 404 handling, which throws Symfony's
+        // stock NotFoundHttpException rather than Statamic's own subclass. See GH-14167.
+        Route::get('/non-statamic-404', function () {
+            throw new SymfonyNotFoundHttpException;
+        });
+
+        $global = GlobalSet::make('site_settings')->save();
+        $global->in('en')->data(['site_name' => 'Test Site'])->save();
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('errors.404', 'Not found: {{ site_settings:site_name }}');
+
+        $this->get('/non-statamic-404')
+            ->assertNotFound()
+            ->assertSee('Not found: Test Site');
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #14167

## Problem

Statamic's own HTTP exception classes (`Statamic\Exceptions\NotFoundHttpException`, `ForbiddenHttpException`, `UnauthorizedHttpException`) hydrate the cascade via `RendersHttpExceptions::contents()` before rendering an `errors.{status}` Antlers template. That's the only place that calls `Cascade::instance()->hydrate()`.

A 404 (or other HTTP error) thrown from outside Statamic's own stack — e.g. Livewire's default 404 handling, which throws Symfony's stock `NotFoundHttpException` rather than Statamic's subclass — never goes through that path. Laravel falls back to its default exception rendering, which renders the Antlers error template directly with no cascade hydrated. Any `{{ global_set_variable }}` reference in that template then throws a `BadMethodCallException`.

The CP route group already gets its own exception handler swapped in via `SwapCpExceptionHandler` middleware, but the front-end route group has no equivalent, and that middleware only covers Statamic's own exception classes anyway — a generic Symfony exception bypasses it either way since it doesn't define its own `render()` method.

## Fix

Registers a `renderable()` callback on the app's exception handler (`src/Providers/AppServiceProvider.php`) that:
- Skips CP/API routes and JSON requests (already handled elsewhere).
- Only engages when a matching `errors.{status}` view exists.
- Hydrates the cascade and renders the error template through Statamic's `View` class, the same way `RendersHttpExceptions::contents()` does.

This only fires for exceptions that don't already define their own `render()` method (Statamic's own exception classes are checked first by Laravel and never reach this callback), and it's discarded for CP routes since `SwapCpExceptionHandler` rebinds the exception handler singleton to `ControlPanelExceptionHandler`, which has its own `render()` that doesn't consult `renderable()` callbacks.

## Test plan

- [x] Added `it_hydrates_the_cascade_for_a_404_thrown_outside_of_statamics_own_exception_stack` to `tests/FrontendTest.php`, which throws a bare `Symfony\Component\HttpKernel\Exception\NotFoundHttpException` from an ad-hoc route (mirroring Livewire's default 404 path) with an `errors.404` template referencing a global set variable via colon syntax, and asserts it renders successfully.
- [ ] **Not run locally** — this environment doesn't have a PHP runtime available, so the test is written but unverified here. Written following the existing conventions in `tests/FrontendTest.php` (`FakesViews`, `withFakeViews`/`viewShouldReturnRaw`) and `tests/View/CascadeTest.php` (`GlobalSet` setup). Relying on CI to validate.