### PR TITLE
[6.x] Generate the French locale in CI instead of installing a language pack

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -74,15 +74,11 @@ jobs:
           echo "result=true" >> $GITHUB_OUTPUT
           echo "result=true" >> $env:GITHUB_OUTPUT
 
-      - name: Update apt sources
-        if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
-        run: |
-          sudo apt-get check || sudo apt --fix-broken install -y
-          sudo apt-get update
-
       - name: Install French Locale
         if: steps.should-run-tests.outputs.result == 'true' && matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install language-pack-fr
+        run: |
+          sudo locale-gen fr_FR.UTF-8
+          locale -a | grep -q '^fr_FR\.utf8$'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2


### PR DESCRIPTION
CI would sometimes hang for 45+ minutes on the "Update apt sources" step, stalling on an unresponsive `azure.archive.ubuntu.com` mirror. Cancelling and re-running usually cleared it.

The only reason we touched apt was to get a French locale for `FrontendTest::it_sets_the_locale`, added back in #6945. But `language-pack-fr` is a translations package — the reason it gives us a usable locale at all is that its postinst shells out to `locale-gen`. The `locales` package is already on the runner image, so we can generate the locale directly and skip the network entirely. Both apt steps go away.

Behaviour is unchanged. `language-pack-fr` generated `fr_FR.UTF-8` and not the ISO-8859-1 `fr_FR`, so the locale list in that test resolves the same way before and after.

The added `locale -a | grep -q` line asserts the locale is actually there. Without it a missing locale goes unnoticed: `setlocale()` returns false and leaves the locale untouched, so the test configures the French site with the original locale and then asserts it sees that same value. It passes without testing anything.
