### PR TITLE
[6.x] Fix Antlers identifiers erroring before the parser has been resolved

### DIFF
--- a/src/View/Antlers/Language/Analyzers/NodeTypeAnalyzer.php
+++ b/src/View/Antlers/Language/Analyzers/NodeTypeAnalyzer.php
@@ -30,7 +30,7 @@ class NodeTypeAnalyzer
     public static function analyzeParametersForModifiers(AntlersNode $node)
     {
         foreach ($node->parameters as $parameter) {
-            $parameter->isModifierParameter = self::$environmentDetails->isModifier($parameter->name);
+            $parameter->isModifierParameter = self::environmentDetails()->isModifier($parameter->name);
         }
     }
 
@@ -42,6 +42,11 @@ class NodeTypeAnalyzer
             return;
         }
 
-        $node->isTagNode = self::$environmentDetails->isTag($node->name->name);
+        $node->isTagNode = self::environmentDetails()->isTag($node->name->name);
+    }
+
+    private static function environmentDetails(): EnvironmentDetails
+    {
+        return self::$environmentDetails ??= app(EnvironmentDetails::class);
     }
 }

--- a/tests/Antlers/Parser/IdentifierFinderTest.php
+++ b/tests/Antlers/Parser/IdentifierFinderTest.php
@@ -3,6 +3,8 @@
 namespace Tests\Antlers\Parser;
 
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Antlers;
+use Statamic\View\Antlers\Language\Analyzers\NodeTypeAnalyzer;
 use Statamic\View\Antlers\Language\Parser\IdentifierFinder;
 use Tests\Antlers\ParserTestCase;
 
@@ -29,5 +31,13 @@ EOT;
             'the_limit',
             'title',
         ], (new IdentifierFinder)->getIdentifiers($template));
+    }
+
+    #[Test]
+    public function it_finds_identifiers_when_nothing_has_resolved_the_parser()
+    {
+        NodeTypeAnalyzer::$environmentDetails = null;
+
+        $this->assertEquals(['slug'], Antlers::identifiers('blog/{{ slug }}'));
     }
 }


### PR DESCRIPTION
Creating an entry can fail with `Call to a member function isTag() on null` when an addon calls `Antlers::identifiers()` during a control panel request (SEO Pro does this from its previews fieldtype).

`NodeTypeAnalyzer::$environmentDetails` is only assigned as a side effect of the container resolving `EnvironmentDetails`, which happens when something builds a parser. `Antlers::identifiers()` runs the document parser directly, so if nothing else in the request has resolved a parser yet, the analyzer is left with a null. Whether that had happened by then was incidental, which is why #14988 (site config values no longer go through Antlers unless they actually contain Antlers) started surfacing it.

The analyzer now resolves the environment details itself the first time it needs them.

Fixes #15220
