### PR TITLE
[6.x] Forms 2: Temporary file upload fixes

### DIFF
--- a/src/Forms/Email.php
+++ b/src/Forms/Email.php
@@ -5,6 +5,7 @@ namespace Statamic\Forms;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
 use Statamic\Contracts\Forms\Submission;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Blueprint;
@@ -161,7 +162,9 @@ class Email extends Mailable
             : config('statamic.system.file_uploads_path', 'statamic/file-uploads');
 
         foreach ($value as $file) {
-            $this->attachFromStorageDisk($disk, $basePath.'/'.$file);
+            if (Storage::disk($disk)->exists($path = "{$basePath}/{$file}")) {
+                $this->attachFromStorageDisk($disk, $path);
+            }
         }
     }
 

--- a/src/Forms/Submission.php
+++ b/src/Forms/Submission.php
@@ -292,6 +292,10 @@ class Submission implements Augmentable, ContainsQueryableValues, SubmissionCont
         $withEvents = $this->withEvents;
         $this->withEvents = true;
 
+        if ($withEvents) {
+            DeleteTemporaryFiles::dispatchSync($this);
+        }
+
         FormSubmission::delete($this);
 
         if ($withEvents) {

--- a/src/Jobs/DeletePartialFormSubmissions.php
+++ b/src/Jobs/DeletePartialFormSubmissions.php
@@ -6,9 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Statamic\Contracts\Forms\Submission;
 use Statamic\Facades\FormSubmission;
-use Statamic\Forms\DeleteTemporaryFiles;
 
 class DeletePartialFormSubmissions implements ShouldQueue
 {
@@ -26,10 +24,6 @@ class DeletePartialFormSubmissions implements ShouldQueue
             ->where('partial', true)
             ->where('date', '<', $threshold)
             ->get()
-            ->each(function (Submission $submission): void {
-                DeleteTemporaryFiles::dispatchSync($submission);
-
-                $submission->delete();
-            });
+            ->each->delete();
     }
 }

--- a/tests/Forms/EmailTest.php
+++ b/tests/Forms/EmailTest.php
@@ -352,6 +352,24 @@ class EmailTest extends TestCase
     }
 
     #[Test]
+    public function it_skips_attachments_whose_temporary_files_no_longer_exist()
+    {
+        Storage::fake('local');
+
+        $form = tap(Form::make('test')->formFields([
+            'fields' => [
+                ['handle' => 'document', 'field' => ['type' => 'files', 'max_files' => 1]],
+            ],
+        ]))->save();
+
+        $submission = $form->makeSubmission()->data(['document' => now()->timestamp.'/resume.pdf']);
+
+        $email = tap(new Email($submission, ['to' => 'test@test.com', 'attachments' => true], Site::default()))->build();
+
+        $this->assertEmpty($email->attachments);
+    }
+
+    #[Test]
     public function it_attaches_files_from_files_field_on_the_configured_disk_and_path()
     {
         config([

--- a/tests/Forms/SubmissionTest.php
+++ b/tests/Forms/SubmissionTest.php
@@ -17,6 +17,7 @@ use Statamic\Events\SubmissionSaving;
 use Statamic\Facades\Form;
 use Statamic\Facades\Site;
 use Statamic\Forms\CreateAssetsFromFileUploads;
+use Statamic\Forms\DeleteTemporaryFiles;
 use Statamic\Forms\SendEmails;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
@@ -270,6 +271,32 @@ class SubmissionTest extends TestCase
         Event::assertNotDispatched(SubmissionDeleted::class);
 
         $this->assertTrue($return);
+    }
+
+    #[Test]
+    public function deleting_dispatches_delete_temporary_files()
+    {
+        Bus::fake();
+
+        $form = tap(Form::make('contact_us'))->save();
+        $submission = tap($form->makeSubmission())->save();
+
+        $submission->delete();
+
+        Bus::assertDispatchedSync(DeleteTemporaryFiles::class);
+    }
+
+    #[Test]
+    public function deleting_quietly_does_not_dispatch_delete_temporary_files()
+    {
+        Bus::fake();
+
+        $form = tap(Form::make('contact_us'))->save();
+        $submission = tap($form->makeSubmission())->save();
+
+        $submission->deleteQuietly();
+
+        Bus::assertNotDispatched(DeleteTemporaryFiles::class);
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes a couple of issues around form submissions' temporary file uploads.

* Fixes an issue where emails would fail to send when an attached temporary file upload no longer exists on disk.
   * This was happening because temporary files can be cleaned up before a queued email is sent, and attaching a missing file throws an exception at send time.
   * This PR fixes it by skipping files that no longer exist.
* Fixes an issue where deleting a submission would leave its temporary file uploads behind on disk.
   * This was happening because the `DeleteTemporaryFiles` job was only dispatched when finalizing a submission or when cleaning up abandoned partial submissions — deleting a submission from the Control Panel never triggered it.
   * This PR fixes it by dispatching the job from the submission's `delete()` method. Quiet deletes are excluded, since finalizing a submission on a non-storing form deletes it quietly *before* sending emails, which still need the files for attachments.
