### PR TITLE
[6.x] Fix Link field's Asset mode height

### DIFF
--- a/resources/js/components/fieldtypes/LinkFieldtype.vue
+++ b/resources/js/components/fieldtypes/LinkFieldtype.vue
@@ -5,7 +5,7 @@
             <Select :options v-model="option" :adaptive-width="true" />
         </div>
 
-        <div class="flex-1 flex">
+        <div class="flex min-w-0 flex-1">
             <Input v-if="option === 'url'" :read-only="isReadOnly" v-model="urlValue" />
 
             <component

--- a/resources/js/components/fieldtypes/assets/AssetRow.vue
+++ b/resources/js/components/fieldtypes/assets/AssetRow.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- Safari doesn't support `position: relative` on `<tr>` elements, but these two properties can be used as an alternative. Source: https://mtsknn.fi/blog/relative-tr-in-safari/ transform: translate(0); clip-path: inset(0); -->
     <tr class="group relative bg-white hover:bg-gray-50 dark:bg-gray-900 dark:hover:bg-gray-900 border-b dark:border-gray-600 last:border-b-0" :class="{ 'cursor-grab': !readOnly }" style="transform: translate(0); clip-path: inset(0);">
-        <td class="flex h-full min-w-0 items-center gap-2 p-3 sm:gap-3">
+        <td class="flex h-full min-w-0 items-center gap-2 p-3 sm:gap-3 [.link-fieldtype_&]:py-1.5">
             <div
                 v-if="canShowSvg"
                 class="img svg-img flex size-7 items-center justify-center bg-cover bg-center bg-no-repeat text-center"
@@ -36,7 +36,7 @@
             </button>
             <div v-if="readOnly" v-text="asset.size" class="asset-filesize hidden shrink-0 px-2 text-sm leading-5 text-gray-600 dark:text-gray-400 @xs:block" />
         </td>
-        <td v-if="!readOnly" class="absolute top-0 right-0 flex items-center bg-linear-to-r to-20% from-transparent to-white p-3 ps-8 align-middle text-end group-hover:to-gray-50 dark:to-gray-900 dark:group-hover:to-gray-900">
+        <td v-if="!readOnly" class="absolute top-0 right-0 flex items-center bg-linear-to-r to-20% from-transparent to-white p-3 ps-8 align-middle text-end group-hover:to-gray-50 dark:to-gray-900 dark:group-hover:to-gray-900 [.link-fieldtype_&]:py-1.5">
             <ui-badge
                 v-if="showSetAlt && needsAlt"
                 as="button"

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -1,5 +1,5 @@
 <template>
-    <div data-asset-browser class="@container relative w-full bg-gray-50 dark:bg-transparent rounded-xl">
+    <div data-asset-browser class="@container relative w-full bg-gray-50 dark:bg-transparent rounded-xl [.link-fieldtype_&]:bg-transparent">
         <div
             v-if="hasPendingDynamicFolder"
             class="w-full rounded-md border border-dashed px-4 py-3 text-sm text-gray-700 dark:border-gray-300 dark:text-gray-200"
@@ -45,7 +45,7 @@
                         @keyup.space.enter="openSelector"
                     />
 
-                    <div class="text-sm text-gray-600 dark:text-gray-400 flex items-center flex-1 gap-1 ms-1" v-if="canUpload">
+                    <div class="text-sm text-gray-600 dark:text-gray-400 hidden not-[.link-fieldtype_&]:flex items-center flex-1 gap-1 ms-1" v-if="canUpload">
                         <ui-icon name="upload-cloud" class="size-5 text-gray-500 me-2" />
                         <div class="text-xs">
                             <span class="leading-tight" v-text="`${__('Drag & drop here or')}&nbsp;`" />
@@ -130,7 +130,7 @@
                     </sortable-list>
 
                     <div
-                        class="relative overflow-hidden rounded-xl border border-gray-300 dark:border-gray-700"
+                        class="relative overflow-hidden rounded-xl border border-gray-300 dark:border-gray-700 [.link-fieldtype_&]:rounded-lg"
                         :class="{ 'not-[.link-fieldtype_&]:border-t-0! not-[.link-fieldtype_&]:rounded-t-none': !isReadOnly && (showPicker || uploads.length), 'border-dashed': isReadOnly }"
                         v-if="displayMode === 'list'"
                     >


### PR DESCRIPTION
Was too big before and it bothered me. It's fixed now.

**Before**
<img width="1220" height="250" alt="CleanShot 2026-08-21 at 16 30 07@2x" src="https://github.com/user-attachments/assets/b14bf0c5-0ac4-4cfc-81d5-8e4b6319e574" />

**After**
<img width="1220" height="216" alt="CleanShot 2026-08-21 at 16 29 01@2x" src="https://github.com/user-attachments/assets/6588b57b-00cb-41d4-91f5-9bda1dbbf7aa" />
