### PR TITLE
[6.x] Fix toasts being replayed on partial reloads

### DIFF
--- a/resources/js/components/Toasts.js
+++ b/resources/js/components/Toasts.js
@@ -26,9 +26,12 @@ export default class Toasts {
 
         router.on('success', (event) => {
             const toasts = event.detail.page.props._toasts;
-            if (toasts && Array.isArray(toasts)) {
-                this.#displayToasts(toasts);
-            }
+
+            if (!Array.isArray(toasts) || !toasts.length) return;
+
+            delete event.detail.page.props._toasts;
+
+            this.#displayToasts(toasts);
         });
     }
 

--- a/resources/js/tests/Toasts.test.js
+++ b/resources/js/tests/Toasts.test.js
@@ -1,0 +1,62 @@
+import { test, expect, beforeEach, vi } from 'vitest';
+
+// Mock @inertiajs/vue3 router before importing the component so it captures
+// the mock instead of the real router.
+vi.mock('@inertiajs/vue3', () => {
+    const listeners = { success: [] };
+    return {
+        router: {
+            on: (event, callback) => {
+                listeners[event].push(callback);
+                return () => {
+                    listeners[event] = listeners[event].filter((cb) => cb !== callback);
+                };
+            },
+            __listeners: listeners,
+        },
+    };
+});
+
+const fakeAxios = { interceptors: { response: { use: () => {} } } };
+
+let toasts;
+let fireSuccess;
+
+beforeEach(async () => {
+    vi.resetModules();
+    const { router } = await import('@inertiajs/vue3');
+    router.__listeners.success = [];
+    const { default: Toasts } = await import('../components/Toasts.js');
+    toasts = new Toasts();
+    toasts.success = vi.fn();
+    toasts.error = vi.fn();
+    toasts.registerInterceptor(fakeAxios);
+    fireSuccess = (page) => router.__listeners.success.forEach((cb) => cb({ detail: { page } }));
+});
+
+test('toasts in the page props are displayed', () => {
+    fireSuccess({ props: { _toasts: [{ type: 'success', message: 'Saved' }] } });
+
+    expect(toasts.success).toHaveBeenCalledTimes(1);
+    expect(toasts.success).toHaveBeenCalledWith('Saved', { duration: undefined });
+});
+
+test('nothing happens without toasts in the page props', () => {
+    fireSuccess({ props: {} });
+    fireSuccess({ props: { _toasts: [] } });
+
+    expect(toasts.success).not.toHaveBeenCalled();
+});
+
+test('toasts are not replayed by partial reloads', () => {
+    const page = { props: { _toasts: [{ type: 'success', message: 'Saved' }] } };
+
+    fireSuccess(page);
+
+    // Simulate a partial reload of the same component: Inertia merges the partial
+    // response - which carries no _toasts key - into the existing page props.
+    page.props = { ...page.props, time: '12:00:00' };
+    fireSuccess(page);
+
+    expect(toasts.success).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
This PR fixes a problem where toast messages on Inertia CP pages are replayed on every partial reload. We ran into this on a custom page that polls a queue via `usePoll(5000, { only: [...] })` after a `form.post()` redirect. The success toast reappeared every 5 seconds until navigating away.

The problem: `_toasts` is shared as a regular Inertia prop, but it is flash data. Partial responses only contain the requested props, and Inertia merges them into the existing page props. So a stale `_toasts` survives every partial reload, and the `success` listener in `Toasts.js` re-displays it each time.

To reproduce the problem: Flash a toast on any CP page that uses `usePoll(…, { only: [...] })`.
See "Reproduction Code" down below.

The fix removes the prop from the page props once the toasts have been displayed, so a later partial reload has nothing left to replay.

An alternative approach would be to change toasts logic to Inertia's flash data (`Inertia::flash()`). But that requires inertia-laravel >= 2.0.16 and touches the initial page load path (`displayInitialToasts()`). So it felt a bit too big of a change for this bugfix.

---

<details>
<summary>Reproduction Code</summary>

```php
// routes/cp.php
Route::get('toast-repro', fn () => Inertia::render('toast-repro/Index', ['time' => now()->toTimeString()]));
Route::post('toast-repro', fn () => redirect('/cp/toast-repro')->with('success', 'Flashed once'));
```

```vue
<!-- resources/js/cp/pages/toast-repro/Index.vue -->
<script setup>
import { router, usePoll } from '@statamic/cms/inertia'

defineProps({ time: String })

usePoll(3000, { only: ['time'] })
</script>

<template>
    <div>
        <p>{{ time }}</p>
        <button @click="router.post('/cp/toast-repro')">Flash a toast</button>
    </div>
</template>
```

```js
// resources/js/cp/cp.js
import Index from './pages/toast-repro/Index.vue'

Statamic.$inertia.register('toast-repro/Index', Index)
```

Click the button: expected is one toast, actual is a toast every 3 seconds
</details>