### PR TITLE
[6.x] Add a way to opt out of popper z-index control

### DIFF
--- a/resources/css/components/stacks.css
+++ b/resources/css/components/stacks.css
@@ -17,7 +17,7 @@
 .stacks-on-stacks {
     body:has(&) {
         /* Reka poppers should be on top of open stacks. Reka's popper z-index in this case is set to auto and we can't control it through Reka. We also can't use a direct descendant selector because the popper is inside a portal, so instead we'll check to see if certain conditions are present. */
-        [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-portal-z])) {
+        [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-z-manipulation])) {
             z-index: var(--z-index-portal)!important;
         }
     }

--- a/resources/css/components/stacks.css
+++ b/resources/css/components/stacks.css
@@ -17,7 +17,7 @@
 .stacks-on-stacks {
     body:has(&) {
         /* Reka poppers should be on top of open stacks. Reka's popper z-index in this case is set to auto and we can't control it through Reka. We also can't use a direct descendant selector because the popper is inside a portal, so instead we'll check to see if certain conditions are present. */
-        [data-reka-popper-content-wrapper] {
+        [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-portal-z])) {
             z-index: var(--z-index-portal)!important;
         }
     }

--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -156,7 +156,7 @@ code:not(pre *) {
     Pull Reka poppers above modals/stacks/etc. We can't use a descendant selector
     because poppers portal outside the overlay DOM.
 
-    Opt out with [data-ui-exclude-portal-z] when a popper should stay below an unrelated
+    Opt out with [data-ui-exclude-z-manipulation] when a popper should stay below an unrelated
     overlay (e.g. a compact array popover open behind a confirmation modal). DOM selectors
     can't tell us whether the popper belongs to the overlay because of portals/the virtual DOM.
 */
@@ -165,6 +165,6 @@ body:has(
     .stack,
     .live-preview,
     .code-fullscreen
-) [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-portal-z])) {
+) [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-z-manipulation])) {
     z-index: var(--z-index-portal)!important;
 }

--- a/resources/css/elements/base.css
+++ b/resources/css/elements/base.css
@@ -152,15 +152,19 @@ code:not(pre *) {
     }
 }
 
-/**
-	Override the z-index of Reka's popper content wrapper under certain conditions.
-	We can't use a direct descendant selector because the DatePicker is inside a Portal.
+/*
+    Pull Reka poppers above modals/stacks/etc. We can't use a descendant selector
+    because poppers portal outside the overlay DOM.
+
+    Opt out with [data-ui-exclude-portal-z] when a popper should stay below an unrelated
+    overlay (e.g. a compact array popover open behind a confirmation modal). DOM selectors
+    can't tell us whether the popper belongs to the overlay because of portals/the virtual DOM.
 */
 body:has(
-	[data-ui-modal-content],
-	.stack,
-	.live-preview,
-	.code-fullscreen
-) [data-reka-popper-content-wrapper] {
+    [data-ui-modal-content],
+    .stack,
+    .live-preview,
+    .code-fullscreen
+) [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-portal-z])) {
     z-index: var(--z-index-portal)!important;
 }

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -190,7 +190,7 @@
 </template>
 
 <style>
-body:has(:is(.bard-fullscreen, .replicator-fullscreen)) [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-portal-z])) {
+body:has(:is(.bard-fullscreen, .replicator-fullscreen)) [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-z-manipulation])) {
     z-index: var(--z-index-portal) !important;
 }
 </style>

--- a/resources/js/components/fieldtypes/replicator/SetPicker.vue
+++ b/resources/js/components/fieldtypes/replicator/SetPicker.vue
@@ -190,7 +190,7 @@
 </template>
 
 <style>
