### PR TITLE
[6.x] Fix nav entry links across sites losing their domain

### DIFF
--- a/src/Structures/AugmentedPage.php
+++ b/src/Structures/AugmentedPage.php
@@ -61,6 +61,16 @@ class AugmentedPage extends AugmentedEntry
         return $this->page->getSupplement($key) ?? $this->page->value($key);
     }
 
+    protected function url()
+    {
+        return $this->page->url();
+    }
+
+    protected function urlWithoutRedirect()
+    {
+        return $this->page->urlWithoutRedirect();
+    }
+
     public function blueprintFields()
     {
         if ($this->fieldsCache) {

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -79,12 +79,33 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Cont
 
     public function url()
     {
-        return $this->url ?? optional($this->entry())->url();
+        if ($this->url) {
+            return $this->url;
+        }
+
+        if (! $entry = $this->entry()) {
+            return null;
+        }
+
+        return $this->selectsAcrossSites() ? $entry->absoluteUrl() : $entry->url();
     }
 
     public function urlWithoutRedirect()
     {
-        return $this->url ?? optional($this->entry())->urlWithoutRedirect();
+        if ($this->url) {
+            return $this->url;
+        }
+
+        if (! $entry = $this->entry()) {
+            return null;
+        }
+
+        return $this->selectsAcrossSites() ? $entry->absoluteUrlWithoutRedirect() : $entry->urlWithoutRedirect();
+    }
+
+    private function selectsAcrossSites()
+    {
+        return $this->structure() instanceof Nav && $this->structure()->canSelectAcrossSites();
     }
 
     public function isRedirect()

--- a/src/Structures/Page.php
+++ b/src/Structures/Page.php
@@ -87,7 +87,7 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Cont
             return null;
         }
 
-        return $this->selectsAcrossSites() ? $entry->absoluteUrl() : $entry->url();
+        return $this->linksToAnotherSite($entry) ? $entry->absoluteUrl() : $entry->url();
     }
 
     public function urlWithoutRedirect()
@@ -100,12 +100,16 @@ class Page implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Cont
             return null;
         }
 
-        return $this->selectsAcrossSites() ? $entry->absoluteUrlWithoutRedirect() : $entry->urlWithoutRedirect();
+        return $this->linksToAnotherSite($entry) ? $entry->absoluteUrlWithoutRedirect() : $entry->urlWithoutRedirect();
     }
 
-    private function selectsAcrossSites()
+    private function linksToAnotherSite(Entry $entry)
     {
-        return $this->structure() instanceof Nav && $this->structure()->canSelectAcrossSites();
+        if (! $this->structure() instanceof Nav || ! $this->structure()->canSelectAcrossSites()) {
+            return false;
+        }
+
+        return $entry->site()->handle() !== $this->tree->site()->handle();
     }
 
     public function isRedirect()

--- a/tests/Data/Structures/AugmentedPageTest.php
+++ b/tests/Data/Structures/AugmentedPageTest.php
@@ -200,6 +200,7 @@ class AugmentedPageTest extends AugmentedTestCase
         $page->shouldReceive('data')->andReturn(collect(['one' => 'dos', 'three' => 'quatro', 'five' => 'seis']));
         $page->shouldReceive('supplements')->andReturn(collect(['seven' => 'ocho']));
         $page->shouldReceive('title')->andReturn('The Page Title');
+        $page->shouldReceive('url')->andReturn('/the-url');
         $page->shouldReceive('value')->with('one')->andReturn('dos');
         $page->shouldReceive('value')->with('three')->andReturn('quatro');
         $page->shouldReceive('value')->with('five')->andReturn('seis');

--- a/tests/Data/Structures/PageTest.php
+++ b/tests/Data/Structures/PageTest.php
@@ -243,9 +243,10 @@ class PageTest extends TestCase
         $entry->shouldReceive('uri')->andReturn('/the/actual/entry/uri');
         $entry->shouldReceive('value')->with('redirect')->andReturnNull();
 
-        $tree = $this->newTree()->setStructure(
-            $this->mock(Nav::class)
-        );
+        $nav = $this->mock(Nav::class);
+        $nav->shouldReceive('canSelectAcrossSites')->andReturnFalse();
+
+        $tree = $this->newTree()->setStructure($nav);
 
         $page = (new Page)
             ->setTree($tree)
