### PR TITLE
[6.x] Fix site URLs configured with Antlers being treated as external

### DIFF
--- a/src/Facades/Endpoint/URL.php
+++ b/src/Facades/Endpoint/URL.php
@@ -438,11 +438,11 @@ class URL
         $sites = Site::all();
 
         self::$hasRelativeSiteCache = $sites->contains(
-            fn ($site) => Str::startsWith((string) ($site->rawConfig()['url'] ?? ''), '/')
+            fn ($site) => Str::startsWith((string) $site->url(), '/')
         );
 
         self::$absoluteSiteUrlsCache = $sites
-            ->map(fn ($site) => $site->rawConfig()['url'] ?? null)
+            ->map(fn ($site) => $site->url())
             ->filter(fn ($siteUrl) => self::isAbsolute($siteUrl))
             ->map(fn ($siteUrl) => self::getDomainFromAbsolute($siteUrl));
 

--- a/tests/Facades/UrlTest.php
+++ b/tests/Facades/UrlTest.php
@@ -315,6 +315,41 @@ class UrlTest extends TestCase
     }
 
     #[Test]
+    public function it_determines_external_url_to_application_when_site_urls_are_configured_with_antlers()
+    {
+        config(['app.frontend_url' => 'http://frontend-site.com']);
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => '{{ config:app:frontend_url }}'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => '{{ config:app:frontend_url }}/fr'],
+        ]);
+
+        $this->assertFalse(URL::isExternalToApplication('http://frontend-site.com/'));
+        $this->assertFalse(URL::isExternalToApplication('http://frontend-site.com/fr/'));
+        $this->assertTrue(URL::isExternalToApplication('http://external-site.com/'));
+    }
+
+    #[Test]
+    public function it_tidies_urls_on_site_hosts_configured_with_antlers()
+    {
+        config(['app.frontend_url' => 'http://frontend-site.com']);
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => '{{ config:app:frontend_url }}'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => '{{ config:app:frontend_url }}/fr'],
+        ]);
+
+        $this->assertSame('http://frontend-site.com', URL::tidy('http://frontend-site.com/'));
+        $this->assertSame('http://frontend-site.com/fr', URL::tidy('http://frontend-site.com/fr/'));
+        $this->assertSame('http://external-site.com/page/', URL::tidy('http://external-site.com/page/'));
+
+        URL::enforceTrailingSlashes();
+
+        $this->assertSame('http://frontend-site.com/fr/', URL::tidy('http://frontend-site.com/fr'));
+        $this->assertSame('http://external-site.com/page', URL::tidy('http://external-site.com/page'));
+    }
+
+    #[Test]
     #[DataProvider('assembleProvider')]
     public function it_can_assemble_urls($segments, $assembled)
     {


### PR DESCRIPTION
This pull request fixes an issue where URLs on a site's own host were left untouched by `URL::tidy()` when the site's URL is configured with Antlers, keeping trailing slashes on permalinks, canonical URLs, sitemap entries, etc. This mostly affects headless setups, where the site URLs (eg. `{{ config:app:frontend_url }}/fr`) point at a different host than `APP_URL`.

This was happening because `URL::ensureSiteCaches()` built its list of known site hosts from `rawConfig()['url']` — the unresolved config value. An Antlers value like `{{ config:app:frontend_url }}/fr` isn't an absolute URL, so it was filtered out of the list and the site's host was never recognised as belonging to the application. Single-host setups were unaffected because the host also matches `config('app.url')`, which is checked separately.

This PR fixes it by building the site caches from `$site->url()` — the resolved config value the `Site` object has already computed by that point, so there's no extra parsing involved.

Fixes #15232