### PR TITLE
[6.x] Improve info icons in grid headers

### DIFF
--- a/resources/js/components/fieldtypes/grid/HeaderCell.vue
+++ b/resources/js/components/fieldtypes/grid/HeaderCell.vue
@@ -1,10 +1,10 @@
 <template>
     <th v-show="field.type !== 'hidden'" scope="col">
-        <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
             <div>
                 <template v-if="!field.hide_display">{{ __(field.display || field.handle) }}</template>
             </div>
-            <ui-icon name="info-square" class="size-3 text-xs text-gray-600 hover:text-gray-700" v-if="field.instructions" v-tooltip="{ content: $markdown(__(field.instructions)), html: true }" />
+            <ui-icon name="info-square" class="size-3.5! text-xs text-gray-500 hover:text-gray-600" v-if="field.instructions" v-tooltip="{ content: $markdown(__(field.instructions)), html: true }" />
         </div>
     </th>
 </template>


### PR DESCRIPTION
## Description of the Problem

"Info" icons felt a bit broken when they appeared in grid field headers

<img width="3420" height="2146" alt="2026-08-19 at 10 39 00@2x" src="https://github.com/user-attachments/assets/5c15ced5-d1d2-4f4b-8dda-7af28572b81b" />

## What this PR Does

- Shifts them left, next to the title of the header so there's less confusion about their association
- Makes them a bit subtler

<img width="3420" height="2146" alt="2026-08-19 at 10 36 55@2x" src="https://github.com/user-attachments/assets/2c5ca24b-571f-422e-8856-e6a5a798df80" />

## How to Reproduce

1. Easily seen in `/cp/sites`