### PR TITLE
[6.x] Add missing tooltips to global header

### DIFF
--- a/resources/js/components/global-header/Logo.vue
+++ b/resources/js/components/global-header/Logo.vue
@@ -28,6 +28,7 @@ function toggleNav() {
                 class="flex items-center group rounded-xs cursor-pointer"
                 data-cp-global-nav-toggle
                 :aria-label="__('Toggle Nav')"
+                v-tooltip="__('Toggle Nav')"
                 style="--focus-outline-offset: 0.2rem;"
                 @click.stop="toggleNav"
             >
@@ -36,7 +37,7 @@ function toggleNav() {
                 </div>
             </button>
             <Link :href="cp_url('/')" v-tooltip="version" style="--focus-outline-offset: var(--outline-offset-button);">
-                <img v-if="customLogoImage" :src="customLogoImage" :alt="cmsName" class="w-full max-w-[260px] max-h-7" v-tooltip="version">
+                <img v-if="customLogoImage" :src="customLogoImage" :alt="cmsName" class="w-full max-w-[260px] max-h-7">
                 <span v-if="customLogoText && !customLogoImage" class="font-medium text-white whitespace-nowrap">{{ customLogoText }}</span>
             </Link>
         </div>
@@ -48,6 +49,7 @@ function toggleNav() {
                 class="flex items-center group rounded-xs cursor-pointer"
                 data-cp-global-nav-toggle
                 :aria-label="__('Toggle Nav')"
+                v-tooltip="__('Toggle Nav')"
                 style="--focus-outline-offset: 0.2rem;"
                 @click.stop="toggleNav"
             >

--- a/resources/js/components/global-header/ProBadge.vue
+++ b/resources/js/components/global-header/ProBadge.vue
@@ -18,7 +18,7 @@ const problemBadgeColor = computed(() => {
 <template>
     <Badge v-if="licensing.valid" :text="__('Pro')" size="sm" class="bg-white/15!" />
 
-    <Badge v-else :color="problemBadgeColor" class="max-[500px]:hidden" foo="bar" v-tooltip="licensing.requestFailureMessage">
+    <Badge v-else :color="problemBadgeColor" class="max-[500px]:hidden" v-tooltip="licensing.requestFailureMessage">
         {{ __('Pro') }} – {{ licensing.isOnPublicDomain ? __('statamic::messages.licensing_error_unlicensed') : __('Trial Mode') }}
     </Badge>
 </template>

--- a/resources/js/components/global-header/SupportButton.vue
+++ b/resources/js/components/global-header/SupportButton.vue
@@ -10,7 +10,8 @@ const { supportUrl: url } = useStatamicPageProps();
         v-if="url"
         :href="url"
         :aria-label="__('Support')"
-        class="inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85! v-popper--has-tooltip"
+        v-tooltip="__('Support')"
+        class="inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85!"
         target="_blank"
     >
         <Icon name="support" />

--- a/resources/js/components/global-header/UserDropdown.vue
+++ b/resources/js/components/global-header/UserDropdown.vue
@@ -12,7 +12,7 @@ const isImpersonating = computed((() => user.is_impersonating));
 <template>
     <Dropdown align="end" v-cloak>
         <template #trigger>
-            <Button :icon-only="true" variant="ghost">
+            <Button :icon-only="true" variant="ghost" :aria-label="__('User Menu')">
                 <Avatar :user="user" />
             </Button>
         </template>

--- a/resources/js/components/global-header/ViewSiteButton.vue
+++ b/resources/js/components/global-header/ViewSiteButton.vue
@@ -9,7 +9,8 @@ const { selectedSiteUrl: url } = useStatamicPageProps();
     <a
         :href="url"
         :aria-label="__('View Site')"
-        class="inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85! v-popper--has-tooltip"
+        v-tooltip="__('View Site')"
+        class="inline-flex items-center justify-center whitespace-nowrap shrink-0 font-medium antialiased cursor-pointer no-underline disabled:text-white/60 dark:disabled:text-white/50 disabled:cursor-not-allowed [&_svg]:shrink-0 [&_svg]:text-gray-925 [&_svg]:opacity-60 dark:[&_svg]:text-white bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/15 dark:hover:text-gray-200 h-8 text-[0.8125rem] leading-tight rounded-lg px-0 gap-0 w-8 [&_svg]:size-4 -me-2 [&_svg]:text-white/85!"
         target="_blank"
     >
         <Icon name="visit-website" />


### PR DESCRIPTION
This pull request adds missing tooltips to some of the global header buttons, and cleans up a bit of leftover code along the way.

- Added `v-tooltip` to the Support button, the "View Site" button and the nav toggle. With the same pattern the layout toggle (`MaxWidthButton`) already uses.
- Added the missing `aria-label` to the user dropdown trigger. (No tooltip there on purpose)
- Removed the stale `v-popper--has-tooltip` classes.
- Simplified the duplicated `v-tooltip="version"` on the logo.
- Removed a stray `foo="bar"` from `ProBadge.vue` :-)

`User Menu` is the only new string and it should probably be translated. It's screen reader only, so at least a missing translation won't show up anywhere in the UI.

Preview:
<img width="343" height="82" alt="image" src="https://github.com/user-attachments/assets/0b1f2924-fa5b-4a35-9045-57bbd4ba6c1f" />
