### PR TITLE
[6.x] Improve tooltips

### DIFF
--- a/resources/css/components/tooltips.css
+++ b/resources/css/components/tooltips.css
@@ -9,3 +9,7 @@
 .v-popper--theme-tooltip .v-popper__inner {
     padding: 5px 10px !important;
 }
+
+.v-popper--theme-tooltip:has(.tooltip-popper-interactive) {
+    pointer-events: auto;
+}

--- a/resources/css/components/tooltips.css
+++ b/resources/css/components/tooltips.css
@@ -10,7 +10,6 @@
     padding: 5px 10px !important;
 }
 
-/* Copyable and HTML tooltips can be hovered and clicked. */
 .v-popper--theme-tooltip:has(.tooltip-popper-interactive),
 .v-popper--theme-tooltip:has(.tooltip-popper-interactive) .v-popper__wrapper {
     pointer-events: auto;

--- a/resources/css/components/tooltips.css
+++ b/resources/css/components/tooltips.css
@@ -10,6 +10,8 @@
     padding: 5px 10px !important;
 }
 
-.v-popper--theme-tooltip:has(.tooltip-popper-interactive) {
+/* Copyable and HTML tooltips can be hovered and clicked. */
+.v-popper--theme-tooltip:has(.tooltip-popper-interactive),
+.v-popper--theme-tooltip:has(.tooltip-popper-interactive) .v-popper__wrapper {
     pointer-events: auto;
 }

--- a/resources/css/components/tooltips.css
+++ b/resources/css/components/tooltips.css
@@ -10,6 +10,10 @@
     padding: 5px 10px !important;
 }
 
