### PR TITLE
[6.x] Import `Log` facade to fix PHPStan analysis

### DIFF
--- a/src/Auth/Protect/Protection.php
+++ b/src/Auth/Protect/Protection.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Auth\Protect;
 
+use Illuminate\Support\Facades\Log;
 use InvalidArgumentException;
 use Statamic\Contracts\Auth\Protect\Protectable;
 use Statamic\Facades\URL;
@@ -82,7 +83,7 @@ class Protection
 
     protected function log($message)
     {
-        \Log::debug(vsprintf('%s Denying access to %s.', [
+        Log::debug(vsprintf('%s Denying access to %s.', [
             $message,
             $this->url(),
         ]));

--- a/src/Stache/Stache.php
+++ b/src/Stache/Stache.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\Log;
 use Statamic\Events\StacheCleared;
 use Statamic\Events\StacheWarmed;
 use Statamic\Extensions\FileStore;
@@ -271,7 +272,7 @@ class Stache
         // Disable parallel processing if using Redis cache (serialization issues)
         $cacheDriver = config('statamic.stache.cache_store', config('cache.default'));
         if ($cacheDriver === 'redis') {
-            \Log::info('Parallel warming disabled due to Redis cache driver');
+            Log::info('Parallel warming disabled due to Redis cache driver');
 
             return false;
         }
@@ -303,12 +304,12 @@ class Stache
             $driver = $config['concurrency_driver'] ?? 'process';
 
             if (empty($closures)) {
-                \Log::info('Closures are empty, skipping parallel warming');
+                Log::info('Closures are empty, skipping parallel warming');
             }
 
             Concurrency::driver($driver)->run($closures);
         } catch (\Exception $e) {
-            \Log::warning('Parallel warming failed, falling back to sequential: '.$e->getMessage());
+            Log::warning('Parallel warming failed, falling back to sequential: '.$e->getMessage());
             $stores->each->warm();
         }
     }

--- a/src/Tags/Assets.php
+++ b/src/Tags/Assets.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Tags;
 
+use Illuminate\Support\Facades\Log;
 use Statamic\Assets\Asset as AssetModel;
 use Statamic\Assets\AssetCollection;
 use Statamic\Contracts\Query\Builder;
@@ -88,7 +89,7 @@ class Assets extends Tags
     protected function assetsFromContainer($id, $path)
     {
         if (! $id && ! $path) {
-            \Log::debug('No asset container ID or path was specified.');
+            Log::debug('No asset container ID or path was specified.');
 
             return collect();
         }

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -4,6 +4,7 @@ namespace Statamic\Tags;
 
 use Facades\Statamic\Imaging\Attributes;
 use Facades\Statamic\Imaging\ImageValidator;
+use Illuminate\Support\Facades\Log;
 use League\Glide\Server;
 use Statamic\Contracts\Assets\Asset as AssetContract;
 use Statamic\Contracts\Data\Augmentable;
@@ -146,7 +147,7 @@ class Glide extends Tags
 
                 return $data;
             } catch (\Exception $e) {
-                \Log::error($e->getMessage());
+                Log::error($e->getMessage());
             }
         })->filter()->all();
 
@@ -205,7 +206,7 @@ class Glide extends Tags
         try {
             $url = $this->isValidExtension($item) ? $this->getManipulator($item)->build() : $this->normalizeItem($item);
         } catch (\Exception $e) {
-            \Log::error($e->getMessage());
+            Log::error($e->getMessage());
 
             return;
         }
@@ -230,7 +231,7 @@ class Glide extends Tags
             $source = $cache->read($path);
             $url = 'data:'.$cache->mimeType($path).';base64,'.base64_encode($source);
         } catch (\Exception $e) {
-            \Log::error($e->getMessage());
+            Log::error($e->getMessage());
 
             return;
         }


### PR DESCRIPTION
This pull request fixes an issue where the PHPStan "Analyze" workflow fails on any pull request touching `src/`.

This was happening because [PHPStan 2.2.9](https://github.com/phpstan/phpstan/releases/tag/2.2.9) (released 22nd August) no longer resolves unimported root-namespace facade aliases like `\Log`, and the workflow installs the latest dependencies on every run. Four files were still calling `\Log::` directly.

This PR fixes it by importing the `Illuminate\Support\Facades\Log` facade in those files, matching the convention used everywhere else in the codebase.