### PR TITLE
[6.x] Multisite - entry grouping

### DIFF
--- a/resources/css/components/fieldtypes/grid.css
+++ b/resources/css/components/fieldtypes/grid.css
@@ -101,6 +101,58 @@
         }
     }
 
+    /* GRID FIELDTYPE / SECTIONED MODIFIER
+    =================================================== */
+    /* Grid whose column headers double as the enclosing publish section's header.
+      - e.g. A site group in `cp/sites`
+      - the table and its headers go transparent so the headers sit on the section background
+      - the rows take over the card background, border and corners
+      - headers stay real table headers, so they keep aligning with their columns
+    */
+    .grid-table--sectioned {
+        @apply rounded-none border-0 bg-transparent shadow-none dark:bg-transparent;
+
+        thead th {
+            @apply static border-b-0 bg-transparent dark:bg-transparent;
+            &:first-child {
+                @apply rounded-ss-none;
+            }
+            &:last-child {
+                @apply rounded-se-none;
+            }
+        }
+
+        > tbody > tr {
+            > td {
+                @apply bg-white dark:bg-gray-900;
+
+                &:first-child {
+                    @apply border-s dark:border-s-gray-700;
+                }
+
+                &:last-child {
+                    @apply border-e dark:border-e-gray-700;
+                }
+            }
+
+            &:first-child > td {
+                @apply border-t dark:border-t-gray-700;
+
+                &:first-child {
+                    @apply rounded-ss-[7px];
+                }
+
+                &:last-child {
+                    @apply rounded-se-[7px];
+                }
+            }
+
+            &:last-child > td {
+                @apply border-b dark:border-b-gray-700;
+            }
+        }
+    }
+
     .grid-item-header {
         @apply flex cursor-move items-center justify-between border-b bg-gray-200 px-4 py-2 text-sm outline-hidden;
     }

--- a/resources/js/bootstrap/fieldtypes.js
+++ b/resources/js/bootstrap/fieldtypes.js
@@ -28,6 +28,7 @@ import FieldsFieldtype from '../components/fieldtypes/grid/FieldsFieldtype.vue';
 import FilesFieldtype from '../components/fieldtypes/FilesFieldtype.vue';
 import FloatFieldtype from '../components/fieldtypes/FloatFieldtype.vue';
 import Sites from '../components/globals/Sites.vue';
+import SitesIndexFieldtype from '../components/fieldtypes/SitesIndexFieldtype.vue';
 import Grid from '../components/fieldtypes/grid/Grid.vue';
 import GridIndex from '../components/fieldtypes/grid/GridIndex.vue';
 import GroupFieldtype from '../components/fieldtypes/GroupFieldtype.vue';
