### PR TITLE
[6.x] Resolve NoCache session via app() in StaticCaching hydrated callback

### DIFF
--- a/src/StaticCaching/ServiceProvider.php
+++ b/src/StaticCaching/ServiceProvider.php
@@ -86,7 +86,7 @@ class ServiceProvider extends LaravelServiceProvider
         // When the cascade gets hydrated, insert it into the
         // nocache session so it can filter out contextual data.
         Cascade::hydrated(function ($cascade) {
-            $this->app[Session::class]->setCascade($cascade->toArray());
+            app(Session::class)->setCascade($cascade->toArray());
         });
 
         Blade::directive('nocache', function ($exp) {


### PR DESCRIPTION
Resolves the NoCache `Session` via `app()` inside the `Cascade::hydrated` callback instead of the captured `$this->app`.

Normally PHP rebuilds the whole app for every request, so `$this->app` inside a service provider always points at the app handling the current request. Under long-lived runtimes like Laravel Octane, the app boots once and stays alive, and each incoming request gets a fresh copy of the container. The closure registered in `StaticCaching\ServiceProvider::boot()` holds onto `$this->app` from that original boot, so when the cascade gets hydrated it writes the cascade data into the `Session` on the original boot-time container — one that never serves requests and keeps accumulating state for the worker's lifetime — instead of the one handling the current request. Resolving with `app()` targets whichever container is currently active, which is what Laravel's [Octane container-injection guidance](https://laravel.com/docs/octane#container-injection) recommends.

This is the same `$this->app` pattern that was fixed in `AuthServiceProvider` in #9240. Under PHP-FPM the boot-time container and the request container are the same instance, so nothing changes there.