-body:has(:is(.bard-fullscreen, .replicator-fullscreen)) [data-reka-popper-content-wrapper] {
+body:has(:is(.bard-fullscreen, .replicator-fullscreen)) [data-reka-popper-content-wrapper]:not(:has([data-ui-exclude-portal-z])) {
     z-index: var(--z-index-portal) !important;
 }
 </style>

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -71,8 +71,8 @@ const props = defineProps({
 	taggable: { type: Boolean, default: false },
 	/** Controls the appearance of the combobox. <br><br> Options: `default`, `filled`, `ghost`, `subtle` */
 	variant: { type: String, default: 'default' },
-	/** When `true`, skip the elevated portal z-index while a modal/stack is open. Use when this combobox can remain open behind an unrelated overlay (e.g. a confirmation modal). */
-	excludePortalZ: { type: Boolean, default: false },
+	/** When `true`, skip the elevated z-index override while a modal/stack is open. Use when this combobox can remain open behind an unrelated overlay (e.g. a confirmation modal). */
+	excludeZManipulation: { type: Boolean, default: false },
 });
 
 defineOptions({
@@ -464,7 +464,7 @@ defineExpose({
                             adaptiveWidth && 'w-max max-w-md',
                         ]"
                         data-ui-combobox-content
-                        :data-ui-exclude-portal-z="excludePortalZ ? '' : undefined"
+                        :data-ui-exclude-z-manipulation="excludeZManipulation ? '' : undefined"
                         @escape-key-down="focus"
                     >
                         <FocusScope

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -71,6 +71,8 @@ const props = defineProps({
 	taggable: { type: Boolean, default: false },
 	/** Controls the appearance of the combobox. <br><br> Options: `default`, `filled`, `ghost`, `subtle` */
 	variant: { type: String, default: 'default' },
+	/** When `true`, skip the elevated portal z-index while a modal/stack is open. Use when this combobox can remain open behind an unrelated overlay (e.g. a confirmation modal). */
+	excludePortalZ: { type: Boolean, default: false },
 });
 
 defineOptions({
@@ -462,6 +464,7 @@ defineExpose({
                             adaptiveWidth && 'w-max max-w-md',
                         ]"
                         data-ui-combobox-content
+                        :data-ui-exclude-portal-z="excludePortalZ ? '' : undefined"
                         @escape-key-down="focus"
                     >
                         <FocusScope

--- a/resources/js/components/ui/Popover.vue
+++ b/resources/js/components/ui/Popover.vue
@@ -24,8 +24,8 @@ const props = defineProps({
     open: { type: Boolean, default: false },
     /** When `true`, clicking outside the modal will dismiss it. */
     dismissible: { type: Boolean, default: true },
-    /** When `true`, skip the elevated portal z-index while a modal/stack is open. Use when this popover can remain open behind an unrelated overlay (e.g. a confirmation modal). */
-    excludePortalZ: { type: Boolean, default: false },
+    /** When `true`, skip the elevated z-index override while a modal/stack is open. Use when this popover can remain open behind an unrelated overlay (e.g. a confirmation modal). */
+    excludeZManipulation: { type: Boolean, default: false },
 });
 
 const popoverContentClasses = cva({
@@ -67,7 +67,7 @@ function updateOpen(value) {
         <PopoverPortal>
             <PopoverContent
                 data-ui-popover-content
-                :data-ui-exclude-portal-z="excludePortalZ ? '' : undefined"
+                :data-ui-exclude-z-manipulation="excludeZManipulation ? '' : undefined"
                 :class="[popoverContentClasses, $attrs.class]"
                 :align
                 :sideOffset="offset"

--- a/resources/js/components/ui/Popover.vue
+++ b/resources/js/components/ui/Popover.vue
@@ -24,6 +24,8 @@ const props = defineProps({
     open: { type: Boolean, default: false },
     /** When `true`, clicking outside the modal will dismiss it. */
     dismissible: { type: Boolean, default: true },
+    /** When `true`, skip the elevated portal z-index while a modal/stack is open. Use when this popover can remain open behind an unrelated overlay (e.g. a confirmation modal). */
+    excludePortalZ: { type: Boolean, default: false },
 });
 
 const popoverContentClasses = cva({
@@ -65,6 +67,7 @@ function updateOpen(value) {
         <PopoverPortal>
             <PopoverContent
                 data-ui-popover-content
+                :data-ui-exclude-portal-z="excludePortalZ ? '' : undefined"
                 :class="[popoverContentClasses, $attrs.class]"
                 :align
                 :sideOffset="offset"


### PR DESCRIPTION
## Description of the Problem

When a modal, stack, live preview, or fullscreen code editor is open, we pull the Reka popper `z-index` up so things like Comboboxes and DatePickers inside those overlays still appear on top.

We need to do this because Reka sets `z-index: auto;` and we can't programmatically override it. So instead we use CSS's `:has` to test if the DOM has certain things. Not ideal, but there we go.

That blanket rule also elevates poppers that were already open *behind* an unrelated overlay. For example, a compact array popover can stay open when its “Delete Row” confirmation modal appears — and because both portal to the body, we can't query the DOM structure to understand if the popper belongs to the modal. The popover ends up stacking above the confirmation.

## What this PR Does

Adds an opt-out for that z-index rule:

- Popovers and Comboboxes accept `excludeManipulationZ`
- When set, content gets `data-ui-exclude-manipulation-z`
- The portal z-index overrides in `base.css`, `stacks.css`, and SetPicker skip wrappers that contain that attribute

Consumers that can remain open behind an unrelated overlay can opt out; poppers that belong inside the overlay keep the default elevate behavior.

## How to Reproduce

1. Open a Popover or Combobox that remains open when a confirmation modal appears (e.g. compact array (in `cp/sites` → Custom Attributes → delete a filled row).
2. Without `excludeManipulationZ`, the popper sits above the confirmation modal.
3. With `excludeManipulationZ` on that Popover/Combobox, the confirmation modal stacks above the popper as expected.