### PR TITLE
[6.x] Multisite - Fix localization switch sending the browser to /entries/null

### DIFF
--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -662,10 +662,6 @@ export default {
             } else {
                 this.createLocalization(localization);
             }
-
-            if (this.isBase) {
-                window.history.replaceState({}, '', localization.url + window.location.hash);
-            }
         },
 
         editLocalization(localization) {
@@ -693,6 +689,10 @@ export default {
                 this.localizing = false;
                 this.initialPublished = data.values.published;
                 this.readOnly = data.readOnly;
+
+                if (this.isBase && localization.url) {
+                    window.history.replaceState({}, '', localization.url + window.location.hash);
+                }
 
                 this.trackDirtyStateTimeout = setTimeout(() => (this.trackDirtyState = true), 500); // after any fieldtypes do a debounced update
             });

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -290,10 +290,6 @@ export default {
         switchToLocalization(localization) {
             this.localizing = localization.handle;
 
-            if (this.publishContainer === 'base') {
-                window.history.replaceState({}, '', localization.url + window.location.hash);
-            }
-
             this.$axios.get(localization.url).then((response) => {
                 const data = response.data;
                 this.values = data.values;
@@ -309,6 +305,10 @@ export default {
                 this.localizing = false;
                 this.afterActionSuccessfullyCompleted(data);
                 this.$nextTick(() => this.$refs.container.clearDirtyState());
+
+                if (this.publishContainer === 'base' && localization.url) {
+                    window.history.replaceState({}, '', localization.url + window.location.hash);
+                }
             });
         },
 

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -421,10 +421,6 @@ export default {
             } else {
                 this.createLocalization(localization);
             }
-
-            if (this.publishContainer === 'base') {
-                window.history.replaceState({}, '', localization.url + window.location.hash);
-            }
         },
 
         editLocalization(localization) {
@@ -445,6 +441,10 @@ export default {
                 this.reference = data.reference;
                 this.localizing = false;
                 this.$nextTick(() => this.$refs.container.clearDirtyState());
+
+                if (this.publishContainer === 'base' && localization.url) {
+                    window.history.replaceState({}, '', localization.url + window.location.hash);
+                }
             });
         },
 


### PR DESCRIPTION
## Description of the Problem

Creating a new localization rewrites the browser URL to `/entries/null`.
Even though the page will continue to save, the URL does not change which means a refresh breaks the page.

<img width="3420" height="2146" alt="2026-08-21 at 13 30 56@2x" src="https://github.com/user-attachments/assets/2ecff50b-8be4-482c-96b2-98040b33ce31" />

## What this PR Does

Wait until after a successful load before updating history so we don't stringify `null` into the path.

## How to Reproduce

1. Enable multisite
2. On an entry, choose a localization that doesn't exist yet (e.g. origin confirmation modal appears)
3. The URL switches to `/entries/null` and stays broken even after the localization is created; refreshing fails