### PR TITLE
[6.x] Fix reordering a paginated orderable collection corrupting the tree

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -43,6 +43,7 @@ return [
     'collection_configure_template_instructions' => 'Set this collection\'s default template. Entries can override this setting with a `template` field.',
     'collection_configure_title_format_instructions' => 'Automatically generate titles for entries in this collection. [Read more](https://statamic.dev/collections#titles).',
     'collection_configure_title_instructions' => 'Use a plural noun, such as \'Articles\' or \'Products\'',
+    'collection_entries_reorder_out_of_date' => 'The entry listing is out of date. Refresh the page and try reordering again.',
     'collection_next_steps_blueprints_description' => 'Manage the blueprints and fields available for this collection. Keep organized with fieldsets.',
     'collection_next_steps_configure_description' => 'Configure URLs and routes, define blueprints, date behaviors, ordering and other options.',
     'collection_next_steps_create_entry_description' => 'Create the first entry or stub out a handful of placeholder entries—whatever suits your needs.',

--- a/resources/js/components/entries/Listing.vue
+++ b/resources/js/components/entries/Listing.vue
@@ -139,7 +139,7 @@ export default {
                     this.$toast.success(__('Entries successfully reordered'));
                 })
                 .catch((e) => {
-                    this.$toast.error(__('Something went wrong'));
+                    this.$toast.error(e.response?.data?.message || __('Something went wrong'));
                 });
         },
     },

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -440,6 +440,13 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
 
         $this->ancestors()->each(fn ($entry) => Blink::forget('entry-descendants-'.$entry->id()));
 
+        if ($isNew && $this->collection()->orderable()) {
+            // The entry only gets appended to the tree when it's read, so anything that
+            // read it before now would have cached a version without this entry in it.
+            $this->collection()->structure()->flushCache($this->locale());
+            $this->collection()->updateEntryOrder([$this->id()]);
+        }
+
         $stack = InitiatorStack::entry($this)->push();
 
         $this->directDescendants()->each->{$withEvents ? 'save' : 'saveQuietly'}();

--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -5,6 +5,8 @@ namespace Statamic\Http\Controllers\CP\Collections;
 use Illuminate\Http\Request;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class ReorderEntriesController extends CpController
 {
     public function __invoke(Request $request, $collection)

--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -20,29 +20,41 @@ class ReorderEntriesController extends CpController
 
         $tree = $collection->structure()->in($request->site);
 
-        $contents = collect($tree->tree())->keyBy('entry');
+        $branches = collect($tree->tree())->keyBy('entry');
 
-        $reorderPayload = $request->ids;
+        // A descending collection lists the tree in reverse. Work in the order the
+        // listing was in, then flip it back before saving.
+        $descending = $collection->sortDirection() === 'desc';
 
-        if ($collection->sortDirection() === 'desc') {
-            $reorderPayload = array_reverse($reorderPayload);
+        $ids = $descending
+            ? $branches->keys()->reverse()->values()
+            : $branches->keys();
+
+        $offset = ($request->page - 1) * $request->perPage;
+
+        $submitted = collect($request->ids)->map(fn ($id) => (string) $id);
+        $current = $ids->slice($offset, $request->perPage)->map(fn ($id) => (string) $id);
+
+        // If the submitted ids aren't a rearrangement of the page being reordered, the
+        // listing was out of date. Continuing would duplicate and drop entries.
+        if ($submitted->sort()->values()->all() !== $current->sort()->values()->all()) {
+            abort(409, __('statamic::messages.collection_entries_reorder_out_of_date'));
         }
 
-        $reorderedEntries = clone $contents;
+        $reordered = $ids->values()->all();
 
-        $contents
-            ->keys()
-            ->forPage($request->page, $request->perPage)
-            ->zip($reorderPayload)
-            ->each(function ($operation) use ($contents, &$reorderedEntries) {
-                $reorderedEntries->put(
-                    $operation[0],
-                    $contents->get($operation[1])
-                );
-            });
+        foreach ($request->ids as $index => $id) {
+            $reordered[$offset + $index] = $id;
+        }
+
+        $reordered = collect($reordered);
+
+        if ($descending) {
+            $reordered = $reordered->reverse();
+        }
 
         $tree
-            ->tree($reorderedEntries->values()->all())
+            ->tree($reordered->map(fn ($id) => $branches->get($id))->values()->all())
             ->save();
     }
 }

--- a/src/Structures/CollectionStructure.php
+++ b/src/Structures/CollectionStructure.php
@@ -110,6 +110,14 @@ class CollectionStructure extends Structure
             ->all();
     }
 
