### PR TITLE
[6.x] Resolve dictionary fieldtype permissions via the CP guard

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -42,7 +42,7 @@ Route::name('statamic.')->group(function () {
         Route::get('protect/password', [PasswordProtectController::class, 'show'])->name('protect.password.show')->middleware([HandleInertiaRequests::class]);
         Route::post('protect/password', [PasswordProtectController::class, 'store'])->name('protect.password.store');
 
-        Route::get('fieldtypes/dictionaries/{dictionary}', DictionaryFieldtypeController::class)->middleware('throttle:statamic.dictionaries')->name('dictionary-fieldtype');
+        Route::get('fieldtypes/dictionaries/{dictionary}', DictionaryFieldtypeController::class)->middleware([CPAuthGuard::class, 'throttle:statamic.dictionaries'])->name('dictionary-fieldtype');
 
         Route::group(['prefix' => 'auth', 'middleware' => [AuthGuard::class]], function () {
             Route::get('logout', [LoginController::class, 'logout'])->name('logout');

--- a/src/Providers/AuthServiceProvider.php
+++ b/src/Providers/AuthServiceProvider.php
@@ -152,7 +152,9 @@ class AuthServiceProvider extends ServiceProvider
                 return null;
             }
 
-            $user = User::fromUser($user);
+            if (! $user = User::fromUser($user)) {
+                return null;
+            }
 
             if ($user->isSuper()) {
                 return true;

--- a/tests/Fieldtypes/DictionaryTest.php
+++ b/tests/Fieldtypes/DictionaryTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Fieldtypes;
 
 use Facades\Statamic\Fields\FieldtypeRepository;
+use Illuminate\Auth\GenericUser;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Dictionaries\Countries;
@@ -137,6 +138,55 @@ class DictionaryTest extends TestCase
             ->getJson($this->optionsUrl('restricted'))
             ->assertOk()
             ->assertJsonStructure(['data' => [['key', 'value']]]);
+    }
+
+    #[Test]
+    public function a_cp_user_can_request_options_when_the_cp_guard_is_not_the_default_guard()
+    {
+        config([
+            'statamic.users.guards.cp' => 'cp',
+            'auth.guards.cp' => config('auth.guards.web'),
+        ]);
+
+        RestrictedDictionary::register();
+
+        $this->actingAs(User::make()->makeSuper(), 'cp');
+        $this->app['auth']->shouldUse('web');
+
+        $this
+            ->getJson($this->optionsUrl('restricted'))
+            ->assertOk()
+            ->assertJsonStructure(['data' => [['key', 'value']]]);
+    }
+
+    #[Test]
+    public function a_cp_user_can_request_options_while_a_non_statamic_user_is_authenticated_on_the_default_guard()
+    {
+        config([
+            'statamic.users.guards.cp' => 'cp',
+            'auth.guards.cp' => config('auth.guards.web'),
+        ]);
+
+        RestrictedDictionary::register();
+
+        $this->actingAs(User::make()->makeSuper(), 'cp');
+        $this->actingAs(new GenericUser(['id' => 1]), 'web');
+
+        $this
+            ->getJson($this->optionsUrl('restricted'))
+            ->assertOk()
+            ->assertJsonStructure(['data' => [['key', 'value']]]);
+    }
+
+    #[Test]
+    public function a_non_statamic_user_cannot_request_options_from_a_dictionary_that_does_not_allow_public_access()
+    {
+        RestrictedDictionary::register();
+
+        $this
+            ->actingAs(new GenericUser(['id' => 1]))
+            ->getJson($this->optionsUrl('restricted'))
+            ->assertForbidden();
     }
 
     #[Test]

--- a/tests/Permissions/GateTest.php
+++ b/tests/Permissions/GateTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Permissions;
 
+use Illuminate\Auth\GenericUser;
 use Illuminate\Support\Facades\Gate;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -62,6 +63,12 @@ class GateTest extends TestCase
             Gate::allows($permission),
             'User should '.($expectsToBeAllowed ? '' : 'not ').'be allowed.'
         );
+    }
+
+    #[Test]
+    public function gate_checks_for_a_non_statamic_user_are_denied()
+    {
+        $this->assertFalse(Gate::forUser(new GenericUser(['id' => 1]))->allows('access cp'));
     }
 
     public static function gateProvider()


### PR DESCRIPTION
This pull request fixes an issue where the dictionary fieldtype endpoint resolved the `access cp` permission using the default auth guard, rather than the guard configured for the Control Panel.

When the default guard differed from the CP guard, dictionary dropdowns in the Control Panel would silently render empty, since the endpoint would return a 403 even for authenticated CP users. Worse, when a non-Statamic user was authenticated on the default guard, the endpoint would return a 500 (`Call to a member function isSuper() on null`), because the `Gate::after` callback in the `AuthServiceProvider` didn't account for `User::fromUser()` returning `null`.

This PR fixes it by adding the CP `AuthGuard` middleware to the dictionary fieldtype route, so the permission check is resolved against the CP guard. Only the guard middleware is applied, not the full CP middleware group, so dictionaries which allow public access remain accessible to guests. This PR also returns `null` from the `Gate::after` callback when the authenticated user isn't a Statamic user, so the gate abstains rather than erroring.

Fixes #15204