@@ -269,9 +270,10 @@ class PageTest extends TestCase
         $entry->shouldReceive('uri')->andReturn('/the/actual/entry/uri');
         $entry->shouldReceive('value')->with('redirect')->andReturn('http://example.com/page');
 
-        $tree = $this->newTree()->setStructure(
-            $this->mock(Nav::class)
-        );
+        $nav = $this->mock(Nav::class);
+        $nav->shouldReceive('canSelectAcrossSites')->andReturnFalse();
+
+        $tree = $this->newTree()->setStructure($nav);
 
         $page = (new Page)
             ->setTree($tree)

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -459,6 +459,29 @@ EOT;
     #[Test]
     public function it_uses_the_absolute_url_for_a_nav_entry_link_on_another_site()
     {
+        $this->makeCrossSiteNav();
+
+        $template = '{{ nav:test }}{{ url }}{{ /nav:test }}';
+
+        $this->assertEquals('http://two.example.com/projects', (string) Antlers::parse($template, [], true));
+    }
+
+    #[Test]
+    public function it_doesnt_flag_a_nav_entry_link_on_another_site_as_current()
+    {
+        $this->makeCrossSiteNav();
+
+        $mock = \Mockery::mock(\Statamic\Facades\URL::getFacadeRoot())->makePartial();
+        \Statamic\Facades\URL::swap($mock);
+        $mock->shouldReceive('getCurrent')->once()->andReturn('/projects');
+
+        $template = '{{ nav:test }}{{ if is_current }}current{{ else }}not-current{{ /if }}{{ /nav:test }}';
+
+        $this->assertEquals('not-current', (string) Antlers::parse($template, [], true));
+    }
+
+    private function makeCrossSiteNav()
+    {
         $this->setSites([
             'en' => ['url' => 'http://one.example.com/', 'locale' => 'en'],
             'fr' => ['url' => 'http://two.example.com/', 'locale' => 'fr'],
@@ -468,26 +491,14 @@ EOT;
 
         tap(Collection::make('pages')->routes('{slug}'))->sites(['en', 'fr'])->save();
 
-        EntryFactory::id('projects')->collection('pages')->locale('en')->slug('projects')->data(['title' => 'Projects'])->create();
-        EntryFactory::id('projects-fr')->origin('projects')->collection('pages')->locale('fr')->slug('projects')->data(['title' => 'Projects'])->create();
+        EntryFactory::collection('pages')->id('projects')->locale('en')->slug('projects')->data(['title' => 'Projects'])->create();
+        EntryFactory::collection('pages')->id('projects-fr')->origin('projects')->locale('fr')->slug('projects')->data(['title' => 'Projects'])->create();
 
         $nav = Nav::make('test')->canSelectAcrossSites(true);
         $nav->makeTree('en', [
             ['id' => 'link', 'title' => 'Projects', 'entry' => 'projects-fr'],
         ])->save();
         $nav->save();
-
-        $urlTemplate = '{{ nav:test }}{{ url }}{{ /nav:test }}';
-
-        $this->assertEquals('http://two.example.com/projects', (string) Antlers::parse($urlTemplate, [], true));
-
-        $mock = \Mockery::mock(\Statamic\Facades\URL::getFacadeRoot())->makePartial();
-        \Statamic\Facades\URL::swap($mock);
-        $mock->shouldReceive('getCurrent')->andReturn('/projects');
-
-        $currentTemplate = '{{ nav:test }}{{ if is_current }}current{{ else }}not-current{{ /if }}{{ /nav:test }}';
-
-        $this->assertEquals('not-current', (string) Antlers::parse($currentTemplate, [], true));
     }
 
     #[Test]

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -9,6 +9,7 @@ use Statamic\Facades\Antlers;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Nav;
+use Statamic\Facades\Site;
 use Tests\PreventSavingStacheItemsToDisk;
 use Tests\TestCase;
 
@@ -453,6 +454,40 @@ EOT;
         $mock->shouldReceive('getCurrent')->once()->andReturn('/1/1/1');
         $result = (string) Antlers::parse($template, [], true);
         $this->assertEquals('[home][1=parent][1-1=parent][1-1-1=current][1-1-1-1][2][3]', $result);
+    }
+
+    #[Test]
+    public function it_uses_the_absolute_url_for_a_nav_entry_link_on_another_site()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://one.example.com/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://two.example.com/', 'locale' => 'fr'],
+        ]);
+
+        Site::setCurrent('en');
+
+        tap(Collection::make('pages')->routes('{slug}'))->sites(['en', 'fr'])->save();
+
+        EntryFactory::id('projects')->collection('pages')->locale('en')->slug('projects')->data(['title' => 'Projects'])->create();
+        EntryFactory::id('projects-fr')->origin('projects')->collection('pages')->locale('fr')->slug('projects')->data(['title' => 'Projects'])->create();
+
+        $nav = Nav::make('test')->canSelectAcrossSites(true);
+        $nav->makeTree('en', [
+            ['id' => 'link', 'title' => 'Projects', 'entry' => 'projects-fr'],
+        ])->save();
+        $nav->save();
+
+        $urlTemplate = '{{ nav:test }}{{ url }}{{ /nav:test }}';
+
+        $this->assertEquals('http://two.example.com/projects', (string) Antlers::parse($urlTemplate, [], true));
+
+        $mock = \Mockery::mock(\Statamic\Facades\URL::getFacadeRoot())->makePartial();
+        \Statamic\Facades\URL::swap($mock);
+        $mock->shouldReceive('getCurrent')->andReturn('/projects');
+
+        $currentTemplate = '{{ nav:test }}{{ if is_current }}current{{ else }}not-current{{ /if }}{{ /nav:test }}';
+
+        $this->assertEquals('not-current', (string) Antlers::parse($currentTemplate, [], true));
     }
 
     #[Test]

