### PR TITLE
[6.x] Augment nav blueprint fields onto manual-URL nav items

### DIFF
--- a/src/Structures/AugmentedPage.php
+++ b/src/Structures/AugmentedPage.php
@@ -37,6 +37,7 @@ class AugmentedPage extends AugmentedEntry
         $keys = $keys
             ->merge($this->page->data()->keys())
             ->merge($this->page->supplements()->keys())
+            ->merge($this->blueprintFields()->keys())
             ->merge(['entry_id']);
 
         $keys = Statamic::isApiRoute() ? $this->apiKeys($keys) : $keys;

--- a/tests/Data/Structures/AugmentedPageTest.php
+++ b/tests/Data/Structures/AugmentedPageTest.php
@@ -17,6 +17,7 @@ class AugmentedPageTest extends AugmentedTestCase
     {
         $page = Mockery::mock(Page::class);
         $page->shouldReceive('reference')->andReturnFalse();
+        $page->shouldReceive('blueprint')->andReturnNull();
         $page->shouldReceive('data')->andReturn(collect(['one' => 'two', 'three' => 'four']));
         $page->shouldReceive('supplements')->andReturn(collect(['five' => 'six']));
 
@@ -32,6 +33,39 @@ class AugmentedPageTest extends AugmentedTestCase
             'one',
             'three',
             'five',
+        ];
+
+        $actual = $augmented->keys();
+
+        $this->assertEquals(
+            collect($expected)->sort()->values()->all(),
+            collect($actual)->sort()->values()->all()
+        );
+    }
+
+    #[Test]
+    public function it_gets_page_keys_from_the_blueprint_when_there_is_no_entry()
+    {
+        $pageBlueprint = Blueprint::makeFromFields([
+            'target_blank' => ['type' => 'toggle'],
+        ])->setNamespace('navs')->setHandle('main');
+
+        $page = Mockery::mock(Page::class);
+        $page->shouldReceive('reference')->andReturnFalse();
+        $page->shouldReceive('blueprint')->andReturn($pageBlueprint);
+        $page->shouldReceive('data')->andReturn(collect(['title' => 'Child', 'url' => 'https://example.com']));
+        $page->shouldReceive('supplements')->andReturn(collect());
+
+        $augmented = new AugmentedPage($page);
+
+        $expected = [
+            'id',
+            'entry_id',
+            'title',
+            'url',
+            'uri',
+            'permalink',
+            'target_blank',
         ];
 
         $actual = $augmented->keys();


### PR DESCRIPTION
Fields defined on a navigation blueprint only reach nav items that reference an entry. A manual-URL item, including a manual-URL child under an entry-backed parent, falls back to a hardcoded key list, so Antlers resolves the missing key against the enclosing scope instead of the item's own value. In practice a manual-URL child silently inherits its parent's field value.

`AugmentedPage::keys()` only merges `blueprintFields()->keys()` through `parent::keys()`, which only runs when the page has an entry. `blueprintFields()` already resolves the right blueprint for both entry and non-entry pages, it just wasn't merged into the key list on the non-entry branch.

This merges `blueprintFields()->keys()` into the key list unconditionally, so manual-URL items report their own blueprint field values instead of the parent's.

Fixes #15233