+.v-popper--theme-tooltip a {
+    @apply underline;
+}
+
 .v-popper--theme-tooltip:has(.tooltip-popper-interactive),
 .v-popper--theme-tooltip:has(.tooltip-popper-interactive) .v-popper__wrapper {
     pointer-events: auto;

--- a/resources/js/components/Tooltips.vue
+++ b/resources/js/components/Tooltips.vue
@@ -81,9 +81,10 @@ watch([isVisible, targetEl, content], async ([visible, target]) => {
                             class="cursor-pointer hover:underline"
                             role="button"
                             tabindex="0"
-                            :aria-label="__('Copy')"
+                            :aria-label="__('Copy :handle to clipboard', { handle: displayContent })"
                             @click.stop="copy(displayContent)"
                             @keydown.enter.prevent="copy(displayContent)"
+                            @keydown.space.prevent="copy(displayContent)"
                         >{{ displayContent }}</span>
                         <template v-else>{{ displayContent }}</template>
                     </div>

--- a/resources/js/components/Tooltips.vue
+++ b/resources/js/components/Tooltips.vue
@@ -4,7 +4,7 @@ import { Tooltip as VTooltip } from 'floating-vue';
 import DOMPurify from 'dompurify';
 import { useTooltip } from '@/composables/tooltip.js';
 
-const { isVisible, content, html, targetEl } = useTooltip();
+const { isVisible, content, html, targetEl, persist, hide } = useTooltip();
 
 const showTooltip = ref(false);
 const wrapperStyle = ref({});
@@ -66,8 +66,14 @@ watch([isVisible, targetEl, content], async ([visible, target]) => {
             >
                 <span :style="spanStyle" />
                 <template #popper>
-                    <div v-if="displayHtml" v-html="displayContent" />
-                    <template v-else>{{ displayContent }}</template>
+                    <div
+                        :class="{ 'tooltip-popper-interactive': displayHtml }"
+                        @mouseenter="displayHtml && persist()"
+                        @mouseleave="displayHtml && hide()"
+                    >
+                        <div v-if="displayHtml" v-html="displayContent" />
+                        <template v-else>{{ displayContent }}</template>
+                    </div>
                 </template>
             </VTooltip>
         </div>

--- a/resources/js/components/Tooltips.vue
+++ b/resources/js/components/Tooltips.vue
@@ -67,7 +67,7 @@ watch([isVisible, targetEl, content], async ([visible, target]) => {
                 :shown="showTooltip"
                 :triggers="[]"
                 placement="top"
-                :distance="6"
+                :distance="10"
             >
                 <span :style="spanStyle" />
                 <template #popper>

--- a/resources/js/components/Tooltips.vue
+++ b/resources/js/components/Tooltips.vue
@@ -5,7 +5,7 @@ import DOMPurify from 'dompurify';
 import { useTooltip } from '@/composables/tooltip.js';
 import useCopy from '@/composables/copy';
 
-const { isVisible, content, html, copyable, targetEl, persist, hide } = useTooltip();
+const { isVisible, content, html, copyable, targetEl, registerContentEl } = useTooltip();
 const { copySupported, copy } = useCopy();
 
 const showTooltip = ref(false);
@@ -67,19 +67,18 @@ watch([isVisible, targetEl, content], async ([visible, target]) => {
                 :shown="showTooltip"
                 :triggers="[]"
                 placement="top"
-                :distance="10"
+                :distance="6"
             >
                 <span :style="spanStyle" />
                 <template #popper>
                     <div
+                        :ref="registerContentEl"
                         :class="{ 'tooltip-popper-interactive': isInteractive }"
-                        @mouseenter="isInteractive && persist()"
-                        @mouseleave="isInteractive && hide()"
                     >
                         <div v-if="displayHtml" v-html="displayContent" />
                         <span
                             v-else-if="displayCopyable && copySupported"
-                            class="cursor-pointer"
+                            class="cursor-pointer hover:underline"
                             role="button"
                             tabindex="0"
                             :aria-label="__('Copy')"

--- a/resources/js/components/Tooltips.vue
+++ b/resources/js/components/Tooltips.vue
@@ -1,10 +1,12 @@
 <script setup>
-import { ref, watch, nextTick } from 'vue';
+import { ref, watch, nextTick, computed } from 'vue';
 import { Tooltip as VTooltip } from 'floating-vue';
 import DOMPurify from 'dompurify';
 import { useTooltip } from '@/composables/tooltip.js';
+import useCopy from '@/composables/copy';
 
-const { isVisible, content, html, targetEl, persist, hide } = useTooltip();
+const { isVisible, content, html, copyable, targetEl, persist, hide } = useTooltip();
+const { copySupported, copy } = useCopy();
 
 const showTooltip = ref(false);
 const wrapperStyle = ref({});
@@ -12,6 +14,8 @@ const spanStyle = ref({});
 const tooltipKey = ref(0);
 const displayContent = ref('');
 const displayHtml = ref(false);
+const displayCopyable = ref(false);
+const isInteractive = computed(() => displayHtml.value || displayCopyable.value);
 
 function updatePosition() {
     if (!targetEl.value) {
@@ -42,6 +46,7 @@ watch([isVisible, targetEl, content], async ([visible, target]) => {
     if (visible && target) {
         // Update content and position (handles both initial show and target changes)
         displayHtml.value = html.value;
+        displayCopyable.value = copyable.value;
         displayContent.value = displayHtml.value ? DOMPurify.sanitize(content.value ?? '') : content.value;
         updatePosition();
         tooltipKey.value++;
@@ -67,11 +72,20 @@ watch([isVisible, targetEl, content], async ([visible, target]) => {
                 <span :style="spanStyle" />
                 <template #popper>
                     <div
-                        :class="{ 'tooltip-popper-interactive': displayHtml }"
-                        @mouseenter="displayHtml && persist()"
-                        @mouseleave="displayHtml && hide()"
+                        :class="{ 'tooltip-popper-interactive': isInteractive }"
+                        @mouseenter="isInteractive && persist()"
+                        @mouseleave="isInteractive && hide()"
                     >
                         <div v-if="displayHtml" v-html="displayContent" />
+                        <span
+                            v-else-if="displayCopyable && copySupported"
+                            class="cursor-pointer"
+                            role="button"
+                            tabindex="0"
+                            :aria-label="__('Copy')"
+                            @click.stop="copy(displayContent)"
+                            @keydown.enter.prevent="copy(displayContent)"
+                        >{{ displayContent }}</span>
                         <template v-else>{{ displayContent }}</template>
                     </div>
                 </template>

--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -284,7 +284,7 @@ const fieldtypeComponentEvents = computed(() => ({
                         />
                     </Transition>
                     <template v-if="shouldShowLabelText">
-                        <span v-tooltip="config.handle">
+                        <span v-tooltip="{ content: config.handle, copyable: true }">
                             {{ __(config.display) }}
                         </span>
                     </template>

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -41,29 +41,74 @@ function contains(rect, x, y, pad = EDGE) {
     );
 }
 
-function gapRect(trigger, popper) {
-    const left = Math.min(trigger.left, popper.left);
-    const right = Math.max(trigger.right, popper.right);
+export function tooltipGapRect(trigger, popper) {
+    if (!trigger || !popper) return null;
 
-    if (popper.bottom <= trigger.top) return { left, right, top: popper.bottom, bottom: trigger.top };
-    if (popper.top >= trigger.bottom) return { left, right, top: trigger.bottom, bottom: popper.top };
+    if (popper.bottom <= trigger.top) {
+        return {
+            left: Math.min(trigger.left, popper.left),
+            right: Math.max(trigger.right, popper.right),
+            top: popper.bottom,
+            bottom: trigger.top,
+        };
+    }
+
+    if (popper.top >= trigger.bottom) {
+        return {
+            left: Math.min(trigger.left, popper.left),
+            right: Math.max(trigger.right, popper.right),
+            top: trigger.bottom,
+            bottom: popper.top,
+        };
+    }
+
+    if (popper.right <= trigger.left) {
+        return {
+            left: popper.right,
+            right: trigger.left,
+            top: Math.min(trigger.top, popper.top),
+            bottom: Math.max(trigger.bottom, popper.bottom),
+        };
+    }
+
+    if (popper.left >= trigger.right) {
+        return {
+            left: trigger.right,
+            right: popper.left,
+            top: Math.min(trigger.top, popper.top),
+            bottom: Math.max(trigger.bottom, popper.bottom),
+        };
+    }
 
     return null;
 }
 
-function isPointerInside(x, y) {
-    const trigger = triggerRect();
-    const popper = popperRect();
+export function isInTooltipHoverRegion(x, y, trigger, popper, edge = EDGE) {
+    if (contains(trigger, x, y, edge) || contains(popper, x, y, edge)) return true;
 
-    if (contains(trigger, x, y) || contains(popper, x, y)) return true;
+    // Popper isn't measured yet — keep the tooltip so the pointer can cross the gap.
+    if (trigger && !popper) return true;
 
-    return !!trigger && !!popper && contains(gapRect(trigger, popper), x, y, 0);
+    return !!trigger && !!popper && contains(tooltipGapRect(trigger, popper), x, y, 0);
+}
+
+function isOverInteractiveTooltip() {
+    if (pointer) {
+        return isInTooltipHoverRegion(pointer.x, pointer.y, triggerRect(), popperRect());
+    }
+
+    if (targetEl.value?.matches?.(':hover')) return true;
+    if (contentEl.value?.matches?.(':hover')) return true;
+    if (contentEl.value?.closest?.('.v-popper__popper')?.matches?.(':hover')) return true;
+
+    // Still mounting, and we have not seen a pointer yet.
+    return isVisible.value && isInteractive() && !popperRect();
 }
 
 function onPointerMove(event) {
     pointer = { x: event.clientX, y: event.clientY };
 
-    if (!isPointerInside(pointer.x, pointer.y)) dismiss();
+    if (!isOverInteractiveTooltip()) dismiss();
 }
 
 function startTracking() {
@@ -115,6 +160,7 @@ function dismiss() {
 
     isVisible.value = false;
     targetEl.value = null;
+    contentEl.value = null;
     content.value = '';
     html.value = false;
     copyable.value = false;
@@ -145,8 +191,7 @@ function show(el, options) {
 
 function hide() {
     if (isVisible.value && isInteractive()) {
-        if (pointer && !isPointerInside(pointer.x, pointer.y)) dismiss();
-        return;
+        if (isOverInteractiveTooltip()) return;
     }
 
     dismiss();
@@ -158,6 +203,10 @@ function dismissFor(el) {
 
 function registerContentEl(el) {
     contentEl.value = el ?? null;
+
+    if (el && isVisible.value && isInteractive() && !isOverInteractiveTooltip()) {
+        dismiss();
+    }
 }
 
 export function useTooltip() {

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -12,7 +12,8 @@ let pendingEl = null;
 let tracking = false;
 let pointer = null;
 
-const EDGE = 4;
+const EDGE = 12;
+const GAP_SLACK = 16;
 
 function isInteractive() {
     return html.value || copyable.value;
@@ -46,8 +47,8 @@ export function tooltipGapRect(trigger, popper) {
 
     if (popper.bottom <= trigger.top) {
         return {
-            left: Math.min(trigger.left, popper.left),
-            right: Math.max(trigger.right, popper.right),
+            left: Math.min(trigger.left, popper.left) - GAP_SLACK,
+            right: Math.max(trigger.right, popper.right) + GAP_SLACK,
             top: popper.bottom,
             bottom: trigger.top,
         };
@@ -55,8 +56,8 @@ export function tooltipGapRect(trigger, popper) {
 
     if (popper.top >= trigger.bottom) {
         return {
-            left: Math.min(trigger.left, popper.left),
-            right: Math.max(trigger.right, popper.right),
+            left: Math.min(trigger.left, popper.left) - GAP_SLACK,
+            right: Math.max(trigger.right, popper.right) + GAP_SLACK,
             top: trigger.bottom,
             bottom: popper.top,
         };
@@ -66,8 +67,8 @@ export function tooltipGapRect(trigger, popper) {
         return {
             left: popper.right,
             right: trigger.left,
-            top: Math.min(trigger.top, popper.top),
-            bottom: Math.max(trigger.bottom, popper.bottom),
+            top: Math.min(trigger.top, popper.top) - GAP_SLACK,
+            bottom: Math.max(trigger.bottom, popper.bottom) + GAP_SLACK,
         };
     }
 
@@ -75,8 +76,8 @@ export function tooltipGapRect(trigger, popper) {
         return {
             left: trigger.right,
             right: popper.left,
-            top: Math.min(trigger.top, popper.top),
-            bottom: Math.max(trigger.bottom, popper.bottom),
+            top: Math.min(trigger.top, popper.top) - GAP_SLACK,
+            bottom: Math.max(trigger.bottom, popper.bottom) + GAP_SLACK,
         };
     }
 

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -3,6 +3,7 @@ import { ref, shallowRef, readonly } from 'vue';
 const isVisible = ref(false);
 const content = ref('');
 const html = ref(false);
+const copyable = ref(false);
 const targetEl = shallowRef(null);
 
 let hideTimeout = null;
@@ -14,12 +15,15 @@ function setContent(el, options) {
     if (typeof options === 'string') {
         content.value = options;
         html.value = false;
+        copyable.value = false;
     } else if (options && typeof options === 'object') {
         content.value = options.content || '';
         html.value = options.html || false;
+        copyable.value = options.copyable || false;
     } else {
         content.value = '';
         html.value = false;
+        copyable.value = false;
     }
 }
 
@@ -65,7 +69,8 @@ function hide() {
         targetEl.value = null;
         content.value = '';
         html.value = false;
-    }, html.value ? 200 : 50);
+        copyable.value = false;
+    }, html.value || copyable.value ? 200 : 50);
 }
 
 export function useTooltip() {
@@ -73,6 +78,7 @@ export function useTooltip() {
         isVisible: readonly(isVisible),
         content: readonly(content),
         html: readonly(html),
+        copyable: readonly(copyable),
         targetEl: readonly(targetEl),
         show,
         persist,

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -8,6 +8,7 @@ const targetEl = shallowRef(null);
 const contentEl = shallowRef(null);
 
 let showTimeout = null;
+let hideTimeout = null;
 let pendingEl = null;
 let tracking = false;
 let pointer = null;
@@ -176,6 +177,11 @@ function dismiss() {
         showTimeout = null;
     }
 
+    if (hideTimeout) {
+        clearTimeout(hideTimeout);
+        hideTimeout = null;
+    }
+
     pendingEl = null;
 
     isVisible.value = false;
@@ -187,11 +193,17 @@ function dismiss() {
 }
 
 function show(el, options) {
+    // Cancel a pending hide so hopping to an adjacent trigger can keep the tooltip up.
+    if (hideTimeout) {
+        clearTimeout(hideTimeout);
+        hideTimeout = null;
+    }
+
     if (showTimeout) {
         clearTimeout(showTimeout);
     }
 
-    // If already visible, update immediately (for moving between adjacent elements)
+    // Already visible: swap content immediately instead of blinking through the show delay.
     if (isVisible.value) {
         setContent(el, options);
         return;
@@ -210,11 +222,32 @@ function show(el, options) {
 }
 
 function hide() {
-    if (isVisible.value && isInteractive()) {
-        if (isOverInteractiveTooltip()) return;
+    // Interactive tooltips (html / copyable) are kept alive by pointer tracking,
+    // so mouseleave on the trigger must not start a hide timer.
+    if (isInteractive()) {
+        if (isVisible.value && isOverInteractiveTooltip()) return;
+        dismiss();
+        return;
     }
 
-    dismiss();
+    if (showTimeout) {
+        clearTimeout(showTimeout);
+        showTimeout = null;
+        pendingEl = null;
+    }
+
+    if (!isVisible.value) return;
+
+    // Brief grace so mouseleave on A + mouseenter on B (e.g. Bard toolbar)
+    // still sees isVisible and takes the instant-swap path in show().
+    if (hideTimeout) {
+        clearTimeout(hideTimeout);
+    }
+
+    hideTimeout = setTimeout(() => {
+        hideTimeout = null;
+        dismiss();
+    }, 50);
 }
 
 function dismissFor(el, event) {

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -5,9 +5,90 @@ const content = ref('');
 const html = ref(false);
 const copyable = ref(false);
 const targetEl = shallowRef(null);
+const contentEl = shallowRef(null);
 
-let hideTimeout = null;
 let showTimeout = null;
+let pendingEl = null;
+let tracking = false;
+let pointer = null;
+
+/* Slack around each rect, for subpixel rounding and the pointer sitting on a border. */
+const EDGE = 4;
+
+function isInteractive() {
+    return html.value || copyable.value;
+}
+
+function popperRect() {
+    const el = contentEl.value;
+    if (!el?.isConnected) return null;
+
+    return (el.closest('.v-popper__popper') ?? el).getBoundingClientRect();
+}
+
+function triggerRect() {
+    const el = targetEl.value;
+
+    return el?.isConnected ? el.getBoundingClientRect() : null;
+}
+
+function contains(rect, x, y, pad = EDGE) {
+    return (
+        !!rect &&
+        x >= rect.left - pad &&
+        x <= rect.right + pad &&
+        y >= rect.top - pad &&
+        y <= rect.bottom + pad
+    );
+}
+
+/* The arrow and offset leave a gap between the trigger and the popper. Bridge it with a
+   rect covering only that gap, so the pointer can travel between the two. */
+function gapRect(trigger, popper) {
+    const left = Math.min(trigger.left, popper.left);
+    const right = Math.max(trigger.right, popper.right);
+
+    if (popper.bottom <= trigger.top) return { left, right, top: popper.bottom, bottom: trigger.top };
+    if (popper.top >= trigger.bottom) return { left, right, top: trigger.bottom, bottom: popper.top };
+
+    return null;
+}
+
+function isPointerInside(x, y) {
+    const trigger = triggerRect();
+    const popper = popperRect();
+
+    if (contains(trigger, x, y) || contains(popper, x, y)) return true;
+
+    return !!trigger && !!popper && contains(gapRect(trigger, popper), x, y, 0);
+}
+
+function onPointerMove(event) {
+    pointer = { x: event.clientX, y: event.clientY };
+
+    if (!isPointerInside(pointer.x, pointer.y)) dismiss();
+}
+
+function onPointerGone() {
+    dismiss();
+}
+
+function startTracking() {
+    if (tracking) return;
+    tracking = true;
+    document.addEventListener('mousemove', onPointerMove, true);
+    document.addEventListener('mouseleave', onPointerGone);
+    window.addEventListener('blur', onPointerGone);
+}
+
+function stopTracking() {
+    if (!tracking) return;
+    tracking = false;
+    pointer = null;
+    document.removeEventListener('mousemove', onPointerMove, true);
+    document.removeEventListener('mouseleave', onPointerGone);
+    window.removeEventListener('blur', onPointerGone);
+}
 
 function setContent(el, options) {
     targetEl.value = el;
@@ -25,18 +106,28 @@ function setContent(el, options) {
         html.value = false;
         copyable.value = false;
     }
+
+    isInteractive() ? startTracking() : stopTracking();
 }
 
-function persist() {
-    if (hideTimeout) {
-        clearTimeout(hideTimeout);
-        hideTimeout = null;
+function dismiss() {
+    stopTracking();
+
+    if (showTimeout) {
+        clearTimeout(showTimeout);
+        showTimeout = null;
     }
+
+    pendingEl = null;
+
+    isVisible.value = false;
+    targetEl.value = null;
+    content.value = '';
+    html.value = false;
+    copyable.value = false;
 }
 
 function show(el, options) {
-    persist();
-
     if (showTimeout) {
         clearTimeout(showTimeout);
     }
@@ -47,7 +138,10 @@ function show(el, options) {
         return;
     }
 
+    pendingEl = el;
+
     showTimeout = setTimeout(() => {
+        pendingEl = null;
         setContent(el, options);
 
         if (content.value) {
@@ -57,20 +151,24 @@ function show(el, options) {
 }
 
 function hide() {
-    if (showTimeout) {
-        clearTimeout(showTimeout);
-        showTimeout = null;
+    /* An interactive tooltip stays open when the pointer leaves the trigger heading for
+       the popper. The pointer tracker dismisses it once it's outside both and the gap. */
+    if (isVisible.value && isInteractive()) {
+        if (pointer && !isPointerInside(pointer.x, pointer.y)) dismiss();
+        return;
     }
 
-    persist();
+    dismiss();
+}
 
-    hideTimeout = setTimeout(() => {
-        isVisible.value = false;
-        targetEl.value = null;
-        content.value = '';
-        html.value = false;
-        copyable.value = false;
-    }, html.value || copyable.value ? 200 : 50);
+/* Only tear down when the element owning the tooltip goes away, so unrelated elements
+   unmounting can't close a tooltip the pointer is currently using. */
+function dismissFor(el) {
+    if (targetEl.value === el || pendingEl === el) dismiss();
+}
+
+function registerContentEl(el) {
+    contentEl.value = el ?? null;
 }
 
 export function useTooltip() {
@@ -81,7 +179,9 @@ export function useTooltip() {
         copyable: readonly(copyable),
         targetEl: readonly(targetEl),
         show,
-        persist,
         hide,
+        dismiss,
+        dismissFor,
+        registerContentEl,
     };
 }

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -23,11 +23,15 @@ function setContent(el, options) {
     }
 }
 
-function show(el, options) {
+function persist() {
     if (hideTimeout) {
         clearTimeout(hideTimeout);
         hideTimeout = null;
     }
+}
+
+function show(el, options) {
+    persist();
 
     if (showTimeout) {
         clearTimeout(showTimeout);
@@ -54,12 +58,14 @@ function hide() {
         showTimeout = null;
     }
 
+    persist();
+
     hideTimeout = setTimeout(() => {
         isVisible.value = false;
         targetEl.value = null;
         content.value = '';
         html.value = false;
-    }, 50);
+    }, html.value ? 200 : 50);
 }
 
 export function useTooltip() {
@@ -69,6 +75,7 @@ export function useTooltip() {
         html: readonly(html),
         targetEl: readonly(targetEl),
         show,
+        persist,
         hide,
     };
 }

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -12,7 +12,6 @@ let pendingEl = null;
 let tracking = false;
 let pointer = null;
 
-/* Slack around each rect, for subpixel rounding and the pointer sitting on a border. */
 const EDGE = 4;
 
 function isInteractive() {
@@ -42,8 +41,6 @@ function contains(rect, x, y, pad = EDGE) {
     );
 }
 
-/* The arrow and offset leave a gap between the trigger and the popper. Bridge it with a
-   rect covering only that gap, so the pointer can travel between the two. */
 function gapRect(trigger, popper) {
     const left = Math.min(trigger.left, popper.left);
     const right = Math.max(trigger.right, popper.right);
@@ -69,16 +66,12 @@ function onPointerMove(event) {
     if (!isPointerInside(pointer.x, pointer.y)) dismiss();
 }
 
-function onPointerGone() {
-    dismiss();
-}
-
 function startTracking() {
     if (tracking) return;
     tracking = true;
     document.addEventListener('mousemove', onPointerMove, true);
-    document.addEventListener('mouseleave', onPointerGone);
-    window.addEventListener('blur', onPointerGone);
+    document.addEventListener('mouseleave', dismiss);
+    window.addEventListener('blur', dismiss);
 }
 
 function stopTracking() {
@@ -86,8 +79,8 @@ function stopTracking() {
     tracking = false;
     pointer = null;
     document.removeEventListener('mousemove', onPointerMove, true);
-    document.removeEventListener('mouseleave', onPointerGone);
-    window.removeEventListener('blur', onPointerGone);
+    document.removeEventListener('mouseleave', dismiss);
+    window.removeEventListener('blur', dismiss);
 }
 
 function setContent(el, options) {
@@ -151,8 +144,6 @@ function show(el, options) {
 }
 
 function hide() {
-    /* An interactive tooltip stays open when the pointer leaves the trigger heading for
-       the popper. The pointer tracker dismisses it once it's outside both and the gap. */
     if (isVisible.value && isInteractive()) {
         if (pointer && !isPointerInside(pointer.x, pointer.y)) dismiss();
         return;
@@ -161,8 +152,6 @@ function hide() {
     dismiss();
 }
 
-/* Only tear down when the element owning the tooltip goes away, so unrelated elements
-   unmounting can't close a tooltip the pointer is currently using. */
 function dismissFor(el) {
     if (targetEl.value === el || pendingEl === el) dismiss();
 }
@@ -180,7 +169,6 @@ export function useTooltip() {
         targetEl: readonly(targetEl),
         show,
         hide,
-        dismiss,
         dismissFor,
         registerContentEl,
     };

--- a/resources/js/composables/tooltip.js
+++ b/resources/js/composables/tooltip.js
@@ -93,14 +93,33 @@ export function isInTooltipHoverRegion(x, y, trigger, popper, edge = EDGE) {
     return !!trigger && !!popper && contains(tooltipGapRect(trigger, popper), x, y, 0);
 }
 
+function isTriggerEngaged() {
+    const el = targetEl.value;
+    if (!el?.isConnected) return false;
+
+    return (
+        el.matches(':hover') ||
+        el.matches(':focus') ||
+        el.matches(':focus-visible') ||
+        el.contains(document.activeElement)
+    );
+}
+
+function isPopperEngaged() {
+    const el = contentEl.value;
+    if (!el?.isConnected) return false;
+
+    const popper = el.closest('.v-popper__popper') ?? el;
+
+    return popper.matches(':hover') || popper.contains(document.activeElement);
+}
+
 function isOverInteractiveTooltip() {
+    if (isTriggerEngaged() || isPopperEngaged()) return true;
+
     if (pointer) {
         return isInTooltipHoverRegion(pointer.x, pointer.y, triggerRect(), popperRect());
     }
-
-    if (targetEl.value?.matches?.(':hover')) return true;
-    if (contentEl.value?.matches?.(':hover')) return true;
-    if (contentEl.value?.closest?.('.v-popper__popper')?.matches?.(':hover')) return true;
 
     // Still mounting, and we have not seen a pointer yet.
     return isVisible.value && isInteractive() && !popperRect();
@@ -198,7 +217,12 @@ function hide() {
     dismiss();
 }
 
-function dismissFor(el) {
+function dismissFor(el, event) {
+    const next = event?.relatedTarget;
+    const popper = contentEl.value?.closest?.('.v-popper__popper') ?? contentEl.value;
+
+    if (next && popper?.contains?.(next)) return;
+
     if (targetEl.value === el || pendingEl === el) dismiss();
 }
 

--- a/resources/js/directives/tooltip.js
+++ b/resources/js/directives/tooltip.js
@@ -12,6 +12,12 @@ function getOptions(binding) {
     return value;
 }
 
+function isHtmlTooltip(binding) {
+    const options = getOptions(binding);
+
+    return !!(options && typeof options === 'object' && options.html);
+}
+
 function isNativelyFocusable(el) {
     const tag = el.tagName;
 
@@ -21,12 +27,28 @@ function isNativelyFocusable(el) {
     );
 }
 
-function shouldBecomeFocusable(el) {
-    if (el.hasAttribute('tabindex') || isNativelyFocusable(el) || el.closest('label')) {
-        return false;
-    }
+function wantsAddedTabIndex(el, binding) {
+    if (!isHtmlTooltip(binding)) return false;
+    if (isNativelyFocusable(el) || el.closest('label')) return false;
+    if (el.hasAttribute('tabindex') && !el._tooltipAddedTabIndex) return false;
 
     return true;
+}
+
+function syncTabIndex(el, binding) {
+    if (wantsAddedTabIndex(el, binding)) {
+        if (el._tooltipAddedTabIndex) return;
+
+        el.tabIndex = 0;
+        el._tooltipAddedTabIndex = true;
+
+        return;
+    }
+
+    if (el._tooltipAddedTabIndex) {
+        el.removeAttribute('tabindex');
+        delete el._tooltipAddedTabIndex;
+    }
 }
 
 function handleMouseEnter(el, binding) {
@@ -43,10 +65,7 @@ export default {
         el._tooltipMouseLeave = hide;
         el._tooltipBlur = (event) => dismissFor(el, event);
 
-        if (shouldBecomeFocusable(el)) {
-            el.tabIndex = 0;
-            el._tooltipAddedTabIndex = true;
-        }
+        syncTabIndex(el, binding);
 
         el.addEventListener('mouseenter', el._tooltipMouseEnter);
         el.addEventListener('mouseleave', el._tooltipMouseLeave);
@@ -56,6 +75,7 @@ export default {
 
     updated(el, binding) {
         el._tooltipBinding = binding;
+        syncTabIndex(el, binding);
     },
 
     beforeUnmount(el) {

--- a/resources/js/directives/tooltip.js
+++ b/resources/js/directives/tooltip.js
@@ -1,6 +1,6 @@
 import { useTooltip } from '@/composables/tooltip.js';
 
-const { show, hide } = useTooltip();
+const { show, hide, dismissFor } = useTooltip();
 
 function getOptions(binding) {
     const value = binding.value;
@@ -19,24 +19,17 @@ function handleMouseEnter(el, binding) {
     }
 }
 
-function handleMouseLeave(event) {
-    if (event.relatedTarget?.closest?.('.v-popper__popper')) {
-        return;
-    }
-
-    hide();
-}
-
 export default {
     mounted(el, binding) {
         el._tooltipBinding = binding;
         el._tooltipMouseEnter = () => handleMouseEnter(el, el._tooltipBinding);
-        el._tooltipMouseLeave = handleMouseLeave;
+        el._tooltipMouseLeave = hide;
+        el._tooltipBlur = () => dismissFor(el);
 
         el.addEventListener('mouseenter', el._tooltipMouseEnter);
         el.addEventListener('mouseleave', el._tooltipMouseLeave);
         el.addEventListener('focus', el._tooltipMouseEnter);
-        el.addEventListener('blur', el._tooltipMouseLeave);
+        el.addEventListener('blur', el._tooltipBlur);
     },
 
     updated(el, binding) {
@@ -47,7 +40,7 @@ export default {
         el.removeEventListener('mouseenter', el._tooltipMouseEnter);
         el.removeEventListener('mouseleave', el._tooltipMouseLeave);
         el.removeEventListener('focus', el._tooltipMouseEnter);
-        el.removeEventListener('blur', el._tooltipMouseLeave);
-        hide();
+        el.removeEventListener('blur', el._tooltipBlur);
+        dismissFor(el);
     },
 };

--- a/resources/js/directives/tooltip.js
+++ b/resources/js/directives/tooltip.js
@@ -12,6 +12,23 @@ function getOptions(binding) {
     return value;
 }
 
+function isNativelyFocusable(el) {
+    const tag = el.tagName;
+
+    return (
+        ['A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'SUMMARY'].includes(tag) ||
+        el.isContentEditable
+    );
+}
+
+function shouldBecomeFocusable(el) {
+    if (el.hasAttribute('tabindex') || isNativelyFocusable(el) || el.closest('label')) {
+        return false;
+    }
+
+    return true;
+}
+
 function handleMouseEnter(el, binding) {
     const options = getOptions(binding);
     if (options) {
@@ -24,7 +41,12 @@ export default {
         el._tooltipBinding = binding;
         el._tooltipMouseEnter = () => handleMouseEnter(el, el._tooltipBinding);
         el._tooltipMouseLeave = hide;
-        el._tooltipBlur = () => dismissFor(el);
+        el._tooltipBlur = (event) => dismissFor(el, event);
+
+        if (shouldBecomeFocusable(el)) {
+            el.tabIndex = 0;
+            el._tooltipAddedTabIndex = true;
+        }
 
         el.addEventListener('mouseenter', el._tooltipMouseEnter);
         el.addEventListener('mouseleave', el._tooltipMouseLeave);
@@ -41,6 +63,10 @@ export default {
         el.removeEventListener('mouseleave', el._tooltipMouseLeave);
         el.removeEventListener('focus', el._tooltipMouseEnter);
         el.removeEventListener('blur', el._tooltipBlur);
+        if (el._tooltipAddedTabIndex) {
+            el.removeAttribute('tabindex');
+            delete el._tooltipAddedTabIndex;
+        }
         dismissFor(el);
     },
 };

--- a/resources/js/directives/tooltip.js
+++ b/resources/js/directives/tooltip.js
@@ -12,45 +12,6 @@ function getOptions(binding) {
     return value;
 }
 
-function isHtmlTooltip(binding) {
-    const options = getOptions(binding);
-
-    return !!(options && typeof options === 'object' && options.html);
-}
-
-function isNativelyFocusable(el) {
-    const tag = el.tagName;
-
-    return (
-        ['A', 'BUTTON', 'INPUT', 'SELECT', 'TEXTAREA', 'SUMMARY'].includes(tag) ||
-        el.isContentEditable
-    );
-}
-
-function wantsAddedTabIndex(el, binding) {
-    if (!isHtmlTooltip(binding)) return false;
-    if (isNativelyFocusable(el) || el.closest('label')) return false;
-    if (el.hasAttribute('tabindex') && !el._tooltipAddedTabIndex) return false;
-
-    return true;
-}
-
-function syncTabIndex(el, binding) {
-    if (wantsAddedTabIndex(el, binding)) {
-        if (el._tooltipAddedTabIndex) return;
-
-        el.tabIndex = 0;
-        el._tooltipAddedTabIndex = true;
-
-        return;
-    }
-
-    if (el._tooltipAddedTabIndex) {
-        el.removeAttribute('tabindex');
-        delete el._tooltipAddedTabIndex;
-    }
-}
-
 function handleMouseEnter(el, binding) {
     const options = getOptions(binding);
     if (options) {
@@ -65,8 +26,6 @@ export default {
         el._tooltipMouseLeave = hide;
         el._tooltipBlur = (event) => dismissFor(el, event);
 
-        syncTabIndex(el, binding);
-
         el.addEventListener('mouseenter', el._tooltipMouseEnter);
         el.addEventListener('mouseleave', el._tooltipMouseLeave);
         el.addEventListener('focus', el._tooltipMouseEnter);
@@ -75,7 +34,6 @@ export default {
 
     updated(el, binding) {
         el._tooltipBinding = binding;
-        syncTabIndex(el, binding);
     },
 
     beforeUnmount(el) {
@@ -83,10 +41,6 @@ export default {
         el.removeEventListener('mouseleave', el._tooltipMouseLeave);
         el.removeEventListener('focus', el._tooltipMouseEnter);
         el.removeEventListener('blur', el._tooltipBlur);
-        if (el._tooltipAddedTabIndex) {
-            el.removeAttribute('tabindex');
-            delete el._tooltipAddedTabIndex;
-        }
         dismissFor(el);
     },
 };

--- a/resources/js/directives/tooltip.js
+++ b/resources/js/directives/tooltip.js
@@ -19,7 +19,11 @@ function handleMouseEnter(el, binding) {
     }
 }
 
-function handleMouseLeave() {
+function handleMouseLeave(event) {
+    if (event.relatedTarget?.closest?.('.v-popper__popper')) {
+        return;
+    }
+
     hide();
 }
 

--- a/resources/js/tests/tooltip.test.js
+++ b/resources/js/tests/tooltip.test.js
@@ -1,0 +1,181 @@
+import { test, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+    isInTooltipHoverRegion,
+    tooltipGapRect,
+    useTooltip,
+} from '../composables/tooltip';
+
+const trigger = { left: 100, right: 200, top: 200, bottom: 220 };
+const popperAbove = { left: 110, right: 190, top: 160, bottom: 190 };
+const popperBelow = { left: 110, right: 190, top: 230, bottom: 260 };
+const popperLeft = { left: 20, right: 90, top: 180, bottom: 240 };
+const popperRight = { left: 210, right: 280, top: 180, bottom: 240 };
+
+let mounted = [];
+
+function box(rect) {
+    const el = document.createElement('div');
+    el.getBoundingClientRect = () => ({
+        ...rect,
+        width: rect.right - rect.left,
+        height: rect.bottom - rect.top,
+        x: rect.left,
+        y: rect.top,
+        toJSON() {},
+    });
+    el.hovered = false;
+    el.matches = (selector) => selector === ':hover' && el.hovered;
+    el.closest = (selector) => (selector === '.v-popper__popper' ? el : null);
+    document.body.appendChild(el);
+    mounted.push(el);
+
+    return el;
+}
+
+function resetTooltip() {
+    const { hide, targetEl, dismissFor } = useTooltip();
+    if (targetEl.value) dismissFor(targetEl.value);
+    hide();
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    resetTooltip();
+});
+
+afterEach(() => {
+    resetTooltip();
+    mounted.forEach((el) => el.remove());
+    mounted = [];
+    vi.useRealTimers();
+});
+
+test('it treats the trigger and popper as inside the hover region', () => {
+    expect(isInTooltipHoverRegion(150, 210, trigger, popperAbove)).toBe(true);
+    expect(isInTooltipHoverRegion(150, 175, trigger, popperAbove)).toBe(true);
+});
+
+test('it treats the gap between a stacked trigger and popper as inside', () => {
+    expect(isInTooltipHoverRegion(150, 195, trigger, popperAbove)).toBe(true);
+    expect(isInTooltipHoverRegion(150, 225, trigger, popperBelow)).toBe(true);
+});
+
+test('it treats the gap between a side-placed trigger and popper as inside', () => {
+    expect(isInTooltipHoverRegion(95, 210, trigger, popperLeft)).toBe(true);
+    expect(isInTooltipHoverRegion(205, 210, trigger, popperRight)).toBe(true);
+});
+
+test('it treats points outside the hover region as outside', () => {
+    expect(isInTooltipHoverRegion(50, 50, trigger, popperAbove)).toBe(false);
+    expect(isInTooltipHoverRegion(50, 195, trigger, popperAbove)).toBe(false);
+});
+
+test('it keeps the hover region open while the popper is unmeasured', () => {
+    expect(isInTooltipHoverRegion(50, 50, trigger, null)).toBe(true);
+    expect(isInTooltipHoverRegion(150, 195, trigger, null)).toBe(true);
+});
+
+test('tooltipGapRect returns null when the rects overlap', () => {
+    const overlapping = { left: 120, right: 180, top: 210, bottom: 250 };
+
+    expect(tooltipGapRect(trigger, overlapping)).toBeNull();
+});
+
+test('an interactive tooltip stays open while the pointer crosses the gap', () => {
+    const { show, hide, isVisible, registerContentEl } = useTooltip();
+    const triggerEl = box(trigger);
+    const popperEl = box(popperAbove);
+    triggerEl.hovered = true;
+
+    show(triggerEl, { content: 'title', copyable: true });
+    vi.advanceTimersByTime(200);
+    registerContentEl(popperEl);
+
+    expect(isVisible.value).toBe(true);
+
+    triggerEl.hovered = false;
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 195, bubbles: true }));
+    hide();
+
+    expect(isVisible.value).toBe(true);
+});
+
+test('an interactive tooltip dismisses when the pointer leaves the hover region', () => {
+    const { show, isVisible, registerContentEl } = useTooltip();
+    const triggerEl = box(trigger);
+    const popperEl = box(popperAbove);
+    triggerEl.hovered = true;
+
+    show(triggerEl, { content: 'title', copyable: true });
+    vi.advanceTimersByTime(200);
+    registerContentEl(popperEl);
+
+    expect(isVisible.value).toBe(true);
+
+    triggerEl.hovered = false;
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50, clientY: 50, bubbles: true }));
+
+    expect(isVisible.value).toBe(false);
+});
+
+test('an interactive tooltip stays open while crossing the gap before the popper mounts', () => {
+    const { show, hide, isVisible, registerContentEl } = useTooltip();
+    const triggerEl = box(trigger);
+    const popperEl = box(popperAbove);
+
+    show(triggerEl, { content: 'title', copyable: true });
+    vi.advanceTimersByTime(200);
+
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 150, clientY: 195, bubbles: true }));
+    hide();
+
+    expect(isVisible.value).toBe(true);
+
+    registerContentEl(popperEl);
+
+    expect(isVisible.value).toBe(true);
+});
+
+test('registering the popper dismisses when the pointer is unknown and nothing is hovered', () => {
+    const { show, isVisible, registerContentEl } = useTooltip();
+    const triggerEl = box(trigger);
+    const popperEl = box(popperAbove);
+
+    show(triggerEl, { content: 'title', copyable: true });
+    vi.advanceTimersByTime(200);
+    registerContentEl(popperEl);
+
+    expect(isVisible.value).toBe(false);
+});
+
+test('hide dismisses an interactive tooltip when the pointer is unknown and the trigger is no longer hovered', () => {
+    const { show, hide, isVisible, registerContentEl } = useTooltip();
+    const triggerEl = box(trigger);
+    const popperEl = box(popperAbove);
+    triggerEl.hovered = true;
+
+    show(triggerEl, { content: 'title', copyable: true });
+    vi.advanceTimersByTime(200);
+    registerContentEl(popperEl);
+
+    expect(isVisible.value).toBe(true);
+
+    triggerEl.hovered = false;
+    hide();
+
+    expect(isVisible.value).toBe(false);
+});
+
+test('a plain tooltip still dismisses immediately on hide', () => {
+    const { show, hide, isVisible } = useTooltip();
+    const triggerEl = box(trigger);
+
+    show(triggerEl, 'Hello');
+    vi.advanceTimersByTime(200);
+
+    expect(isVisible.value).toBe(true);
+
+    hide();
+
+    expect(isVisible.value).toBe(false);
+});

--- a/resources/js/tests/tooltip.test.js
+++ b/resources/js/tests/tooltip.test.js
@@ -65,6 +65,11 @@ test('it treats the gap between a side-placed trigger and popper as inside', () 
     expect(isInTooltipHoverRegion(205, 210, trigger, popperRight)).toBe(true);
 });
 
+test('it treats a slight sideways drift in the gap as inside', () => {
+    expect(isInTooltipHoverRegion(208, 195, trigger, popperAbove)).toBe(true);
+    expect(isInTooltipHoverRegion(92, 195, trigger, popperAbove)).toBe(true);
+});
+
 test('it treats points outside the hover region as outside', () => {
     expect(isInTooltipHoverRegion(50, 50, trigger, popperAbove)).toBe(false);
     expect(isInTooltipHoverRegion(50, 195, trigger, popperAbove)).toBe(false);

--- a/resources/js/tests/tooltip.test.js
+++ b/resources/js/tests/tooltip.test.js
@@ -24,7 +24,13 @@ function box(rect) {
         toJSON() {},
     });
     el.hovered = false;
-    el.matches = (selector) => selector === ':hover' && el.hovered;
+    el.focused = false;
+    el.matches = (selector) => {
+        if (selector === ':hover') return el.hovered;
+        if (selector === ':focus' || selector === ':focus-visible') return el.focused;
+
+        return false;
+    };
     el.closest = (selector) => (selector === '.v-popper__popper' ? el : null);
     document.body.appendChild(el);
     mounted.push(el);
@@ -151,6 +157,19 @@ test('registering the popper dismisses when the pointer is unknown and nothing i
     registerContentEl(popperEl);
 
     expect(isVisible.value).toBe(false);
+});
+
+test('an interactive tooltip stays open when the trigger is focused without a pointer', () => {
+    const { show, isVisible, registerContentEl } = useTooltip();
+    const triggerEl = box(trigger);
+    const popperEl = box(popperAbove);
+    triggerEl.focused = true;
+
+    show(triggerEl, { content: 'title', copyable: true });
+    vi.advanceTimersByTime(200);
+    registerContentEl(popperEl);
+
+    expect(isVisible.value).toBe(true);
 });
 
 test('hide dismisses an interactive tooltip when the pointer is unknown and the trigger is no longer hovered', () => {

--- a/resources/js/tests/tooltip.test.js
+++ b/resources/js/tests/tooltip.test.js
@@ -190,7 +190,7 @@ test('hide dismisses an interactive tooltip when the pointer is unknown and the 
     expect(isVisible.value).toBe(false);
 });
 
-test('a plain tooltip still dismisses immediately on hide', () => {
+test('a plain tooltip dismisses after a short hide delay', () => {
     const { show, hide, isVisible } = useTooltip();
     const triggerEl = box(trigger);
 
@@ -200,6 +200,39 @@ test('a plain tooltip still dismisses immediately on hide', () => {
     expect(isVisible.value).toBe(true);
 
     hide();
+
+    expect(isVisible.value).toBe(true);
+
+    vi.advanceTimersByTime(50);
+
+    expect(isVisible.value).toBe(false);
+});
+
+test('hopping between adjacent plain tooltips updates immediately', () => {
+    const { show, hide, isVisible, content } = useTooltip();
+    const first = box(trigger);
+    const second = box({ left: 210, right: 310, top: 200, bottom: 220 });
+
+    show(first, 'Bold');
+    vi.advanceTimersByTime(200);
+
+    expect(isVisible.value).toBe(true);
+    expect(content.value).toBe('Bold');
+
+    hide();
+    show(second, 'Italic');
+
+    expect(isVisible.value).toBe(true);
+    expect(content.value).toBe('Italic');
+});
+
+test('leaving a pending plain tooltip cancels the show delay', () => {
+    const { show, hide, isVisible } = useTooltip();
+    const triggerEl = box(trigger);
+
+    show(triggerEl, 'Hello');
+    hide();
+    vi.advanceTimersByTime(200);
 
     expect(isVisible.value).toBe(false);
 });


### PR DESCRIPTION
## Description of the Problem

- Once upon a time you could _copy a field handle_ by clicking the label
- This behaviour was deprecated some time ago because clicking a label should focus its related input field instead—for accessibility (understandable, but also a shame that we lost this utility!)
- There's some annoying hover-tunnel behaviour where you can't reach any links in a tooltip—like we have for the table headings `cp/sites`

## What this PR Does

<img width="300" alt="IMG_1996" src="https://github.com/user-attachments/assets/05f9b163-24b7-4703-a056-f5bfd6e9f0e8" />

- Makes handle tooltips cilckable – which copies the handle to the clipboard
- Fixes some annoying tooltip behaviour – where the tooltip disappears when you move the mouse upwards into the tooltip.
  - Previously if you didn't move the mouse fast enough the tooltip would disappear.
  - The hover gap is now handled by tracking the pointer against the label, the tooltip, and the space between them rather than a hide delay
  - This means you can also reach links in tooltips now

## How to Reproduce

1. Try hovering over a field name in a publish form, then clicking the tooltip handle
2. Also try `cp/sites` and hovering over the little "info" icon