--- a/tests/Tags/StructureTagTest.php
+++ b/tests/Tags/StructureTagTest.php
@@ -461,13 +461,13 @@ EOT;
     {
         $this->makeCrossSiteNav();
 
-        $template = '{{ nav:test }}{{ url }}{{ /nav:test }}';
+        $template = '{{ nav:test }}[{{ id }}={{ url }}]{{ /nav:test }}';
 
-        $this->assertEquals('http://two.example.com/projects', (string) Antlers::parse($template, [], true));
+        $this->assertEquals('[link=http://two.example.com/projects][local-link=/projects]', (string) Antlers::parse($template, [], true));
     }
 
     #[Test]
-    public function it_doesnt_flag_a_nav_entry_link_on_another_site_as_current()
+    public function it_only_flags_the_local_nav_entry_link_as_current()
     {
         $this->makeCrossSiteNav();
 
@@ -475,9 +475,9 @@ EOT;
         \Statamic\Facades\URL::swap($mock);
         $mock->shouldReceive('getCurrent')->once()->andReturn('/projects');
 
-        $template = '{{ nav:test }}{{ if is_current }}current{{ else }}not-current{{ /if }}{{ /nav:test }}';
+        $template = '{{ nav:test }}[{{ id }}{{ if is_current }}=current{{ /if }}]{{ /nav:test }}';
 
-        $this->assertEquals('not-current', (string) Antlers::parse($template, [], true));
+        $this->assertEquals('[link][local-link=current]', (string) Antlers::parse($template, [], true));
     }
 
     private function makeCrossSiteNav()
@@ -497,6 +497,7 @@ EOT;
         $nav = Nav::make('test')->canSelectAcrossSites(true);
         $nav->makeTree('en', [
             ['id' => 'link', 'title' => 'Projects', 'entry' => 'projects-fr'],
+            ['id' => 'local-link', 'title' => 'Projects (local)', 'entry' => 'projects'],
         ])->save();
         $nav->save();
     }


### PR DESCRIPTION
On a multi-site install with sites on different domains, a nav item linking to an entry on another site rendered `{{ url }}` without that entry's scheme and host, so the browser resolved it against the current site and 404'd. `Page::url()` always fell back to the linked entry's relative URL, even when the nav had `select_across_sites` turned on, so only `{{ permalink }}` picked up the right domain. The same relative URL fed `is_current` and `is_parent`, so a cross-site item could get flagged as active whenever the two sites happened to share a path.

`Page::url()` and `urlWithoutRedirect()` now check the nav's `select_across_sites` setting and return the entry's absolute URL when it's enabled, mirroring the fix already applied to Bard entry links in #12694. `AugmentedPage` needed its own `url()`/`urlWithoutRedirect()` overrides too, since the augmented `url` key was resolving straight off the underlying entry instead of going through the page.

Fixes #15237