+    public function flushCache($site = null)
+    {
+        Blink::forget('collection-structure-tree-'.$this->handle().'-'.($site ?? '*'));
+        Blink::forget('collection-structure-tree-entries::'.$this->handle().'::'.($site ?? '*'));
+
+        return parent::flushCache($site);
+    }
+
     public function save()
     {
         $this->collection()->structure($this)->save();

--- a/src/Structures/Structure.php
+++ b/src/Structures/Structure.php
@@ -53,6 +53,19 @@ abstract class Structure implements Augmentable, StructureContract
         return $this->fluentlyGetOrSet('expectsRoot')->args(func_get_args());
     }
 
+    public function flushCache($site = null)
+    {
+        Facades\Blink::forget($site
+            ? 'structure-'.$this->handle().'-'.$site.'-*'
+            : 'structure-'.$this->handle().'-*');
+
+        $trees = $site ? collect([$this->in($site)]) : $this->trees();
+
+        $trees->filter()->each->flushCache();
+
+        return $this;
+    }
+
     public function trees()
     {
         return collect($this->trees);

--- a/src/Structures/Tree.php
+++ b/src/Structures/Tree.php
@@ -177,16 +177,23 @@ abstract class Tree implements ContainsQueryableValues, Contract, Localization
         return ($this->cachedFlattenedPageOrder ??= $this->flattenedPages()->map->reference()->flip())->get($reference);
     }
 
+    public function flushCache()
+    {
+        $this->cachedFlattenedPages = null;
+        $this->cachedFlattenedPagesById = null;
+        $this->cachedFlattenedPagesByReference = null;
+        $this->cachedFlattenedPageOrder = null;
+
+        return $this;
+    }
+
     public function save()
     {
         if ($this->dispatchSavingEvent() === false) {
             return false;
         }
 
-        $this->cachedFlattenedPages = null;
-        $this->cachedFlattenedPagesById = null;
-        $this->cachedFlattenedPagesByReference = null;
-        $this->cachedFlattenedPageOrder = null;
+        $this->flushCache();
 
         Blink::forget('collection-structure-tree*');
 

--- a/tests/Feature/Entries/ReorderEntriesTest.php
+++ b/tests/Feature/Entries/ReorderEntriesTest.php
@@ -6,6 +6,7 @@ use Facades\Tests\Factories\EntryFactory;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Stache;
 use Statamic\Facades\User;
 use Statamic\Structures\CollectionStructure;
 use Tests\FakesRoles;
@@ -142,6 +143,105 @@ class ReorderEntriesTest extends TestCase
         $this->assertEquals(5, Entry::find(4)->order());
         $this->assertEquals(6, Entry::find(5)->order());
         $this->assertEquals(7, Entry::find(7)->order());
+    }
+
+    #[Test]
+    public function it_reorders_paginated_entries_in_a_descending_collection()
+    {
+        $this->collection->sortDirection('desc')->save();
+
+        EntryFactory::id('1')->slug('one')->collection('test')->create();
+        EntryFactory::id('2')->slug('two')->collection('test')->create();
+        EntryFactory::id('3')->slug('three')->collection('test')->create();
+        EntryFactory::id('4')->slug('four')->collection('test')->create();
+        EntryFactory::id('5')->slug('five')->collection('test')->create();
+
+        $this->structure->in('en')->tree([
+            ['entry' => '1'],
+            ['entry' => '2'],
+            ['entry' => '3'],
+            ['entry' => '4'],
+            ['entry' => '5'],
+        ])->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'reorder test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        // The listing shows 5, 4, 3, 2, 1. The first page contains 5, 4, 3.
+        $this
+            ->actingAs($user)
+            ->reorder(['page' => 1, 'perPage' => 3, 'ids' => [3, 5, 4]])
+            ->assertOk();
+
+        $this->assertEquals([
+            ['entry' => '1'],
+            ['entry' => '2'],
+            ['entry' => '4'],
+            ['entry' => '5'],
+            ['entry' => '3'],
+        ], $this->structure->in('en')->tree());
+    }
+
+    #[Test]
+    public function it_doesnt_reorder_when_the_submitted_entries_arent_on_the_page_being_reordered()
+    {
+        EntryFactory::id('1')->slug('one')->collection('test')->create();
+        EntryFactory::id('2')->slug('two')->collection('test')->create();
+        EntryFactory::id('3')->slug('three')->collection('test')->create();
+        EntryFactory::id('4')->slug('four')->collection('test')->create();
+
+        $tree = [
+            ['entry' => '1'],
+            ['entry' => '2'],
+            ['entry' => '3'],
+            ['entry' => '4'],
+        ];
+
+        $this->structure->in('en')->tree($tree)->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'reorder test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        // The first page of the tree is 1, 2, 3, but the listing was showing 4 in there.
+        $this
+            ->actingAs($user)
+            ->reorder(['page' => 1, 'perPage' => 3, 'ids' => [1, 4, 2]])
+            ->assertStatus(409);
+
+        $this->assertEquals($tree, $this->structure->in('en')->tree());
+    }
+
+    #[Test]
+    public function creating_an_entry_gives_it_the_correct_order_when_the_tree_has_already_been_read()
+    {
+        EntryFactory::id('1')->slug('one')->collection('test')->create();
+        EntryFactory::id('2')->slug('two')->collection('test')->create();
+        EntryFactory::id('3')->slug('three')->collection('test')->create();
+
+        $this->structure->in('en')->tree([
+            ['entry' => '1'],
+            ['entry' => '2'],
+            ['entry' => '3'],
+        ])->save();
+
+        // Read the tree before the entry is created, so it gets cached without it.
+        $this->structure->in('en')->tree();
+
+        EntryFactory::id('4')->slug('four')->collection('test')->create();
+
+        $this->assertEquals([
+            ['entry' => '1'],
+            ['entry' => '2'],
+            ['entry' => '3'],
+            ['entry' => '4'],
+        ], $this->structure->in('en')->tree());
+
+        $this->assertEquals(4, Entry::find('4')->order());
+
+        $this->assertEquals(
+            ['1' => 1, '2' => 2, '3' => 3, '4' => 4],
+            Stache::store('entries::test')->index('order')->items()->all()
+        );
     }
 
     private function reorder($payload)


