### PR TITLE
[6.x] Forms 2: Generate field handles from labels

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -159,6 +159,7 @@ return [
     'form_fake_submission_generation_disabled' => 'Generating fake submissions is disabled for this form.',
     'form_fake_submission_cancelled' => 'Fake submission was cancelled by a form event listener.',
     'form_fake_submission_generated' => 'Fake submission generated.',
+    'form_fields_handle_instructions' => 'Auto-generated from the label. It can\'t be changed after saving the form.',
     'form_fields_instructions_instructions' => 'Additional field instructions like this.',
     'form_navigation' => 'Form navigation',
     'getting_started_widget_collections' => 'Collections hold the different content types that make up your site, helping you stay organized.',

--- a/resources/js/components/forms/builder/ActionInspector.vue
+++ b/resources/js/components/forms/builder/ActionInspector.vue
@@ -27,6 +27,7 @@ const suggestableConditionFields = computed(() => {
         .slice(0, pageIndex.value + 1)
         .flatMap((page) => page.sections)
         .flatMap((section) => section.fields)
+        .filter((f) => f.type === 'import' || f.handle)
         .map((f) => ({
             handle: f.handle,
             config: {

--- a/resources/js/components/forms/builder/FieldInspector.vue
+++ b/resources/js/components/forms/builder/FieldInspector.vue
@@ -47,6 +47,10 @@ const modifiedFields = ref<string[]>([]);
 
 let skipNextPreviewUpdate = false;
 
+const extraValues = computed(() => ({
+    isNew: !!field.value.isNew,
+}));
+
 const shouldShowValidationTab = computed(() => collectsValue(getFieldtypeCategoryHandle(field.value.config.type)));
 
 const adjustedBlueprint = computed(() => {
@@ -84,7 +88,10 @@ const load = () => {
         .post(cp_url(`forms/${form.handle}/builder/fields/edit`), {
             type: field.value.fieldtype,
             reference: field.value.type === 'reference' ? field.value.field_reference : false,
-            values: field.value.config,
+            values: {
+                ...field.value.config,
+                handle: field.value.handle,
+            },
         })
         .then((response) => {
             loading.value = false;
@@ -126,11 +133,16 @@ const updatePreview = debounce(() => {
         .then((response) => {
             if (field.value._id !== fieldId) return;
 
-            field.value.config = response.data.values;
+            const { handle, ...config } = response.data.values;
+
+            field.value.config = config;
 
             if (response.data.preview) {
                 field.value.preview = {
-                    config: { ...response.data.preview.config, handle: field.value.handle },
+                    config: {
+                        ...response.data.preview.config,
+                        handle: field.value.handle ?? field.value._id,
+                    },
                     value: response.data.preview.value,
                     meta: response.data.preview.meta,
                 };
@@ -152,6 +164,7 @@ const suggestableConditionFields = computed(() => {
         .flatMap((page) => page.sections)
         .flatMap((section) => section.fields)
         .filter((f) => f._id !== field.value._id)
+        .filter((f) => f.type === 'import' || f.handle)
         .filter((f) => f.type === 'import' || collectsValue(getFieldtypeCategoryHandle(f.config.type)))
         .map((f) => ({
             handle: f.handle,
@@ -200,6 +213,10 @@ watch(values, () => {
     updatePreview();
 }, { deep: true });
 
+watch(() => values.value?.handle, (handle: string) => {
+    if (field.value.isNew && handle !== undefined) field.value.handle = handle;
+});
+
 watch(modifiedFields, (fields) => {
     if (field.value.type === 'reference') {
         field.value.config_overrides = fields;
@@ -242,6 +259,7 @@ onMounted(() => load());
                         :blueprint="adjustedBlueprint"
                         :meta
                         :errors
+                        :extra-values
                         v-model="values"
                         v-model:modified-fields="modifiedFields"
                         :origin-values

--- a/resources/js/components/forms/builder/Section.vue
+++ b/resources/js/components/forms/builder/Section.vue
@@ -15,7 +15,7 @@ const props = defineProps<{
     canDeleteSection: boolean,
 }>();
 
-const { clearInspector, dirty, fieldtypes, fieldView, inspect, inspecting, inspectorType, pages } = injectBuilderContext();
+const { clearInspector, dirty, ensureUniqueDisplay, fieldtypes, fieldView, inspect, inspecting, inspectorType, pages } = injectBuilderContext();
 
 const isOnlySection = computed(() => pages.value.flatMap((page) => page.sections).length === 1);
 
@@ -54,7 +54,7 @@ const containerMeta = computed(() => {
     const meta = {};
 
     props.section.fields.forEach((field) => {
-        if (field.preview?.meta) meta[field.handle] = field.preview.meta;
+        if (field.preview?.meta) meta[field.preview.config.handle] = field.preview.meta;
     });
 
     return meta;
@@ -64,7 +64,7 @@ const containerValues = computed(() => {
     const values = {};
 
     props.section.fields.forEach((field) => {
-        if (field.preview?.value) values[field.handle] = field.preview.value;
+        if (field.preview?.value) values[field.preview.config.handle] = field.preview.value;
     });
 
     return values;
@@ -83,15 +83,16 @@ const updateFieldWidth = (field, width) => {
 const duplicateField = (field) => {
     const { section } = props;
     const index = section.fields.indexOf(field);
-    const handle = uniqid({ withoutHyphens: true });
+    const _id = uniqid();
 
     const newField = {
         ...field,
-        _id: `${section._id}-${section.fields.length}`,
-        handle,
-        config: { ...field.config, display: `${field.config.display} (${__('Duplicate')})` },
+        _id,
+        handle: null,
+        isNew: true,
+        config: { ...field.config, display: ensureUniqueDisplay(`${field.config.display} (${__('Duplicate')})`) },
         preview: {
-            config: { ...field.preview.config, handle },
+            config: { ...field.preview.config, handle: _id },
             value: field.preview.value,
             meta: field.preview.meta,
         },

--- a/resources/js/pages/forms/Builder.vue
+++ b/resources/js/pages/forms/Builder.vue
@@ -197,21 +197,25 @@ const addField = (pageId: string, sectionId: string, fieldtypeHandle: string, at
     const fieldtype = props.fieldtypes.find((f) => f.handle === fieldtypeHandle);
     if (!fieldtype) return;
 
-    const handle = uniqid({ withoutHyphens: true });
+    const _id = uniqid();
 
     const field = {
-        _id: handle,
+        _id,
         config: {
             type: fieldtypeHandle,
-            display: __(fieldtype.title),
+            display: ensureUniqueDisplay(__(fieldtype.title)),
             hidden: false,
         },
         fieldtype: fieldtypeHandle,
-        handle,
+        handle: null,
+        isNew: true,
         icon: fieldtype?.icon || 'fieldtype-generic',
         type: 'inline',
         preview: {
-            config: { ...fieldtype.preview?.config, handle },
+            config: {
+                ...fieldtype.preview?.config,
+                handle: _id,
+            },
             value: fieldtype.preview?.value,
             meta: fieldtype.preview?.meta,
         },
@@ -222,6 +226,20 @@ const addField = (pageId: string, sectionId: string, fieldtypeHandle: string, at
     dirty();
 
     setTimeout(() => document.getElementById('field_display')?.select(), 250);
+};
+
+const ensureUniqueDisplay = (display: string): string => {
+    const displays = pages.value
+        .flatMap((page) => page.sections)
+        .flatMap((section) => section.fields)
+        .map((field) => field.config?.display);
+
+    if (!displays.includes(display)) return display;
+
+    let count = 2;
+    while (displays.includes(`${display} ${count}`)) count++;
+
+    return `${display} ${count}`;
 };
 
 const onFieldtypeDrop = ({ pageId, fieldtypeHandle, sectionId, sectionIndex, fieldIndex }) => {
@@ -293,6 +311,11 @@ const save = () => {
 
     axios.patch(props.action, formFields.value)
         .then((response) => {
+            pages.value
+                .flatMap((page) => page.sections)
+                .flatMap((section) => section.fields)
+                .forEach((field) => delete field.isNew);
+
             clearDirtyState();
             Statamic.$toast.success(__('Saved'));
         })
@@ -347,6 +370,7 @@ provideBuilderContext({
     deletePage,
     clearInspector,
     dirty,
+    ensureUniqueDisplay,
     errors,
     fieldtypes: props.fieldtypes,
     fieldView,

--- a/src/Fields/Field.php
+++ b/src/Fields/Field.php
@@ -507,19 +507,7 @@ class Field implements Arrayable
 
     public static function commonFieldOptions(): Fields
     {
-        $reserved = [
-            'content_type',
-            'elseif',
-            'endif',
-            'endunless',
-            'if',
-            'length',
-            'reference',
-            'resource',
-            'status',
-            'unless',
-            'views',
-        ];
+        $reserved = static::reservedHandles();
 
         $fields = collect([
             'display' => [
@@ -634,5 +622,22 @@ class Field implements Arrayable
         ])->map(fn ($field, $handle) => compact('handle', 'field'))->values()->all();
 
         return new ConfigFields($fields);
+    }
+
+    public static function reservedHandles(): array
+    {
+        return [
+            'content_type',
+            'elseif',
+            'endif',
+            'endunless',
+            'if',
+            'length',
+            'reference',
+            'resource',
+            'status',
+            'unless',
+            'views',
+        ];
     }
 }

--- a/src/Forms/Fields/FormField.php
+++ b/src/Forms/Fields/FormField.php
@@ -5,6 +5,7 @@ namespace Statamic\Forms\Fields;
 use Facades\Statamic\Forms\Fields\FormFieldtypeRepository;
 use Statamic\Fields\ConfigFields;
 use Statamic\Fields\Field;
+use Statamic\Rules\Handle;
 use Statamic\Support\Arr;
 use Statamic\Support\Str;
 
@@ -58,12 +59,29 @@ class FormField
 
     public static function commonFieldOptions(): ConfigFields
     {
+        $reserved = [...Field::reservedHandles(), 'date', 'message', 'messages'];
+
         $fields = collect([
             'display' => [
                 'display' => __('Label'),
                 'type' => 'text',
                 'focus' => true,
                 'validate' => 'required',
+            ],
+            'handle' => [
+                'display' => __('Handle'),
+                'instructions' => __('statamic::messages.form_fields_handle_instructions'),
+                'type' => 'slug',
+                'from' => 'display',
+                'async' => false,
+                'separator' => '_',
+                'validate' => [
+                    'required',
+                    new Handle,
+                    'not_in:'.implode(',', $reserved),
+                ],
+                'show_regenerate' => true,
+                'if' => ['isNew' => 'equals true'],
             ],
             'instructions' => [
                 'display' => __('Help Text'),

--- a/src/Forms/Fields/FormFieldTransformer.php
+++ b/src/Forms/Fields/FormFieldTransformer.php
@@ -38,6 +38,10 @@ class FormFieldTransformer extends FieldTransformer
 
         $field = collect($submitted['config'])
             ->reject(function ($value, $key) use ($fields) {
+                if ($key === 'isNew') {
+                    return true;
+                }
+
                 if ($key === 'icon' && ! $fields->has('icon')) {
                     return true;
                 }

--- a/src/Http/Controllers/CP/Forms/FormBuilderController.php
+++ b/src/Http/Controllers/CP/Forms/FormBuilderController.php
@@ -119,11 +119,14 @@ class FormBuilderController extends CpController
 
                     $fields = $blueprint
                         ->fields()
-                        ->addValues($field['config'] ?? [])
+                        ->addValues([
+                            ...$field['config'] ?? [],
+                            'handle' => $field['handle'] ?? null,
+                        ])
                         ->preProcess();
 
                     try {
-                        $fields->validate();
+                        $fields->validate([], ['handle.not_in' => __('statamic::validation.reserved')]);
                     } catch (ValidationException $e) {
                         foreach ($e->errors() as $handle => $messages) {
                             $errors["{$field['_id']}.{$handle}"] = $messages;

--- a/tests/Feature/Forms/FormBuilderTest.php
+++ b/tests/Feature/Forms/FormBuilderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Forms;
 
 use Facades\Statamic\Console\Processes\Composer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Fieldset;
 use Statamic\Facades\Form;
@@ -404,6 +405,91 @@ class FormBuilderTest extends TestCase
         // Both field errors should be present
         $this->assertArrayHasKey('field1_id.required_option', $errors);
         $this->assertArrayHasKey('field2_id.required_option', $errors);
+    }
+
+    #[Test]
+    public function it_validates_that_fields_have_a_handle()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'configure forms']]);
+        $user = User::make()->assignRole('test')->save();
+        $form = tap(Form::make('test'))->save();
+
+        $payload = [
+            'pages' => [
+                [
+                    '_id' => 'page1',
+                    'sections' => [
+                        [
+                            '_id' => 'section1',
+                            'display' => 'Section',
+                            'fields' => [
+                                [
+                                    '_id' => 'field1',
+                                    'handle' => null,
+                                    'type' => 'inline',
+                                    'fieldtype' => 'short_answer',
+                                    'config' => ['type' => 'short_answer', 'display' => 'Name'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this
+            ->actingAs($user)
+            ->patch(cp_route('forms.builder.update', $form->handle()), $payload)
+            ->assertSessionHasErrors(['field1.handle']);
+    }
+
+    #[Test]
+    #[DataProvider('invalidHandles')]
+    public function it_validates_the_handle($handle)
+    {
+        $this->setTestRoles(['test' => ['access cp', 'configure forms']]);
+        $user = User::make()->assignRole('test')->save();
+        $form = tap(Form::make('test'))->save();
+
+        $payload = [
+            'pages' => [
+                [
+                    '_id' => 'page1',
+                    'sections' => [
+                        [
+                            '_id' => 'section1',
+                            'display' => 'Section',
+                            'fields' => [
+                                [
+                                    '_id' => 'field1',
+                                    'handle' => $handle,
+                                    'type' => 'inline',
+                                    'fieldtype' => 'short_answer',
+                                    'config' => ['type' => 'short_answer', 'display' => 'Name'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this
+            ->actingAs($user)
+            ->patch(cp_route('forms.builder.update', $form->handle()), $payload)
+            ->assertSessionHasErrors(['field1.handle']);
+    }
+
+    public static function invalidHandles(): array
+    {
+        return [
+            'starts with a number' => ['1invalid'],
+            'invalid characters' => ['not valid'],
+            'reserved word' => ['if'],
+            'reserved forms word: date' => ['date'],
+            'reserved forms word: message' => ['message'],
+            'reserved forms word: messages' => ['messages'],
+        ];
     }
 
     #[Test]

--- a/tests/Forms/Fields/FormFieldTransformerTest.php
+++ b/tests/Forms/Fields/FormFieldTransformerTest.php
@@ -120,6 +120,23 @@ class FormFieldTransformerTest extends TestCase
     }
 
     #[Test]
+    public function it_removes_is_new_from_inline_field_config()
+    {
+        $field = FormFieldTransformer::fromVue([
+            'handle' => 'my_field',
+            'type' => 'inline',
+            'fieldtype' => 'short_answer',
+            'config' => [
+                'type' => 'short_answer',
+                'display' => 'My Field',
+                'isNew' => true,
+            ],
+        ]);
+
+        $this->assertArrayNotHasKey('isNew', $field['field']);
+    }
+
+    #[Test]
     public function it_removes_full_width_from_field_config()
     {
         $fromVue = FormFieldTransformer::fromVue([


### PR DESCRIPTION
This pull request changes how field handles work in the form builder. Previously, when you added a field, Statamic would generate a random ID for its handle, rather than "slugifying" the label like the blueprint builder does.

The motivation for random IDs was that changing a field's label later wouldn't leave it with a stale, mismatched handle — with Forms 2.0, we really want people to use the `{{ fields }}` loop to dynamically render fields, rather than hard coding fields, which isn't practical when clients might be editing forms. However, over time, the random handles have become a little awkward:

* When you're looking at a submission's YAML file, it's really difficult to identify fields.
* When we send webhooks, the keys in the payload are a bunch of gibberish with no way to know which field is which.
* When integrating with Google Sheets, we use the handle as the column name (to avoid creating a new column when a label changes), but again, the column names are all gibberish.
* If you wanted to match up a handle to a label, you'd need to dig into the form's fields array, since handles aren't exposed anywhere in the UI.

This PR fixes it by generating handles from labels, like the blueprint builder:

* When you add a field, a "Handle" setting is shown in the field inspector, auto-generated from the label as you type.
* Once the form has been saved, the handle can no longer be changed (to avoid breaking references in submissions and logic), and the handle setting is hidden.
* Handles are validated when saving the form: they're required, must be unique, and can't use reserved words — including the forms-specific ones (`date`, `message` and `messages`), [as per the docs](https://statamic.dev/knowledge-base/tips/reserved-words#forms).
* To prevent handle collisions when adding multiple fields of the same type without renaming them, default labels are made unique ("Toggle", "Toggle 2").

> [!WARNING]
> Forms created before this PR will have randomly generated handles. Any handle starting with a digit will now fail validation when saving the form, so you may need to fix up or recreate fields on existing forms.
