### PR TITLE
[6.x] Fix nav:breadcrumbs including home when include_home is false

### DIFF
--- a/src/Tags/Nav.php
+++ b/src/Tags/Nav.php
@@ -23,6 +23,7 @@ class Nav extends Structure
 
         if (! $this->params->bool('include_home', true)) {
             array_shift($segments);
+            $segments = array_values(array_filter($segments, fn ($segment) => $segment !== ''));
         }
 
         $crumbs = collect($segments)->map(function () use (&$segments) {

--- a/tests/Tags/NavBreadcrumbsTest.php
+++ b/tests/Tags/NavBreadcrumbsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Tags;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Collection;
+use Statamic\Facades\Parse;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class NavBreadcrumbsTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $collection = tap(Collection::make('pages')->routes('{parent_uri}/{slug}')->structureContents(['root' => true]))->save();
+
+        EntryFactory::collection('pages')->id('home')->slug('home')->data(['title' => 'Home'])->create();
+        EntryFactory::collection('pages')->id('about')->slug('about')->data(['title' => 'About'])->create();
+        EntryFactory::collection('pages')->id('team')->slug('team')->data(['title' => 'Team'])->create();
+
+        $collection->structure()->in('en')->tree([
+            ['entry' => 'home'],
+            ['entry' => 'about', 'children' => [
+                ['entry' => 'team'],
+            ]],
+        ])->save();
+    }
+
+    private function tag($tag)
+    {
+        return (string) Parse::template($tag, [], trusted: true);
+    }
+
+    #[Test]
+    public function it_includes_home_by_default()
+    {
+        $this->get('/about/team');
+
+        $titles = $this->tag('{{ nav:breadcrumbs }}{{ title }}|{{ /nav:breadcrumbs }}');
+
+        $this->assertSame('Home|About|Team|', $titles);
+    }
+
+    #[Test]
+    public function it_excludes_home_when_include_home_is_false()
+    {
+        $this->get('/about/team');
+
+        $titles = $this->tag('{{ nav:breadcrumbs include_home="false" }}{{ title }}|{{ /nav:breadcrumbs }}');
+
+        $this->assertSame('About|Team|', $titles);
+    }
+
+    #[Test]
+    public function it_excludes_home_when_include_home_is_false_on_a_top_level_page()
+    {
+        $this->get('/about');
+
+        $titles = $this->tag('{{ nav:breadcrumbs include_home="false" }}{{ title }}|{{ /nav:breadcrumbs }}');
+
+        $this->assertSame('About|', $titles);
+    }
+
+    #[Test]
+    public function it_returns_no_breadcrumbs_on_the_home_page_when_include_home_is_false()
+    {
+        $this->get('/');
+
+        $titles = $this->tag('{{ nav:breadcrumbs include_home="false" }}{{ title }}|{{ /nav:breadcrumbs }}');
+
+        $this->assertSame('', $titles);
+    }
+}


### PR DESCRIPTION
### What
`{{ nav:breadcrumbs include_home="false" }}` still showed the home entry when the current page resolved to a root-adjacent segment.

### Why
In `breadcrumbs()`, when `include_home` is `false`, `array_shift($segments)` drops the leading `/` marker. When the current URL is the site root (`/`), the remaining segments array is left containing a single empty string. That empty string is then imploded and passed through `URL::tidy()`, which normalizes an empty string back to `/`, and `Data::findByUri('/')` resolves that to the Home entry — reintroducing the crumb the caller explicitly asked to exclude.

### Fix
After shifting off the home segment, filter out any resulting empty segments before building URIs, so an empty/root segment is never fed into `tidy()`/`findByUri()`.

### Test plan
- Added `tests/Tags/NavBreadcrumbsTest.php` covering:
  - default `include_home` behavior (home included)
  - `include_home="false"` on a nested page (home excluded, other crumbs intact)
  - `include_home="false"` on a top-level page
  - `include_home="false"` while viewing the home page itself (no breadcrumbs at all, previously incorrectly returned the home crumb)

Fixes #12584
