### PR TITLE
[6.x] Fix localized dates leaking into later template usages

### DIFF
--- a/src/Http/Middleware/Localize.php
+++ b/src/Http/Middleware/Localize.php
@@ -40,7 +40,7 @@ class Localize
                 return $date->forHumans();
             }
 
-            return $date->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
+            return $date->copy()->setTimezone(Statamic::displayTimezone())->format(Statamic::dateFormat());
         });
 
         $response = $next($request);

--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -3352,7 +3352,7 @@ class CoreModifiers extends Modifier
         }
 
         if (config('statamic.system.localize_dates_in_modifiers')) {
-            $value->setTimezone(Statamic::displayTimezone());
+            $value = $value->copy()->setTimezone(Statamic::displayTimezone());
         }
 
         return $value;

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -737,6 +737,26 @@ class FrontendTest extends TestCase
     }
 
     #[Test]
+    public function outputting_a_date_does_not_localize_it_for_the_rest_of_the_template()
+    {
+        config([
+            'statamic.system.date_format' => 'H:i',
+            'statamic.system.display_timezone' => 'Europe/Zurich', // +1 hour
+            'statamic.system.localize_dates_in_modifiers' => false,
+        ]);
+
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('some_template', '<p>{{ date }}</p><p>{{ date format="H:i" }}</p>');
+
+        tap($this->makeCollection()->dated(true))->save();
+        tap($this->makePage('about', ['with' => ['template' => 'some_template']])->date(Carbon::parse('2025-01-01 18:25')))->save();
+
+        $this->get('/about')
+            ->assertSee('<p>19:25</p>', false)
+            ->assertSee('<p>18:25</p>', false);
+    }
+
+    #[Test]
     public function it_sets_the_locale()
     {
         // You can only set the locale to one that is actually installed on the server.

--- a/tests/Modifiers/FormatTest.php
+++ b/tests/Modifiers/FormatTest.php
@@ -30,6 +30,18 @@ class FormatTest extends TestCase
         $this->assertSame('1st January 2025 4:45pm', $this->modify(Carbon::parse('2025-01-01 15:45'), 'jS F Y g:ia'));
     }
 
+    #[Test]
+    public function it_does_not_mutate_the_original_date_when_localizing()
+    {
+        config()->set('statamic.system.localize_dates_in_modifiers', true);
+
+        $date = Carbon::parse('2025-01-01 15:45');
+
+        $this->modify($date, 'g:ia');
+
+        $this->assertSame('UTC', $date->timezone->getName());
+    }
+
     public function modify($value, $format)
     {
         return Modify::value($value)->format($format)->fetch();


### PR DESCRIPTION
This pull request fixes an issue where date modifiers would ignore `localize_dates_in_modifiers => false` and output dates in the display timezone — but only when the same date had already been output plainly earlier in the template.

This was happening because Carbon instances are mutable, and a dated entry's `date` is a single memoized instance shared by every usage in the template. The `Localize` middleware's `toStringFormat` callback called `setTimezone()` on it directly, so the first plain `{{ date }}` output shifted the shared instance into the display timezone and every later modifier saw the shifted date. (Date fieldtype values weren't affected, since augmentation creates a fresh Carbon instance on each access — which is why the behaviour seemed inconsistent between fields.)

This PR fixes it by copying the date before localizing it, both in the middleware's `toStringFormat` callback and in `CoreModifiers::carbon()`, which had the same mutation in the other direction when `localize_dates_in_modifiers` is enabled.

Fixes #13869