@@ -102,6 +103,7 @@ export default function registerFieldtypes(app) {
     app.component('files-fieldtype', FilesFieldtype);
     app.component('float-fieldtype', FloatFieldtype);
     app.component('global_set_sites-fieldtype', Sites);
+    app.component('sites-fieldtype-index', SitesIndexFieldtype);
     app.component('grid-fieldtype', Grid);
     app.component('grid-fieldtype-index', GridIndex);
     app.component('group-fieldtype', GroupFieldtype);

--- a/resources/js/components/SiteSelector.vue
+++ b/resources/js/components/SiteSelector.vue
@@ -62,7 +62,7 @@ function groupLabel(option) {
                 v-if="option._groupLabel"
                 size="sm"
                 class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                :text="__(option._groupLabel)"
+                :text="option._groupLabel"
             />
         </template>
     </Select>

--- a/resources/js/components/SiteSelector.vue
+++ b/resources/js/components/SiteSelector.vue
@@ -1,23 +1,69 @@
 <script setup>
-import { Select } from '@/components/ui';
+import { computed } from 'vue';
+import { Icon, Select, Subheading } from '@/components/ui';
+import {
+    flatOptionsFromSiteGroups,
+    groupItemsBySiteGroup,
+    hasNamedSiteGroups,
+    selectedSiteGroupLabel,
+} from '@/util/site-groups.js';
 
-defineProps({
+const props = defineProps({
     sites: { type: Array, required: true },
     modelValue: { type: String, required: true },
 });
 
 defineEmits(['update:modelValue']);
+
+const hasNamedGroups = computed(() => hasNamedSiteGroups(props.sites));
+
+const options = computed(() => {
+    if (!hasNamedGroups.value) {
+        return props.sites;
+    }
+
+    return flatOptionsFromSiteGroups(groupItemsBySiteGroup(props.sites));
+});
+
+function groupLabel(option) {
+    return selectedSiteGroupLabel(option, hasNamedGroups.value);
+}
 </script>
 
 <template>
     <Select
         class="w-36"
-        :options="sites"
+        :options="options"
         option-label="name"
         option-value="handle"
         align="end"
         :adaptive-width="true"
+        :virtualize="!hasNamedGroups"
         :model-value="modelValue"
         @update:model-value="$emit('update:modelValue', $event)"
-    />
+    >
+        <template #selected-option="{ option }">
+            <span v-if="option" class="flex min-w-0 items-center gap-1.5">
+                <template v-if="groupLabel(option)">
+                    <span class="truncate">{{ groupLabel(option) }}</span>
+                    <Icon name="chevron-right" class="size-3.5! shrink-0 text-gray-700 dark:text-white/70" aria-hidden="true" />
+                </template>
+                <span class="truncate">{{ __(option.name) }}</span>
+            </span>
+        </template>
+
+        <template v-if="hasNamedGroups" #before-option="option">
+            <div
+                v-if="option._showGroupSeparator"
+                class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
+                role="separator"
+            />
+            <Subheading
+                v-if="option._groupLabel"
+                size="sm"
+                class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                :text="__(option._groupLabel)"
+            />
+        </template>
+    </Select>
 </template>

--- a/resources/js/components/SiteSelector.vue
+++ b/resources/js/components/SiteSelector.vue
@@ -32,7 +32,7 @@ function groupLabel(option) {
 
 <template>
     <Select
-        class="w-36"
+        class="w-60"
         :options="options"
         option-label="name"
         option-value="handle"

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -169,6 +169,7 @@
                                 v-if="showLocalizationSelector"
                                 :localizations
                                 :localizing="localizing !== null"
+                                :confirming-switch="!!pendingLocalization"
                                 @selected="localizationSelected"
                             />
                         </div>

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -256,6 +256,7 @@
                                     <Icon name="chevron-right" class="size-3.5! text-gray-700 dark:text-white/70" aria-hidden="true" />
                                 </template>
                                 <span class="truncate">{{ __(option.label) }}</span>
+                                <Badge v-if="option.origin" class="ms-1.5" size="sm" color="orange" :text="__('Origin')" />
                             </span>
                         </template>
 
@@ -274,16 +275,19 @@
                         </template>
 
                         <template #option="option">
-                            <div class="flex min-w-0 items-center">
-                                <span
-                                    class="little-dot me-2 shrink-0"
-                                    :class="{
-                                        'bg-green-600': option.published,
-                                        'bg-gray-500': !option.published,
-                                        'bg-red-500': !option.exists,
-                                    }"
-                                />
-                                <span class="truncate">{{ __(option.label) }}</span>
+                            <div class="flex min-w-0 items-center gap-x-2">
+                                <div class="flex min-w-0 items-center">
+                                    <span
+                                        class="little-dot me-2 shrink-0"
+                                        :class="{
+                                            'bg-green-600': option.published,
+                                            'bg-gray-500': !option.published,
+                                            'bg-red-500': !option.exists,
+                                        }"
+                                    />
+                                    <span class="truncate">{{ __(option.label) }}</span>
+                                </div>
+                                <Badge v-if="option.origin" class="ms-2" size="sm" color="orange" :text="__('Origin')" />
                             </div>
                         </template>
                     </Select>
@@ -313,6 +317,7 @@ import HasActions from '../publish/HasActions';
 import striptags from 'striptags';
 import clone from '@/util/clone.js';
 import {
+    Badge,
     Button,
     Card,
     CardPanel,
@@ -341,6 +346,7 @@ import {
     flatOptionsFromSiteGroups,
     groupItemsBySiteGroup,
     hasNamedSiteGroups,
+    preferredOriginHandle,
     selectedSiteGroupLabel,
 } from '@/util/site-groups.js';
 import { computed, ref } from 'vue';
@@ -351,6 +357,7 @@ export default {
     mixins: [HasPreferences, HasActions],
 
     components: {
+        Badge,
         Button,
         Card,
         CardPanel,
@@ -571,6 +578,14 @@ export default {
             return this.getPreference('after_save') ?? 'listing';
         },
 
+        defaultOriginHandle() {
+            return preferredOriginHandle(
+                this.localizations,
+                this.localizing || null,
+                this.originBehavior,
+            );
+        },
+
         originOptions() {
             const existing = this.localizations
                 .filter((localization) => localization.exists)
@@ -581,6 +596,7 @@ export default {
                     group_handle: localization.group_handle,
                     published: localization.published,
                     exists: localization.exists,
+                    origin: localization.handle === this.defaultOriginHandle,
                 }));
 
             return flatOptionsFromSiteGroups(groupItemsBySiteGroup(existing));
@@ -722,6 +738,11 @@ export default {
             this.$dirty.remove(this.publishContainer);
 
             this.localizing = localization;
+            this.selectedOrigin = preferredOriginHandle(
+                this.localizations,
+                localization,
+                this.originBehavior,
+            );
 
             if (localization.exists) {
                 this.editLocalization(localization);
@@ -949,10 +970,11 @@ export default {
     created() {
         window.history.replaceState({}, document.title, document.location.href.replace('created=true', ''));
 
-        this.selectedOrigin =
-            this.originBehavior === 'active'
-                ? this.localizations.find((l) => l.active)?.handle
-                : this.localizations.find((l) => l.root)?.handle;
+        this.selectedOrigin = preferredOriginHandle(
+            this.localizations,
+            this.localizations.find((localization) => localization.active),
+            this.originBehavior,
+        );
     },
 
     beforeUnmount() {

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -234,7 +234,37 @@
         >
             <div class="publish-fields">
                 <ui-field class="form-group field-w-100" :label="__('Origin')" :instructions="__('messages.entry_origin_instructions')">
-                    <Select class="w-full" v-model="selectedOrigin" :options="originOptions" placeholder="" />
+                    <Select
+                        class="w-full"
+                        v-model="selectedOrigin"
+                        :options="originOptions"
+                        :virtualize="!originHasNamedGroups"
+                        placeholder=""
+                    >
+                        <template #selected-option="{ option }">
+                            <span class="flex min-w-0 items-center gap-1.5">
+                                <template v-if="selectedOriginGroupLabel(option)">
+                                    <span class="truncate">{{ selectedOriginGroupLabel(option) }}</span>
+                                    <Icon name="chevron-right" class="size-3.5! text-gray-700 dark:text-white/70" aria-hidden="true" />
+                                </template>
+                                <span class="truncate">{{ __(option.label) }}</span>
+                            </span>
+                        </template>
+
+                        <template #before-option="option">
+                            <div
+                                v-if="option._showGroupSeparator"
+                                class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
+                                role="separator"
+                            />
+                            <Subheading
+                                v-if="option._groupLabel"
+                                size="sm"
+                                class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                                :text="__(option._groupLabel)"
+                            />
+                        </template>
+                    </Select>
                 </ui-field>
             </div>
         </confirmation-modal>
@@ -285,6 +315,12 @@ import {
 	Stack,
 } from '@ui';
 import resetValuesFromResponse from '@/util/resetValuesFromResponse.js';
+import {
+    flatOptionsFromSiteGroups,
+    groupItemsBySiteGroup,
+    hasNamedSiteGroups,
+    selectedSiteGroupLabel,
+} from '@/util/site-groups.js';
 import { computed, ref } from 'vue';
 import { Pipeline, Request, BeforeSaveHooks, AfterSaveHooks, PipelineStopped } from '@ui/Publish/SavePipeline.js';
 import { router } from '@inertiajs/vue3';
@@ -514,12 +550,20 @@ export default {
         },
 
         originOptions() {
-            return this.localizations
+            const existing = this.localizations
                 .filter((localization) => localization.exists)
                 .map((localization) => ({
                     value: localization.handle,
                     label: localization.name,
+                    group: localization.group,
+                    group_handle: localization.group_handle,
                 }));
+
+            return flatOptionsFromSiteGroups(groupItemsBySiteGroup(existing));
+        },
+
+        originHasNamedGroups() {
+            return hasNamedSiteGroups(this.originOptions);
         },
 
         direction() {
@@ -722,6 +766,10 @@ export default {
         cancelLocalization() {
             this.selectingOrigin = false;
             this.localizing = false;
+        },
+
+        selectedOriginGroupLabel(option) {
+            return selectedSiteGroupLabel(option, this.originHasNamedGroups);
         },
 
         localizationStatusText(localization) {

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -243,6 +243,14 @@
                     >
                         <template #selected-option="{ option }">
                             <span class="flex min-w-0 items-center gap-1.5">
+                                <span
+                                    class="little-dot shrink-0"
+                                    :class="{
+                                        'bg-green-600': option.published,
+                                        'bg-gray-500': !option.published,
+                                        'bg-red-500': !option.exists,
+                                    }"
+                                />
                                 <template v-if="selectedOriginGroupLabel(option)">
                                     <span class="truncate">{{ selectedOriginGroupLabel(option) }}</span>
                                     <Icon name="chevron-right" class="size-3.5! text-gray-700 dark:text-white/70" aria-hidden="true" />
@@ -263,6 +271,20 @@
                                 class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
                                 :text="__(option._groupLabel)"
                             />
+                        </template>
+
+                        <template #option="option">
+                            <div class="flex min-w-0 items-center">
+                                <span
+                                    class="little-dot me-2 shrink-0"
+                                    :class="{
+                                        'bg-green-600': option.published,
+                                        'bg-gray-500': !option.published,
+                                        'bg-red-500': !option.exists,
+                                    }"
+                                />
+                                <span class="truncate">{{ __(option.label) }}</span>
+                            </div>
                         </template>
                     </Select>
                 </ui-field>
@@ -557,6 +579,8 @@ export default {
                     label: localization.name,
                     group: localization.group,
                     group_handle: localization.group_handle,
+                    published: localization.published,
+                    exists: localization.exists,
                 }));
 
             return flatOptionsFromSiteGroups(groupItemsBySiteGroup(existing));

--- a/resources/js/components/entries/PublishForm.vue
+++ b/resources/js/components/entries/PublishForm.vue
@@ -271,7 +271,7 @@
                                 v-if="option._groupLabel"
                                 size="sm"
                                 class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                                :text="__(option._groupLabel)"
+                                :text="option._groupLabel"
                             />
                         </template>
 

--- a/resources/js/components/fieldtypes/SitesIndexFieldtype.vue
+++ b/resources/js/components/fieldtypes/SitesIndexFieldtype.vue
@@ -1,0 +1,47 @@
+<template>
+    <div class="flex flex-wrap gap-x-3 gap-y-1">
+        <ItemLabel
+            v-for="(item, index) in items"
+            :key="index"
+            :item="item"
+            :group-label="groupLabel(item)"
+        />
+    </div>
+</template>
+
+<script>
+import IndexFieldtype from './IndexFieldtype.vue';
+import ItemLabel from '../inputs/relationship/ItemLabel.vue';
+import {
+    hasNamedSiteGroups,
+    selectedSiteGroupLabel,
+} from '@/util/site-groups.js';
+
+export default {
+    mixins: [IndexFieldtype],
+
+    components: {
+        ItemLabel,
+    },
+
+    computed: {
+        items() {
+            if (!this.value) {
+                return [];
+            }
+
+            return Array.isArray(this.value) ? this.value : [this.value];
+        },
+
+        namedGroupsExist() {
+            return hasNamedSiteGroups(Statamic.$config.get('sites') || []);
+        },
+    },
+
+    methods: {
+        groupLabel(item) {
+            return selectedSiteGroupLabel(item, this.namedGroupsExist);
+        },
+    },
+};
+</script>

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -129,7 +129,7 @@ export default {
             let key = field;
 
             if (relative && this.fieldPathPrefix) {
-                let dottedPrefix = this.fieldPathPrefix.replace(new RegExp('\.' + this.handle + '$'), '');
+                let dottedPrefix = this.fieldPathPrefix.replace(new RegExp('\\.' + this.handle + '$'), '');
                 key = dottedPrefix + '.' + field;
             }
 

--- a/resources/js/components/fieldtypes/SlugFieldtype.vue
+++ b/resources/js/components/fieldtypes/SlugFieldtype.vue
@@ -74,15 +74,17 @@ export default {
         source() {
             if (!this.generate) return;
 
-            const field = this.config.from || 'title';
-            let key = field;
+            const from = this.valueFrom(this.config.from || 'title', { relative: true });
 
-            if (this.fieldPathPrefix) {
-                let dottedPrefix = this.fieldPathPrefix.replace(new RegExp('\.' + this.handle + '$'), '');
-                key = dottedPrefix + '.' + field;
-            }
+            if (!from) return from;
 
-            return data_get(this.publishContainer?.values, key);
+            const prefix = this.config.prefix_from
+                ? this.valueFrom(this.config.prefix_from, { relative: false })
+                : null;
+
+            if (!prefix) return from;
+
+            return `${prefix} ${from}`;
         },
 
         language() {
@@ -121,6 +123,17 @@ export default {
             if (this.handle === 'slug' && container.name === this.publishContainer.name && this.config.localizable) {
                 this.$refs.slugify.reset();
             }
+        },
+
+        valueFrom(field, { relative }) {
+            let key = field;
+
+            if (relative && this.fieldPathPrefix) {
+                let dottedPrefix = this.fieldPathPrefix.replace(new RegExp('\.' + this.handle + '$'), '');
+                key = dottedPrefix + '.' + field;
+            }
+
+            return data_get(this.publishContainer?.values, key);
         },
 
         sync() {

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -36,7 +36,14 @@
                         @blur="blurred"
                     />
 
-                    <ui-button size="sm" v-if="canAddRows" v-text="__(addRowButtonLabel)" @click.prevent="addRow" />
+                    <Teleport
+                        v-if="canAddRows"
+                        :disabled="!usesExternalAddRow"
+                        defer
+                        :to="addRowTeleportTarget"
+                    >
+                        <ui-button size="sm" v-text="__(addRowButtonLabel)" @click.prevent="addRow" />
+                    </Teleport>
                 </section>
             </div>
         </element-container>
@@ -84,6 +91,10 @@ export default {
         isInGridField: true,
     },
 
+    inject: {
+        sectionAddRowTarget: { default: null },
+    },
+
     computed: {
         component() {
             const stackAt = this.config.stack_at ?? 550;
@@ -114,6 +125,16 @@ export default {
 
         addRowButtonLabel() {
             return __(this.config.add_row) || __('Add Row');
+        },
+
+        usesExternalAddRow() {
+            return !!this.sectionAddRowTarget && !!this.config.headers_in_section && !this.fullScreenMode;
+        },
+
+        addRowTeleportTarget() {
+            if (!this.usesExternalAddRow) return 'body';
+
+            return `[${this.sectionAddRowTarget}="${CSS.escape(this.handle)}"]`;
         },
 
         hasMaxRows() {
@@ -256,6 +277,7 @@ export default {
                 metaPathPrefix: { get: () => this.metaPathPrefix },
                 fullScreenMode: { get: () => this.fullScreenMode },
                 toggleFullScreen: { get: () => this.toggleFullScreen },
+                usesExternalAddRow: { get: () => this.usesExternalAddRow },
             });
             return grid;
         },

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -10,7 +10,7 @@
                 >
                 </publish-field-fullscreen-header>
 
-                <section :class="{ 'mt-14 p-4': fullScreenMode }">
+                <section ref="gridBody" :class="{ 'mt-14 p-4': fullScreenMode }">
 
                     <ui-error-message v-if="hasExcessRows" :text="__('Max Rows') + ': ' + maxRows" />
                     <ui-error-message v-else-if="hasNotEnoughRows" :text="__('Min Rows') + ': ' + minRows" />
@@ -207,6 +207,7 @@ export default {
 
             this.updateRowMeta(id, this.meta.new);
             this.update([...this.value, row]);
+            this.$nextTick(() => this.$nextTick(() => this.focusNewRow()));
         },
 
         updated(index, row) {
@@ -252,6 +253,23 @@ export default {
 
         focus() {
             // TODO
+        },
+
+        focusNewRow() {
+            const root = this.$refs.gridBody;
+
+            if (!root) return;
+
+            const row =
+                root.querySelector('.grid-table tbody tr:last-child') ||
+                root.querySelector('.grid-stacked > :last-child');
+
+            const focusable = row?.querySelector(
+                'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])',
+            );
+
+            focusable?.focus();
+            row?.scrollIntoView({ block: 'nearest' });
         },
 
         blurred() {

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -10,7 +10,7 @@
                 >
                 </publish-field-fullscreen-header>
 
-                <section ref="gridBody" :class="{ 'mt-14 p-4': fullScreenMode }">
+                <section :class="{ 'mt-14 p-4': fullScreenMode }">
 
                     <ui-error-message v-if="hasExcessRows" :text="__('Max Rows') + ': ' + maxRows" />
                     <ui-error-message v-else-if="hasNotEnoughRows" :text="__('Min Rows') + ': ' + minRows" />
@@ -207,7 +207,7 @@ export default {
 
             this.updateRowMeta(id, this.meta.new);
             this.update([...this.value, row]);
-            this.$nextTick(() => this.$nextTick(() => this.focusNewRow()));
+            this.focusNewRow(id);
         },
 
         updated(index, row) {
@@ -255,21 +255,21 @@ export default {
             // TODO
         },
 
-        focusNewRow() {
-            const root = this.$refs.gridBody;
-
-            if (!root) return;
-
-            const row =
-                root.querySelector('.grid-table tbody tr:last-child') ||
-                root.querySelector('.grid-stacked > :last-child');
-
+        focusNewRow(id, attempts = 0) {
+            const row = document.querySelector(`[data-grid-row-id="${CSS.escape(id)}"]`);
             const focusable = row?.querySelector(
                 'input:not([type="hidden"]):not([disabled]), textarea:not([disabled]), select:not([disabled])',
             );
 
-            focusable?.focus();
-            row?.scrollIntoView({ block: 'nearest' });
+            if (focusable) {
+                focusable.focus();
+                row.scrollIntoView({ block: 'nearest' });
+                return;
+            }
+
+            if (attempts < 20) {
+                requestAnimationFrame(() => this.focusNewRow(id, attempts + 1));
+            }
         },
 
         blurred() {

--- a/resources/js/components/fieldtypes/grid/Grid.vue
+++ b/resources/js/components/fieldtypes/grid/Grid.vue
@@ -207,7 +207,11 @@ export default {
 
             this.updateRowMeta(id, this.meta.new);
             this.update([...this.value, row]);
-            this.focusNewRow(id);
+
+            // Only auto-focus on Configure Sites sectioned grids, not every Grid in the CP.
+            if (this.config.headers_in_section) {
+                this.focusNewRow(id);
+            }
         },
 
         updated(index, row) {

--- a/resources/js/components/fieldtypes/grid/Row.vue
+++ b/resources/js/components/fieldtypes/grid/Row.vue
@@ -1,5 +1,8 @@
 <template>
-    <tr :class="[sortableItemClass, { 'opacity-50': isExcessive, 'inset-ring-1 inset-ring-red': hasError }]">
+    <tr
+        :data-grid-row-id="values._id"
+        :class="[sortableItemClass, { 'opacity-50': isExcessive, 'inset-ring-1 inset-ring-red': hasError }]"
+    >
         <td v-if="grid.isReorderable" class="drag-handle" :class="sortableHandleClass"></td>
 
         <FieldsProvider

--- a/resources/js/components/fieldtypes/grid/Stacked.vue
+++ b/resources/js/components/fieldtypes/grid/Stacked.vue
@@ -1,10 +1,11 @@
 <template>
-    <div :class="{ 'mb-4': rows.length > 0 }">
+    <div :class="{ 'mb-4': (rows.length > 0 || usesSectionRowSortable) && !grid.usesExternalAddRow }">
         <sortable-list
             :model-value="rows"
             :vertical="true"
             :item-class="sortableItemClass"
             :handle-class="sortableHandleClass"
+            :disabled="usesSectionRowSortable"
             append-to="body"
             constrain-dimensions
             @dragstart="$emit('focus')"
@@ -13,8 +14,10 @@
             v-slot="{}"
         >
             <div
+                ref="zone"
                 class="grid-stacked space-y-8"
                 :class="{
+                    'publish-section-row-zone min-h-16': usesSectionRowSortable,
                     // 'mt-0': !allowFullscreen && hideDisplay,
                     // 'mt-4': !hideDisplay,
                 }"

--- a/resources/js/components/fieldtypes/grid/StackedRow.vue
+++ b/resources/js/components/fieldtypes/grid/StackedRow.vue
@@ -2,6 +2,7 @@
     <div
         class="@container/panel bg-white dark:bg-gray-850 rounded-xl ring ring-gray-300 dark:ring-x-0 dark:ring-b-0 dark:ring-gray-700 shadow-ui-md"
         :class="[sortableItemClass, { 'opacity-50': isExcessive, 'ring-red-500': hasError }]"
+        :data-grid-row-id="values._id"
         :data-error="hasError ?? undefined"
     >
         <header class="bg-gray-50 dark:bg-gray-900 rounded-t-xl border-b border-gray-300 dark:border-gray-700 ps-4 pe-2 py-1.5 flex items-center justify-between">

--- a/resources/js/components/fieldtypes/grid/Table.vue
+++ b/resources/js/components/fieldtypes/grid/Table.vue
@@ -1,5 +1,12 @@
 <template>
-    <table class="grid-table" :class="{ 'mb-4': rows.length > 0 }" v-if="rows.length > 0">
+    <table
+        class="grid-table"
+        :class="{
+            'mb-4': (rows.length > 0 || usesSectionRowSortable) && !grid.usesExternalAddRow,
+            'grid-table--sectioned': showsHeadersInSection && !grid.fullScreenMode,
+        }"
+        v-if="rows.length > 0 || usesSectionRowSortable"
+    >
         <thead>
             <tr>
                 <th class="w-3" v-if="grid.isReorderable"></th>
@@ -12,13 +19,14 @@
             :vertical="true"
             :item-class="sortableItemClass"
             :handle-class="sortableHandleClass"
+            :disabled="usesSectionRowSortable"
             append-to="body"
             @dragstart="$emit('focus')"
             @dragend="$emit('blur')"
             @update:model-value="(rows) => $emit('sorted', rows)"
             v-slot="{}"
         >
-            <tbody>
+            <tbody ref="zone" :class="{ 'publish-section-row-zone': usesSectionRowSortable }">
                 <grid-row
                     v-for="(row, index) in rows"
                     :key="`row-${row._id}`"
@@ -40,6 +48,9 @@
                     @focus="$emit('focus')"
                     @blur="$emit('blur')"
                 />
+                <tr v-if="usesSectionRowSortable && !rows.length">
+                    <td :colspan="emptyColspan" class="h-16"></td>
+                </tr>
             </tbody>
         </sortable-list>
     </table>
@@ -58,6 +69,12 @@ export default {
         GridRow,
         GridHeaderCell,
         SortableList,
+    },
+
+    computed: {
+        emptyColspan() {
+            return this.fields.length + (this.grid.isReorderable ? 1 : 0) + 1;
+        },
     },
 };
 </script>

--- a/resources/js/components/fieldtypes/grid/View.vue
+++ b/resources/js/components/fieldtypes/grid/View.vue
@@ -10,6 +10,7 @@ export default {
     data() {
         return {
             errorsById: {},
+            sectionRowZoneEl: null,
         };
     },
 
@@ -96,13 +97,15 @@ export default {
         registerSectionRowZone() {
             if (!this.usesSectionRowSortable || !this.$refs.zone) return;
 
-            this.sectionRowSortable.register(this.$refs.zone, this.name);
+            this.sectionRowZoneEl = this.$refs.zone;
+            this.sectionRowSortable.register(this.sectionRowZoneEl, this.name);
         },
 
         unregisterSectionRowZone() {
-            if (!this.sectionRowSortable || !this.$refs.zone) return;
+            if (!this.sectionRowSortable || !this.sectionRowZoneEl) return;
 
-            this.sectionRowSortable.unregister(this.$refs.zone);
+            this.sectionRowSortable.unregister(this.sectionRowZoneEl);
+            this.sectionRowZoneEl = null;
         },
     },
 };

--- a/resources/js/components/fieldtypes/grid/View.vue
+++ b/resources/js/components/fieldtypes/grid/View.vue
@@ -2,7 +2,10 @@
 export default {
     props: ['fields', 'rows', 'meta', 'name', 'canDeleteRows', 'canAddRows', 'allowFullscreen', 'hideDisplay', 'errors', 'readOnly'],
 
-    inject: ['grid'],
+    inject: {
+        grid: 'grid',
+        sectionRowSortable: { default: null },
+    },
 
     data() {
         return {
@@ -11,12 +14,24 @@ export default {
     },
 
     computed: {
+        usesSectionRowSortable() {
+            return !!this.sectionRowSortable && this.grid.isReorderable;
+        },
+
         sortableItemClass() {
-            return `${this.name}-sortable-item`;
+            return this.usesSectionRowSortable
+                ? this.sectionRowSortable.itemClass
+                : `${this.name}-sortable-item`;
         },
 
         sortableHandleClass() {
-            return `${this.name}-drag-handle`;
+            return this.usesSectionRowSortable
+                ? this.sectionRowSortable.handleClass
+                : `${this.name}-drag-handle`;
+        },
+
+        showsHeadersInSection() {
+            return !!this.grid.config.headers_in_section;
         },
 
         fieldPathPrefix() {
@@ -56,6 +71,17 @@ export default {
                 }, {});
             },
         },
+        rows() {
+            this.$nextTick(() => this.registerSectionRowZone());
+        },
+    },
+
+    mounted() {
+        this.$nextTick(() => this.registerSectionRowZone());
+    },
+
+    unmounted() {
+        this.unregisterSectionRowZone();
     },
 
     methods: {
@@ -65,7 +91,19 @@ export default {
             }
 
             return this.errorsById.hasOwnProperty(id) && this.errorsById[id].length > 0;
-        }
+        },
+
+        registerSectionRowZone() {
+            if (!this.usesSectionRowSortable || !this.$refs.zone) return;
+
+            this.sectionRowSortable.register(this.$refs.zone, this.name);
+        },
+
+        unregisterSectionRowZone() {
+            if (!this.sectionRowSortable || !this.$refs.zone) return;
+
+            this.sectionRowSortable.unregister(this.$refs.zone);
+        },
     },
 };
 </script>

--- a/resources/js/components/global-header/SiteSelector.vue
+++ b/resources/js/components/global-header/SiteSelector.vue
@@ -14,10 +14,16 @@
             class="[&_[data-ui-combobox-trigger]]:text-white/85"
         >
             <template #selected-option="{ option }">
-                <div class="size-4">
+                <div class="size-4 shrink-0">
                     <Icon name="globe-arrow" class="text-gray-900 dark:text-white dark:opacity-50" />
                 </div>
-                <span class="block truncate">{{ __(':name Site', { name: option.name }) }}</span>
+                <span class="flex min-w-0 items-center gap-1.5">
+                    <template v-if="groupLabel(option)">
+                        <span class="truncate">{{ groupLabel(option) }}</span>
+                        <Icon name="chevron-right" class="size-3.5! opacity-75" aria-hidden="true" />
+                    </template>
+                    <span class="truncate">{{ __(':name Site', { name: option.name }) }}</span>
+                </span>
             </template>
         </Select>
     </div>
@@ -37,9 +43,21 @@ export default {
         active() {
             return Statamic.$config.get('selectedSite');
         },
+
+        hasNamedGroups() {
+            return this.sites.some((site) => site.group);
+        },
     },
 
     methods: {
+        groupLabel(option) {
+            if (option.group) {
+                return __(option.group);
+            }
+
+            return this.hasNamedGroups ? __('Other') : null;
+        },
+
         selected(siteHandle) {
             if (siteHandle !== this.active) {
                 window.location = cp_url(`select-site/${siteHandle}`);

--- a/resources/js/components/global-header/SiteSelector.vue
+++ b/resources/js/components/global-header/SiteSelector.vue
@@ -37,7 +37,7 @@
                     v-if="option._groupLabel"
                     size="sm"
                     class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                    :text="__(option._groupLabel)"
+                    :text="option._groupLabel"
                 />
             </template>
         </Select>

--- a/resources/js/components/global-header/SiteSelector.vue
+++ b/resources/js/components/global-header/SiteSelector.vue
@@ -2,8 +2,9 @@
     <div v-if="sites.length > 1" class="flex h-full items-center animate-in fade-in duration-750 fill-mode-forwards" data-ui-global-site-selector>
         <Select
             :model-value="active"
-            :options="sites"
+            :options="comboboxOptions"
             :searchable="false"
+            :virtualize="!hasNamedGroups"
             @update:model-value="selected"
             option-label="name"
             option-value="handle"
@@ -25,15 +26,35 @@
                     <span class="truncate">{{ __(':name Site', { name: option.name }) }}</span>
                 </span>
             </template>
+
+            <template v-if="hasNamedGroups" #before-option="option">
+                <div
+                    v-if="option._showGroupSeparator"
+                    class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
+                    role="separator"
+                />
+                <Subheading
+                    v-if="option._groupLabel"
+                    size="sm"
+                    class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                    :text="__(option._groupLabel)"
+                />
+            </template>
         </Select>
     </div>
 </template>
 
 <script>
-import { Icon, Select } from '@/components/ui';
+import { Icon, Select, Subheading } from '@/components/ui';
+import {
+    flatOptionsFromSiteGroups,
+    groupItemsBySiteGroup,
+    hasNamedSiteGroups,
+    selectedSiteGroupLabel,
+} from '@/util/site-groups.js';
 
 export default {
-    components: { Icon, Select },
+    components: { Icon, Select, Subheading },
 
     computed: {
         sites() {
@@ -45,17 +66,21 @@ export default {
         },
 
         hasNamedGroups() {
-            return this.sites.some((site) => site.group);
+            return hasNamedSiteGroups(this.sites);
+        },
+
+        comboboxOptions() {
+            if (!this.hasNamedGroups) {
+                return this.sites;
+            }
+
+            return flatOptionsFromSiteGroups(groupItemsBySiteGroup(this.sites));
         },
     },
 
     methods: {
         groupLabel(option) {
-            if (option.group) {
-                return __(option.group);
-            }
-
-            return this.hasNamedGroups ? __('Other') : null;
+            return selectedSiteGroupLabel(option, this.hasNamedGroups);
         },
 
         selected(siteHandle) {

--- a/resources/js/components/globals/Sites.vue
+++ b/resources/js/components/globals/Sites.vue
@@ -15,30 +15,61 @@
             </tr>
         </thead>
         <tbody>
-            <tr v-for="site in sites" :key="site.handle">
-                <td class="grid-cell">
-                    <div class="flex items-center gap-2">
-                        <Switch v-model="site.enabled" />
-                        <Heading :text="__(site.name)" />
-                    </div>
-                </td>
-                <td class="grid-cell">
-                    <Select
-                        class="w-full"
-                        :options="siteOriginOptions(site)"
-                        :clearable="true"
-                        :model-value="site.origin"
-                        @update:model-value="site.origin = $event"
-                    />
-                </td>
-            </tr>
+            <template v-for="group in siteGroups" :key="group.key">
+                <tr v-if="hasNamedGroups">
+                    <td colspan="2" class="bg-gray-50 dark:bg-gray-800 !py-2">
+                        <Subheading
+                            size="sm"
+                            class="px-1 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                            :text="__(group.label)"
+                        />
+                    </td>
+                </tr>
+                <tr v-for="site in group.items" :key="site.handle">
+                    <td class="grid-cell">
+                        <div class="flex items-center gap-2">
+                            <Switch v-model="site.enabled" />
+                            <Heading :text="__(site.name)" />
+                        </div>
+                    </td>
+                    <td class="grid-cell">
+                        <Select
+                            class="w-full"
+                            :options="siteOriginOptions(site)"
+                            :clearable="true"
+                            :virtualize="!hasNamedGroups"
+                            :model-value="site.origin"
+                            @update:model-value="site.origin = $event"
+                        >
+                            <template v-if="hasNamedGroups" #before-option="option">
+                                <div
+                                    v-if="option._showGroupSeparator"
+                                    class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
+                                    role="separator"
+                                />
+                                <Subheading
+                                    v-if="option._groupLabel"
+                                    size="sm"
+                                    class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                                    :text="__(option._groupLabel)"
+                                />
+                            </template>
+                        </Select>
+                    </td>
+                </tr>
+            </template>
         </tbody>
     </table>
 </template>
 
 <script>
 import Fieldtype from '../fieldtypes/Fieldtype.vue';
-import { Switch, Heading, Select } from '@/components/ui';
+import { Switch, Heading, Select, Subheading } from '@/components/ui';
+import {
+    flatOptionsFromSiteGroups,
+    groupItemsBySiteGroup,
+    hasNamedSiteGroups,
+} from '@/util/site-groups.js';
 
 export default {
     mixins: [Fieldtype],
@@ -47,6 +78,7 @@ export default {
         Switch,
         Heading,
         Select,
+        Subheading,
     },
 
     data() {
@@ -55,17 +87,41 @@ export default {
         };
     },
 
+    computed: {
+        hasNamedGroups() {
+            return hasNamedSiteGroups(this.sites);
+        },
+
+        siteGroups() {
+            return groupItemsBySiteGroup(this.sites);
+        },
+    },
+
     watch: {
-        sites(sites) {
-            this.update(sites);
+        sites: {
+            deep: true,
+            handler(sites) {
+                this.update(sites);
+            },
         },
     },
 
     methods: {
         siteOriginOptions(site) {
-            return this.sites
-                .map((s) => ({ value: s.handle, label: __(s.name) }))
-                .filter((s) => s.value !== site.handle);
+            const options = this.sites
+                .filter((s) => s.handle !== site.handle)
+                .map((s) => ({
+                    value: s.handle,
+                    label: __(s.name),
+                    group: s.group,
+                    group_handle: s.group_handle,
+                }));
+
+            if (!this.hasNamedGroups) {
+                return options;
+            }
+
+            return flatOptionsFromSiteGroups(groupItemsBySiteGroup(options));
         },
     },
 };

--- a/resources/js/components/globals/Sites.vue
+++ b/resources/js/components/globals/Sites.vue
@@ -21,7 +21,7 @@
                         <Subheading
                             size="sm"
                             class="px-1 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                            :text="__(group.label)"
+                            :text="group.label"
                         />
                     </td>
                 </tr>
@@ -62,7 +62,7 @@
                                         v-if="option._groupLabel"
                                         size="sm"
                                         class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                                        :text="__(option._groupLabel)"
+                                        :text="option._groupLabel"
                                     />
                                 </template>
                             </template>

--- a/resources/js/components/globals/Sites.vue
+++ b/resources/js/components/globals/Sites.vue
@@ -41,18 +41,30 @@
                             :model-value="site.origin"
                             @update:model-value="site.origin = $event"
                         >
-                            <template v-if="hasNamedGroups" #before-option="option">
-                                <div
-                                    v-if="option._showGroupSeparator"
-                                    class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
-                                    role="separator"
-                                />
-                                <Subheading
-                                    v-if="option._groupLabel"
-                                    size="sm"
-                                    class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                                    :text="__(option._groupLabel)"
-                                />
+                            <template #selected-option="{ option }">
+                                <span v-if="option" class="flex min-w-0 items-center gap-1.5">
+                                    <template v-if="originGroupLabel(option)">
+                                        <span class="truncate">{{ originGroupLabel(option) }}</span>
+                                        <Icon name="chevron-right" class="size-3.5! shrink-0 text-gray-700 dark:text-white/70" aria-hidden="true" />
+                                    </template>
+                                    <span class="truncate">{{ option.label }}</span>
+                                </span>
+                            </template>
+
+                            <template #before-option="option">
+                                <template v-if="hasNamedGroups">
+                                    <div
+                                        v-if="option._showGroupSeparator"
+                                        class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
+                                        role="separator"
+                                    />
+                                    <Subheading
+                                        v-if="option._groupLabel"
+                                        size="sm"
+                                        class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                                        :text="__(option._groupLabel)"
+                                    />
+                                </template>
                             </template>
                         </Select>
                     </td>
@@ -64,17 +76,19 @@
 
 <script>
 import Fieldtype from '../fieldtypes/Fieldtype.vue';
-import { Switch, Heading, Select, Subheading } from '@/components/ui';
+import { Icon, Switch, Heading, Select, Subheading } from '@/components/ui';
 import {
     flatOptionsFromSiteGroups,
     groupItemsBySiteGroup,
     hasNamedSiteGroups,
+    selectedSiteGroupLabel,
 } from '@/util/site-groups.js';
 
 export default {
     mixins: [Fieldtype],
 
     components: {
+        Icon,
         Switch,
         Heading,
         Select,
@@ -83,7 +97,7 @@ export default {
 
     data() {
         return {
-            sites: this.value,
+            sites: this.value ?? [],
         };
     },
 
@@ -93,11 +107,15 @@ export default {
         },
 
         siteGroups() {
-            return groupItemsBySiteGroup(this.sites);
+            return groupItemsBySiteGroup(this.sites ?? []);
         },
     },
 
     watch: {
+        value(value) {
+            this.sites = value ?? [];
+        },
+
         sites: {
             deep: true,
             handler(sites) {
@@ -107,8 +125,16 @@ export default {
     },
 
     methods: {
+        originGroupLabel(option) {
+            if (!option || !this.hasNamedGroups) {
+                return null;
+            }
+
+            return selectedSiteGroupLabel(option, true);
+        },
+
         siteOriginOptions(site) {
-            const options = this.sites
+            const options = (this.sites ?? [])
                 .filter((s) => s.handle !== site.handle)
                 .map((s) => ({
                     value: s.handle,

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -119,7 +119,7 @@ export default {
                 return null;
             }
 
-            return __(this.itemWithSiteGroup.group);
+            return this.itemWithSiteGroup.group;
         },
 
         itemWithSiteGroup() {

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -74,7 +74,6 @@ import { getActivePinia } from 'pinia';
 import InlineEditForm from './InlineEditForm.vue';
 import ItemLabel from './ItemLabel.vue';
 import { Button, Dropdown, DropdownMenu, DropdownItem, publishContextKey as containerContextKey } from '@/components/ui';
-import { selectedSiteGroupLabel } from '@/util/site-groups.js';
 
 export default {
     components: {
@@ -115,22 +114,12 @@ export default {
             return __(this.item.title);
         },
 
-        sitesHaveNamedGroups() {
-            if (this.config?.type !== 'sites') {
-                return false;
-            }
-
-            const sites = Statamic.$config.get('sites') || [];
-
-            return sites.some((site) => site.group);
-        },
-
         groupLabel() {
-            if (this.config?.type !== 'sites') {
+            if (this.config?.type !== 'sites' || !this.itemWithSiteGroup.group) {
                 return null;
             }
 
-            return selectedSiteGroupLabel(this.itemWithSiteGroup, this.sitesHaveNamedGroups);
+            return __(this.itemWithSiteGroup.group);
         },
 
         itemWithSiteGroup() {

--- a/resources/js/components/inputs/relationship/Item.vue
+++ b/resources/js/components/inputs/relationship/Item.vue
@@ -9,20 +9,24 @@
             <div
                 v-if="item.invalid"
                 v-tooltip.top="__('messages.relationship_item_unavailable')"
-                v-text="__(item.title)"
                 class="line-clamp-1 text-sm text-gray-500 dark:text-gray-400"
-            />
+            >
+                <ItemLabel :item="item" :group-label="groupLabel" />
+            </div>
 
             <a
                 v-if="!item.invalid && editable"
                 @click.prevent="edit"
-                v-text="__(item.title)"
                 class="line-clamp-1 text-sm text-gray-600 dark:text-gray-300"
-                v-tooltip="item.title"
+                v-tooltip="itemTitle"
                 :href="item.edit_url"
-            />
+            >
+                <ItemLabel :item="item" :group-label="groupLabel" />
+            </a>
 
-            <div v-if="!item.invalid && !editable" v-text="__(item.title)" />
+            <div v-if="!item.invalid && !editable" class="line-clamp-1">
+                <ItemLabel :item="item" :group-label="groupLabel" />
+            </div>
 
             <inline-edit-form
                 v-if="isEditing"
@@ -68,7 +72,9 @@
 <script>
 import { getActivePinia } from 'pinia';
 import InlineEditForm from './InlineEditForm.vue';
+import ItemLabel from './ItemLabel.vue';
 import { Button, Dropdown, DropdownMenu, DropdownItem, publishContextKey as containerContextKey } from '@/components/ui';
+import { selectedSiteGroupLabel } from '@/util/site-groups.js';
 
 export default {
     components: {
@@ -77,6 +83,7 @@ export default {
         DropdownMenu,
         Dropdown,
         InlineEditForm,
+        ItemLabel,
     },
 
     inject: {
@@ -101,6 +108,48 @@ export default {
         return {
             isEditing: false,
         };
+    },
+
+    computed: {
+        itemTitle() {
+            return __(this.item.title);
+        },
+
+        sitesHaveNamedGroups() {
+            if (this.config?.type !== 'sites') {
+                return false;
+            }
+
+            const sites = Statamic.$config.get('sites') || [];
+
+            return sites.some((site) => site.group);
+        },
+
+        groupLabel() {
+            if (this.config?.type !== 'sites') {
+                return null;
+            }
+
+            return selectedSiteGroupLabel(this.itemWithSiteGroup, this.sitesHaveNamedGroups);
+        },
+
+        itemWithSiteGroup() {
+            if (this.item.group || this.item.group_handle) {
+                return this.item;
+            }
+
+            const site = (Statamic.$config.get('sites') || []).find((site) => site.handle === this.item.id);
+
+            if (!site) {
+                return this.item;
+            }
+
+            return {
+                ...this.item,
+                group: site.group,
+                group_handle: site.group_handle,
+            };
+        },
     },
 
     methods: {

--- a/resources/js/components/inputs/relationship/ItemLabel.vue
+++ b/resources/js/components/inputs/relationship/ItemLabel.vue
@@ -1,0 +1,22 @@
+<template>
+    <span class="inline-flex min-w-0 items-center gap-1.5">
+        <template v-if="groupLabel">
+            <span class="truncate">{{ groupLabel }}</span>
+            <Icon name="chevron-right" class="size-3.5! shrink-0 text-gray-700 dark:text-white/70" aria-hidden="true" />
+        </template>
+        <span class="truncate">{{ __(item.title) }}</span>
+    </span>
+</template>
+
+<script>
+import { Icon } from '@/components/ui';
+
+export default {
+    components: { Icon },
+
+    props: {
+        item: { type: Object, required: true },
+        groupLabel: { type: String, default: null },
+    },
+};
+</script>

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -29,7 +29,7 @@
                     v-if="option._groupLabel"
                     size="sm"
                     class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                    :text="__(option._groupLabel)"
+                    :text="option._groupLabel"
                 />
             </template>
             <template #option="{ title, hint, status }">

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -3,7 +3,7 @@
         <Combobox
             searchable
             :disabled="config.disabled"
-            :ignore-filter="typeahead"
+            :ignore-filter="typeahead || hasNamedGroups"
             :max-selections="maxSelections"
             :model-value="items.map((item) => item.id)"
             :multiple
@@ -13,11 +13,25 @@
             :taggable="isTaggable"
             :close-on-select="isTaggable"
             :search-keys="searchKeys"
+            :virtualize="!hasNamedGroups"
             option-label="title"
             option-value="id"
             @update:modelValue="itemsSelected"
-            @search="search"
+            @search="onSearch"
         >
+            <template #before-option="option" v-if="hasNamedGroups">
+                <div
+                    v-if="option._showGroupSeparator"
+                    class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
+                    role="separator"
+                />
+                <Subheading
+                    v-if="option._groupLabel"
+                    size="sm"
+                    class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                    :text="__(option._groupLabel)"
+                />
+            </template>
             <template #option="{ title, hint, status }">
                 <div class="flex w-full text-left items-center gap-2">
                     <StatusIndicator v-if="status" :status="status" />
@@ -40,10 +54,16 @@
 </template>
 
 <script>
-import { Combobox, StatusIndicator } from '@/components/ui';
+import { Combobox, StatusIndicator, Subheading } from '@/components/ui';
+import {
+    flatOptionsFromSiteGroups,
+    groupItemsBySiteGroup,
+    hasNamedSiteGroups,
+} from '@/util/site-groups.js';
 import { ref, watch } from 'vue';
 import { router } from '@inertiajs/vue3';
 import axios from 'axios';
+import fuzzysort from 'fuzzysort';
 
 const optionsCache = ref({});
 const loaders = ref({});
@@ -52,6 +72,7 @@ export default {
     components: {
         StatusIndicator,
         Combobox,
+        Subheading,
     },
 
     props: {
@@ -70,6 +91,7 @@ export default {
         return {
             requested: false,
             options: [],
+            searchQuery: '',
             abortController: null,
             removeNavigationListener: null,
         };
@@ -102,12 +124,30 @@ export default {
 			return JSON.stringify({ ...this.parameters, url: this.url });
 	    },
 
-        comboboxOptions() {
+        rawOptions() {
             // Combobox resolves the selected label from this list, so a selected item missing
             // from it (e.g. a just-created term) would otherwise display as its raw id.
             const missing = this.items.filter((item) => !this.options.some((option) => option.id === item.id));
 
             return [...this.options, ...missing];
+        },
+
+        hasNamedGroups() {
+            return hasNamedSiteGroups(this.rawOptions);
+        },
+
+        comboboxOptions() {
+            if (!this.hasNamedGroups) {
+                return this.rawOptions;
+            }
+
+            const query = this.searchQuery;
+
+            return flatOptionsFromSiteGroups(groupItemsBySiteGroup(this.rawOptions), {
+                filterItems: (items) => query
+                    ? fuzzysort.go(query, items, { keys: ['title', 'group', 'id'] }).map((result) => result.obj)
+                    : items,
+            });
         },
 
         noOptionsText() {
@@ -175,6 +215,16 @@ export default {
             loading(true);
 
             this.request({ search }).then((response) => loading(false));
+        },
+
+        onSearch(query, loading) {
+            if (this.typeahead) {
+                this.search(query, loading);
+
+                return;
+            }
+
+            this.searchQuery = query;
         },
 
         itemsSelected(items) {

--- a/resources/js/components/terms/PublishForm.vue
+++ b/resources/js/components/terms/PublishForm.vue
@@ -103,6 +103,7 @@
                                 v-if="showLocalizationSelector"
                                 :localizations
                                 :localizing
+                                :confirming-switch="!!pendingLocalization"
                                 @selected="localizationSelected"
                             />
                         </div>

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -73,6 +73,8 @@ const props = defineProps({
 	variant: { type: String, default: 'default' },
 	/** When `true`, skip the elevated z-index override while a modal/stack is open. Use when this combobox can remain open behind an unrelated overlay (e.g. a confirmation modal). */
 	excludeZManipulation: { type: Boolean, default: false },
+	/** When `false`, options are rendered without virtualization. Useful for variable-height options. */
+	virtualize: { type: Boolean, default: true },
 });
 
 defineOptions({
@@ -491,7 +493,7 @@ defineExpose({
                                 </ComboboxEmpty>
 
                                 <ComboboxVirtualizer
-                                    v-if="filteredOptions.length"
+                                    v-if="virtualize && filteredOptions.length"
                                     :estimate-size="40"
                                     :options="filteredOptions"
                                     :text-content="(opt) => getOptionLabel(opt)"
@@ -517,6 +519,31 @@ defineExpose({
                                         </ComboboxItem>
                                     </div>
                                 </ComboboxVirtualizer>
+
+                                <template v-else-if="filteredOptions.length">
+                                    <div
+                                        v-for="option in filteredOptions"
+                                        :key="`${getOptionValue(option)}-${isDisabled(option)}`"
+                                        class="py-1 px-2 w-full overflow-x-hidden"
+                                    >
+                                        <ComboboxItem
+                                            as="button"
+                                            :value="getOptionValue(option)"
+                                            :text-value="getOptionLabel(option)"
+                                            :disabled="isDisabled(option)"
+                                            :class="itemClasses({ size: size, selected: isSelected(option) })"
+                                            :data-ui-combobox-item="getOptionValue(option)"
+                                            :title="getOptionLabel(option)"
+                                            @select="select"
+                                        >
+                                            <slot name="option" v-bind="option">
+                                                <img v-if="option.image" :src="option.image" class="size-5 rounded-full" :alt="getOptionLabel(option)">
+                                                <span v-if="labelHtml" class="truncate" v-html="getOptionLabel(option)" />
+                                                <span class="truncate" v-else>{{ __(getOptionLabel(option)) }}</span>
+                                            </slot>
+                                        </ComboboxItem>
+                                    </div>
+                                </template>
                             </div>
                         </FocusScope>
                     </ComboboxContent>

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -478,7 +478,7 @@ defineExpose({
                                 event.preventDefault();
                             }"
                         >
-                            <div class="relative max-h-[300px] overflow-y-auto py-2 st-custom-scrollbar" data-ui-combobox-viewport>
+                            <div class="relative max-h-[300px] overflow-y-auto py-1.5 pb-2 st-custom-scrollbar" data-ui-combobox-viewport>
                                 <!-- Hidden width measurer for wide dropdown mode -->
                                 <div v-if="adaptiveWidth" aria-hidden="true" class="h-0 overflow-y-clip px-2">
                                     <div v-for="option in filteredOptions" :key="getOptionValue(option)" class="py-1.5 px-2 text-sm whitespace-nowrap">

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -478,7 +478,7 @@ defineExpose({
                                 event.preventDefault();
                             }"
                         >
-                            <div class="relative max-h-[300px] overflow-y-auto py-2" data-ui-combobox-viewport>
+                            <div class="relative max-h-[300px] overflow-y-auto py-2 st-custom-scrollbar" data-ui-combobox-viewport>
                                 <!-- Hidden width measurer for wide dropdown mode -->
                                 <div v-if="adaptiveWidth" aria-hidden="true" class="h-0 overflow-y-clip px-2">
                                     <div v-for="option in filteredOptions" :key="getOptionValue(option)" class="py-1.5 px-2 text-sm whitespace-nowrap">

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -461,7 +461,7 @@ defineExpose({
                         :side-offset="5"
                         position="popper"
                         :class="[
-                            'shadow-ui-sm z-(--z-index-above) rounded-lg border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-800',
+                            'shadow-ui-sm z-(--z-index-above) rounded-md !rounded-se-sm border border-gray-200 bg-white dark:border-white/10 dark:bg-gray-800',
                             'max-h-[var(--reka-combobox-content-available-height)] min-w-[var(--reka-combobox-trigger-width)] overflow-hidden',
                             adaptiveWidth && 'w-max max-w-md',
                         ]"

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -524,24 +524,27 @@ defineExpose({
                                     <div
                                         v-for="option in filteredOptions"
                                         :key="`${getOptionValue(option)}-${isDisabled(option)}`"
-                                        class="py-1 px-2 w-full overflow-x-hidden"
+                                        class="w-full overflow-x-hidden"
                                     >
-                                        <ComboboxItem
-                                            as="button"
-                                            :value="getOptionValue(option)"
-                                            :text-value="getOptionLabel(option)"
-                                            :disabled="isDisabled(option)"
-                                            :class="itemClasses({ size: size, selected: isSelected(option) })"
-                                            :data-ui-combobox-item="getOptionValue(option)"
-                                            :title="getOptionLabel(option)"
-                                            @select="select"
-                                        >
-                                            <slot name="option" v-bind="option">
-                                                <img v-if="option.image" :src="option.image" class="size-5 rounded-full" :alt="getOptionLabel(option)">
-                                                <span v-if="labelHtml" class="truncate" v-html="getOptionLabel(option)" />
-                                                <span class="truncate" v-else>{{ __(getOptionLabel(option)) }}</span>
-                                            </slot>
-                                        </ComboboxItem>
+                                        <slot name="before-option" v-bind="option" />
+                                        <div class="py-1 px-2">
+                                            <ComboboxItem
+                                                as="button"
+                                                :value="getOptionValue(option)"
+                                                :text-value="getOptionLabel(option)"
+                                                :disabled="isDisabled(option)"
+                                                :class="itemClasses({ size: size, selected: isSelected(option) })"
+                                                :data-ui-combobox-item="getOptionValue(option)"
+                                                :title="getOptionLabel(option)"
+                                                @select="select"
+                                            >
+                                                <slot name="option" v-bind="option">
+                                                    <img v-if="option.image" :src="option.image" class="size-5 rounded-full" :alt="getOptionLabel(option)">
+                                                    <span v-if="labelHtml" class="truncate" v-html="getOptionLabel(option)" />
+                                                    <span class="truncate" v-else>{{ __(getOptionLabel(option)) }}</span>
+                                                </slot>
+                                            </ComboboxItem>
+                                        </div>
                                     </div>
                                 </template>
                             </div>

--- a/resources/js/components/ui/Publish/Localization.vue
+++ b/resources/js/components/ui/Publish/Localization.vue
@@ -14,8 +14,8 @@ defineProps({
 </script>
 
 <template>
-    <div class="flex items-center justify-between gap-x-2">
-        <div class="flex flex-1 items-center" :class="{ 'line-through opacity-50': !localization.exists }">
+    <div class="flex items-center gap-x-2">
+        <div class="flex min-w-0 items-center" :class="{ 'line-through opacity-50': !localization.exists }">
             <span
                 class="little-dot me-2"
                 :class="{
@@ -24,13 +24,11 @@ defineProps({
                      'bg-red-500': !localization.exists,
                 }"
             />
-            {{ __(localization.name) }}
+            <span class="truncate">{{ __(localization.name) }}</span>
             <Icon name="loading" class="ms-2" v-if="localizing === localization.handle" />
         </div>
-        <div class="flex items-center gap-1.5">
-            <Badge size="sm" color="orange" v-if="localization.origin" :text="__('Origin')" />
-            <Badge size="sm" color="blue" v-if="localization.active" :text="__('Active')" />
-            <Badge size="sm" color="purple" v-if="localization.root && !localization.origin && !localization.active" :text="__('Root')" />
-        </div>
+        <Badge size="sm" color="orange" v-if="localization.origin" :text="__('Origin')" />
+        <Badge size="sm" color="blue" v-if="localization.active" :text="__('Active')" />
+        <Badge size="sm" color="purple" v-if="localization.root && !localization.origin && !localization.active" :text="__('Root')" />
     </div>
 </template>

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -183,7 +183,7 @@ function selectedGroupLabel(option) {
                             v-if="option._groupLabel"
                             size="sm"
                             class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
-                            :text="__(option._groupLabel)"
+                            :text="option._groupLabel"
                         />
                     </template>
 

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -163,7 +163,7 @@ function selectedGroupLabel(option) {
                         <span class="flex min-w-0 items-center gap-1.5">
                             <template v-if="selectedGroupLabel(option)">
                                 <span class="truncate">{{ selectedGroupLabel(option) }}</span>
-                                <Icon name="chevron-right" class="size-3.5! shrink-0 text-gray-400 dark:text-white/40" aria-hidden="true" />
+                                <Icon name="chevron-right" class="size-3.5! text-gray-700 dark:text-white/70" aria-hidden="true" />
                             </template>
                             <span class="truncate">{{ __(option.name) }}</span>
                         </span>

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -135,7 +135,7 @@ function handleSearch(query) {
                         <span class="flex min-w-0 items-center gap-1.5">
                             <template v-if="option.group">
                                 <span class="truncate">{{ __(option.group) }}</span>
-                                <Icon name="chevron-right" class="size-3.5 shrink-0 text-gray-400 dark:text-white/40" aria-hidden="true" />
+                                <Icon name="chevron-right" class="size-3.5! text-gray-400 dark:text-white/40" aria-hidden="true" />
                             </template>
                             <span class="truncate">{{ __(option.name) }}</span>
                         </span>
@@ -145,13 +145,13 @@ function handleSearch(query) {
                         <div class="flex w-full min-w-0 flex-col">
                             <div
                                 v-if="option._showGroupSeparator"
-                                class="mb-1 border-t border-gray-200 dark:border-gray-700"
+                                class="mb-3 -mt-1.5 -mx-2 border-t border-gray-200 dark:border-gray-700"
                                 role="separator"
                             />
                             <Subheading
                                 v-if="option._groupLabel"
                                 size="sm"
-                                class="-mx-0.5 px-0.5 pb-1.5 pt-0.5 font-semibold uppercase tracking-wide"
+                                class="-mx-2 px-0.5 pb-3 pt-0.5 font-semibold uppercase text-gray-950 text-2xs"
                                 :text="__(option._groupLabel)"
                             />
                             <Localization :localization="option" :localizing />

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -81,9 +81,13 @@ const selectedLabel = computed(() => {
 
     if (!active) return '';
 
-    const name = __(active.name);
+    return __(active.name);
+});
 
-    return active.group ? `${__(active.group)} / ${name}` : name;
+const selectedGroup = computed(() => {
+    const active = activeLocalization.value;
+
+    return active?.group ? __(active.group) : null;
 });
 
 function selectLocalization(localization) {
@@ -117,7 +121,13 @@ function selectLocalization(localization) {
                             :id="comboboxId"
                             class="flex h-10 w-full cursor-pointer items-center justify-between rounded-lg border border-gray-300 bg-linear-to-b from-white to-gray-50 px-4 text-md text-gray-900 shadow-ui-sm focus-within:focus-outline dark:border-gray-700 dark:from-gray-850 dark:to-gray-900 dark:text-gray-300 dark:shadow-ui-md"
                         >
-                            <span class="block truncate text-start">{{ selectedLabel }}</span>
+                            <span class="flex min-w-0 items-center gap-1.5 text-start">
+                                <template v-if="selectedGroup">
+                                    <span class="truncate">{{ selectedGroup }}</span>
+                                    <Icon name="chevron-right" class="size-3.5 shrink-0 text-gray-400 dark:text-white/40" aria-hidden="true" />
+                                </template>
+                                <span class="truncate">{{ selectedLabel }}</span>
+                            </span>
                             <Icon name="chevron-down" class="ms-1.5 size-4 text-gray-400 dark:text-white/40" aria-hidden="true" />
                         </ComboboxTrigger>
                     </ComboboxAnchor>

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -144,7 +144,7 @@ function handleSearch(query) {
                     <template #before-option="option">
                         <div
                             v-if="option._showGroupSeparator"
-                            class="mx-2 mb-1 mt-1 border-t border-gray-200 dark:border-gray-700"
+                            class="mx-2 mb-2.25 mt-0.75 border-t border-gray-200 dark:border-gray-700"
                             role="separator"
                         />
                         <Subheading

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -141,21 +141,22 @@ function handleSearch(query) {
                         </span>
                     </template>
 
+                    <template #before-option="option">
+                        <div
+                            v-if="option._showGroupSeparator"
+                            class="mx-2 mb-1 mt-1 border-t border-gray-200 dark:border-gray-700"
+                            role="separator"
+                        />
+                        <Subheading
+                            v-if="option._groupLabel"
+                            size="sm"
+                            class="px-2.5 pb-1 pt-1.5 font-semibold uppercase tracking-wide text-gray-950 text-2xs dark:text-gray-300"
+                            :text="__(option._groupLabel)"
+                        />
+                    </template>
+
                     <template #option="option">
-                        <div class="flex w-full min-w-0 flex-col">
-                            <div
-                                v-if="option._showGroupSeparator"
-                                class="mb-3 -mt-1.5 -mx-2 border-t border-gray-200 dark:border-gray-700"
-                                role="separator"
-                            />
-                            <Subheading
-                                v-if="option._groupLabel"
-                                size="sm"
-                                class="-mx-2 px-0.5 pb-3 pt-0.5 font-semibold uppercase text-gray-950 text-2xs"
-                                :text="__(option._groupLabel)"
-                            />
-                            <Localization :localization="option" :localizing />
-                        </div>
+                        <Localization :localization="option" :localizing />
                     </template>
                 </Combobox>
             </template>

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -10,6 +10,12 @@ import {
 import { computed, ref, useId, watch } from 'vue';
 import fuzzysort from 'fuzzysort';
 import Localization from './Localization.vue';
+import {
+    flatOptionsFromSiteGroups,
+    groupItemsBySiteGroup,
+    hasNamedSiteGroups,
+    selectedSiteGroupLabel,
+} from '@/util/site-groups.js';
 
 const props = defineProps({
     localizations: {
@@ -27,8 +33,6 @@ const props = defineProps({
 });
 
 const emit = defineEmits(['selected']);
-
-const UNGROUPED_KEY = 'other';
 
 const comboboxId = useId();
 const searchQuery = ref('');
@@ -58,61 +62,21 @@ const selectedLocalization = computed(() => {
     return activeLocalization.value;
 });
 
-const localizationGroups = computed(() => {
-    const groups = [];
-    const indexByKey = new Map();
+const localizationGroups = computed(() => groupItemsBySiteGroup(props.localizations));
 
-    for (const localization of props.localizations) {
-        const isUngrouped = !localization.group && !localization.group_handle;
-        const key = isUngrouped
-            ? UNGROUPED_KEY
-            : (localization.group_handle || localization.group);
-        const label = isUngrouped ? __('Other') : localization.group;
-
-        if (!indexByKey.has(key)) {
-            indexByKey.set(key, groups.length);
-            groups.push({ key, label, localizations: [] });
-        }
-
-        groups[indexByKey.get(key)].localizations.push(localization);
-    }
-
-    const named = groups.filter((group) => group.key !== UNGROUPED_KEY);
-    const other = groups.filter((group) => group.key === UNGROUPED_KEY);
-
-    return [...named, ...other];
-});
-
-const hasNamedGroups = computed(() => localizationGroups.value.some((group) => group.key !== UNGROUPED_KEY));
+const hasNamedGroups = computed(() => hasNamedSiteGroups(localizationGroups.value));
 
 const useCombobox = computed(() => hasNamedGroups.value || props.localizations.length > 5);
 
 const comboboxOptions = computed(() => {
     const query = searchQuery.value;
-    let isFirstVisibleOption = true;
 
-    return localizationGroups.value.flatMap((group) => {
-        const localizations = query
+    return flatOptionsFromSiteGroups(localizationGroups.value, {
+        filterItems: (localizations) => query
             ? fuzzysort
-                .go(query, group.localizations, { keys: ['name', 'group', 'handle'] })
+                .go(query, localizations, { keys: ['name', 'group', 'handle'] })
                 .map((result) => result.obj)
-            : group.localizations;
-
-        if (!localizations.length) {
-            return [];
-        }
-
-        return localizations.map((localization, index) => {
-            const option = {
-                ...localization,
-                _groupLabel: index === 0 ? group.label : null,
-                _showGroupSeparator: index === 0 && !isFirstVisibleOption,
-            };
-
-            isFirstVisibleOption = false;
-
-            return option;
-        });
+            : localizations,
     });
 });
 
@@ -129,11 +93,7 @@ function handleSearch(query) {
 }
 
 function selectedGroupLabel(option) {
-    if (option.group) {
-        return __(option.group);
-    }
-
-    return hasNamedGroups.value ? __('Other') : null;
+    return selectedSiteGroupLabel(option, hasNamedGroups.value);
 }
 </script>
 

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -47,13 +47,18 @@ const activeLocalization = computed(() => {
     return props.localizations.find((localization) => localization.active);
 });
 
+const UNGROUPED_KEY = 'other';
+
 const localizationGroups = computed(() => {
     const groups = [];
     const indexByKey = new Map();
 
     for (const localization of props.localizations) {
-        const key = localization.group_handle || localization.group || '__ungrouped__';
-        const label = localization.group || null;
+        const isUngrouped = !localization.group && !localization.group_handle;
+        const key = isUngrouped
+            ? UNGROUPED_KEY
+            : (localization.group_handle || localization.group);
+        const label = isUngrouped ? __('Other') : localization.group;
 
         if (!indexByKey.has(key)) {
             indexByKey.set(key, groups.length);
@@ -63,10 +68,13 @@ const localizationGroups = computed(() => {
         groups[indexByKey.get(key)].localizations.push(localization);
     }
 
-    return groups;
+    const named = groups.filter((group) => group.key !== UNGROUPED_KEY);
+    const other = groups.filter((group) => group.key === UNGROUPED_KEY);
+
+    return [...named, ...other];
 });
 
-const hasNamedGroups = computed(() => localizationGroups.value.some((group) => group.label));
+const hasNamedGroups = computed(() => localizationGroups.value.some((group) => group.key !== UNGROUPED_KEY));
 
 const selectedLabel = computed(() => {
     const active = activeLocalization.value;

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -4,8 +4,21 @@ import {
     Combobox,
     Card,
     Panel,
+    Subheading,
+    Icon,
 } from '@ui';
-import { computed, useId } from 'vue';
+import {
+    ComboboxAnchor,
+    ComboboxContent,
+    ComboboxGroup,
+    ComboboxItem,
+    ComboboxLabel,
+    ComboboxPortal,
+    ComboboxRoot,
+    ComboboxTrigger,
+    ComboboxViewport,
+} from 'reka-ui';
+import { computed, ref, useId } from 'vue';
 import Localization from './Localization.vue';
 
 const props = defineProps({
@@ -23,21 +36,130 @@ const props = defineProps({
     },
 });
 
-defineEmits(['selected']);
+const emit = defineEmits(['selected']);
 
 const comboboxId = useId();
+const dropdownOpen = ref(false);
 
 const panelHeading = computed(() => props.heading || __('Working In'));
 
 const activeLocalization = computed(() => {
     return props.localizations.find((localization) => localization.active);
 });
+
+const localizationGroups = computed(() => {
+    const groups = [];
+    const indexByKey = new Map();
+
+    for (const localization of props.localizations) {
+        const key = localization.group_handle || localization.group || '__ungrouped__';
+        const label = localization.group || null;
+
+        if (!indexByKey.has(key)) {
+            indexByKey.set(key, groups.length);
+            groups.push({ key, label, localizations: [] });
+        }
+
+        groups[indexByKey.get(key)].localizations.push(localization);
+    }
+
+    return groups;
+});
+
+const hasNamedGroups = computed(() => localizationGroups.value.some((group) => group.label));
+
+const selectedLabel = computed(() => {
+    const active = activeLocalization.value;
+
+    if (!active) return '';
+
+    const name = __(active.name);
+
+    return active.group ? `${__(active.group)} / ${name}` : name;
+});
+
+function selectLocalization(localization) {
+    if (!localization) return;
+
+    dropdownOpen.value = false;
+    emit('selected', localization);
+}
 </script>
 
 <template>
     <Panel v-if="localizations.length > 1" :heading="panelHeading" icon="globe-arrow">
         <Card class="p-3! space-y-1">
-            <template v-if="localizations.length > 5">
+            <template v-if="hasNamedGroups">
+                <Label
+                    :for="comboboxId"
+                    :text="panelHeading"
+                    class="sr-only"
+                />
+
+                <ComboboxRoot
+                    class="w-full"
+                    :open="dropdownOpen"
+                    :model-value="activeLocalization?.handle"
+                    ignore-filter
+                    @update:open="dropdownOpen = $event"
+                    @update:model-value="(handle) => selectLocalization(localizations.find((l) => l.handle === handle))"
+                >
+                    <ComboboxAnchor class="block w-full">
+                        <ComboboxTrigger
+                            :id="comboboxId"
+                            class="flex h-10 w-full cursor-pointer items-center justify-between rounded-lg border border-gray-300 bg-linear-to-b from-white to-gray-50 px-4 text-md text-gray-900 shadow-ui-sm focus-within:focus-outline dark:border-gray-700 dark:from-gray-850 dark:to-gray-900 dark:text-gray-300 dark:shadow-ui-md"
+                        >
+                            <span class="block truncate text-start">{{ selectedLabel }}</span>
+                            <Icon name="chevron-down" class="ms-1.5 size-4 text-gray-400 dark:text-white/40" aria-hidden="true" />
+                        </ComboboxTrigger>
+                    </ComboboxAnchor>
+
+                    <ComboboxPortal>
+                        <ComboboxContent
+                            position="popper"
+                            :side-offset="5"
+                            class="z-(--z-index-above) max-h-[var(--reka-combobox-content-available-height)] min-w-[var(--reka-combobox-trigger-width)] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-ui-sm dark:border-white/10 dark:bg-gray-800"
+                        >
+                            <ComboboxViewport class="max-h-[300px] space-y-1 overflow-y-auto py-2">
+                                <template
+                                    v-for="(group, groupIndex) in localizationGroups"
+                                    :key="group.key"
+                                >
+                                    <ComboboxGroup class="px-2">
+                                        <ComboboxLabel v-if="group.label" as-child>
+                                            <Subheading
+                                                size="sm"
+                                                class="px-2 py-1.5 font-semibold uppercase tracking-wide"
+                                                :text="__(group.label)"
+                                            />
+                                        </ComboboxLabel>
+
+                                        <ComboboxItem
+                                            v-for="option in group.localizations"
+                                            :key="option.handle"
+                                            :value="option.handle"
+                                            :text-value="option.name"
+                                            as="button"
+                                            class="w-full cursor-pointer rounded-lg px-2 py-2 text-sm outline-hidden data-highlighted:bg-gray-100 dark:data-highlighted:bg-gray-700"
+                                            :class="option.active ? 'bg-blue-100 dark:bg-gray-700' : ''"
+                                        >
+                                            <Localization :localization="option" :localizing />
+                                        </ComboboxItem>
+                                    </ComboboxGroup>
+
+                                    <div
+                                        v-if="groupIndex < localizationGroups.length - 1"
+                                        class="mx-2 my-1 border-t border-gray-200 dark:border-gray-700"
+                                        role="separator"
+                                    />
+                                </template>
+                            </ComboboxViewport>
+                        </ComboboxContent>
+                    </ComboboxPortal>
+                </ComboboxRoot>
+            </template>
+
+            <template v-else-if="localizations.length > 5">
                 <Label
                     :for="comboboxId"
                     :text="panelHeading"
@@ -51,7 +173,7 @@ const activeLocalization = computed(() => {
                     option-value="handle"
                     option-label="name"
                     :model-value="activeLocalization?.handle"
-                    @update:modelValue="$emit('selected', localizations.find(l => l.handle === $event))"
+                    @update:modelValue="(handle) => selectLocalization(localizations.find(l => l.handle === handle))"
                 >
                     <template #option="option">
                         <Localization :localization="option" :localizing />
@@ -70,7 +192,7 @@ const activeLocalization = computed(() => {
                     :key="option.handle"
                     class="w-full cursor-pointer px-4 py-2 text-sm rounded-lg"
                     :class="option.active ? 'dark:bg-gray-700 bg-blue-100' : 'dark:hover:bg-gray-800 hover:bg-gray-100'"
-                    @click="$emit('selected', option)"
+                    @click="selectLocalization(option)"
                 >
                     <Localization :localization="option" :localizing />
                 </button>

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -7,18 +7,8 @@ import {
     Subheading,
     Icon,
 } from '@ui';
-import {
-    ComboboxAnchor,
-    ComboboxContent,
-    ComboboxGroup,
-    ComboboxItem,
-    ComboboxLabel,
-    ComboboxPortal,
-    ComboboxRoot,
-    ComboboxTrigger,
-    ComboboxViewport,
-} from 'reka-ui';
 import { computed, ref, useId } from 'vue';
+import fuzzysort from 'fuzzysort';
 import Localization from './Localization.vue';
 
 const props = defineProps({
@@ -38,16 +28,16 @@ const props = defineProps({
 
 const emit = defineEmits(['selected']);
 
+const UNGROUPED_KEY = 'other';
+
 const comboboxId = useId();
-const dropdownOpen = ref(false);
+const searchQuery = ref('');
 
 const panelHeading = computed(() => props.heading || __('Working In'));
 
 const activeLocalization = computed(() => {
     return props.localizations.find((localization) => localization.active);
 });
-
-const UNGROUPED_KEY = 'other';
 
 const localizationGroups = computed(() => {
     const groups = [];
@@ -76,108 +66,53 @@ const localizationGroups = computed(() => {
 
 const hasNamedGroups = computed(() => localizationGroups.value.some((group) => group.key !== UNGROUPED_KEY));
 
-const selectedLabel = computed(() => {
-    const active = activeLocalization.value;
+const useCombobox = computed(() => hasNamedGroups.value || props.localizations.length > 5);
 
-    if (!active) return '';
+const comboboxOptions = computed(() => {
+    const query = searchQuery.value;
+    let isFirstVisibleOption = true;
 
-    return __(active.name);
-});
+    return localizationGroups.value.flatMap((group) => {
+        const localizations = query
+            ? fuzzysort
+                .go(query, group.localizations, { keys: ['name', 'group', 'handle'] })
+                .map((result) => result.obj)
+            : group.localizations;
 
-const selectedGroup = computed(() => {
-    const active = activeLocalization.value;
+        if (!localizations.length) {
+            return [];
+        }
 
-    return active?.group ? __(active.group) : null;
+        return localizations.map((localization, index) => {
+            const option = {
+                ...localization,
+                _groupLabel: index === 0 ? group.label : null,
+                _showGroupSeparator: index === 0 && !isFirstVisibleOption,
+            };
+
+            isFirstVisibleOption = false;
+
+            return option;
+        });
+    });
 });
 
 function selectLocalization(localization) {
     if (!localization) return;
 
-    dropdownOpen.value = false;
+    searchQuery.value = '';
     emit('selected', localization);
+}
+
+function handleSearch(query) {
+    searchQuery.value = query;
 }
 </script>
 
 <template>
     <Panel v-if="localizations.length > 1" :heading="panelHeading" icon="globe-arrow">
         <Card class="p-3! space-y-1">
-            <template v-if="hasNamedGroups">
-                <Label
-                    :for="comboboxId"
-                    :text="panelHeading"
-                    class="sr-only"
-                />
-
-                <ComboboxRoot
-                    class="w-full"
-                    :open="dropdownOpen"
-                    :model-value="activeLocalization?.handle"
-                    ignore-filter
-                    @update:open="dropdownOpen = $event"
-                    @update:model-value="(handle) => selectLocalization(localizations.find((l) => l.handle === handle))"
-                >
-                    <ComboboxAnchor class="block w-full">
-                        <ComboboxTrigger
-                            :id="comboboxId"
-                            class="flex h-10 w-full cursor-pointer items-center justify-between rounded-lg border border-gray-300 bg-linear-to-b from-white to-gray-50 px-4 text-md text-gray-900 shadow-ui-sm focus-within:focus-outline dark:border-gray-700 dark:from-gray-850 dark:to-gray-900 dark:text-gray-300 dark:shadow-ui-md"
-                        >
-                            <span class="flex min-w-0 items-center gap-1.5 text-start">
-                                <template v-if="selectedGroup">
-                                    <span class="truncate">{{ selectedGroup }}</span>
-                                    <Icon name="chevron-right" class="size-3.5 shrink-0 text-gray-400 dark:text-white/40" aria-hidden="true" />
-                                </template>
-                                <span class="truncate">{{ selectedLabel }}</span>
-                            </span>
-                            <Icon name="chevron-down" class="ms-1.5 size-4 text-gray-400 dark:text-white/40" aria-hidden="true" />
-                        </ComboboxTrigger>
-                    </ComboboxAnchor>
-
-                    <ComboboxPortal>
-                        <ComboboxContent
-                            position="popper"
-                            :side-offset="5"
-                            class="z-(--z-index-above) w-[var(--reka-combobox-trigger-width)] max-h-[var(--reka-combobox-content-available-height)] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-ui-sm dark:border-white/10 dark:bg-gray-800"
-                        >
-                            <ComboboxViewport class="max-h-[300px] space-y-1 overflow-y-auto py-2">
-                                <template
-                                    v-for="(group, groupIndex) in localizationGroups"
-                                    :key="group.key"
-                                >
-                                    <ComboboxGroup class="px-2">
-                                        <ComboboxLabel v-if="group.label" as-child>
-                                            <Subheading
-                                                size="sm"
-                                                class="px-2 py-1.5 font-semibold uppercase tracking-wide"
-                                                :text="__(group.label)"
-                                            />
-                                        </ComboboxLabel>
-
-                                        <ComboboxItem
-                                            v-for="option in group.localizations"
-                                            :key="option.handle"
-                                            :value="option.handle"
-                                            :text-value="option.name"
-                                            as="button"
-                                            class="w-full cursor-pointer rounded-lg px-2 py-2 text-sm outline-hidden data-highlighted:bg-gray-100 dark:data-highlighted:bg-gray-700"
-                                            :class="option.active ? 'bg-blue-100 dark:bg-gray-700' : ''"
-                                        >
-                                            <Localization :localization="option" :localizing />
-                                        </ComboboxItem>
-                                    </ComboboxGroup>
-
-                                    <div
-                                        v-if="groupIndex < localizationGroups.length - 1"
-                                        class="mx-2 my-1 border-t border-gray-200 dark:border-gray-700"
-                                        role="separator"
-                                    />
-                                </template>
-                            </ComboboxViewport>
-                        </ComboboxContent>
-                    </ComboboxPortal>
-                </ComboboxRoot>
-            </template>
-
-            <template v-else-if="localizations.length > 5">
+            <template v-if="useCombobox">
                 <Label
                     :for="comboboxId"
                     :text="panelHeading"
@@ -187,14 +122,40 @@ function selectLocalization(localization) {
                 <Combobox
                     :id="comboboxId"
                     class="flex-1"
-                    :options="localizations"
+                    :options="comboboxOptions"
                     option-value="handle"
                     option-label="name"
                     :model-value="activeLocalization?.handle"
+                    :virtualize="!hasNamedGroups"
+                    ignore-filter
+                    @search="handleSearch"
                     @update:modelValue="(handle) => selectLocalization(localizations.find(l => l.handle === handle))"
                 >
+                    <template #selected-option="{ option }">
+                        <span class="flex min-w-0 items-center gap-1.5">
+                            <template v-if="option.group">
+                                <span class="truncate">{{ __(option.group) }}</span>
+                                <Icon name="chevron-right" class="size-3.5 shrink-0 text-gray-400 dark:text-white/40" aria-hidden="true" />
+                            </template>
+                            <span class="truncate">{{ __(option.name) }}</span>
+                        </span>
+                    </template>
+
                     <template #option="option">
-                        <Localization :localization="option" :localizing />
+                        <div class="flex w-full min-w-0 flex-col">
+                            <div
+                                v-if="option._showGroupSeparator"
+                                class="mb-1 border-t border-gray-200 dark:border-gray-700"
+                                role="separator"
+                            />
+                            <Subheading
+                                v-if="option._groupLabel"
+                                size="sm"
+                                class="-mx-0.5 px-0.5 pb-1.5 pt-0.5 font-semibold uppercase tracking-wide"
+                                :text="__(option._groupLabel)"
+                            />
+                            <Localization :localization="option" :localizing />
+                        </div>
                     </template>
                 </Combobox>
             </template>

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -7,7 +7,7 @@ import {
     Subheading,
     Icon,
 } from '@ui';
-import { computed, ref, useId, watch } from 'vue';
+import { computed, ref, useId, watch, nextTick } from 'vue';
 import fuzzysort from 'fuzzysort';
 import Localization from './Localization.vue';
 import {
@@ -24,6 +24,10 @@ const props = defineProps({
     },
     localizing: {
         type: [Boolean, String],
+        default: false,
+    },
+    confirmingSwitch: {
+        type: Boolean,
         default: false,
     },
     heading: {
@@ -44,11 +48,40 @@ const activeLocalization = computed(() => {
     return props.localizations.find((localization) => localization.active);
 });
 
+function clearPendingIfStale() {
+    if (!pendingHandle.value) return;
+    if (pendingHandle.value === activeLocalization.value?.handle) {
+        pendingHandle.value = null;
+        return;
+    }
+    if (props.localizing || props.confirmingSwitch) return;
+
+    pendingHandle.value = null;
+}
+
 watch(
     () => activeLocalization.value?.handle,
     (handle) => {
         if (handle && handle === pendingHandle.value) {
             pendingHandle.value = null;
+        }
+    },
+);
+
+watch(
+    () => props.localizing,
+    (localizing, wasLocalizing) => {
+        if (wasLocalizing && !localizing) {
+            clearPendingIfStale();
+        }
+    },
+);
+
+watch(
+    () => props.confirmingSwitch,
+    (confirming, wasConfirming) => {
+        if (wasConfirming && !confirming) {
+            clearPendingIfStale();
         }
     },
 );
@@ -86,6 +119,17 @@ function selectLocalization(localization) {
     searchQuery.value = '';
     pendingHandle.value = localization.handle;
     emit('selected', localization);
+
+    // Parent may abort without starting a switch (e.g. can't create missing localization).
+    if (!localization.exists) {
+        nextTick(() => {
+            if (pendingHandle.value !== localization.handle) return;
+            if (props.localizing || props.confirmingSwitch) return;
+            if (activeLocalization.value?.handle !== localization.handle) {
+                pendingHandle.value = null;
+            }
+        });
+    }
 }
 
 function handleSearch(query) {

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -126,7 +126,7 @@ function selectLocalization(localization) {
                         <ComboboxContent
                             position="popper"
                             :side-offset="5"
-                            class="z-(--z-index-above) max-h-[var(--reka-combobox-content-available-height)] min-w-[var(--reka-combobox-trigger-width)] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-ui-sm dark:border-white/10 dark:bg-gray-800"
+                            class="z-(--z-index-above) w-[var(--reka-combobox-trigger-width)] max-h-[var(--reka-combobox-content-available-height)] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-ui-sm dark:border-white/10 dark:bg-gray-800"
                         >
                             <ComboboxViewport class="max-h-[300px] space-y-1 overflow-y-auto py-2">
                                 <template

--- a/resources/js/components/ui/Publish/Localizations.vue
+++ b/resources/js/components/ui/Publish/Localizations.vue
@@ -7,7 +7,7 @@ import {
     Subheading,
     Icon,
 } from '@ui';
-import { computed, ref, useId } from 'vue';
+import { computed, ref, useId, watch } from 'vue';
 import fuzzysort from 'fuzzysort';
 import Localization from './Localization.vue';
 
@@ -32,11 +32,30 @@ const UNGROUPED_KEY = 'other';
 
 const comboboxId = useId();
 const searchQuery = ref('');
+const pendingHandle = ref(null);
 
 const panelHeading = computed(() => props.heading || __('Working In'));
 
 const activeLocalization = computed(() => {
     return props.localizations.find((localization) => localization.active);
+});
+
+watch(
+    () => activeLocalization.value?.handle,
+    (handle) => {
+        if (handle && handle === pendingHandle.value) {
+            pendingHandle.value = null;
+        }
+    },
+);
+
+const selectedLocalization = computed(() => {
+    if (pendingHandle.value) {
+        return props.localizations.find((localization) => localization.handle === pendingHandle.value)
+            ?? activeLocalization.value;
+    }
+
+    return activeLocalization.value;
 });
 
 const localizationGroups = computed(() => {
@@ -101,11 +120,20 @@ function selectLocalization(localization) {
     if (!localization) return;
 
     searchQuery.value = '';
+    pendingHandle.value = localization.handle;
     emit('selected', localization);
 }
 
 function handleSearch(query) {
     searchQuery.value = query;
+}
+
+function selectedGroupLabel(option) {
+    if (option.group) {
+        return __(option.group);
+    }
+
+    return hasNamedGroups.value ? __('Other') : null;
 }
 </script>
 
@@ -125,7 +153,7 @@ function handleSearch(query) {
                     :options="comboboxOptions"
                     option-value="handle"
                     option-label="name"
-                    :model-value="activeLocalization?.handle"
+                    :model-value="selectedLocalization?.handle"
                     :virtualize="!hasNamedGroups"
                     ignore-filter
                     @search="handleSearch"
@@ -133,9 +161,9 @@ function handleSearch(query) {
                 >
                     <template #selected-option="{ option }">
                         <span class="flex min-w-0 items-center gap-1.5">
-                            <template v-if="option.group">
-                                <span class="truncate">{{ __(option.group) }}</span>
-                                <Icon name="chevron-right" class="size-3.5! text-gray-400 dark:text-white/40" aria-hidden="true" />
+                            <template v-if="selectedGroupLabel(option)">
+                                <span class="truncate">{{ selectedGroupLabel(option) }}</span>
+                                <Icon name="chevron-right" class="size-3.5! shrink-0 text-gray-400 dark:text-white/40" aria-hidden="true" />
                             </template>
                             <span class="truncate">{{ __(option.name) }}</span>
                         </span>

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -61,7 +61,7 @@ const hasOnlyOtherGroup = computed(() => usesGroupEditor.value && listedSections
 
 watch(isEditingSections, (editing) => {
     if (!editing) {
-        closeGroupEditor();
+        closeGroupEditor({ saved: true });
         return;
     }
 
@@ -76,6 +76,7 @@ const editingNewGroup = ref(false);
 const editingGroupHandle = ref(null);
 const editingGroupTitle = ref('');
 const groupTitleError = ref(null);
+const editingSection = ref(null);
 
 function renderInstructions(instructions) {
     return instructions ? markdown(__(instructions), { openLinksInNewTabs: true }) : '';
@@ -221,25 +222,32 @@ function openNewGroupEditor() {
 
     nextTick(() => {
         focusSection(section);
-        editGroup(section);
-        editingNewGroup.value = true;
+        editGroup(section, { isNew: true });
     });
 }
 
-function editGroup(section) {
+function editGroup(section, { isNew = false } = {}) {
     groupEditorOpen.value = true;
-    editingNewGroup.value = false;
+    editingNewGroup.value = isNew;
+    editingSection.value = section;
     editingGroupHandle.value = section.editable_title_handle;
     editingGroupTitle.value = values.value[section.editable_title_handle] || '';
     groupTitleError.value = null;
 }
 
-function closeGroupEditor() {
+function closeGroupEditor({ saved = false } = {}) {
+    const sectionToRemove = !saved && editingNewGroup.value ? editingSection.value : null;
+
     groupEditorOpen.value = false;
     editingNewGroup.value = false;
+    editingSection.value = null;
     editingGroupHandle.value = null;
     editingGroupTitle.value = '';
     groupTitleError.value = null;
+
+    if (sectionToRemove) {
+        removeGroup(sectionToRemove);
+    }
 }
 
 function saveGroupTitle() {
@@ -254,7 +262,7 @@ function saveGroupTitle() {
         setFieldValue(editingGroupHandle.value, title);
     }
 
-    closeGroupEditor();
+    closeGroupEditor({ saved: true });
 }
 
 function removeGroup(section) {

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -550,8 +550,6 @@ onBeforeUnmount(() => {
                             />
                             <Heading :text="sectionTitle(section)" />
                             <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
-                        </div>
-                        <div class="flex shrink-0 items-center">
                             <div v-if="showGroupActions && section.reorderable" class="flex shrink-0 items-center">
                                 <Button
                                     icon="pencil-line"
@@ -568,16 +566,16 @@ onBeforeUnmount(() => {
                                     @click.prevent="removeGroup(section)"
                                 />
                             </div>
-                            <div v-if="section.collapsible" class="flex shrink-0 items-center">
-                                <Button
-                                    @click="toggleSection(section)"
-                                    class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
-                                    :icon="section.collapsed ? 'expand' : 'collapse'"
-                                    size="sm"
-                                    variant="ghost"
-                                    :aria-label="__('Toggle section visibility')"
-                                />
-                            </div>
+                        </div>
+                        <div v-if="section.collapsible" class="flex shrink-0 items-center">
+                            <Button
+                                @click="toggleSection(section)"
+                                class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
+                                :icon="section.collapsed ? 'expand' : 'collapse'"
+                                size="sm"
+                                variant="ghost"
+                                :aria-label="__('Toggle section visibility')"
+                            />
                         </div>
                     </div>
 
@@ -615,8 +613,6 @@ onBeforeUnmount(() => {
                                         />
                                     </Heading>
                                     <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
-                                </div>
-                                <div class="flex shrink-0 items-center">
                                     <div v-if="showGroupActions && section.reorderable" class="flex shrink-0 items-center">
                                         <Button
                                             icon="pencil-line"
@@ -633,16 +629,16 @@ onBeforeUnmount(() => {
                                             @click.prevent="removeGroup(section)"
                                         />
                                     </div>
-                                    <div v-if="section.collapsible" class="flex shrink-0 items-center">
-                                        <Button
-                                            @click="toggleSection(section)"
-                                            class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
-                                            :icon="section.collapsed ? 'expand' : 'collapse'"
-                                            size="sm"
-                                            variant="ghost"
-                                            :aria-label="__('Toggle section visibility')"
-                                        />
-                                    </div>
+                                </div>
+                                <div v-if="section.collapsible" class="flex shrink-0 items-center">
+                                    <Button
+                                        @click="toggleSection(section)"
+                                        class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
+                                        :icon="section.collapsed ? 'expand' : 'collapse'"
+                                        size="sm"
+                                        variant="ghost"
+                                        :aria-label="__('Toggle section visibility')"
+                                    />
                                 </div>
                             </div>
                         </PanelHeader>

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -167,7 +167,12 @@ function insertNamedSection(section) {
 }
 
 function uniqueGroupKey(title) {
-    const base = Statamic.$slug.create(title) || 'group';
+    let base = Statamic.$slug.create(title) || 'group';
+
+    if (base === 'other') {
+        base = 'group';
+    }
+
     let key = base;
     let suffix = 2;
 
@@ -246,12 +251,13 @@ function saveGroupTitle() {
 }
 
 function removeGroup(section) {
-    const moving = values.value[sitesHandleFor(section)] || [];
+    const fromHandle = sitesHandleFor(section);
+    const moving = values.value[fromHandle] || [];
     const next = { ...values.value };
 
     next.group_other_sites = [...(next.group_other_sites || []), ...moving];
     delete next[section.editable_title_handle];
-    delete next[sitesHandleFor(section)];
+    delete next[fromHandle];
 
     const index = tab.sections.findIndex((item) => sectionKey(item) === sectionKey(section));
     if (index !== -1) {
@@ -259,6 +265,9 @@ function removeGroup(section) {
     }
 
     setValues(valuesWithOtherLast(next));
+
+    moving.forEach((row) => moveRowMeta(fromHandle, 'group_other_sites', row._id));
+    unregisterSectionRowZone(fromHandle);
 }
 
 function addGroup(title) {
@@ -430,8 +439,24 @@ function moveRowBetweenZones(event) {
     scheduleRowSortableRebuild();
 }
 
+function ensureGridMeta(handle, templateHandle) {
+    if (meta.value[handle] || !templateHandle) return;
+
+    const templateMeta = meta.value[templateHandle];
+
+    if (!templateMeta) return;
+
+    setFieldMeta(handle, {
+        defaults: deepClone(templateMeta.defaults),
+        new: deepClone(templateMeta.new),
+        existing: {},
+    });
+}
+
 function moveRowMeta(fromHandle, toHandle, rowId) {
-    if (!rowId) return;
+    if (!rowId || fromHandle === toHandle) return;
+
+    ensureGridMeta(toHandle, fromHandle);
 
     const fromMeta = meta.value[fromHandle];
     const toMeta = meta.value[toHandle];

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -7,22 +7,26 @@ import {
     Heading,
     Subheading,
     Card,
+    Editable,
+    Field,
     Icon,
+    Input,
+    Stack,
 } from '@ui';
+import { deepClone } from '@/util/clone.js';
 import FieldsProvider from './FieldsProvider.vue';
 import Fields from './Fields.vue';
 import ShowField from '@/components/field-conditions/ShowField.js';
 import { injectContainerContext } from './Container.vue';
+import { SortableList } from '@/components/sortable/Sortable.js';
+import { Sortable, Plugins, Draggable } from '@shopify/draggable';
 import markdown from '@/util/markdown.js';
-import { computed } from 'vue';
-import { Primitive } from 'reka-ui';
-import { Motion } from 'motion-v';
+import { computed, nextTick, onBeforeUnmount, provide, ref, watch } from 'vue';
 
-const { blueprint, container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField } = injectContainerContext();
+const { container, visibleValues, extraValues, revealerValues, asConfig, hiddenFields, setHiddenField, values, setFieldValue, setValues, readOnly, editingSections, canAddSections, meta, setFieldMeta } = injectContainerContext();
 const tab = injectTabContext();
-const sections = tab.sections;
 const visibleSections = computed(() => {
-    return sections.filter((section) => {
+    return tab.sections.filter((section) => {
         return section.fields.some((field) => {
             return new ShowField(
                 visibleValues.value,
@@ -36,9 +40,50 @@ const visibleSections = computed(() => {
         });
     });
 });
+const reorderableSections = computed(() => visibleSections.value.filter((section) => section.reorderable));
+const usesGroupEditor = computed(() => !!canAddSections?.value);
+const listedSections = computed(() => {
+    if (!usesGroupEditor.value) return visibleSections.value;
+
+    return visibleSections.value.filter((section) => !isOtherSection(section));
+});
+const pinnedSections = computed(() => {
+    if (!usesGroupEditor.value) return [];
+
+    return visibleSections.value.filter(isOtherSection);
+});
+const canReorderSections = computed(() => !readOnly.value && reorderableSections.value.length > 1);
+const isEditingSections = computed(() => !!editingSections?.value);
+const showSectionDragHandles = computed(() => usesGroupEditor.value && isEditingSections.value && !readOnly.value);
+const showAddSection = computed(() => !!canAddSections?.value && isEditingSections.value && !readOnly.value);
+const showGroupActions = computed(() => showAddSection.value);
+const hasOnlyOtherGroup = computed(() => usesGroupEditor.value && listedSections.value.length === 0);
+
+watch(isEditingSections, (editing) => {
+    if (!editing) closeGroupEditor();
+});
+
+const titleSnapshots = ref({});
+const groupEditorOpen = ref(false);
+const editingNewGroup = ref(false);
+const editingGroupHandle = ref(null);
+const editingGroupTitle = ref('');
+const groupTitleError = ref(null);
 
 function renderInstructions(instructions) {
     return instructions ? markdown(__(instructions), { openLinksInNewTabs: true }) : '';
+}
+
+function snapshotTitle(handle) {
+    titleSnapshots.value[handle] = values.value[handle] ?? null;
+}
+
+function updateTitle(handle, value) {
+    setFieldValue(handle, value?.trim() || null);
+}
+
+function cancelTitleEdit(handle) {
+    setFieldValue(handle, titleSnapshots.value[handle]);
 }
 
 function toggleSection(section) {
@@ -47,55 +92,698 @@ function toggleSection(section) {
         section.collapsed = !section.collapsed;
     }
 }
+
+function sectionKey(section) {
+    return section.editable_title_handle || section.fields[0]?.handle;
+}
+
+function reorderSections(reordered) {
+    const reorderedKeys = new Set(reordered.map(sectionKey));
+    const remaining = tab.sections.filter((section) => !reorderedKeys.has(sectionKey(section)));
+
+    tab.sections.splice(0, tab.sections.length, ...reordered, ...remaining);
+    persistGroupOrder(reordered);
+}
+
+function persistGroupOrder(reordered) {
+    const next = {};
+
+    for (const section of reordered) {
+        const nameHandle = section.editable_title_handle;
+        const sitesHandle = sitesHandleFor(section);
+
+        if (nameHandle in values.value) {
+            next[nameHandle] = values.value[nameHandle];
+        }
+
+        if (sitesHandle in values.value) {
+            next[sitesHandle] = values.value[sitesHandle];
+        }
+    }
+
+    for (const [key, value] of Object.entries(values.value)) {
+        if (!(key in next)) {
+            next[key] = value;
+        }
+    }
+
+    setValues(valuesWithOtherLast(next));
+}
+
+function valuesWithOtherLast(next) {
+    const otherSites = 'group_other_sites';
+    const otherName = 'group_other_name';
+    const ordered = {};
+
+    for (const [key, value] of Object.entries(next)) {
+        if (key === otherName || key === otherSites) continue;
+        ordered[key] = value;
+    }
+
+    if (otherName in next) ordered[otherName] = next[otherName];
+    if (otherSites in next) ordered[otherSites] = next[otherSites];
+
+    return ordered;
+}
+
+function sitesHandleFor(section) {
+    return section.fields.find((field) => field.handle.endsWith('_sites'))?.handle
+        ?? section.fields[0]?.handle;
+}
+
+function isOtherSection(section) {
+    return sitesHandleFor(section) === 'group_other_sites';
+}
+
+function insertNamedSection(section) {
+    const index = tab.sections.findIndex(isOtherSection);
+
+    if (index === -1) {
+        tab.sections.push(section);
+        return;
+    }
+
+    tab.sections.splice(index, 0, section);
+}
+
+function uniqueGroupKey(title) {
+    const base = Statamic.$slug.create(title) || 'group';
+    let key = base;
+    let suffix = 2;
+
+    while (`group_${key}_sites` in values.value) {
+        key = `${base}-${suffix++}`;
+    }
+
+    return key;
+}
+
+function sectionTitle(section) {
+    if (!section.editable_title_handle) return __(section.display);
+
+    return values.value[section.editable_title_handle] || __(section.display);
+}
+
+function sectionGridField(section) {
+    return section.fields.find((field) => field.type === 'grid' && field.headers_in_section);
+}
+
+function showsSectionTitleOutside(section) {
+    return !!sectionGridField(section);
+}
+
+function showsSectionTitle(section) {
+    if (hasOnlyOtherGroup.value && isOtherSection(section)) {
+        return false;
+    }
+
+    return true;
+}
+
+const groupTitleInput = ref(null);
+
+function openNewGroupEditor() {
+    const section = addGroup(__('New Group'));
+
+    if (!section) return;
+
+    nextTick(() => {
+        focusSection(section);
+        editGroup(section);
+        editingNewGroup.value = true;
+    });
+}
+
+function editGroup(section) {
+    groupEditorOpen.value = true;
+    editingNewGroup.value = false;
+    editingGroupHandle.value = section.editable_title_handle;
+    editingGroupTitle.value = values.value[section.editable_title_handle] || '';
+    groupTitleError.value = null;
+}
+
+function closeGroupEditor() {
+    groupEditorOpen.value = false;
+    editingNewGroup.value = false;
+    editingGroupHandle.value = null;
+    editingGroupTitle.value = '';
+    groupTitleError.value = null;
+}
+
+function saveGroupTitle() {
+    const title = editingGroupTitle.value.trim();
+
+    if (!title) {
+        groupTitleError.value = __('statamic::validation.required');
+        return;
+    }
+
+    if (editingGroupHandle.value) {
+        setFieldValue(editingGroupHandle.value, title);
+    }
+
+    closeGroupEditor();
+}
+
+function removeGroup(section) {
+    const moving = values.value[sitesHandleFor(section)] || [];
+    const next = { ...values.value };
+
+    next.group_other_sites = [...(next.group_other_sites || []), ...moving];
+    delete next[section.editable_title_handle];
+    delete next[sitesHandleFor(section)];
+
+    const index = tab.sections.findIndex((item) => sectionKey(item) === sectionKey(section));
+    if (index !== -1) {
+        tab.sections.splice(index, 1);
+    }
+
+    setValues(valuesWithOtherLast(next));
+}
+
+function addGroup(title) {
+    const template = reorderableSections.value[0] ?? visibleSections.value[0];
+
+    if (!template) return;
+
+    const key = uniqueGroupKey(title);
+    const templateSitesHandle = sitesHandleFor(template);
+    const nameHandle = `group_${key}_name`;
+    const sitesHandle = `group_${key}_sites`;
+    const sitesField = deepClone(
+        template.fields.find((field) => field.handle === templateSitesHandle)
+            ?? template.fields.find((field) => field.handle?.endsWith('_sites'))
+            ?? template.fields[0],
+    );
+
+    sitesField.handle = sitesHandle;
+
+    const handleField = (sitesField.fields || []).find((field) => field.handle === 'handle');
+    if (handleField) {
+        handleField.prefix_from = nameHandle;
+    }
+
+    const section = {
+        display: title,
+        editable_title_handle: nameHandle,
+        reorderable: true,
+        fields: [
+            {
+                handle: nameHandle,
+                type: 'text',
+                visibility: 'hidden',
+                always_save: true,
+            },
+            sitesField,
+        ],
+    };
+
+    insertNamedSection(section);
+
+    setValues(valuesWithOtherLast({
+        ...values.value,
+        [nameHandle]: title,
+        [sitesHandle]: [],
+    }));
+
+    const templateMeta = meta.value[templateSitesHandle];
+
+    if (templateMeta) {
+        setFieldMeta(sitesHandle, {
+            defaults: deepClone(templateMeta.defaults),
+            new: deepClone(templateMeta.new),
+            existing: {},
+        });
+    }
+
+    return section;
+}
+
+function focusSection(section) {
+    const el = document.querySelector(`[data-section-key="${CSS.escape(sectionKey(section))}"]`);
+
+    el?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el?.focus({ preventScroll: true });
+}
+
+function focusGroupTitleInput() {
+    nextTick(() => groupTitleInput.value?.select());
+}
+
+const SECTION_ROW_ITEM_CLASS = 'publish-section-row-item';
+const SECTION_ROW_HANDLE_CLASS = 'publish-section-row-handle';
+const rowZones = new Map();
+let rowSortable = null;
+let rowSortableRebuildQueued = false;
+
+function registerSectionRowZone(el, handle) {
+    for (const [existing, existingHandle] of rowZones) {
+        if (existingHandle === handle) {
+            rowZones.delete(existing);
+        }
+    }
+
+    rowZones.set(el, handle);
+    scheduleRowSortableRebuild();
+}
+
+function unregisterSectionRowZone(el) {
+    if (typeof el === 'string') {
+        for (const [existing, handle] of rowZones) {
+            if (handle === el) {
+                rowZones.delete(existing);
+            }
+        }
+    } else {
+        rowZones.delete(el);
+    }
+
+    scheduleRowSortableRebuild();
+}
+
+function scheduleRowSortableRebuild() {
+    if (rowSortableRebuildQueued) return;
+
+    rowSortableRebuildQueued = true;
+
+    nextTick(() => {
+        rowSortableRebuildQueued = false;
+        rebuildRowSortable();
+    });
+}
+
+function rebuildRowSortable() {
+    rowSortable?.destroy();
+    rowSortable = null;
+
+    const containers = [...rowZones.keys()].filter((el) => el?.isConnected);
+
+    if (!containers.length || readOnly.value) return;
+
+    rowSortable = new Sortable(containers, {
+        draggable: `.${SECTION_ROW_ITEM_CLASS}`,
+        handle: `.${SECTION_ROW_HANDLE_CLASS}`,
+        delay: 0,
+        distance: 4,
+        swapAnimation: { vertical: true, horizontal: false },
+        plugins: [Plugins.SwapAnimation],
+        mirror: {
+            constrainDimensions: true,
+            appendTo: 'body',
+            xAxis: false,
+        },
+        exclude: {
+            plugins: [Draggable.Plugins.Focusable],
+        },
+    });
+
+    rowSortable.on('sortable:stop', moveRowBetweenZones);
+}
+
+function moveRowBetweenZones(event) {
+    const fromHandle = rowZones.get(event.oldContainer);
+    const toHandle = rowZones.get(event.newContainer);
+
+    if (!fromHandle || !toHandle || event.oldIndex < 0) return;
+
+    const fromRows = [...(values.value[fromHandle] || [])];
+    const toRows = fromHandle === toHandle ? fromRows : [...(values.value[toHandle] || [])];
+    const [row] = fromRows.splice(event.oldIndex, 1);
+
+    if (!row) return;
+
+    const newIndex = Math.min(Math.max(event.newIndex ?? 0, 0), toRows.length);
+    toRows.splice(newIndex, 0, row);
+
+    if (fromHandle === toHandle) {
+        setFieldValue(fromHandle, fromRows);
+        return;
+    }
+
+    setValues(valuesWithOtherLast({
+        ...values.value,
+        [fromHandle]: fromRows,
+        [toHandle]: toRows,
+    }));
+
+    moveRowMeta(fromHandle, toHandle, row._id);
+    scheduleRowSortableRebuild();
+}
+
+function moveRowMeta(fromHandle, toHandle, rowId) {
+    if (!rowId) return;
+
+    const fromMeta = meta.value[fromHandle];
+    const toMeta = meta.value[toHandle];
+
+    if (!fromMeta?.existing || !toMeta) return;
+
+    const { [rowId]: rowMeta, ...restExisting } = fromMeta.existing;
+
+    setFieldMeta(fromHandle, { ...fromMeta, existing: restExisting });
+    setFieldMeta(toHandle, {
+        ...toMeta,
+        existing: { ...toMeta.existing, [rowId]: rowMeta },
+    });
+}
+
+const SECTION_ADD_ROW_ATTR = 'data-grid-add-row';
+
+provide('sectionAddRowTarget', SECTION_ADD_ROW_ATTR);
+
+function sectionAddRowBindings(section) {
+    return { [SECTION_ADD_ROW_ATTR]: sitesHandleFor(section) };
+}
+
+if (canAddSections?.value) {
+    provide('sectionRowSortable', {
+        itemClass: SECTION_ROW_ITEM_CLASS,
+        handleClass: SECTION_ROW_HANDLE_CLASS,
+        register: registerSectionRowZone,
+        unregister: unregisterSectionRowZone,
+    });
+}
+
+onBeforeUnmount(() => {
+    rowSortable?.destroy();
+    rowSortable = null;
+    rowZones.clear();
+});
 </script>
 
 <template>
     <div>
-        <Panel
-            v-for="(section, i) in visibleSections"
-            :key="i"
-            :class="[
-                'mb-6',
-                { 'pb-0': section.collapsed }
-            ]"
+        <SortableList
+            :model-value="listedSections"
+            :disabled="!canReorderSections || !isEditingSections"
+            item-class="publish-section-sortable"
+            handle-class="publish-section-drag-handle"
+            :vertical="true"
+            append-to="body"
+            constrain-dimensions
+            v-slot="{}"
+            @update:model-value="reorderSections"
         >
-            <PanelHeader v-if="section.display || section.collapsible" class="relative flex items-center justify-between">
-                <div class="[&_a]:relative [&_a]:z-(--z-index-above)">
-                    <Heading :text="__(section.display)" />
+            <div>
+                <div
+                    v-for="(section, i) in listedSections"
+                    :key="sectionKey(section) || i"
+                    :data-section-key="sectionKey(section)"
+                    tabindex="-1"
+                    class="outline-none"
+                    :class="{
+                        'publish-section-sortable': section.reorderable,
+                        'mb-8': showsSectionTitleOutside(section),
+                    }"
+                >
+                    <div
+                        v-if="showsSectionTitleOutside(section) && showsSectionTitle(section)"
+                        class="mb-2 flex items-center justify-between gap-3 px-1"
+                    >
+                        <div class="flex min-w-0 flex-1 items-center gap-2">
+                            <Icon
+                                v-if="section.reorderable && showSectionDragHandles"
+                                name="handles-sm"
+                                class="publish-section-drag-handle size-3! shrink-0 cursor-grab text-gray-400"
+                                :aria-label="__('Drag to reorder')"
+                                @mousedown.prevent
+                            />
+                            <Heading :text="sectionTitle(section)" />
+                            <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
+                        </div>
+                        <div class="flex shrink-0 items-center">
+                            <div v-if="showGroupActions && section.reorderable" class="flex shrink-0 items-center">
+                                <Button
+                                    icon="pencil-line"
+                                    size="sm"
+                                    variant="ghost"
+                                    :aria-label="__('Edit Group')"
+                                    @click="editGroup(section)"
+                                />
+                                <Button
+                                    icon="trash"
+                                    size="sm"
+                                    variant="ghost"
+                                    :aria-label="__('Delete Group')"
+                                    @click.prevent="removeGroup(section)"
+                                />
+                            </div>
+                            <div v-if="section.collapsible" class="flex shrink-0 items-center">
+                                <Button
+                                    @click="toggleSection(section)"
+                                    class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
+                                    :icon="section.collapsed ? 'expand' : 'collapse'"
+                                    size="sm"
+                                    variant="ghost"
+                                    :aria-label="__('Toggle section visibility')"
+                                />
+                            </div>
+                        </div>
+                    </div>
+
+                    <Panel
+                        :class="{
+                            'mb-6': !showsSectionTitleOutside(section),
+                            'mb-0!': showsSectionTitleOutside(section),
+                            'pb-0': section.collapsed,
+                        }"
+                    >
+                        <PanelHeader
+                            v-if="!showsSectionTitleOutside(section) && showsSectionTitle(section) && (section.display || section.collapsible || section.editable_title_handle)"
+                            class="pl-2.75! pr-3.25!"
+                        >
+                            <div class="flex items-center justify-between gap-3">
+                                <div class="flex min-w-0 flex-1 items-center gap-2">
+                                    <Icon
+                                        v-if="section.reorderable && showSectionDragHandles"
+                                        name="handles-sm"
+                                        class="publish-section-drag-handle size-3! shrink-0 cursor-grab text-gray-400"
+                                        :aria-label="__('Drag to reorder')"
+                                        @mousedown.prevent
+                                    />
+                                    <Heading v-if="!section.editable_title_handle || usesGroupEditor" :text="sectionTitle(section)" />
+                                    <Heading v-else class="min-w-0">
+                                        <Editable
+                                            :model-value="values[section.editable_title_handle] || ''"
+                                            :activation-mode="'none'"
+                                            submit-mode="both"
+                                            :placeholder="__(section.display)"
+                                            class="publish-section-editable-title min-w-0 field-sizing-content outline-offset-5 rounded-sm"
+                                            @edit="snapshotTitle(section.editable_title_handle)"
+                                            @update:model-value="(value) => updateTitle(section.editable_title_handle, value)"
+                                            @cancel="cancelTitleEdit(section.editable_title_handle)"
+                                        />
+                                    </Heading>
+                                    <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
+                                </div>
+                                <div class="flex shrink-0 items-center">
+                                    <div v-if="showGroupActions && section.reorderable" class="flex shrink-0 items-center">
+                                        <Button
+                                            icon="pencil-line"
+                                            size="sm"
+                                            variant="ghost"
+                                            :aria-label="__('Edit Group')"
+                                            @click="editGroup(section)"
+                                        />
+                                        <Button
+                                            icon="trash"
+                                            size="sm"
+                                            variant="ghost"
+                                            :aria-label="__('Delete Group')"
+                                            @click.prevent="removeGroup(section)"
+                                        />
+                                    </div>
+                                    <div v-if="section.collapsible" class="flex shrink-0 items-center">
+                                        <Button
+                                            @click="toggleSection(section)"
+                                            class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
+                                            :icon="section.collapsed ? 'expand' : 'collapse'"
+                                            size="sm"
+                                            variant="ghost"
+                                            :aria-label="__('Toggle section visibility')"
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        </PanelHeader>
+                        <div
+                            class="publish-section-collapsible grid"
+                            :class="[
+                                section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded',
+                                { 'publish-section-collapsible--interacted': section.collapsibleInteracted },
+                            ]"
+                        >
+                            <div class="publish-section-collapsible__inner min-h-0">
+                                <Card v-if="!usesGroupEditor" :class="{ 'p-0!': asConfig }">
+                                    <FieldsProvider :fields="section.fields">
+                                        <slot :section="section">
+                                            <Fields />
+                                        </slot>
+                                    </FieldsProvider>
+                                </Card>
+                                <FieldsProvider v-else :fields="section.fields">
+                                    <slot :section="section">
+                                        <Fields />
+                                    </slot>
+                                </FieldsProvider>
+                            </div>
+                        </div>
+                    </Panel>
+                    <div
+                        v-if="showsSectionTitleOutside(section)"
+                        v-show="!section.collapsed"
+                        v-bind="sectionAddRowBindings(section)"
+                        class="mt-2 px-1 empty:hidden"
+                    />
+                </div>
+            </div>
+        </SortableList>
+
+        <div
+            v-for="(section, i) in pinnedSections"
+            :key="sectionKey(section) || `pinned-${i}`"
+            :class="{ 'mb-8': showsSectionTitleOutside(section) }"
+        >
+            <div
+                v-if="showsSectionTitleOutside(section) && showsSectionTitle(section)"
+                class="mb-2 flex items-center justify-between gap-3 px-1"
+            >
+                <div class="flex min-w-0 flex-1 items-center gap-2">
+                    <Heading :text="sectionTitle(section)" />
                     <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
                 </div>
-                <Button
-                    @click="toggleSection(section)"
-                    v-if="section.collapsible"
-                    class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
-                    :icon="section.collapsed ? 'expand' : 'collapse'"
-                    size="sm"
-                    variant="ghost"
-                    :aria-label="__('Toggle section visibility')"
-                />
-            </PanelHeader>
-            <div
-                class="publish-section-collapsible grid"
-                :class="[
-                    section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded',
-                    { 'publish-section-collapsible--interacted': section.collapsibleInteracted },
-                ]"
+                <div v-if="section.collapsible" class="flex shrink-0 items-center">
+                    <Button
+                        @click="toggleSection(section)"
+                        class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
+                        :icon="section.collapsed ? 'expand' : 'collapse'"
+                        size="sm"
+                        variant="ghost"
+                        :aria-label="__('Toggle section visibility')"
+                    />
+                </div>
+            </div>
+
+            <Panel
+                :class="{
+                    'mb-6': !showsSectionTitleOutside(section),
+                    'mb-0!': showsSectionTitleOutside(section),
+                    'pb-0': section.collapsed,
+                }"
             >
-                <div class="publish-section-collapsible__inner min-h-0">
-                    <Card :class="{ 'p-0!': asConfig }">
-                        <FieldsProvider :fields="section.fields">
+                <PanelHeader
+                    v-if="!showsSectionTitleOutside(section) && showsSectionTitle(section) && (section.display || section.collapsible)"
+                    class="pl-2.75! pr-3.25!"
+                >
+                    <div class="flex items-center justify-between">
+                        <div class="flex min-w-0 flex-1 items-center gap-2">
+                            <Heading :text="sectionTitle(section)" />
+                            <Subheading v-if="section.instructions" :text="renderInstructions(section.instructions)" />
+                        </div>
+                        <div v-if="section.collapsible" class="flex shrink-0 items-center">
+                            <Button
+                                @click="toggleSection(section)"
+                                class="static! [&_svg]:size-3.5 rounded-xl after:content-[''] after:absolute after:inset-0"
+                                :icon="section.collapsed ? 'expand' : 'collapse'"
+                                size="sm"
+                                variant="ghost"
+                                :aria-label="__('Toggle section visibility')"
+                            />
+                        </div>
+                    </div>
+                </PanelHeader>
+                <div
+                    class="publish-section-collapsible grid"
+                    :class="[
+                        section.collapsed ? 'publish-section-collapsible--collapsed' : 'publish-section-collapsible--expanded',
+                        { 'publish-section-collapsible--interacted': section.collapsibleInteracted },
+                    ]"
+                >
+                    <div class="publish-section-collapsible__inner min-h-0">
+                        <Card v-if="!usesGroupEditor" :class="{ 'p-0!': asConfig }">
+                            <FieldsProvider :fields="section.fields">
+                                <slot :section="section">
+                                    <Fields />
+                                </slot>
+                            </FieldsProvider>
+                        </Card>
+                        <FieldsProvider v-else :fields="section.fields">
                             <slot :section="section">
                                 <Fields />
                             </slot>
                         </FieldsProvider>
-                    </Card>
+                    </div>
                 </div>
+            </Panel>
+            <div
+                v-if="showsSectionTitleOutside(section)"
+                v-show="!section.collapsed"
+                v-bind="sectionAddRowBindings(section)"
+                class="mt-2 px-1 empty:hidden"
+            />
+        </div>
+
+        <div v-if="showAddSection" class="blueprint-add-section-container flex min-h-40 p-2">
+            <button
+                type="button"
+                class="relative flex w-full items-center justify-center rounded-xl border border-dashed border-gray-500 text-gray-700 hover:border-gray hover:text-gray-925 dark:border-gray-500 dark:text-gray-300 dark:hover:border-gray-400 dark:hover:text-gray-200"
+                @click="openNewGroupEditor"
+            >
+                <span class="flex items-center gap-2">
+                    <Icon name="plus" class="size-4" />
+                    {{ __('Add Group') }}
+                </span>
+            </button>
+        </div>
+
+        <Stack
+            size="narrow"
+            :open="groupEditorOpen"
+            :title="editingNewGroup ? __('Add Group') : __('Edit Group')"
+            @update:open="(open) => { if (!open) closeGroupEditor() }"
+            @opened="focusGroupTitleInput"
+        >
+            <div class="space-y-6">
+                <Field id="publish-section-group-title" :label="__('Title')" :error="groupTitleError" required>
+                    <Input
+                        ref="groupTitleInput"
+                        id="publish-section-group-title"
+                        v-model="editingGroupTitle"
+                        :focus="true"
+                        @keyup.enter="saveGroupTitle"
+                    />
+                </Field>
+                <Button class="w-full" variant="primary" :text="__('Save')" @click="saveGroupTitle" />
             </div>
-        </Panel>
+        </Stack>
     </div>
 </template>
 
 <style scoped>
+.publish-section-editable-title :deep(span),
+.publish-section-editable-title :deep(input) {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    border: 0;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    letter-spacing: inherit;
+    outline: none;
+    box-shadow: none;
+}
+
+.publish-section-editable-title :deep(span[data-placeholder]) {
+    color: var(--color-gray-500);
+}
+
+.dark .publish-section-editable-title :deep(span[data-placeholder]) {
+    color: var(--color-gray-400);
+}
+
 .publish-section-collapsible {
     --timing: ease;
     /* No animation on load; enable once the user has toggled this section. */

--- a/resources/js/components/ui/Publish/Sections.vue
+++ b/resources/js/components/ui/Publish/Sections.vue
@@ -60,7 +60,14 @@ const showGroupActions = computed(() => showAddSection.value);
 const hasOnlyOtherGroup = computed(() => usesGroupEditor.value && listedSections.value.length === 0);
 
 watch(isEditingSections, (editing) => {
-    if (!editing) closeGroupEditor();
+    if (!editing) {
+        closeGroupEditor();
+        return;
+    }
+
+    if (hasOnlyOtherGroup.value && !readOnly.value) {
+        nextTick(() => openNewGroupEditor());
+    }
 });
 
 const titleSnapshots = ref({});

--- a/resources/js/components/ui/Select/Select.vue
+++ b/resources/js/components/ui/Select/Select.vue
@@ -40,6 +40,7 @@ const slots = useSlots();
 const usingSelectedOptionSlot = !!slots['selected-option'];
 const usingNoOptionsSlot = !!slots['no-options'];
 const usingOptionSlot = !!slots['option'];
+const usingBeforeOptionSlot = !!slots['before-option'];
 </script>
 
 <template>
@@ -66,6 +67,9 @@ const usingOptionSlot = !!slots['option'];
         </template>
         <template #no-options v-if="usingNoOptionsSlot">
             <slot name="no-options" />
+        </template>
+        <template #before-option="option" v-if="usingBeforeOptionSlot">
+            <slot name="before-option" v-bind="option" />
         </template>
         <template #option="option" v-if="usingOptionSlot">
             <slot name="option" v-bind="option" />

--- a/resources/js/pages/sites/Edit.vue
+++ b/resources/js/pages/sites/Edit.vue
@@ -3,6 +3,7 @@ import Head from '@/pages/layout/Head.vue';
 import { Header, CommandPaletteItem, Button, PublishContainer, DocsCallout } from '@ui';
 import { computed, onMounted, onUnmounted, ref, useTemplateRef } from 'vue';
 import { Pipeline, Request } from '@ui/Publish/SavePipeline.js';
+import { deepClone } from '@/util/clone.js';
 
 const props = defineProps({
     blueprint: Object,
@@ -11,29 +12,80 @@ const props = defineProps({
     updateUrl: String,
 });
 
+const isMultisite = computed(() => Statamic.$config.get('multisiteEnabled'));
+
+function siteHandlesFromValues(values) {
+    if (! isMultisite.value) {
+        return [values.handle];
+    }
+
+    return Object.entries(values)
+        .filter(([key, sites]) => key.endsWith('_sites') && Array.isArray(sites))
+        .flatMap(([, sites]) => sites.map((site) => site.handle));
+}
+
 const container = useTemplateRef('container');
 const values = ref(props.initialValues);
 const errors = ref({});
 const saving = ref(false);
+const editingGroups = ref(false);
+const groupsSnapshot = ref(null);
+const containerKey = ref(0);
 
-const pageTitle = computed(() => Statamic.$config.get('multisiteEnabled') ? __('Configure Sites') : __('Configure Site'));
+const groupsDirty = computed(() => {
+    if (!editingGroups.value || !groupsSnapshot.value) return false;
 
-const initialSiteHandles = computed(() => {
-    return Statamic.$config.get('multisiteEnabled')
-        ? props.initialValues.sites.map((site) => site.handle)
-        : [props.initialValues.handle];
+    return JSON.stringify(values.value) !== JSON.stringify(groupsSnapshot.value);
 });
 
-const currentSiteHandles = computed(() => {
-    return Statamic.$config.get('multisiteEnabled')
-        ? values.value.sites.map((site) => site.handle)
-        : [values.value.handle];
-});
+const pageTitle = computed(() => isMultisite.value ? __('Configure Sites') : __('Configure Site'));
+
+const initialSiteHandles = computed(() => siteHandlesFromValues(props.initialValues));
+
+const currentSiteHandles = computed(() => siteHandlesFromValues(values.value));
 
 const initialHandleChanged = computed(() => initialSiteHandles.value.filter((handle) => !currentSiteHandles.value.includes(handle)).length > 0);
 const initialHandleChangedWarning = computed(() => __('Warning! Changing a site handle may break existing site content!'));
 
+const hasOnlyOtherGroup = computed(() => {
+    if (! isMultisite.value || ! props.blueprint?.tabs) {
+        return false;
+    }
+
+    const sections = props.blueprint.tabs.flatMap((tab) => tab.sections ?? []);
+
+    return sections.length > 0 && ! sections.some((section) => section.reorderable);
+});
+
+const editSiteGroupsLabel = computed(() => hasOnlyOtherGroup.value ? __('Add Site Groups') : __('Edit Site Groups'));
+
+function startEditingGroups() {
+    groupsSnapshot.value = deepClone(values.value);
+    editingGroups.value = true;
+}
+
+function stopEditingGroups() {
+    editingGroups.value = false;
+    groupsSnapshot.value = null;
+}
+
+function discardGroupChanges() {
+    values.value = deepClone(groupsSnapshot.value);
+    containerKey.value++;
+    stopEditingGroups();
+}
+
+function groupNamesFromValues(formValues) {
+    return Object.fromEntries(
+        Object.entries(formValues).filter(([key, value]) => /^group_.+_name$/.test(key) && typeof value === 'string'),
+    );
+}
+
 function save() {
+    if (editingGroups.value && !groupsDirty.value) {
+        return;
+    }
+
     if (initialHandleChanged.value && !confirm(initialHandleChangedWarning.value)) {
         return;
     }
@@ -41,12 +93,12 @@ function save() {
     new Pipeline()
         .provide({ container, errors, saving })
         .through([
-            new Request(props.updateUrl, 'patch')
+            new Request(props.updateUrl, 'patch', groupNamesFromValues(values.value))
         ])
         .then((response) => {
             Statamic.$toast.success(__('Saved'));
 
-            if (Statamic.$config.get('multisiteEnabled')) {
+            if (isMultisite.value) {
                 window.location.reload();
             }
         });
@@ -56,6 +108,8 @@ let saveKeyBinding;
 
 onMounted(() => {
     saveKeyBinding = Statamic.$keys.bindGlobal(['mod+s'], (e) => {
+        if (editingGroups.value && !groupsDirty.value) return;
+
         e.preventDefault();
         save();
     });
@@ -65,10 +119,33 @@ onUnmounted(() => saveKeyBinding.destroy());
 </script>
 
 <template>
-    <Head :title="__('Configure Sites')" />
+    <Head :title="pageTitle" />
 
     <div class="max-w-page mx-auto">
         <Header :title="pageTitle" icon="site">
+            <CommandPaletteItem
+                v-if="!editingGroups && isMultisite"
+                :category="$commandPalette.category.Actions"
+                :text="editSiteGroupsLabel"
+                icon="navigation"
+                :action="startEditingGroups"
+                v-slot="{ text, action }"
+            >
+                <Button icon="navigation" :text="text" @click="action" />
+            </CommandPaletteItem>
+            <Button
+                v-if="editingGroups && !groupsDirty"
+                :text="__('Cancel')"
+                :disabled="saving"
+                @click="stopEditingGroups"
+            />
+            <Button
+                v-if="editingGroups && groupsDirty"
+                :text="__('Discard Changes')"
+                variant="filled"
+                :disabled="saving"
+                @click="discardGroupChanges"
+            />
             <CommandPaletteItem
                 :category="$commandPalette.category.Actions"
                 :text="__('Save')"
@@ -77,12 +154,20 @@ onUnmounted(() => saveKeyBinding.destroy());
                 prioritize
                 v-slot="{ text, action }"
             >
-                <Button type="submit" variant="primary" @click="action">{{ text }}</Button>
+                <Button
+                    type="submit"
+                    variant="primary"
+                    :text="text"
+                    :loading="saving"
+                    :disabled="editingGroups && !groupsDirty"
+                    @click="action"
+                />
             </CommandPaletteItem>
         </Header>
 
         <PublishContainer
             v-if="blueprint"
+            :key="containerKey"
             ref="container"
             name="sites"
             reference="sites"
@@ -90,6 +175,7 @@ onUnmounted(() => saveKeyBinding.destroy());
             v-model="values"
             :meta
             :errors
+            :provide="{ editingSections: editingGroups, canAddSections: isMultisite }"
         />
 
         <DocsCallout :topic="__('Multi-Site')" url="multi-site" />

--- a/resources/js/pages/sites/Edit.vue
+++ b/resources/js/pages/sites/Edit.vue
@@ -26,10 +26,12 @@ function siteHandlesFromValues(values) {
 
 const container = useTemplateRef('container');
 const values = ref(props.initialValues);
+const blueprintState = ref(deepClone(props.blueprint));
 const errors = ref({});
 const saving = ref(false);
 const editingGroups = ref(false);
 const groupsSnapshot = ref(null);
+const blueprintSnapshot = ref(null);
 const containerKey = ref(0);
 
 const groupsDirty = computed(() => {
@@ -48,11 +50,11 @@ const initialHandleChanged = computed(() => initialSiteHandles.value.filter((han
 const initialHandleChangedWarning = computed(() => __('Warning! Changing a site handle may break existing site content!'));
 
 const hasOnlyOtherGroup = computed(() => {
-    if (! isMultisite.value || ! props.blueprint?.tabs) {
+    if (! isMultisite.value || ! blueprintState.value?.tabs) {
         return false;
     }
 
-    const sections = props.blueprint.tabs.flatMap((tab) => tab.sections ?? []);
+    const sections = blueprintState.value.tabs.flatMap((tab) => tab.sections ?? []);
 
     return sections.length > 0 && ! sections.some((section) => section.reorderable);
 });
@@ -61,23 +63,26 @@ const editSiteGroupsLabel = computed(() => hasOnlyOtherGroup.value ? __('Add Sit
 
 function startEditingGroups() {
     groupsSnapshot.value = deepClone(values.value);
+    blueprintSnapshot.value = deepClone(blueprintState.value);
     editingGroups.value = true;
 }
 
 function stopEditingGroups() {
     editingGroups.value = false;
     groupsSnapshot.value = null;
+    blueprintSnapshot.value = null;
 }
 
 function discardGroupChanges() {
     values.value = deepClone(groupsSnapshot.value);
+    blueprintState.value = deepClone(blueprintSnapshot.value);
     containerKey.value++;
     stopEditingGroups();
 }
 
 function groupNamesFromValues(formValues) {
     return Object.fromEntries(
-        Object.entries(formValues).filter(([key, value]) => /^group_.+_name$/.test(key) && typeof value === 'string'),
+        Object.entries(formValues).filter(([key, value]) => /^group_[A-Za-z0-9_-]+_name$/.test(key) && typeof value === 'string'),
     );
 }
 
@@ -166,12 +171,12 @@ onUnmounted(() => saveKeyBinding.destroy());
         </Header>
 
         <PublishContainer
-            v-if="blueprint"
+            v-if="blueprintState"
             :key="containerKey"
             ref="container"
             name="sites"
             reference="sites"
-            :blueprint
+            :blueprint="blueprintState"
             v-model="values"
             :meta
             :errors

--- a/resources/js/tests/util/site-groups.test.js
+++ b/resources/js/tests/util/site-groups.test.js
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import {
+    flatOptionsFromSiteGroups,
+    groupItemsBySiteGroup,
+    hasNamedSiteGroups,
+    preferredOriginHandle,
+    selectedSiteGroupLabel,
+    siteGroupKey,
+    UNGROUPED_SITE_GROUP_KEY,
+} from '@/util/site-groups.js';
+
+beforeEach(() => {
+    globalThis.__ = (string) => string;
+    globalThis.Statamic = {
+        $config: {
+            get: () => [
+                { handle: 'en', name: 'English', group: 'UK', group_handle: 'uk' },
+                { handle: 'fr', name: 'French', group: 'UK', group_handle: 'uk' },
+                { handle: 'de', name: 'German', group: 'EU', group_handle: 'eu' },
+                { handle: 'nl', name: 'Dutch' },
+            ],
+        },
+    };
+});
+
+describe('siteGroupKey', () => {
+    test('uses group_handle, then group, then other', () => {
+        expect(siteGroupKey({ group_handle: 'uk', group: 'UK' })).toBe('uk');
+        expect(siteGroupKey({ group: 'UK' })).toBe('UK');
+        expect(siteGroupKey({})).toBe(UNGROUPED_SITE_GROUP_KEY);
+    });
+});
+
+describe('groupItemsBySiteGroup', () => {
+    test('keeps named groups in first-seen order and Other last', () => {
+        const groups = groupItemsBySiteGroup([
+            { handle: 'en', group: 'UK', group_handle: 'uk' },
+            { handle: 'nl' },
+            { handle: 'fr', group: 'UK', group_handle: 'uk' },
+            { handle: 'de', group: 'EU', group_handle: 'eu' },
+        ]);
+
+        expect(groups.map((group) => group.key)).toEqual(['uk', 'eu', UNGROUPED_SITE_GROUP_KEY]);
+        expect(groups[0].items.map((item) => item.handle)).toEqual(['en', 'fr']);
+        expect(groups[2].label).toBe('Other');
+    });
+});
+
+describe('hasNamedSiteGroups', () => {
+    test('detects named groups from items or grouped structure', () => {
+        expect(hasNamedSiteGroups([{ handle: 'nl' }])).toBe(false);
+        expect(hasNamedSiteGroups([{ handle: 'en', group: 'UK' }])).toBe(true);
+        expect(hasNamedSiteGroups(groupItemsBySiteGroup([{ handle: 'en', group: 'UK' }]))).toBe(true);
+    });
+});
+
+describe('flatOptionsFromSiteGroups', () => {
+    test('adds headers and separators for visible groups', () => {
+        const options = flatOptionsFromSiteGroups(groupItemsBySiteGroup([
+            { handle: 'en', name: 'English', group: 'UK', group_handle: 'uk' },
+            { handle: 'de', name: 'German', group: 'EU', group_handle: 'eu' },
+        ]));
+
+        expect(options[0]._groupLabel).toBe('UK');
+        expect(options[0]._showGroupSeparator).toBe(false);
+        expect(options[1]._groupLabel).toBe('EU');
+        expect(options[1]._showGroupSeparator).toBe(true);
+    });
+
+    test('can filter items while regrouping headers', () => {
+        const options = flatOptionsFromSiteGroups(groupItemsBySiteGroup([
+            { handle: 'en', name: 'English', group: 'UK', group_handle: 'uk' },
+            { handle: 'fr', name: 'French', group: 'UK', group_handle: 'uk' },
+            { handle: 'de', name: 'German', group: 'EU', group_handle: 'eu' },
+        ]), {
+            filterItems: (items) => items.filter((item) => item.handle !== 'en'),
+        });
+
+        expect(options.map((option) => option.handle)).toEqual(['fr', 'de']);
+        expect(options[0]._groupLabel).toBe('UK');
+        expect(options[1]._groupLabel).toBe('EU');
+    });
+});
+
+describe('selectedSiteGroupLabel', () => {
+    test('returns group name, Other, or null', () => {
+        expect(selectedSiteGroupLabel({ group: 'UK' }, true)).toBe('UK');
+        expect(selectedSiteGroupLabel({}, true)).toBe('Other');
+        expect(selectedSiteGroupLabel({}, false)).toBeNull();
+    });
+});
+
+describe('preferredOriginHandle', () => {
+    test('prefers an existing site in the target group', () => {
+        const localizations = [
+            { handle: 'en', exists: true, root: true, group: 'UK', group_handle: 'uk' },
+            { handle: 'fr', exists: true, group: 'UK', group_handle: 'uk', origin_handle: 'en' },
+            { handle: 'de', exists: false, group: 'EU', group_handle: 'eu' },
+        ];
+
+        expect(preferredOriginHandle(localizations, localizations[2])).toBe('en');
+    });
+
+    test('follows a former group origin that moved outside the group', () => {
+        const localizations = [
+            { handle: 'en', exists: true, root: true, group: 'UK', group_handle: 'uk' },
+            { handle: 'fr', exists: true, group: 'EU', group_handle: 'eu', origin_handle: 'en' },
+            { handle: 'de', exists: true, group: 'EU', group_handle: 'eu', origin_handle: 'fr' },
+        ];
+
+        // Creating another EU site should still prefer fr's origin (en) once fr left... 
+        // Actually: fr is IN eu with origin en outside. de is in eu with origin fr.
+        // preferred for a new EU target should find sameGroup [fr, de], groupOriginHandle.
+        expect(preferredOriginHandle(localizations, {
+            handle: 'nl',
+            exists: false,
+            group: 'EU',
+            group_handle: 'eu',
+        })).toBe('fr');
+    });
+
+    test('falls back to root when the target group has no existing sites', () => {
+        const localizations = [
+            { handle: 'en', exists: true, root: true, group: 'UK', group_handle: 'uk' },
+            { handle: 'fr', exists: true, group: 'UK', group_handle: 'uk', origin_handle: 'en' },
+            { handle: 'de', exists: false, group: 'EU', group_handle: 'eu' },
+        ];
+
+        expect(preferredOriginHandle(localizations, localizations[2], 'root')).toBe('en');
+    });
+
+    test('returns null when nothing exists yet', () => {
+        expect(preferredOriginHandle([{ handle: 'en', exists: false }], { handle: 'fr' })).toBeNull();
+    });
+});

--- a/resources/js/tests/util/site-groups.test.js
+++ b/resources/js/tests/util/site-groups.test.js
@@ -129,6 +129,26 @@ describe('preferredOriginHandle', () => {
         expect(preferredOriginHandle(localizations, localizations[2], 'root')).toBe('en');
     });
 
+    test('falls back to root for select behavior even when another site is active', () => {
+        const localizations = [
+            { handle: 'en', exists: true, root: true, active: false, group: 'UK', group_handle: 'uk' },
+            { handle: 'fr', exists: true, active: true, group: 'UK', group_handle: 'uk', origin_handle: 'en' },
+            { handle: 'de', exists: false, group: 'EU', group_handle: 'eu' },
+        ];
+
+        expect(preferredOriginHandle(localizations, localizations[2], 'select')).toBe('en');
+    });
+
+    test('falls back to the active site when origin behavior is active', () => {
+        const localizations = [
+            { handle: 'en', exists: true, root: true, active: false, group: 'UK', group_handle: 'uk' },
+            { handle: 'fr', exists: true, active: true, group: 'UK', group_handle: 'uk', origin_handle: 'en' },
+            { handle: 'de', exists: false, group: 'EU', group_handle: 'eu' },
+        ];
+
+        expect(preferredOriginHandle(localizations, localizations[2], 'active')).toBe('fr');
+    });
+
     test('returns null when nothing exists yet', () => {
         expect(preferredOriginHandle([{ handle: 'en', exists: false }], { handle: 'fr' })).toBeNull();
     });

--- a/resources/js/util/site-groups.js
+++ b/resources/js/util/site-groups.js
@@ -71,7 +71,7 @@ export function flatOptionsFromSiteGroups(groups, { filterItems = (items) => ite
 
 export function selectedSiteGroupLabel(item, namedGroupsExist) {
     if (item?.group) {
-        return __(item.group);
+        return item.group;
     }
 
     return namedGroupsExist ? __('Other') : null;

--- a/resources/js/util/site-groups.js
+++ b/resources/js/util/site-groups.js
@@ -1,5 +1,13 @@
 export const UNGROUPED_SITE_GROUP_KEY = 'other';
 
+export function siteGroupKey(item) {
+    if (!item?.group && !item?.group_handle) {
+        return UNGROUPED_SITE_GROUP_KEY;
+    }
+
+    return item.group_handle || item.group;
+}
+
 /**
  * Group sites/localizations by named site group. Ungrouped items come last under "Other".
  */
@@ -8,10 +16,8 @@ export function groupItemsBySiteGroup(items) {
     const indexByKey = new Map();
 
     for (const item of items) {
-        const isUngrouped = !item.group && !item.group_handle;
-        const key = isUngrouped
-            ? UNGROUPED_SITE_GROUP_KEY
-            : (item.group_handle || item.group);
+        const isUngrouped = siteGroupKey(item) === UNGROUPED_SITE_GROUP_KEY;
+        const key = siteGroupKey(item);
         const label = isUngrouped ? __('Other') : item.group;
 
         if (!indexByKey.has(key)) {
@@ -69,4 +75,89 @@ export function selectedSiteGroupLabel(item, namedGroupsExist) {
     }
 
     return namedGroupsExist ? __('Other') : null;
+}
+
+/**
+ * Prefer an existing site in the target's group as the origin.
+ * Prefer the localization that entered the group from outside (or the root).
+ * If the group has no existing sites, fall back to originBehavior.
+ */
+export function preferredOriginHandle(localizations, target, originBehavior = 'root') {
+    const existing = (localizations ?? []).filter((localization) => localization.exists);
+
+    if (!existing.length) {
+        return null;
+    }
+
+    const targetKey = target ? siteGroupKey(target) : null;
+    const sameGroup = targetKey
+        ? existingInSiteOrder(existing).filter((localization) => siteGroupKey(localization) === targetKey)
+        : [];
+
+    if (sameGroup.length) {
+        return groupOriginHandle(sameGroup);
+    }
+
+    if (originBehavior !== 'root') {
+        const active = existing.find((localization) => localization.active);
+        if (active) {
+            return active.handle;
+        }
+    }
+
+    const root = existing.find((localization) => localization.root);
+    if (root) {
+        return root.handle;
+    }
+
+    return existing[0]?.handle ?? null;
+}
+
+/**
+ * Prefer the localization that entered the group from outside, or the root.
+ * If that site leaves the group, use whichever remaining site now points outside.
+ */
+function groupOriginHandle(sameGroup) {
+    const handles = new Set(sameGroup.map((localization) => localization.handle));
+
+    const entryPoint = sameGroup.find(({ origin_handle: origin }) => {
+        if (origin === undefined) return false;
+
+        return !origin || !handles.has(origin);
+    });
+
+    if (entryPoint) {
+        return entryPoint.handle;
+    }
+
+    const tracked = sameGroup.find((localization) => localization.origin)
+        ?? sameGroup.find((localization) => localization.root);
+
+    return (tracked ?? sameGroup[0]).handle;
+}
+
+function existingInSiteOrder(existing) {
+    const byHandle = new Map(existing.map((localization) => [localization.handle, localization]));
+    const ordered = siteOrderHandles()
+        .map((handle) => byHandle.get(handle))
+        .filter(Boolean);
+
+    if (!ordered.length) {
+        return existing;
+    }
+
+    const seen = new Set(ordered.map((localization) => localization.handle));
+    const rest = existing.filter((localization) => !seen.has(localization.handle));
+
+    return [...ordered, ...rest];
+}
+
+function siteOrderHandles() {
+    const sites = typeof Statamic !== 'undefined' ? Statamic.$config?.get?.('sites') : null;
+
+    if (!Array.isArray(sites) || !sites.length) {
+        return [];
+    }
+
+    return sites.map((site) => site.handle);
 }

--- a/resources/js/util/site-groups.js
+++ b/resources/js/util/site-groups.js
@@ -1,0 +1,72 @@
+export const UNGROUPED_SITE_GROUP_KEY = 'other';
+
+/**
+ * Group sites/localizations by named site group. Ungrouped items come last under "Other".
+ */
+export function groupItemsBySiteGroup(items) {
+    const groups = [];
+    const indexByKey = new Map();
+
+    for (const item of items) {
+        const isUngrouped = !item.group && !item.group_handle;
+        const key = isUngrouped
+            ? UNGROUPED_SITE_GROUP_KEY
+            : (item.group_handle || item.group);
+        const label = isUngrouped ? __('Other') : item.group;
+
+        if (!indexByKey.has(key)) {
+            indexByKey.set(key, groups.length);
+            groups.push({ key, label, items: [] });
+        }
+
+        groups[indexByKey.get(key)].items.push(item);
+    }
+
+    const named = groups.filter((group) => group.key !== UNGROUPED_SITE_GROUP_KEY);
+    const other = groups.filter((group) => group.key === UNGROUPED_SITE_GROUP_KEY);
+
+    return [...named, ...other];
+}
+
+export function hasNamedSiteGroups(groupsOrItems) {
+    const groups = Array.isArray(groupsOrItems?.[0]?.items)
+        ? groupsOrItems
+        : groupItemsBySiteGroup(groupsOrItems ?? []);
+
+    return groups.some((group) => group.key !== UNGROUPED_SITE_GROUP_KEY);
+}
+
+/**
+ * Flatten grouped items into Combobox/Select options with header metadata.
+ */
+export function flatOptionsFromSiteGroups(groups, { filterItems = (items) => items } = {}) {
+    let isFirstVisibleOption = true;
+
+    return groups.flatMap((group) => {
+        const items = filterItems(group.items);
+
+        if (!items.length) {
+            return [];
+        }
+
+        return items.map((item, index) => {
+            const option = {
+                ...item,
+                _groupLabel: index === 0 ? group.label : null,
+                _showGroupSeparator: index === 0 && !isFirstVisibleOption,
+            };
+
+            isFirstVisibleOption = false;
+
+            return option;
+        });
+    });
+}
+
+export function selectedSiteGroupLabel(item, namedGroupsExist) {
+    if (item?.group) {
+        return __(item.group);
+    }
+
+    return namedGroupsExist ? __('Other') : null;
+}

--- a/resources/js/util/site-groups.js
+++ b/resources/js/util/site-groups.js
@@ -97,7 +97,7 @@ export function preferredOriginHandle(localizations, target, originBehavior = 'r
         return groupOriginHandle(sameGroup, existing);
     }
 
-    if (originBehavior !== 'root') {
+    if (originBehavior === 'active') {
         const active = existing.find((localization) => localization.active);
         if (active) {
             return active.handle;

--- a/resources/js/util/site-groups.js
+++ b/resources/js/util/site-groups.js
@@ -79,8 +79,7 @@ export function selectedSiteGroupLabel(item, namedGroupsExist) {
 
 /**
  * Prefer an existing site in the target's group as the origin.
- * Prefer the localization that entered the group from outside (or the root).
- * If the group has no existing sites, fall back to originBehavior.
+ * If the group has none yet, fall back to originBehavior.
  */
 export function preferredOriginHandle(localizations, target, originBehavior = 'root') {
     const existing = (localizations ?? []).filter((localization) => localization.exists);
@@ -95,7 +94,7 @@ export function preferredOriginHandle(localizations, target, originBehavior = 'r
         : [];
 
     if (sameGroup.length) {
-        return groupOriginHandle(sameGroup);
+        return groupOriginHandle(sameGroup, existing);
     }
 
     if (originBehavior !== 'root') {
@@ -114,26 +113,79 @@ export function preferredOriginHandle(localizations, target, originBehavior = 'r
 }
 
 /**
- * Prefer the localization that entered the group from outside, or the root.
- * If that site leaves the group, use whichever remaining site now points outside.
+ * Prefer the first localization in the group (the one that entered from outside,
+ * or the in-group root). If that site later leaves the group, follow it outside
+ * instead of promoting another in-group site to Origin.
  */
-function groupOriginHandle(sameGroup) {
-    const handles = new Set(sameGroup.map((localization) => localization.handle));
+function groupOriginHandle(sameGroup, allExisting) {
+    const inGroup = new Set(sameGroup.map((localization) => localization.handle));
+    const byHandle = new Map(allExisting.map((localization) => [localization.handle, localization]));
+
+    const chainHead = sameGroup.find((localization) => (
+        sameGroup.some((other) => other.origin_handle === localization.handle)
+    ));
+
+    if (chainHead) {
+        return chainHead.handle;
+    }
 
     const entryPoint = sameGroup.find(({ origin_handle: origin }) => {
         if (origin === undefined) return false;
 
-        return !origin || !handles.has(origin);
-    });
+        return !origin || !inGroup.has(origin);
+    }) ?? sameGroup[0];
 
-    if (entryPoint) {
+    if (!entryPoint) {
+        return null;
+    }
+
+    const parentHandle = entryPoint.origin_handle;
+
+    if (!parentHandle) {
         return entryPoint.handle;
     }
 
-    const tracked = sameGroup.find((localization) => localization.origin)
-        ?? sameGroup.find((localization) => localization.root);
+    if (inGroup.has(parentHandle)) {
+        return entryPoint.handle;
+    }
 
-    return (tracked ?? sameGroup[0]).handle;
+    const parent = byHandle.get(parentHandle);
+
+    if (!parent) {
+        return entryPoint.handle;
+    }
+
+    // Parent is outside the group. If anything exists that isn't that parent or
+    // descended from it, the parent is a former in-group origin that moved out —
+    // keep pointing at it. Otherwise this is the first localization in the group
+    // (created from the global root/default) and it stays the group origin.
+    const hasUnrelatedLocalizations = allExisting.some((localization) => (
+        localization.handle !== parentHandle
+        && !descendsFrom(localization, parentHandle, byHandle)
+    ));
+
+    return hasUnrelatedLocalizations ? parentHandle : entryPoint.handle;
+}
+
+function descendsFrom(localization, ancestorHandle, byHandle) {
+    let current = localization;
+    const seen = new Set();
+
+    while (current?.origin_handle) {
+        if (seen.has(current.handle)) {
+            return false;
+        }
+
+        seen.add(current.handle);
+
+        if (current.origin_handle === ancestorHandle) {
+            return true;
+        }
+
+        current = byHandle.get(current.origin_handle);
+    }
+
+    return false;
 }
 
 function existingInSiteOrder(existing) {

--- a/src/Facades/Site.php
+++ b/src/Facades/Site.php
@@ -11,6 +11,7 @@ use Statamic\Sites\Sites;
  * @method static mixed authorized()
  * @method static mixed default()
  * @method static bool hasMultiple()
+ * @method static \Illuminate\Support\Collection filterByGroup($handles, ?string $siteHandle)
  * @method static mixed get($handle)
  * @method static mixed findByUrl($url)
  * @method static mixed current()
@@ -21,7 +22,9 @@ use Statamic\Sites\Sites;
  * @method static self setSites($sites)
  * @method static self setSiteValue(string $site, string $key, $value)
  * @method static string path()
- * @method static \Statamic\Fields\Blueprint blueprint()
+ * @method static \Statamic\Fields\Blueprint blueprint(array $values = [])
+ * @method static array blueprintValues()
+ * @method static array configFromBlueprintValues(array $values)
  * @method static array config()
  *
  * @see \Statamic\Sites\Sites

--- a/src/Facades/Site.php
+++ b/src/Facades/Site.php
@@ -24,6 +24,7 @@ use Statamic\Sites\Sites;
  * @method static string path()
  * @method static \Statamic\Fields\Blueprint blueprint(array $values = [])
  * @method static array blueprintValues()
+ * @method static array normalizeBlueprintValues(array $values)
  * @method static array configFromBlueprintValues(array $values)
  * @method static array config()
  *

--- a/src/Fields/Section.php
+++ b/src/Fields/Section.php
@@ -50,6 +50,8 @@ class Section
             'instructions' => $this->instructions(),
             'collapsible' => $this->collapsible() ?: null,
             'collapsed' => $this->collapsed() ?: null,
+            'editable_title_handle' => Arr::get($this->contents, 'editable_title_handle'),
+            'reorderable' => Arr::get($this->contents, 'reorderable') ?: null,
         ]) + [
             'fields' => $this->fields()->toPublishArray(),
         ];

--- a/src/Fieldtypes/Sites.php
+++ b/src/Fieldtypes/Sites.php
@@ -7,7 +7,7 @@ use Statamic\Facades\User;
 
 class Sites extends Relationship
 {
-    protected $indexComponent = 'text';
+    protected $indexComponent = 'sites';
 
     protected function authorizeItemData($id): bool
     {
@@ -64,6 +64,14 @@ class Sites extends Relationship
             $items = collect([$items]);
         }
 
-        return $items->map->name()->join(', ');
+        return $items
+            ->filter()
+            ->map(fn ($site) => [
+                'title' => $site->name(),
+                'group' => $site->group(),
+                'group_handle' => $site->groupHandle(),
+            ])
+            ->values()
+            ->all();
     }
 }

--- a/src/Fieldtypes/Sites.php
+++ b/src/Fieldtypes/Sites.php
@@ -20,6 +20,8 @@ class Sites extends Relationship
             return [
                 'id' => $id,
                 'title' => $site->name(),
+                'group' => $site->group(),
+                'group_handle' => $site->groupHandle(),
             ];
         }
 
@@ -30,11 +32,12 @@ class Sites extends Relationship
     {
         return Site::all()
             ->filter(fn ($site) => User::current()->can('view', $site))
-            ->sortBy('name')
             ->map(function ($site) {
                 return [
                     'id' => $site->handle(),
                     'title' => $site->name(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                 ];
             })->values();
     }

--- a/src/Fieldtypes/Sites.php
+++ b/src/Fieldtypes/Sites.php
@@ -30,8 +30,15 @@ class Sites extends Relationship
 
     public function getIndexItems($request)
     {
-        return Site::all()
-            ->filter(fn ($site) => User::current()->can('view', $site))
+        $sites = Site::all()
+            ->filter(fn ($site) => User::current()->can('view', $site));
+
+        // Preserve sites.yaml order when groups exist; otherwise keep the old A–Z sort.
+        if (! $sites->contains(fn ($site) => $site->group())) {
+            $sites = $sites->sortBy->name();
+        }
+
+        return $sites
             ->map(function ($site) {
                 return [
                     'id' => $site->handle(),

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -714,6 +714,8 @@ class CollectionsController extends CpController
                 return [
                     'handle' => $site->handle(),
                     'name' => $site->name(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                 ];
             })
             ->values()

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -147,10 +147,13 @@ class EntriesController extends CpController
             'localizations' => $this->getAuthorizedSitesForCollection($collection)->map(function ($handle) use ($entry) {
                 $localized = $entry->in($handle);
                 $exists = $localized !== null;
+                $site = Site::get($handle);
 
                 return [
                     'handle' => $handle,
-                    'name' => Site::get($handle)->name(),
+                    'name' => $site->name(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                     'active' => $handle === $entry->locale(),
                     'exists' => $exists,
                     'root' => $exists ? $localized->isRoot() : false,
@@ -336,9 +339,13 @@ class EntriesController extends CpController
             'published' => $collection->defaultPublishState(),
             'locale' => $site->handle(),
             'localizations' => $this->getAuthorizedSitesForCollection($collection)->map(function ($handle) use ($collection, $site, $blueprint) {
+                $localizationSite = Site::get($handle);
+
                 return [
                     'handle' => $handle,
-                    'name' => Site::get($handle)->name(),
+                    'name' => $localizationSite->name(),
+                    'group' => $localizationSite->group(),
+                    'group_handle' => $localizationSite->groupHandle(),
                     'active' => $handle === $site->handle(),
                     'exists' => false,
                     'published' => false,

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -158,6 +158,7 @@ class EntriesController extends CpController
                     'exists' => $exists,
                     'root' => $exists ? $localized->isRoot() : false,
                     'origin' => $exists ? $localized->id() === optional($entry->origin())->id() : null,
+                    'origin_handle' => $exists ? optional($localized->origin())->locale() : null,
                     'published' => $exists ? $localized->published() : false,
                     'status' => $exists ? $localized->status() : null,
                     'url' => $exists ? $localized->editUrl() : null,

--- a/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
+++ b/src/Http/Controllers/CP/Collections/EntryRevisionsController.php
@@ -86,10 +86,13 @@ class EntryRevisionsController extends CpController
             'localizations' => $this->getAuthorizedSitesForCollection($entry->collection())->map(function ($handle) use ($entry) {
                 $localized = $entry->in($handle);
                 $exists = $localized !== null;
+                $site = Site::get($handle);
 
                 return [
                     'handle' => $handle,
-                    'name' => Site::get($handle)->name(),
+                    'name' => $site->name(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                     'active' => $handle === $entry->locale(),
                     'exists' => $exists,
                     'root' => $exists ? $localized->isRoot() : false,

--- a/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
@@ -55,9 +55,13 @@ class GlobalVariablesController extends CpController
             'originValues' => $originValues ?? null,
             'originMeta' => $originMeta ?? null,
             'localizations' => $this->getAuthorizedLocalizationsForVariables($variables)->map(function ($localized) use ($variables) {
+                $site = $localized->site();
+
                 return [
                     'handle' => $localized->locale(),
-                    'name' => $localized->site()->name(),
+                    'name' => $site->name(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                     'active' => $localized->locale() === $variables->locale(),
                     'origin' => ! $localized->hasOrigin(),
                     'url' => $localized->editUrl(),

--- a/src/Http/Controllers/CP/Globals/GlobalsController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalsController.php
@@ -72,6 +72,8 @@ class GlobalsController extends CpController
                 return [
                     'name' => $site->name(),
                     'handle' => $site->handle(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                     'enabled' => $set->sites()->contains($site->handle()),
                     'origin' => $set->origins()->get($site->handle()),
                 ];

--- a/src/Http/Controllers/CP/Navigation/NavigationController.php
+++ b/src/Http/Controllers/CP/Navigation/NavigationController.php
@@ -132,9 +132,13 @@ class NavigationController extends CpController
             'blueprintUrl' => cp_route('blueprints.navigation.edit', $nav->handle()),
             'site' => $site,
             'sites' => $this->getAuthorizedTreesForNav($nav)->map(function ($tree) {
+                $site = $tree->site();
+
                 return [
                     'handle' => $tree->locale(),
-                    'name' => $tree->site()->name(),
+                    'name' => $site->name(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                     'url' => $tree->showUrl(),
                 ];
             })->values()->all(),

--- a/src/Http/Controllers/CP/Sites/SitesController.php
+++ b/src/Http/Controllers/CP/Sites/SitesController.php
@@ -76,21 +76,21 @@ class SitesController extends CpController
 
     private function isGroupNameKey(string $key): bool
     {
-        return (bool) preg_match('/^group_.+_name$/', $key);
+        return (bool) preg_match('/^group_[A-Za-z0-9_-]+_name$/', $key);
     }
 
     private function emptySitesError(array $request): array
     {
         $keys = collect($request)
             ->keys()
-            ->filter(fn ($key) => is_string($key) && preg_match('/^group_.+_sites$/', $key));
+            ->filter(fn ($key) => is_string($key) && preg_match('/^group_[A-Za-z0-9_-]+_sites$/', $key));
 
         if ($keys->isEmpty()) {
             $keys = collect(['group_other_sites']);
         }
 
         return $keys
-            ->mapWithKeys(fn ($key) => [$key => [__('This field is required.')]])
+            ->mapWithKeys(fn ($key) => [$key => [__('statamic::validation.required')]])
             ->all();
     }
 
@@ -99,7 +99,7 @@ class SitesController extends CpController
         $handles = collect();
 
         foreach ($values as $key => $sites) {
-            if (! is_array($sites) || ! preg_match('/^group_.+_sites$/', $key)) {
+            if (! is_array($sites) || ! preg_match('/^group_[A-Za-z0-9_-]+_sites$/', $key)) {
                 continue;
             }
 

--- a/src/Http/Controllers/CP/Sites/SitesController.php
+++ b/src/Http/Controllers/CP/Sites/SitesController.php
@@ -55,9 +55,9 @@ class SitesController extends CpController
         $sites = Site::configFromBlueprintValues($values);
 
         if (Site::multiEnabled() && empty($sites)) {
-            throw ValidationException::withMessages([
-                'group_other_sites' => [__('This field is required.')],
-            ]);
+            throw ValidationException::withMessages(
+                $this->emptySitesError($request->all())
+            );
         }
 
         Site::setSites($sites)->save();
@@ -77,6 +77,21 @@ class SitesController extends CpController
     private function isGroupNameKey(string $key): bool
     {
         return (bool) preg_match('/^group_.+_name$/', $key);
+    }
+
+    private function emptySitesError(array $request): array
+    {
+        $keys = collect($request)
+            ->keys()
+            ->filter(fn ($key) => is_string($key) && preg_match('/^group_.+_sites$/', $key));
+
+        if ($keys->isEmpty()) {
+            $keys = collect(['group_other_sites']);
+        }
+
+        return $keys
+            ->mapWithKeys(fn ($key) => [$key => [__('This field is required.')]])
+            ->all();
     }
 
     private function uniqueHandleRules(array $values): array

--- a/src/Http/Controllers/CP/Sites/SitesController.php
+++ b/src/Http/Controllers/CP/Sites/SitesController.php
@@ -8,6 +8,8 @@ use Inertia\Inertia;
 use Statamic\Facades\Site;
 use Statamic\Http\Controllers\CP\CpController;
 
+use function Statamic\trans as __;
+
 class SitesController extends CpController
 {
     public function __construct()

--- a/src/Http/Controllers/CP/Sites/SitesController.php
+++ b/src/Http/Controllers/CP/Sites/SitesController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\CP\Sites;
 
 use Illuminate\Http\Request;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Statamic\Facades\Site;
 use Statamic\Http\Controllers\CP\CpController;
@@ -33,46 +34,78 @@ class SitesController extends CpController
 
     private function values(): array
     {
-        $sites = collect(Site::config())
-            ->map(fn ($site, $handle) => array_merge(['handle' => $handle], $site))
-            ->values()
-            ->all();
-
-        if (! Site::multiEnabled()) {
-            return $sites[0];
-        }
-
-        return ['sites' => $sites];
+        return Site::blueprintValues();
     }
 
     public function update(Request $request)
     {
-        $blueprint = Site::blueprint();
+        $blueprint = Site::blueprint($request->all());
 
         $fields = $blueprint
             ->fields()
             ->addValues($request->all());
 
-        $fields->validate();
+        $fields->validate($this->uniqueHandleRules($request->all()));
 
-        $values = $fields
-            ->process()
-            ->values()
-            ->all();
+        $values = $this->valuesInRequestOrder(
+            $request->all(),
+            $fields->process()->values()->all()
+        );
 
-        // Normalize form values to sites config, since we always want array of sites keyed by handle, etc.
-        $sites = collect(Site::multiEnabled() ? $values['sites'] : [$values])
-            ->keyBy('handle')
-            ->transform(function ($site) {
-                return collect($site)
-                    ->except(['id', 'handle'])
-                    ->filter()
-                    ->all();
-            })
-            ->all();
+        $sites = Site::configFromBlueprintValues($values);
+
+        if (Site::multiEnabled() && empty($sites)) {
+            throw ValidationException::withMessages([
+                'group_other_sites' => [__('This field is required.')],
+            ]);
+        }
 
         Site::setSites($sites)->save();
 
         return response('', 204);
+    }
+
+    private function valuesInRequestOrder(array $request, array $values): array
+    {
+        return collect(array_keys($request))
+            ->filter(fn ($key) => array_key_exists($key, $values) || $this->isGroupNameKey($key))
+            ->mapWithKeys(fn ($key) => [$key => array_key_exists($key, $values) ? $values[$key] : $request[$key]])
+            ->union($values)
+            ->all();
+    }
+
+    private function isGroupNameKey(string $key): bool
+    {
+        return (bool) preg_match('/^group_.+_name$/', $key);
+    }
+
+    private function uniqueHandleRules(array $values): array
+    {
+        $handles = collect();
+
+        foreach ($values as $key => $sites) {
+            if (! is_array($sites) || ! preg_match('/^group_.+_sites$/', $key)) {
+                continue;
+            }
+
+            foreach ($sites as $index => $site) {
+                $handle = $site['handle'] ?? null;
+
+                if (! is_string($handle) || $handle === '') {
+                    continue;
+                }
+
+                $handles["{$key}.{$index}.handle"] = $handle;
+            }
+        }
+
+        $duplicates = $handles->countBy()->filter(fn ($count) => $count > 1)->keys();
+
+        return $handles
+            ->filter(fn ($handle) => $duplicates->contains($handle))
+            ->map(fn () => [
+                fn ($attribute, $value, $fail) => $fail(__('statamic::validation.unique')),
+            ])
+            ->all();
     }
 }

--- a/src/Http/Controllers/CP/Sites/SitesController.php
+++ b/src/Http/Controllers/CP/Sites/SitesController.php
@@ -41,16 +41,18 @@ class SitesController extends CpController
 
     public function update(Request $request)
     {
-        $blueprint = Site::blueprint($request->all());
+        $payload = Site::normalizeBlueprintValues($request->all());
+
+        $blueprint = Site::blueprint($payload);
 
         $fields = $blueprint
             ->fields()
-            ->addValues($request->all());
+            ->addValues($payload);
 
-        $fields->validate($this->uniqueHandleRules($request->all()));
+        $fields->validate($this->uniqueHandleRules($payload));
 
         $values = $this->valuesInRequestOrder(
-            $request->all(),
+            $payload,
             $fields->process()->values()->all()
         );
 
@@ -58,7 +60,7 @@ class SitesController extends CpController
 
         if (Site::multiEnabled() && empty($sites)) {
             throw ValidationException::withMessages(
-                $this->emptySitesError($request->all())
+                $this->emptySitesError($payload)
             );
         }
 

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -122,10 +122,13 @@ class TermsController extends CpController
             'permalink' => $term->absoluteUrl(),
             'localizations' => $this->getAuthorizedSitesForTaxonomy($taxonomy)->map(function ($handle) use ($term) {
                 $localized = $term->in($handle);
+                $site = Site::get($handle);
 
                 return [
                     'handle' => $handle,
-                    'name' => Site::get($handle)->name(),
+                    'name' => $site->name(),
+                    'group' => $site->group(),
+                    'group_handle' => $site->groupHandle(),
                     'active' => $handle === $term->locale(),
                     'exists' => true,
                     'root' => $localized->isRoot(),
@@ -241,9 +244,13 @@ class TermsController extends CpController
             'published' => $taxonomy->defaultPublishState(),
             'locale' => $site->handle(),
             'localizations' => $this->getAuthorizedSitesForTaxonomy($taxonomy)->map(function ($handle) use ($taxonomy, $site) {
+                $localizationSite = Site::get($handle);
+
                 return [
                     'handle' => $handle,
-                    'name' => Site::get($handle)->name(),
+                    'name' => $localizationSite->name(),
+                    'group' => $localizationSite->group(),
+                    'group_handle' => $localizationSite->groupHandle(),
                     'active' => $handle === $site->handle(),
                     'exists' => false,
                     'published' => false,

--- a/src/Http/View/Composers/JavascriptComposer.php
+++ b/src/Http/View/Composers/JavascriptComposer.php
@@ -98,6 +98,8 @@ class JavascriptComposer
                 'handle' => $site->handle(),
                 'lang' => $site->lang(),
                 'direction' => $site->direction(),
+                'group' => $site->group(),
+                'group_handle' => $site->groupHandle(),
             ];
         })->values();
     }

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -63,6 +63,13 @@ class Site implements Augmentable
         return is_string($group) && $group !== '' ? $group : null;
     }
 
+    public function groupHandle(): ?string
+    {
+        $handle = $this->config['group_handle'] ?? null;
+
+        return is_string($handle) && $handle !== '' ? $handle : null;
+    }
+
     public function url()
     {
         return URL::tidy($this->config['url'], true);

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -56,6 +56,13 @@ class Site implements Augmentable
         return $this->config['lang'] ?? $this->shortLocale();
     }
 
+    public function group(): ?string
+    {
+        $group = $this->config['group'] ?? null;
+
+        return is_string($group) && $group !== '' ? $group : null;
+    }
+
     public function url()
     {
         return URL::tidy($this->config['url'], true);
@@ -154,6 +161,7 @@ class Site implements Augmentable
             'url' => $this->url(),
             'permalink' => $this->absoluteUrl(),
             'direction' => $this->direction(),
+            'group' => $this->group(),
             'attributes' => $this->attributes(),
         ];
     }

--- a/src/Sites/Site.php
+++ b/src/Sites/Site.php
@@ -169,6 +169,7 @@ class Site implements Augmentable
             'permalink' => $this->absoluteUrl(),
             'direction' => $this->direction(),
             'group' => $this->group(),
+            'group_handle' => $this->groupHandle(),
             'attributes' => $this->attributes(),
         ];
     }

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -18,6 +18,8 @@ use function Statamic\trans as __;
 
 class Sites
 {
+    const OTHER_GROUP_KEY = 'other';
+
     protected $sites;
     protected $current;
     protected ?Closure $currentUrlCallback = null;
@@ -54,6 +56,15 @@ class Sites
     public function hasMultiple()
     {
         return $this->sites->count() > 1;
+    }
+
+    public function filterByGroup($handles, ?string $siteHandle)
+    {
+        if (! $siteHandle || ! ($site = $this->get($siteHandle)) || ! ($group = $site->group())) {
+            return collect($handles);
+        }
+
+        return collect($handles)->filter(fn ($handle) => $this->get($handle)?->group() === $group);
     }
 
     public function get($handle)
@@ -174,9 +185,90 @@ class Sites
         File::put($this->path(), YAML::dump($this->config()));
     }
 
-    public function blueprint()
+    public function blueprint(array $values = [])
     {
-        $siteFields = [
+        $siteRowFields = $this->siteRowFields();
+
+        if ($this->multiEnabled()) {
+            return Blueprint::make()->setContents([
+                'tabs' => [
+                    'main' => [
+                        'sections' => $this->multisiteBlueprintSections($siteRowFields, $values),
+                    ],
+                ],
+            ]);
+        }
+
+        return Blueprint::make()->setContents([
+            'fields' => $siteRowFields,
+        ]);
+    }
+
+    public function blueprintValues(): array
+    {
+        if (! $this->multiEnabled()) {
+            $site = $this->default();
+
+            return array_merge(['handle' => $site->handle()], $site->rawConfig());
+        }
+
+        $values = [];
+        $otherSites = [];
+
+        foreach ($this->groupedSites() as $group => $sites) {
+            $key = $this->groupSectionKey($group);
+            $mapped = $sites->map(fn (Site $site) => array_merge(
+                ['handle' => $site->handle()],
+                collect($site->rawConfig())->except('group')->all()
+            ))->values()->all();
+
+            if ($key === self::OTHER_GROUP_KEY) {
+                $otherSites = $mapped;
+
+                continue;
+            }
+
+            $values["group_{$key}_name"] = $group ?: null;
+            $values["group_{$key}_sites"] = $mapped;
+        }
+
+        $values['group_'.self::OTHER_GROUP_KEY.'_sites'] = $otherSites;
+
+        return $values;
+    }
+
+    public function configFromBlueprintValues(array $values): array
+    {
+        if (! $this->multiEnabled()) {
+            return [
+                $values['handle'] => collect($values)->except(['id', 'handle'])->filter()->all(),
+            ];
+        }
+
+        $sites = collect();
+
+        foreach ($values as $key => $groupSites) {
+            if (! is_array($groupSites) || ! preg_match('/^group_(.+)_sites$/', $key, $matches)) {
+                continue;
+            }
+
+            $groupName = $matches[1] === self::OTHER_GROUP_KEY
+                ? null
+                : ($values["group_{$matches[1]}_name"] ?? null);
+            $groupName = is_string($groupName) && $groupName !== '' ? $groupName : null;
+
+            $this->mergeSitesFromGrid($sites, $groupSites, $groupName);
+        }
+
+        return $sites
+            ->keyBy('handle')
+            ->map(fn ($site) => collect($site)->except(['id', 'handle'])->filter()->all())
+            ->all();
+    }
+
+    protected function siteRowFields(): array
+    {
+        return [
             [
                 'handle' => 'name',
                 'field' => [
@@ -252,39 +344,133 @@ class Sites
                 ],
             ],
         ];
+    }
 
-        // If multisite, nest fields in a grid
-        if ($this->multiEnabled()) {
-            $tableWidths = [
-                'attributes' => 30,
-            ];
+    protected function multisiteBlueprintSections(array $siteRowFields, array $values = []): array
+    {
+        $sections = [];
+        $seen = [];
 
-            $siteFields = [
-                [
-                    'handle' => 'sites',
-                    'field' => [
-                        'type' => 'grid',
-                        'hide_display' => true,
-                        'actions' => false,
-                        'fullscreen' => false,
-                        'mode' => 'table',
-                        'stack_at' => 925,
-                        'add_row' => __('Add Site'),
-                        'fields' => collect($siteFields)->map(function ($field) use ($tableWidths) {
-                            $field['field']['width'] = $tableWidths[$field['handle']] ?? 14;
-                            $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
+        foreach ($this->groupedSites() as $group => $sites) {
+            $key = $this->groupSectionKey($group);
 
-                            return $field;
-                        })->all(),
-                        'required' => true,
-                    ],
+            if ($key === self::OTHER_GROUP_KEY) {
+                continue;
+            }
+
+            $seen[$key] = true;
+            $sections[] = $this->groupSection($key, $group ?: null, $siteRowFields);
+        }
+
+        foreach ($values as $handle => $groupSites) {
+            if (! is_array($groupSites) || ! preg_match('/^group_(.+)_sites$/', $handle, $matches)) {
+                continue;
+            }
+
+            $key = $matches[1];
+
+            if ($key === self::OTHER_GROUP_KEY || isset($seen[$key])) {
+                continue;
+            }
+
+            $name = $values["group_{$key}_name"] ?? null;
+            $name = is_string($name) && $name !== '' ? $name : null;
+            $seen[$key] = true;
+            $sections[] = $this->groupSection($key, $name, $siteRowFields);
+        }
+
+        $sections[] = $this->groupSection(self::OTHER_GROUP_KEY, null, $siteRowFields);
+
+        return $sections;
+    }
+
+    protected function groupSection(string $key, ?string $group, array $siteRowFields): array
+    {
+        $isOther = $key === self::OTHER_GROUP_KEY;
+
+        $fields = [];
+
+        if (! $isOther) {
+            $fields[] = [
+                'handle' => "group_{$key}_name",
+                'field' => [
+                    'type' => 'text',
+                    'visibility' => 'hidden',
+                    'always_save' => true,
                 ],
             ];
         }
 
-        return Blueprint::make()->setContents([
-            'fields' => $siteFields,
-        ]);
+        $fields[] = [
+            'handle' => "group_{$key}_sites",
+            'field' => $this->sitesGridField($siteRowFields, $key),
+        ];
+
+        $section = [
+            'display' => $isOther ? __('Other') : $group,
+            'fields' => $fields,
+        ];
+
+        if (! $isOther) {
+            $section['editable_title_handle'] = "group_{$key}_name";
+            $section['reorderable'] = true;
+        }
+
+        return $section;
+    }
+
+    protected function sitesGridField(array $siteRowFields, string $groupKey): array
+    {
+        $tableWidths = [
+            'attributes' => 30,
+        ];
+
+        return [
+            'type' => 'grid',
+            'hide_display' => true,
+            'actions' => false,
+            'fullscreen' => false,
+            'mode' => 'table',
+            'stack_at' => 925,
+            'reorderable' => true,
+            'headers_in_section' => true,
+            'add_row' => __('Add Site'),
+            'fields' => collect($siteRowFields)->map(function ($field) use ($tableWidths, $groupKey) {
+                $field['field']['width'] = $tableWidths[$field['handle']] ?? 14;
+                $field['field']['classes'] = 'max-w-48 min-w-0 overflow-hidden';
+
+                if ($field['handle'] === 'handle' && $groupKey !== self::OTHER_GROUP_KEY) {
+                    $field['field']['prefix_from'] = "group_{$groupKey}_name";
+                }
+
+                return $field;
+            })->all(),
+        ];
+    }
+
+    protected function groupedSites(): Collection
+    {
+        return $this->all()->groupBy(fn (Site $site) => $site->group() ?? '');
+    }
+
+    protected function groupSectionKey(?string $group): string
+    {
+        if ($group === null || $group === '') {
+            return self::OTHER_GROUP_KEY;
+        }
+
+        return Str::slug($group);
+    }
+
+    protected function mergeSitesFromGrid(Collection $sites, array $groupSites, ?string $groupName): void
+    {
+        foreach ($groupSites as $site) {
+            if ($groupName) {
+                $site['group'] = $groupName;
+            }
+
+            $sites->put($site['handle'], $site);
+        }
     }
 
     public function config(): array

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -538,8 +538,17 @@ class Sites
             }
 
             if ($groupName) {
+                unset($site['group'], $site['group_handle']);
+
+                $attributes = $site['attributes'] ?? null;
+                unset($site['attributes']);
+
                 $site['group'] = $groupName;
                 $site['group_handle'] = $groupKey;
+
+                if ($attributes !== null) {
+                    $site['attributes'] = $attributes;
+                }
             } else {
                 unset($site['group'], $site['group_handle']);
             }

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -244,8 +244,36 @@ class Sites
         return $values;
     }
 
+    public function normalizeBlueprintValues(array $values): array
+    {
+        if (! $this->multiEnabled()) {
+            return $values;
+        }
+
+        if ($this->hasGroupedSitesKeys($values)) {
+            return $values;
+        }
+
+        if (! array_key_exists('sites', $values) || ! is_array($values['sites'])) {
+            return $values;
+        }
+
+        $sites = $values['sites'];
+        unset($values['sites']);
+
+        $values['group_'.self::OTHER_GROUP_KEY.'_sites'] = collect($sites)
+            ->filter(fn ($site) => is_array($site))
+            ->map(fn ($site) => collect($site)->except(['group', 'group_handle'])->all())
+            ->values()
+            ->all();
+
+        return $values;
+    }
+
     public function configFromBlueprintValues(array $values): array
     {
+        $values = $this->normalizeBlueprintValues($values);
+
         if (! $this->multiEnabled()) {
             return [
                 $values['handle'] => collect($values)->except(['id', 'handle'])->filter()->all(),
@@ -272,6 +300,17 @@ class Sites
             ->keyBy('handle')
             ->map(fn ($site) => collect($site)->except(['id', 'handle'])->filter()->all())
             ->all();
+    }
+
+    protected function hasGroupedSitesKeys(array $values): bool
+    {
+        foreach (array_keys($values) as $key) {
+            if (is_string($key) && preg_match('/^group_[A-Za-z0-9_-]+_sites$/', $key)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     protected function siteRowFields(): array

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -60,11 +60,25 @@ class Sites
 
     public function filterByGroup($handles, ?string $siteHandle)
     {
-        if (! $siteHandle || ! ($site = $this->get($siteHandle)) || ! ($group = $site->group())) {
+        if (! $siteHandle || ! ($site = $this->get($siteHandle))) {
             return collect($handles);
         }
 
-        return collect($handles)->filter(fn ($handle) => $this->get($handle)?->group() === $group);
+        $groupKey = $site->groupHandle() ?? $site->group();
+
+        if (! $groupKey) {
+            return collect($handles);
+        }
+
+        return collect($handles)->filter(function ($handle) use ($groupKey) {
+            $other = $this->get($handle);
+
+            if (! $other) {
+                return false;
+            }
+
+            return ($other->groupHandle() ?? $other->group()) === $groupKey;
+        });
     }
 
     public function get($handle)
@@ -241,7 +255,7 @@ class Sites
         $sites = collect();
 
         foreach ($values as $key => $groupSites) {
-            if (! is_array($groupSites) || ! preg_match('/^group_(.+)_sites$/', $key, $matches)) {
+            if (! is_array($groupSites) || ! preg_match('/^group_([A-Za-z0-9_-]+)_sites$/', $key, $matches)) {
                 continue;
             }
 

--- a/src/Sites/Sites.php
+++ b/src/Sites/Sites.php
@@ -213,26 +213,19 @@ class Sites
         }
 
         $values = [];
-        $otherSites = [];
 
-        foreach ($this->groupedSites() as $group => $sites) {
-            $key = $this->groupSectionKey($group);
-            $mapped = $sites->map(fn (Site $site) => array_merge(
-                ['handle' => $site->handle()],
-                collect($site->rawConfig())->except('group')->all()
-            ))->values()->all();
+        foreach ($this->namedGroupSections() as $section) {
+            $key = $section['key'];
+            $mapped = $section['sites']->map(fn (Site $site) => $this->siteToBlueprintRow($site))->values()->all();
 
-            if ($key === self::OTHER_GROUP_KEY) {
-                $otherSites = $mapped;
-
-                continue;
-            }
-
-            $values["group_{$key}_name"] = $group ?: null;
+            $values["group_{$key}_name"] = $section['name'];
             $values["group_{$key}_sites"] = $mapped;
         }
 
-        $values['group_'.self::OTHER_GROUP_KEY.'_sites'] = $otherSites;
+        $values['group_'.self::OTHER_GROUP_KEY.'_sites'] = $this->otherSites()
+            ->map(fn (Site $site) => $this->siteToBlueprintRow($site))
+            ->values()
+            ->all();
 
         return $values;
     }
@@ -252,12 +245,13 @@ class Sites
                 continue;
             }
 
-            $groupName = $matches[1] === self::OTHER_GROUP_KEY
+            $groupKey = $matches[1];
+            $groupName = $groupKey === self::OTHER_GROUP_KEY
                 ? null
-                : ($values["group_{$matches[1]}_name"] ?? null);
+                : ($values["group_{$groupKey}_name"] ?? null);
             $groupName = is_string($groupName) && $groupName !== '' ? $groupName : null;
 
-            $this->mergeSitesFromGrid($sites, $groupSites, $groupName);
+            $this->mergeSitesFromGrid($sites, $groupSites, $groupName, $groupKey);
         }
 
         return $sites
@@ -351,15 +345,9 @@ class Sites
         $sections = [];
         $seen = [];
 
-        foreach ($this->groupedSites() as $group => $sites) {
-            $key = $this->groupSectionKey($group);
-
-            if ($key === self::OTHER_GROUP_KEY) {
-                continue;
-            }
-
-            $seen[$key] = true;
-            $sections[] = $this->groupSection($key, $group ?: null, $siteRowFields);
+        foreach ($this->namedGroupSections() as $section) {
+            $seen[$section['key']] = true;
+            $sections[] = $this->groupSection($section['key'], $section['name'], $siteRowFields);
         }
 
         foreach ($values as $handle => $groupSites) {
@@ -448,28 +436,101 @@ class Sites
         ];
     }
 
-    protected function groupedSites(): Collection
+    protected function siteToBlueprintRow(Site $site): array
     {
-        return $this->all()->groupBy(fn (Site $site) => $site->group() ?? '');
+        return array_merge(
+            ['handle' => $site->handle()],
+            collect($site->rawConfig())->except('group', 'group_handle')->all()
+        );
     }
 
-    protected function groupSectionKey(?string $group): string
+    protected function otherSites(): Collection
     {
-        if ($group === null || $group === '') {
-            return self::OTHER_GROUP_KEY;
-        }
-
-        return Str::slug($group);
+        return $this->all()->filter(fn (Site $site) => ! $site->group())->values();
     }
 
-    protected function mergeSitesFromGrid(Collection $sites, array $groupSites, ?string $groupName): void
+    protected function namedGroupSections(): Collection
     {
-        foreach ($groupSites as $site) {
-            if ($groupName) {
-                $site['group'] = $groupName;
+        $buckets = [];
+
+        foreach ($this->all() as $site) {
+            $name = $site->group();
+
+            if (! $name) {
+                continue;
             }
 
-            $sites->put($site['handle'], $site);
+            $storedHandle = $site->groupHandle();
+            $identity = ($storedHandle && $storedHandle !== self::OTHER_GROUP_KEY)
+                ? "handle:{$storedHandle}"
+                : "name:{$name}";
+
+            if (! isset($buckets[$identity])) {
+                $buckets[$identity] = [
+                    'name' => $name,
+                    'handle' => ($storedHandle && $storedHandle !== self::OTHER_GROUP_KEY) ? $storedHandle : null,
+                    'sites' => collect(),
+                ];
+            }
+
+            $buckets[$identity]['sites']->push($site);
+        }
+
+        $seen = [];
+        $sections = collect();
+
+        foreach ($buckets as $bucket) {
+            $key = $this->uniqueGroupSectionKey($bucket['handle'], $bucket['name'], $seen);
+            $seen[$key] = true;
+            $sections->push([
+                'key' => $key,
+                'name' => $bucket['name'],
+                'sites' => $bucket['sites'],
+            ]);
+        }
+
+        return $sections;
+    }
+
+    protected function uniqueGroupSectionKey(?string $preferred, string $name, array $seen): string
+    {
+        if ($preferred && $preferred !== self::OTHER_GROUP_KEY && ! isset($seen[$preferred])) {
+            return $preferred;
+        }
+
+        $base = Str::slug($name) ?: 'group';
+
+        if ($base === self::OTHER_GROUP_KEY) {
+            $base = 'group';
+        }
+
+        $key = $base;
+        $suffix = 2;
+
+        while (isset($seen[$key])) {
+            $key = $base.'-'.$suffix++;
+        }
+
+        return $key;
+    }
+
+    protected function mergeSitesFromGrid(Collection $sites, array $groupSites, ?string $groupName, string $groupKey): void
+    {
+        foreach ($groupSites as $site) {
+            $handle = $site['handle'] ?? null;
+
+            if (! is_string($handle) || $handle === '') {
+                continue;
+            }
+
+            if ($groupName) {
+                $site['group'] = $groupName;
+                $site['group_handle'] = $groupKey;
+            } else {
+                unset($site['group'], $site['group_handle']);
+            }
+
+            $sites->put($handle, $site);
         }
     }
 

--- a/tests/Fields/SectionTest.php
+++ b/tests/Fields/SectionTest.php
@@ -170,4 +170,40 @@ class SectionTest extends TestCase
             ],
         ], $section->toPublishArray());
     }
+
+    #[Test]
+    public function it_includes_reorderable_in_publish_array()
+    {
+        $section = new Section([
+            'display' => 'Test',
+            'reorderable' => true,
+            'fields' => [],
+        ]);
+
+        $this->assertTrue($section->toPublishArray()['reorderable']);
+    }
+
+    #[Test]
+    public function it_omits_reorderable_from_publish_array_when_false()
+    {
+        $section = new Section([
+            'display' => 'Test',
+            'reorderable' => false,
+            'fields' => [],
+        ]);
+
+        $this->assertArrayNotHasKey('reorderable', $section->toPublishArray());
+    }
+
+    #[Test]
+    public function it_includes_editable_title_handle_in_publish_array()
+    {
+        $section = new Section([
+            'display' => 'Test',
+            'editable_title_handle' => 'group_london_name',
+            'fields' => [],
+        ]);
+
+        $this->assertSame('group_london_name', $section->toPublishArray()['editable_title_handle']);
+    }
 }

--- a/tests/Fieldtypes/SitesTest.php
+++ b/tests/Fieldtypes/SitesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Fieldtypes;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\Field;
+use Statamic\Fieldtypes\Sites;
+use Tests\TestCase;
+
+class SitesTest extends TestCase
+{
+    #[Test]
+    public function it_preprocesses_index_values_with_site_groups()
+    {
+        $this->setSites([
+            'en' => [
+                'name' => 'English',
+                'locale' => 'en_US',
+                'url' => '/',
+                'group' => 'UK',
+                'group_handle' => 'uk',
+            ],
+            'fr' => [
+                'name' => 'French',
+                'locale' => 'fr_FR',
+                'url' => '/fr/',
+                'group' => 'EU',
+                'group_handle' => 'eu',
+            ],
+        ]);
+
+        $this->assertEquals([
+            [
+                'title' => 'English',
+                'group' => 'UK',
+                'group_handle' => 'uk',
+            ],
+        ], $this->fieldtype(['max_items' => 1])->preProcessIndex('en'));
+
+        $this->assertEquals([
+            [
+                'title' => 'English',
+                'group' => 'UK',
+                'group_handle' => 'uk',
+            ],
+            [
+                'title' => 'French',
+                'group' => 'EU',
+                'group_handle' => 'eu',
+            ],
+        ], $this->fieldtype()->preProcessIndex(['en', 'fr']));
+    }
+
+    #[Test]
+    public function it_preprocesses_index_values_without_site_groups()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => '/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => '/fr/'],
+        ]);
+
+        $this->assertEquals([
+            [
+                'title' => 'English',
+                'group' => null,
+                'group_handle' => null,
+            ],
+        ], $this->fieldtype(['max_items' => 1])->preProcessIndex('en'));
+    }
+
+    private function fieldtype($config = [])
+    {
+        $field = new Field('test', array_merge([
+            'type' => 'sites',
+        ], $config));
+
+        return (new Sites)->setField($field);
+    }
+}

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -85,6 +85,14 @@ class SiteTest extends TestCase
     }
 
     #[Test]
+    public function gets_group()
+    {
+        $this->assertNull((new Site('en', []))->group());
+        $this->assertNull((new Site('en', ['group' => '']))->group());
+        $this->assertEquals('London', (new Site('en', ['group' => 'London']))->group());
+    }
+
+    #[Test]
     public function gets_is_default()
     {
         $withoutDefault = new Site('en', ['locale' => 'en_US']);

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -93,6 +93,14 @@ class SiteTest extends TestCase
     }
 
     #[Test]
+    public function gets_group_handle()
+    {
+        $this->assertNull((new Site('en', []))->groupHandle());
+        $this->assertNull((new Site('en', ['group_handle' => '']))->groupHandle());
+        $this->assertEquals('london', (new Site('en', ['group_handle' => 'london']))->groupHandle());
+    }
+
+    #[Test]
     public function gets_is_default()
     {
         $withoutDefault = new Site('en', ['locale' => 'en_US']);

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -286,6 +286,8 @@ class SiteTest extends TestCase
     {
         $site = new Site('en', [
             'name' => 'English',
+            'url' => '/',
+            'locale' => 'en_US',
             'group' => 'London',
             'group_handle' => 'london',
         ]);
@@ -316,6 +318,8 @@ class SiteTest extends TestCase
             'url' => '/sub',
             'permalink' => 'http://absolute-url-resolved-from-request.com/sub',
             'direction' => 'ltr',
+            'group' => null,
+            'group_handle' => null,
             'attributes' => [],
         ], $values->map->value()->all());
 

--- a/tests/Sites/SiteTest.php
+++ b/tests/Sites/SiteTest.php
@@ -282,6 +282,21 @@ class SiteTest extends TestCase
     }
 
     #[Test]
+    public function it_augments_group_and_group_handle()
+    {
+        $site = new Site('en', [
+            'name' => 'English',
+            'group' => 'London',
+            'group_handle' => 'london',
+        ]);
+
+        $values = $site->augmented()->all()->map->value()->all();
+
+        $this->assertEquals('London', $values['group']);
+        $this->assertEquals('london', $values['group_handle']);
+    }
+
+    #[Test]
     public function it_is_augmentable()
     {
         $site = new Site('test', [

--- a/tests/Sites/SitesConfigTest.php
+++ b/tests/Sites/SitesConfigTest.php
@@ -387,6 +387,7 @@ class SitesConfigTest extends TestCase
                 'url' => '/ar/',
                 'locale' => 'ar_EG',
                 'group' => 'Middle East',
+                'group_handle' => 'middle-east',
                 'attributes' => [
                     'theme' => 'standard',
                 ],
@@ -442,7 +443,9 @@ class SitesConfigTest extends TestCase
 
         $this->assertSame(['paris', 'en'], array_keys($saved = YAML::file($this->yamlPath)->parse()));
         $this->assertSame('Paris', $saved['paris']['group']);
+        $this->assertSame('paris', $saved['paris']['group_handle']);
         $this->assertSame('London', $saved['en']['group']);
+        $this->assertSame('london', $saved['en']['group_handle']);
     }
 
     #[Test]
@@ -477,6 +480,7 @@ class SitesConfigTest extends TestCase
         $this->assertCount(1, $values['group_middle-east_sites']);
         $this->assertSame('arabic', $values['group_middle-east_sites'][0]['handle']);
         $this->assertArrayNotHasKey('group', $values['group_middle-east_sites'][0]);
+        $this->assertArrayNotHasKey('group_handle', $values['group_middle-east_sites'][0]);
     }
 
     #[Test]
@@ -541,7 +545,9 @@ class SitesConfigTest extends TestCase
         $saved = YAML::file($this->yamlPath)->parse();
 
         $this->assertSame('Paris', $saved['fr']['group']);
+        $this->assertSame('new-group', $saved['fr']['group_handle']);
         $this->assertArrayNotHasKey('group', $saved['default']);
+        $this->assertArrayNotHasKey('group_handle', $saved['default']);
     }
 
     #[Test]
@@ -658,8 +664,11 @@ class SitesConfigTest extends TestCase
         ]);
 
         $this->assertSame('London', $config['en']['group']);
+        $this->assertSame('london', $config['en']['group_handle']);
         $this->assertSame('London', $config['fr']['group']);
+        $this->assertSame('london', $config['fr']['group_handle']);
         $this->assertSame('Paris', $config['paris']['group']);
+        $this->assertSame('paris', $config['paris']['group_handle']);
         $this->assertArrayNotHasKey('group', $config['default'] ?? []);
         $this->assertSame(['en', 'fr', 'paris'], array_keys($config));
     }
@@ -816,6 +825,106 @@ class SitesConfigTest extends TestCase
             ->patchJson(cp_route('sites.update'), $data)
             ->assertStatus(422)
             ->assertJsonValidationErrors(['group_other_sites']);
+    }
+
+    #[Test]
+    public function it_validates_empty_named_groups_when_no_sites_are_submitted()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $this
+            ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
+            ->patchJson(cp_route('sites.update'), [
+                'group_london_name' => 'London',
+                'group_london_sites' => [],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['group_london_sites'])
+            ->assertJsonMissingValidationErrors(['group_other_sites']);
+    }
+
+    #[Test]
+    public function groups_with_the_same_slug_stay_separate()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'en' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+                'group' => 'New York',
+            ],
+            'fr' => [
+                'name' => 'French',
+                'url' => '/fr/',
+                'locale' => 'fr_FR',
+                'group' => 'new york',
+            ],
+        ]);
+
+        $values = Site::blueprintValues();
+
+        $this->assertSame('New York', $values['group_new-york_name']);
+        $this->assertSame('new york', $values['group_new-york-2_name']);
+        $this->assertSame(['en'], collect($values['group_new-york_sites'])->pluck('handle')->all());
+        $this->assertSame(['fr'], collect($values['group_new-york-2_sites'])->pluck('handle')->all());
+    }
+
+    #[Test]
+    public function a_group_named_other_does_not_merge_into_the_ungrouped_section()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'en' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+                'group' => 'Other',
+            ],
+            'fr' => [
+                'name' => 'French',
+                'url' => '/fr/',
+                'locale' => 'fr_FR',
+            ],
+        ]);
+
+        $values = Site::blueprintValues();
+
+        $this->assertSame('Other', $values['group_group_name']);
+        $this->assertSame(['en'], collect($values['group_group_sites'])->pluck('handle')->all());
+        $this->assertSame(['fr'], collect($values['group_other_sites'])->pluck('handle')->all());
+    }
+
+    #[Test]
+    public function stored_group_handles_keep_groups_stable_when_names_slug_the_same()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'en' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+                'group' => 'Cafe',
+                'group_handle' => 'cafe',
+            ],
+            'fr' => [
+                'name' => 'French',
+                'url' => '/fr/',
+                'locale' => 'fr_FR',
+                'group' => 'Café',
+                'group_handle' => 'cafe-2',
+            ],
+        ]);
+
+        $values = Site::blueprintValues();
+
+        $this->assertSame('Cafe', $values['group_cafe_name']);
+        $this->assertSame('Café', $values['group_cafe-2_name']);
+        $this->assertSame(['en'], collect($values['group_cafe_sites'])->pluck('handle')->all());
+        $this->assertSame(['fr'], collect($values['group_cafe-2_sites'])->pluck('handle')->all());
     }
 
     #[Test]

--- a/tests/Sites/SitesConfigTest.php
+++ b/tests/Sites/SitesConfigTest.php
@@ -44,6 +44,13 @@ class SitesConfigTest extends TestCase
         Site::swap(new Sites);
     }
 
+    private function sitesField(array $section): array
+    {
+        return collect($section['fields'])->first(
+            fn ($field) => str_ends_with($field['handle'], '_sites')
+        );
+    }
+
     #[Test]
     public function it_gets_sites_from_yaml()
     {
@@ -341,7 +348,8 @@ class SitesConfigTest extends TestCase
         $this
             ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
             ->patchJson(cp_route('sites.update'), [
-                'sites' => [
+                'group_other_name' => null,
+                'group_other_sites' => [
                     [
                         'id' => 'abcde', // grid fieldtypes submit id, that should get stripped out
                         'name' => 'English',
@@ -350,6 +358,9 @@ class SitesConfigTest extends TestCase
                         'locale' => 'en_US',
                         'lang' => 'slang', // testing custom lang string, because it auto-sets itself off locale
                     ],
+                ],
+                'group_middle-east_name' => 'Middle East',
+                'group_middle-east_sites' => [
                     [
                         'id' => 'fghijk', // grid fieldtypes submit id, that should get stripped out
                         'name' => 'Arabic (Egypt)',
@@ -375,6 +386,7 @@ class SitesConfigTest extends TestCase
                 'name' => 'Arabic (Egypt)',
                 'url' => '/ar/',
                 'locale' => 'ar_EG',
+                'group' => 'Middle East',
                 'attributes' => [
                     'theme' => 'standard',
                 ],
@@ -382,6 +394,294 @@ class SitesConfigTest extends TestCase
         ];
 
         $this->assertSame($expected, YAML::file($this->yamlPath)->parse());
+    }
+
+    #[Test]
+    public function it_saves_groups_in_submitted_order()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'en' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+                'group' => 'London',
+            ],
+            'paris' => [
+                'name' => 'French',
+                'url' => '/paris/',
+                'locale' => 'fr_FR',
+                'group' => 'Paris',
+            ],
+        ]);
+
+        $this
+            ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
+            ->patchJson(cp_route('sites.update'), [
+                'group_paris_name' => 'Paris',
+                'group_paris_sites' => [
+                    [
+                        'name' => 'French',
+                        'handle' => 'paris',
+                        'url' => '/paris/',
+                        'locale' => 'fr_FR',
+                    ],
+                ],
+                'group_london_name' => 'London',
+                'group_london_sites' => [
+                    [
+                        'name' => 'English',
+                        'handle' => 'en',
+                        'url' => '/',
+                        'locale' => 'en_US',
+                    ],
+                ],
+            ])
+            ->assertSuccessful();
+
+        $this->assertSame(['paris', 'en'], array_keys($saved = YAML::file($this->yamlPath)->parse()));
+        $this->assertSame('Paris', $saved['paris']['group']);
+        $this->assertSame('London', $saved['en']['group']);
+    }
+
+    #[Test]
+    public function it_builds_grouped_blueprint_values()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'default' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+            ],
+            'arabic' => [
+                'name' => 'Arabic (Egypt)',
+                'url' => '/ar/',
+                'locale' => 'ar_EG',
+                'group' => 'Middle East',
+            ],
+        ]);
+
+        $values = Site::blueprintValues();
+
+        $this->assertSame([
+            'group_middle-east_name',
+            'group_middle-east_sites',
+            'group_other_sites',
+        ], array_keys($values));
+        $this->assertCount(1, $values['group_other_sites']);
+        $this->assertSame('default', $values['group_other_sites'][0]['handle']);
+        $this->assertSame('Middle East', $values['group_middle-east_name']);
+        $this->assertCount(1, $values['group_middle-east_sites']);
+        $this->assertSame('arabic', $values['group_middle-east_sites'][0]['handle']);
+        $this->assertArrayNotHasKey('group', $values['group_middle-east_sites'][0]);
+    }
+
+    #[Test]
+    public function preprocessed_values_include_group_names()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'default' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+            ],
+            'arabic' => [
+                'name' => 'Arabic (Egypt)',
+                'url' => '/ar/',
+                'locale' => 'ar_EG',
+                'group' => 'Middle East',
+            ],
+        ]);
+
+        $values = Site::blueprint()
+            ->fields()
+            ->addValues(Site::blueprintValues())
+            ->preProcess()
+            ->values()
+            ->all();
+
+        $this->assertSame('Middle East', $values['group_middle-east_name']);
+        $this->assertSame('arabic', $values['group_middle-east_sites'][0]['handle']);
+        $this->assertSame('default', $values['group_other_sites'][0]['handle']);
+    }
+
+    #[Test]
+    public function it_saves_a_newly_added_group_through_cp_endpoint()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $this
+            ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
+            ->patchJson(cp_route('sites.update'), [
+                'group_new-group_name' => 'Paris',
+                'group_new-group_sites' => [
+                    [
+                        'name' => 'French',
+                        'handle' => 'fr',
+                        'url' => '/fr/',
+                        'locale' => 'fr_FR',
+                    ],
+                ],
+                'group_other_sites' => [
+                    [
+                        'name' => 'English',
+                        'handle' => 'default',
+                        'url' => '/',
+                        'locale' => 'en_US',
+                    ],
+                ],
+            ])
+            ->assertSuccessful();
+
+        $saved = YAML::file($this->yamlPath)->parse();
+
+        $this->assertSame('Paris', $saved['fr']['group']);
+        $this->assertArrayNotHasKey('group', $saved['default']);
+    }
+
+    #[Test]
+    public function grouped_blueprint_sections_are_reorderable()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'default' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+            ],
+            'arabic' => [
+                'name' => 'Arabic (Egypt)',
+                'url' => '/ar/',
+                'locale' => 'ar_EG',
+                'group' => 'Middle East',
+            ],
+        ]);
+
+        $sections = Site::blueprint()->contents()['tabs']['main']['sections'];
+
+        $this->assertCount(2, $sections);
+        $this->assertTrue($sections[0]['reorderable']);
+        $this->assertArrayNotHasKey('reorderable', $sections[1]);
+        $this->assertSame('group_middle-east_name', $sections[0]['editable_title_handle']);
+        $this->assertArrayNotHasKey('editable_title_handle', $sections[1]);
+        $this->assertSame('Other', $sections[1]['display']);
+        $this->assertSame('group_middle-east_name', $sections[0]['fields'][0]['handle']);
+        $this->assertSame('hidden', $sections[0]['fields'][0]['field']['visibility']);
+        $this->assertSame('group_other_sites', $this->sitesField($sections[1])['handle']);
+        $this->assertTrue($this->sitesField($sections[0])['field']['headers_in_section']);
+        $this->assertTrue($this->sitesField($sections[1])['field']['headers_in_section']);
+        $this->assertSame(
+            'group_middle-east_name',
+            collect($this->sitesField($sections[0])['field']['fields'])->firstWhere('handle', 'handle')['field']['prefix_from']
+        );
+        $this->assertArrayNotHasKey(
+            'prefix_from',
+            collect($this->sitesField($sections[1])['field']['fields'])->firstWhere('handle', 'handle')['field']
+        );
+    }
+
+    #[Test]
+    public function the_other_group_is_always_last_even_when_empty()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        Site::setSites([
+            'en' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+                'group' => 'London',
+            ],
+        ]);
+
+        $values = Site::blueprintValues();
+        $sections = Site::blueprint()->contents()['tabs']['main']['sections'];
+
+        $this->assertSame([
+            'group_london_name',
+            'group_london_sites',
+            'group_other_sites',
+        ], array_keys($values));
+        $this->assertSame([], $values['group_other_sites']);
+        $this->assertSame('group_london_name', $sections[0]['editable_title_handle']);
+        $this->assertSame('group_other_sites', $this->sitesField($sections[1])['handle']);
+        $this->assertArrayNotHasKey('reorderable', $sections[1]);
+        $this->assertArrayNotHasKey('editable_title_handle', $sections[1]);
+    }
+
+    #[Test]
+    public function it_includes_submitted_groups_in_the_blueprint()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $sections = Site::blueprint([
+            'group_other_sites' => [
+                ['name' => 'English', 'handle' => 'default', 'url' => '/', 'locale' => 'en_US'],
+            ],
+            'group_paris_name' => 'Paris',
+            'group_paris_sites' => [
+                ['name' => 'French', 'handle' => 'paris', 'url' => '/paris/', 'locale' => 'fr_FR'],
+            ],
+        ])->contents()['tabs']['main']['sections'];
+
+        $this->assertSame([
+            'group_paris_name',
+            null,
+        ], collect($sections)->pluck('editable_title_handle')->all());
+        $this->assertSame('group_paris_sites', $this->sitesField($sections[0])['handle']);
+        $this->assertSame('group_other_sites', $this->sitesField($sections[1])['handle']);
+        $this->assertSame('Other', $sections[1]['display']);
+        $this->assertArrayNotHasKey('reorderable', $sections[1]);
+    }
+
+    #[Test]
+    public function it_builds_config_from_grouped_blueprint_values()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $config = Site::configFromBlueprintValues([
+            'group_london_name' => 'London',
+            'group_london_sites' => [
+                ['name' => 'English', 'handle' => 'en', 'url' => '/', 'locale' => 'en_US'],
+                ['name' => 'French', 'handle' => 'fr', 'url' => '/fr/', 'locale' => 'fr_FR'],
+            ],
+            'group_paris_name' => 'Paris',
+            'group_paris_sites' => [
+                ['name' => 'French', 'handle' => 'paris', 'url' => '/paris/', 'locale' => 'fr_FR'],
+            ],
+        ]);
+
+        $this->assertSame('London', $config['en']['group']);
+        $this->assertSame('London', $config['fr']['group']);
+        $this->assertSame('Paris', $config['paris']['group']);
+        $this->assertArrayNotHasKey('group', $config['default'] ?? []);
+        $this->assertSame(['en', 'fr', 'paris'], array_keys($config));
+    }
+
+    #[Test]
+    public function it_preserves_group_order_from_blueprint_values()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $config = Site::configFromBlueprintValues([
+            'group_paris_name' => 'Paris',
+            'group_paris_sites' => [
+                ['name' => 'French', 'handle' => 'paris', 'url' => '/paris/', 'locale' => 'fr_FR'],
+            ],
+            'group_london_name' => 'London',
+            'group_london_sites' => [
+                ['name' => 'English', 'handle' => 'en', 'url' => '/', 'locale' => 'en_US'],
+                ['name' => 'French', 'handle' => 'fr', 'url' => '/fr/', 'locale' => 'fr_FR'],
+            ],
+        ]);
+
+        $this->assertSame(['paris', 'en', 'fr'], array_keys($config));
     }
 
     #[Test]
@@ -401,6 +701,70 @@ class SitesConfigTest extends TestCase
     }
 
     #[Test]
+    public function it_validates_handles_are_unique_across_groups()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $this
+            ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
+            ->patchJson(cp_route('sites.update'), [
+                'group_london_name' => 'London',
+                'group_london_sites' => [
+                    [
+                        'name' => 'English',
+                        'handle' => 'en',
+                        'url' => '/',
+                        'locale' => 'en_US',
+                    ],
+                ],
+                'group_paris_name' => 'Paris',
+                'group_paris_sites' => [
+                    [
+                        'name' => 'English',
+                        'handle' => 'en',
+                        'url' => '/paris/',
+                        'locale' => 'en_GB',
+                    ],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'group_london_sites.0.handle',
+                'group_paris_sites.0.handle',
+            ]);
+    }
+
+    #[Test]
+    public function it_validates_handles_are_unique_within_a_group()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $this
+            ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
+            ->patchJson(cp_route('sites.update'), [
+                'group_other_sites' => [
+                    [
+                        'name' => 'English',
+                        'handle' => 'en',
+                        'url' => '/',
+                        'locale' => 'en_US',
+                    ],
+                    [
+                        'name' => 'English UK',
+                        'handle' => 'en',
+                        'url' => '/uk/',
+                        'locale' => 'en_GB',
+                    ],
+                ],
+            ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors([
+                'group_other_sites.0.handle',
+                'group_other_sites.1.handle',
+            ]);
+    }
+
+    #[Test]
     public function it_validates_required_fields_for_multiple_sites_through_cp_endpoint()
     {
         // Multisite requires this config
@@ -409,7 +773,7 @@ class SitesConfigTest extends TestCase
         $this
             ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
             ->patchJson(cp_route('sites.update'), [
-                'sites' => [
+                'group_other_sites' => [
                     [
                         'handle' => 'english', // this is a required field, so there should be only 3 failures here
                     ],
@@ -421,13 +785,13 @@ class SitesConfigTest extends TestCase
             ->assertStatus(422)
             ->assertJsonCount(7, 'errors')
             ->assertJson(['errors' => [
-                'sites.0.name' => ['This field is required.'],
-                'sites.0.url' => ['This field is required.'],
-                'sites.0.locale' => ['This field is required.'],
-                'sites.1.name' => ['This field is required.'],
-                'sites.1.handle' => ['This field is required.'],
-                'sites.1.url' => ['This field is required.'],
-                'sites.1.locale' => ['This field is required.'],
+                'group_other_sites.0.name' => ['This field is required.'],
+                'group_other_sites.0.url' => ['This field is required.'],
+                'group_other_sites.0.locale' => ['This field is required.'],
+                'group_other_sites.1.name' => ['This field is required.'],
+                'group_other_sites.1.handle' => ['This field is required.'],
+                'group_other_sites.1.url' => ['This field is required.'],
+                'group_other_sites.1.locale' => ['This field is required.'],
             ]]);
     }
 
@@ -435,8 +799,8 @@ class SitesConfigTest extends TestCase
     {
         return [
             'with no sites array' => [[]],
-            'sites array with no elements' => [['sites' => []]],
-            'sites null' => [['sites' => null]],
+            'sites array with no elements' => [['group_other_sites' => []]],
+            'sites null' => [['group_other_sites' => null]],
         ];
     }
 
@@ -451,10 +815,7 @@ class SitesConfigTest extends TestCase
             ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
             ->patchJson(cp_route('sites.update'), $data)
             ->assertStatus(422)
-            ->assertJsonCount(1, 'errors')
-            ->assertJson(['errors' => [
-                'sites' => ['This field is required.'],
-            ]]);
+            ->assertJsonValidationErrors(['group_other_sites']);
     }
 
     #[Test]

--- a/tests/Sites/SitesConfigTest.php
+++ b/tests/Sites/SitesConfigTest.php
@@ -398,6 +398,50 @@ class SitesConfigTest extends TestCase
     }
 
     #[Test]
+    public function it_saves_multiple_sites_through_cp_endpoint_with_legacy_sites_array()
+    {
+        Config::set('statamic.system.multisite', true);
+
+        $this
+            ->actingAs(tap(User::make()->email('chew@bacca.com')->makeSuper())->save())
+            ->patchJson(cp_route('sites.update'), [
+                'sites' => [
+                    [
+                        'id' => 'abcde',
+                        'name' => 'English',
+                        'handle' => 'default',
+                        'url' => '/',
+                        'locale' => 'en_US',
+                        'lang' => 'slang',
+                    ],
+                    [
+                        'name' => 'French',
+                        'handle' => 'french',
+                        'url' => '/fr/',
+                        'locale' => 'fr_FR',
+                    ],
+                ],
+            ])
+            ->assertSuccessful();
+
+        $expected = [
+            'default' => [
+                'name' => 'English',
+                'url' => '/',
+                'locale' => 'en_US',
+                'lang' => 'slang',
+            ],
+            'french' => [
+                'name' => 'French',
+                'url' => '/fr/',
+                'locale' => 'fr_FR',
+            ],
+        ];
+
+        $this->assertSame($expected, YAML::file($this->yamlPath)->parse());
+    }
+
+    #[Test]
     public function it_saves_groups_in_submitted_order()
     {
         Config::set('statamic.system.multisite', true);
@@ -810,6 +854,7 @@ class SitesConfigTest extends TestCase
             'with no sites array' => [[]],
             'sites array with no elements' => [['group_other_sites' => []]],
             'sites null' => [['group_other_sites' => null]],
+            'legacy sites array with no elements' => [['sites' => []]],
         ];
     }
 

--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -57,6 +57,24 @@ class SitesTest extends TestCase
     }
 
     #[Test]
+    public function filters_handles_by_group()
+    {
+        $this->sites->setSites([
+            'en' => ['url' => '/', 'group' => 'London'],
+            'fr' => ['url' => '/fr', 'group' => 'London'],
+            'de' => ['url' => '/de', 'group' => 'Paris'],
+            'nl' => ['url' => '/nl'],
+        ]);
+
+        $handles = collect(['en', 'fr', 'de', 'nl']);
+
+        $this->assertEquals(['en', 'fr'], $this->sites->filterByGroup($handles, 'en')->values()->all());
+        $this->assertEquals(['de'], $this->sites->filterByGroup($handles, 'de')->values()->all());
+        $this->assertEquals(['en', 'fr', 'de', 'nl'], $this->sites->filterByGroup($handles, 'nl')->values()->all());
+        $this->assertEquals(['en', 'fr', 'de', 'nl'], $this->sites->filterByGroup($handles, null)->values()->all());
+    }
+
+    #[Test]
     public function gets_authorized_sites()
     {
         Role::make('test')

--- a/tests/Sites/SitesTest.php
+++ b/tests/Sites/SitesTest.php
@@ -72,6 +72,15 @@ class SitesTest extends TestCase
         $this->assertEquals(['de'], $this->sites->filterByGroup($handles, 'de')->values()->all());
         $this->assertEquals(['en', 'fr', 'de', 'nl'], $this->sites->filterByGroup($handles, 'nl')->values()->all());
         $this->assertEquals(['en', 'fr', 'de', 'nl'], $this->sites->filterByGroup($handles, null)->values()->all());
+
+        $this->sites->setSites([
+            'en' => ['url' => '/', 'group' => 'London', 'group_handle' => 'london'],
+            'fr' => ['url' => '/fr', 'group' => 'London', 'group_handle' => 'paris'],
+            'de' => ['url' => '/de', 'group' => 'London', 'group_handle' => 'london'],
+        ]);
+
+        $this->assertEquals(['en', 'de'], $this->sites->filterByGroup(['en', 'fr', 'de'], 'en')->values()->all());
+        $this->assertEquals(['fr'], $this->sites->filterByGroup(['en', 'fr', 'de'], 'fr')->values()->all());
     }
 
     #[Test]

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -74,15 +74,17 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     protected function getPackageProviders($app)
     {
-        return [
+        return array_values(array_filter([
             \Statamic\Providers\StatamicServiceProvider::class,
             \Inertia\ServiceProvider::class,
             \Rebing\GraphQL\GraphQLServiceProvider::class,
             \Wilderborn\Partyline\ServiceProvider::class,
             \Archetype\ServiceProvider::class,
             \Spatie\LaravelRay\RayServiceProvider::class,
-            \Laravel\Socialite\SocialiteServiceProvider::class,
-        ];
+            class_exists(\Laravel\Socialite\SocialiteServiceProvider::class)
+                ? \Laravel\Socialite\SocialiteServiceProvider::class
+                : null,
+        ]));
     }
 
     protected function getPackageAliases($app)


### PR DESCRIPTION
## Description of the Problem

For multisite installs, sites display as a flat list everywhere (site configuration, entries, site pickers, etc.). 

Larger sites could have multiple locations and related locales (e.g. `Paris > French`, `Paris > English`, and then `Montreal > French`, `Montreal > English`).

In a flat list there’s no way to express that hierarchy, so related sites are hard to understand and manage.

## What this PR Does

- Adds ability to arrange sites into groups with a new sectioned grid interface, with default prefixes, e.g. an `English` site in the group "Paris" will have its handle automatically be prefixed like `paris_english`

<img width="3420" height="2146" alt="2026-08-21 at 17 54 59@2x" src="https://github.com/user-attachments/assets/8f5a7346-b0cc-43b1-a0db-0f10af101646" />

- Comboboxes for localization now have groups

<img width="3420" height="2146" alt="2026-08-24 at 15 20 44@2x" src="https://github.com/user-attachments/assets/b71edf88-93fb-4a63-85a2-699c41b14eaa" />

- Adjusts the way `Origin` works for grouping
  - Here's a simple example where a new group will show the origin outside the group
  - <img width="3420" height="2146" alt="2026-08-24 at 15 22 32@2x" src="https://github.com/user-attachments/assets/3be7bb9b-ae8e-42e4-9543-d28e415bc641" /> 
  - After a group has several localizations, the code picks the first group entry as the new origin reference.
    - Here's an an example of this where a second localization of a group show's both the _group_ origin plus the _root_ (which is effectively the origin of the _group_ origin 🤯)
    - <img width="3420" height="2146" alt="2026-08-24 at 15 26 08@2x" src="https://github.com/user-attachments/assets/e9cec25b-e784-4983-8072-d9e5945a2d94" />
  - If you move the group origin outside the group, then the origin also moves out.
- Fixes https://github.com/statamic/ideas/issues/17

## How to Reproduce

1. Enable multisite and open Configure Sites (/cp/sites).
2. Use Add Site Groups / Edit Site Groups, create groups (e.g. Tokyo, New York), and move sites into them.
3. Save, then check:

- Global header site selector
- An entry’s "Working In" combobox
- Create Localization → Origin select
- Collection/Taxonomy/Nav configure → Sites field
- Globals configure → Sites table + Origin selects
Create a localization into a group that already has a site — Origin should default to that group’s origin (and still follow it if that origin later moves out of the group).