### PR TITLE
[6.x] Improve the UX of taggable comboboxes

### DIFF
--- a/resources/js/components/field-validation/Builder.vue
+++ b/resources/js/components/field-validation/Builder.vue
@@ -256,8 +256,9 @@ export default {
 
         ifSearchNotFoundAddCustom() {
             let rulesSelect = this.$refs.rulesSelect;
-            let rule = rulesSelect.searchQuery.value;
+            let rule = rulesSelect?.searchQuery;
 
+            if (!rule) return;
             if (this.searchNotFound(rulesSelect) || this.hasUnfinishedParameters(rule)) return;
 
             this.add(rule);
@@ -272,7 +273,7 @@ export default {
         },
 
         searchNotFound(rulesSelect) {
-            return rulesSelect.searchQuery.value?.length === 0 || rulesSelect?.filteredOptions.length === 0;
+            return rulesSelect.filteredOptions.length === 0;
         },
 
         updated(rules) {

--- a/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
+++ b/resources/js/components/fieldtypes/FormattingLocalesFieldtype.vue
@@ -18,8 +18,9 @@
                 <span class="text-gray-500 dark:text-gray-400" v-text="getSample(value)" />
             </div>
         </template>
-        <template #option="{ value, label, sample }">
-            <template v-if="value === 'language'">{{ label }}</template>
+        <template #option="{ value, label, sample, create }">
+            <template v-if="create">{{ __('Add ":value"', { value }) }}</template>
+            <template v-else-if="value === 'language'">{{ label }}</template>
             <div v-else class="w-full flex justify-between">
                 <div class="text-start flex-1">
                     {{ label }}

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -191,11 +191,6 @@ export default {
 
             this.$emit('input', items);
         },
-
-        createOption(value) {
-            const existing = this.options.find((option) => option.title === value);
-            return existing || { id: value, title: value };
-        },
     },
 };
 </script>

--- a/resources/js/components/inputs/relationship/SelectField.vue
+++ b/resources/js/components/inputs/relationship/SelectField.vue
@@ -18,10 +18,11 @@
             @update:modelValue="itemsSelected"
             @search="search"
         >
-            <template #option="{ title, hint, status }">
+            <template #option="{ title, hint, status, create }">
                 <div class="flex w-full text-left items-center gap-2">
                     <StatusIndicator v-if="status" :status="status" />
-                    <div v-text="title" class="truncate grow" />
+                    <div v-if="create" class="truncate grow">{{ __('Add ":value"', { value: title }) }}</div>
+                    <div v-else v-text="title" class="truncate grow" />
                     <ui-badge v-if="hint" size="sm" v-text="hint" />
                 </div>
             </template>

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -142,7 +142,9 @@ const itemClasses = cva({
 
 const searchQuery = ref('');
 const dropdownOpen = ref(false);
+const focusedByPointer = ref(false);
 const rootRef = useTemplateRef('root');
+const wrapperRef = useTemplateRef('wrapper');
 const triggerRef = useTemplateRef('trigger');
 const searchInputRef = useTemplateRef('search');
 
@@ -319,6 +321,23 @@ function openDropdown(e) {
     updateDropdownOpen(true);
 }
 
+function onFocus(e) {
+    const byPointer = focusedByPointer.value;
+    focusedByPointer.value = false;
+
+    if (!props.taggable || byPointer || dropdownOpen.value) return;
+    if (!focusCameFromOutside(e)) return;
+
+    updateDropdownOpen(true);
+}
+
+function focusCameFromOutside(e) {
+    if (!e.relatedTarget) return false;
+    if ('rekaCollectionItem' in e.relatedTarget.dataset) return false;
+
+    return !wrapperRef.value?.contains(e.relatedTarget);
+}
+
 function onBlur(e) {
     if (!props.taggable) return;
 
@@ -384,7 +403,13 @@ defineExpose({
 </script>
 
 <template>
-    <div :class="wrapperClasses" v-bind="wrapperAttrs">
+    <div
+        ref="wrapper"
+        :class="wrapperClasses"
+        v-bind="wrapperAttrs"
+        @pointerdown="focusedByPointer = true"
+        @click="focusedByPointer = false"
+    >
         <div class="flex w-full min-w-0">
             <ComboboxRoot
                 ref="root"
@@ -424,6 +449,7 @@ defineExpose({
                                 type="search"
                                 autocomplete="off"
                                 v-model="searchQuery"
+                                @focus="onFocus"
                                 @blur="onBlur"
                                 @paste="onPaste"
                                 @keydown.enter="pushTaggableOption"

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -149,6 +149,7 @@ const triggerRef = useTemplateRef('trigger');
 const searchInputRef = useTemplateRef('search');
 
 watch(searchQuery, (value) => emit('search', value, () => {}));
+
 watch(dropdownOpen, (open) => {
     if (!open) searchQuery.value = '';
 });

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -147,7 +147,9 @@ const triggerRef = useTemplateRef('trigger');
 const searchInputRef = useTemplateRef('search');
 
 watch(searchQuery, (value) => emit('search', value, () => {}));
-watch(dropdownOpen, () => searchQuery.value = '');
+watch(dropdownOpen, (open) => {
+    if (!open) searchQuery.value = '';
+});
 
 const getOptionLabel = (option) => {
     const label = option?.[props.optionLabel];
@@ -390,7 +392,7 @@ defineExpose({
                     <ComboboxTrigger
                         as="div"
                         ref="trigger"
-                        :tabindex="disabled || readOnly ? -1 : 0"
+                        :tabindex="disabled || readOnly || shouldShowInput ? -1 : 0"
                         :class="triggerClasses"
                         data-ui-combobox-trigger
                         @keydown.enter="openDropdown"

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -234,29 +234,39 @@ const placeholder = computed(() => {
 });
 
 const filteredOptions = computed(() => {
-    if (!props.searchable || props.ignoreFilter) {
-        return props.options;
+    let results = [...props.options];
+
+    if (props.searchable && !props.ignoreFilter) {
+        const matches = new Set(
+            fuzzysort
+                .go(searchQuery.value, props.options, {
+                    all: true,
+                    ...(props.searchKeys?.length ? { keys: props.searchKeys } : { key: props.optionLabel }),
+                })
+                .map((result) => result.obj)
+        );
+
+        results = props.options.filter((option) => matches.has(option));
     }
 
-    const matches = new Set(
-        fuzzysort
-            .go(searchQuery.value, props.options, {
-                all: true,
-                ...(props.searchKeys?.length ? { keys: props.searchKeys } : { key: props.optionLabel }),
-            })
-            .map((result) => result.obj)
-    );
-
-    const results = props.options.filter((option) => matches.has(option));
-
-    if (props.taggable && searchQuery.value && results.length === 0) {
-        results.push({
+    if (shouldShowCreateOption.value) {
+        results.unshift({
             [props.optionLabel]: searchQuery.value,
             [props.optionValue]: searchQuery.value,
+            create: true,
         });
     }
 
     return results;
+});
+
+const shouldShowCreateOption = computed(() => {
+    if (!props.taggable || !searchQuery.value) return false;
+
+    const matchesSearchQuery = (option) =>
+        getOptionLabel(option) === searchQuery.value || String(getOptionValue(option)) === searchQuery.value;
+
+    return !props.options.some(matchesSearchQuery) && !selectedOptions.value.some(matchesSearchQuery);
 });
 
 function clear() {
@@ -264,7 +274,9 @@ function clear() {
     emit('update:modelValue', null);
 }
 
-function select() {
+function select(option) {
+    if (option.create) emit('added', getOptionValue(option));
+
     dropdownOpen.value = !shouldCloseOnSelect.value;
     if (shouldCloseOnSelect.value) triggerRef.value?.$el?.focus();
 }
@@ -333,6 +345,7 @@ function onPaste(e) {
 
 function pushTaggableOption(e) {
     if (!props.taggable) return;
+    if (e.defaultPrevented) return; // Reka prevents the event's default when it selects a highlighted option.
     if (e.target.value === '') return;
 
     e.preventDefault();
@@ -509,12 +522,15 @@ defineExpose({
                                             :class="itemClasses({ size: size, selected: isSelected(option) })"
                                             :data-ui-combobox-item="getOptionValue(option)"
                                             :title="getOptionLabel(option)"
-                                            @select="select"
+                                            @select="select(option)"
                                         >
                                             <slot name="option" v-bind="option">
-                                                <img v-if="option.image" :src="option.image" class="size-5 rounded-full" :alt="getOptionLabel(option)">
-                                                <span v-if="labelHtml" class="truncate" v-html="getOptionLabel(option)" />
-                                                <span class="truncate" v-else>{{ __(getOptionLabel(option)) }}</span>
+                                                <span v-if="option.create" class="truncate">{{ __('Add ":value"', { value: getOptionLabel(option) }) }}</span>
+                                                <template v-else>
+                                                    <img v-if="option.image" :src="option.image" class="size-5 rounded-full" :alt="getOptionLabel(option)">
+                                                    <span v-if="labelHtml" class="truncate" v-html="getOptionLabel(option)" />
+                                                    <span class="truncate" v-else>{{ __(getOptionLabel(option)) }}</span>
+                                                </template>
                                             </slot>
                                         </ComboboxItem>
                                     </div>

--- a/resources/js/stories/Combobox.stories.ts
+++ b/resources/js/stories/Combobox.stories.ts
@@ -1164,6 +1164,33 @@ export const TestTaggableEnterSelectsHighlightedOption: Story = {
     },
 };
 
+export const TestTaggableDropdownOpensOnTabFocus: Story = {
+    tags: ['!dev', 'test'],
+    render: () => ({
+        components: { Combobox },
+        setup() {
+            const value = ref<string[]>([]);
+            return { value, options: defaultOptions };
+        },
+        template: `
+            <input data-testid="before" />
+            <Combobox v-model="value" :options="options" multiple taggable placeholder="Add tags..." />
+        `,
+    }),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        canvas.getByTestId('before').focus();
+        await userEvent.tab();
+
+        await new Promise((r) => setTimeout(r, 100));
+
+        const input = document.querySelector('input[type="search"]') as HTMLInputElement;
+        expect(document.activeElement).toBe(input);
+        await expect(document.querySelector('[data-ui-combobox-content]')).toBeTruthy();
+    },
+};
+
 export const TestDropdownOpensOnSpace: Story = {
     tags: ['!dev', 'test'],
     render: () => ({

--- a/resources/js/stories/Combobox.stories.ts
+++ b/resources/js/stories/Combobox.stories.ts
@@ -1076,6 +1076,94 @@ export const TestTaggableSinglePasteDoesNotCommitTags: Story = {
     },
 };
 
+export const TestTaggableShowsAddOptionAlongsideMatches: Story = {
+    tags: ['!dev', 'test'],
+    render: () => ({
+        components: { Combobox },
+        setup() {
+            const value = ref<string[]>([]);
+            return { value, options: defaultOptions };
+        },
+        template: `<Combobox v-model="value" :options="options" multiple taggable placeholder="Add tags..." />`,
+    }),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const trigger = canvas.getByRole('combobox');
+
+        await userEvent.click(trigger);
+
+        const input = document.querySelector('input[type="search"]') as HTMLInputElement;
+        await userEvent.type(input, 'the');
+
+        await new Promise((r) => setTimeout(r, 100));
+
+        const options = document.querySelectorAll('[data-ui-combobox-item]');
+        expect(options.length).toBe(3);
+        expect(options[0].getAttribute('data-ui-combobox-item')).toBe('the');
+        expect(options[0].textContent).toContain('Add "the"');
+    },
+};
+
+export const TestTaggableHidesAddOptionWhenQueryMatchesExistingOption: Story = {
+    tags: ['!dev', 'test'],
+    render: () => ({
+        components: { Combobox },
+        setup() {
+            const value = ref<string[]>([]);
+            return { value, options: defaultOptions };
+        },
+        template: `<Combobox v-model="value" :options="options" multiple taggable placeholder="Add tags..." />`,
+    }),
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+        const trigger = canvas.getByRole('combobox');
+
+        await userEvent.click(trigger);
+
+        const input = document.querySelector('input[type="search"]') as HTMLInputElement;
+        await userEvent.type(input, 'The Midnight');
+
+        await new Promise((r) => setTimeout(r, 100));
+
+        const options = document.querySelectorAll('[data-ui-combobox-item]');
+        expect(options.length).toBe(1);
+        expect(options[0].getAttribute('data-ui-combobox-item')).toBe('the_midnight');
+    },
+};
+
+export const TestTaggableEnterSelectsHighlightedOption: Story = {
+    tags: ['!dev', 'test'],
+    args: {
+        'onUpdate:modelValue': fn(),
+        onAdded: fn(),
+    },
+    render: (args) => ({
+        components: { Combobox },
+        setup() {
+            const value = ref<string[]>([]);
+            return { value, options: defaultOptions, onUpdate: args['onUpdate:modelValue'], onAdded: args.onAdded };
+        },
+        template: `<Combobox v-model="value" :options="options" multiple taggable placeholder="Add tags..." @update:modelValue="onUpdate" @added="onAdded" />`,
+    }),
+    play: async ({ canvasElement, args }) => {
+        const canvas = within(canvasElement);
+        const trigger = canvas.getByRole('combobox');
+
+        await userEvent.click(trigger);
+
+        const input = document.querySelector('input[type="search"]') as HTMLInputElement;
+        await userEvent.type(input, 'the');
+
+        await new Promise((r) => setTimeout(r, 100));
+
+        await userEvent.keyboard('{ArrowDown}');
+        await userEvent.keyboard('{Enter}');
+
+        await expect(args['onUpdate:modelValue']).toHaveBeenCalledWith(['the_midnight']);
+        expect(args.onAdded).not.toHaveBeenCalled();
+    },
+};
+
 export const TestDropdownOpensOnSpace: Story = {
     tags: ['!dev', 'test'],
     render: () => ({


### PR DESCRIPTION
This pull request improves the UX of taggable comboboxes.

* The typed value now always appears as an `Add "..."` option at the top of the dropdown, alongside any matching options, rather than only when nothing matched. Since typing highlights the first option, it's always clear what pressing enter will do.
* Tabbing into a taggable combobox now opens the dropdown, so the available options are visible right away.
* Fixes an issue where tabbing onto a combobox focused the wrapping trigger element first, requiring a second tab to reach the search input.
   * This was happening because both the trigger and the search input were in the tab order.
   * I've fixed it by taking the trigger out of the tab order whenever the search input is visible.
* Fixes an issue where pressing enter after arrowing to an option would add the raw typed text instead of the highlighted option.
   * This was happening because the enter handler always committed the typed text, running after Reka had already selected the highlighted option and overriding its selection.
   * I've fixed it by only committing the typed text when no option is highlighted.
* Fixes an issue where adding a custom validation rule in the rule builder would silently fail in development builds.
   * This was happening because `defineExpose` unwraps refs, so the builder's `added` handler was reading `searchQuery.value` as `undefined` and throwing.
   * I've fixed it by reading the unwrapped value from the combobox ref.

This PR also renders the add option label in the relationship select and formatting locales fieldtypes, since they provide their own option templates.

## Before

https://github.com/user-attachments/assets/243cae95-997e-4962-a340-352a8b85b5d9

## After


https://github.com/user-attachments/assets/b736cb42-ed5b-4efa-80dc-be82e0a6ac34

