### PR TITLE
[6.x] Multisite - turn stacked sites into a table view for larger viewports

### DIFF
--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -86,7 +86,8 @@ export default {
 
     computed: {
         component() {
-            const isNarrow = this.fields.length > 1 && this.containerWidth < 550;
+            const stackAt = this.config.stack_at ?? 550;
+            const isNarrow = this.fields.length > 1 && this.containerWidth < stackAt;
 
             return this.config.mode === 'stacked' || isNarrow ? 'GridStacked' : 'GridTable';
         },

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -258,8 +258,8 @@ class Sites
                 'name' => 14,
                 'handle' => 14,
                 'url' => 14,
-                'locale' => 12,
-                'lang' => 16,
+                'locale' => 14,
+                'lang' => 14,
                 'attributes' => 30,
             ];
 
@@ -271,10 +271,19 @@ class Sites
                         'hide_display' => true,
                         'actions' => false,
                         'fullscreen' => false,
-                        'mode' => 'stacked',
+                        'mode' => 'table',
                         'add_row' => __('Add Site'),
                         'fields' => collect($siteFields)->map(function ($field) use ($tableWidths) {
                             $field['field']['width'] = $tableWidths[$field['handle']] ?? 16;
+
+                            if ($field['handle'] === 'attributes') {
+                                $field['field']['compact'] = true;
+                                $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
+                            }
+
+                            if ($field['handle'] === 'lang') {
+                                $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
+                            }
 
                             return $field;
                         })->all(),

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -272,6 +272,7 @@ class Sites
                         'actions' => false,
                         'fullscreen' => false,
                         'mode' => 'table',
+                        'stack_at' => 925,
                         'add_row' => __('Add Site'),
                         'fields' => collect($siteFields)->map(function ($field) use ($tableWidths) {
                             $field['field']['width'] = $tableWidths[$field['handle']] ?? 16;

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -272,6 +272,7 @@ class Sites
                         'fields' => collect($siteFields)->map(function ($field) use ($tableWidths) {
                             $field['field']['width'] = $tableWidths[$field['handle']] ?? 14;
                             $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
+
                             return $field;
                         })->all(),
                         'required' => true,

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -255,11 +255,6 @@ class Sites
         // If multisite, nest fields in a grid
         if ($this->multiEnabled()) {
             $tableWidths = [
-                'name' => 14,
-                'handle' => 14,
-                'url' => 14,
-                'locale' => 14,
-                'lang' => 14,
                 'attributes' => 30,
             ];
 
@@ -275,13 +270,8 @@ class Sites
                         'stack_at' => 925,
                         'add_row' => __('Add Site'),
                         'fields' => collect($siteFields)->map(function ($field) use ($tableWidths) {
-                            $field['field']['width'] = $tableWidths[$field['handle']] ?? 16;
+                            $field['field']['width'] = $tableWidths[$field['handle']] ?? 14;
                             $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
-
-                            if ($field['handle'] === 'attributes') {
-                                $field['field']['compact'] = true;
-                            }
-
                             return $field;
                         })->all(),
                         'required' => true,

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -276,14 +276,10 @@ class Sites
                         'add_row' => __('Add Site'),
                         'fields' => collect($siteFields)->map(function ($field) use ($tableWidths) {
                             $field['field']['width'] = $tableWidths[$field['handle']] ?? 16;
+                            $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
 
                             if ($field['handle'] === 'attributes') {
                                 $field['field']['compact'] = true;
-                                $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
-                            }
-
-                            if ($field['handle'] === 'lang') {
-                                $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
                             }
 
                             return $field;

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -254,6 +254,15 @@ class Sites
 
         // If multisite, nest fields in a grid
         if ($this->multiEnabled()) {
+            $tableWidths = [
+                'name' => 14,
+                'handle' => 14,
+                'url' => 14,
+                'locale' => 12,
+                'lang' => 16,
+                'attributes' => 30,
+            ];
+
             $siteFields = [
                 [
                     'handle' => 'sites',
@@ -264,7 +273,11 @@ class Sites
                         'fullscreen' => false,
                         'mode' => 'stacked',
                         'add_row' => __('Add Site'),
-                        'fields' => $siteFields,
+                        'fields' => collect($siteFields)->map(function ($field) use ($tableWidths) {
+                            $field['field']['width'] = $tableWidths[$field['handle']] ?? 16;
+
+                            return $field;
+                        })->all(),
                         'required' => true,
                     ],
                 ],


### PR DESCRIPTION
## Description of the Problem

The stacked UI of multisite is not the best way to understand various site configurations at larger viewports.
You have to scroll quite a bit to grok the settings

## What this PR Does

- Switches to `/cp/sites` to a table view at higher viewports.
- Manipulates the table column widths at `/cp/sites` slightly, to improve their balance.
- Adds a `stack_at` variable so we can optionally change when the stack view kicks in. We want to do this for `/cp/sites` because the table view is a bit useless at lower viewports.

### Before

<img width="3420" height="2146" alt="2026-08-17 at 14 27 32@2x" src="https://github.com/user-attachments/assets/485b8b4d-16f6-46fd-8df6-f6c5d700efb9" />

### After

<img width="3420" height="2146" alt="2026-08-17 at 14 27 22@2x" src="https://github.com/user-attachments/assets/9c55e69d-e7cf-4bb2-9fb9-4d7aae128b7b" />


## How to Reproduce

1. Go to `cp/sites` with several sites configured