### PR DESCRIPTION
Fixes #15116
Fixes #11209

Reordering a paginated orderable collection can write a duplicate entry into the tree and silently drop another one. Once that happens, `CollectionStructure::validateTree()` throws `Duplicate entry [...] in [...] collection's structure.` on every read, so the CP listing and the front-end both 500 until the tree YAML is edited by hand.

### What goes wrong

**1. A new entry gets a colliding `order`.**

`Tree::tree()` memoises the *healed* tree (`validateTree()` appends entries that aren't in the stored tree yet) under a key built from the stored tree only. Creating an entry changes the entry set but not the stored tree, so the key is unchanged and the stale healed tree is served for the rest of the request. `entryOrder()` then returns `null`, `Entry::order()` does `null + 1`, and the new entry is indexed as `1` — colliding with whichever entry legitimately sits at tree index 0. That value gets persisted to the `order` index.

**2. The reorder then corrupts the tree.**

The listing is sorted by `order`, so the new entry shows up on page 1 while the tree still has it last. `ReorderEntriesController` zipped the tree's page slice against the submitted ids and `put()` the results, which is only safe when both are the same *set*. When they aren't, one id is written twice and another is never written back.

### The fix

- `Structure::flushCache()` / `Tree::flushCache()` — the flattened-page memoisation on `Tree` was only ever cleared in `Tree::save()`, so clearing the Blink entries alone wasn't enough. Extracted it so it can be flushed on demand, optionally scoped to a single site.
- `Entry::save()` flushes those caches and recalculates the order for a new entry in an orderable collection, so it's resolved against a tree that actually knows about it.
- `ReorderEntriesController` now checks the submitted ids are a rearrangement of the page being reordered, and aborts with a 409 instead of writing something it can't write correctly. Happy to change this to silently reconciling if you'd prefer it never errors.

Also fixes reordering in a collection with `sort_dir: desc`, which was corrupting the tree on any paginated reorder — the payload was reversed but the slice was still taken from the front of the tree. The controller now works in listing order and flips back before saving.

### Note on performance

Creating entries in an orderable collection is slower, because each new entry now re-heals the tree instead of reusing a cached (and wrong) one. Bulk-creating 500 entries went from ~540ms to ~1200ms locally. Per-entry correctness needs a per-entry heal, since each new entry changes what the correct healed tree is, so I didn't see a way around it without giving up the guarantee.

Worth flagging separately: `validateTree()` caches the query *builder* and chains `->where('site', $locale)` onto that same object on every call, so where-clauses accumulate. `flushCache()` clears that entry, but any code path that heals repeatedly within one request is quadratic today — with that cache left in place the 500-entry case above takes 16s.
