### PR TITLE
[6.x] Fix numbers being considered empty by field conditions

### DIFF
--- a/resources/js/components/field-conditions/Validator.js
+++ b/resources/js/components/field-conditions/Validator.js
@@ -9,6 +9,9 @@ const NUMBER_SPECIFIC_COMPARISONS = ['>', '>=', '<', '<='];
 const isEmpty = (value) => {
     if (value === null || value === undefined) return true;
 
+    // Object.keys() would consider numbers empty.
+    if (typeof value === 'number') return false;
+
     return Array.isArray(value) ? value.length === 0 : Object.keys(value).length === 0;
 };
 

--- a/resources/js/tests/FieldConditionsValidator.test.js
+++ b/resources/js/tests/FieldConditionsValidator.test.js
@@ -226,6 +226,8 @@ test('it can check if value is empty', () => {
         last_name: 'HasselHoff',
         user: { email: 'david@hasselhoff.com' },
         favorite_foods: ['lasagna'],
+        age: 43,
+        zero: 0,
         empty_string: '',
         empty_array: [],
         empty_object: {},
@@ -237,6 +239,9 @@ test('it can check if value is empty', () => {
     expect(showFieldIf({ last_name: 'not empty' })).toBe(true);
     expect(showFieldIf({ user: 'empty' })).toBe(false);
     expect(showFieldIf({ favorite_foods: 'empty' })).toBe(false);
+    expect(showFieldIf({ age: 'empty' })).toBe(false);
+    expect(showFieldIf({ age: 'not empty' })).toBe(true);
+    expect(showFieldIf({ zero: 'empty' })).toBe(false);
     expect(showFieldIf({ empty_string: 'empty' })).toBe(true);
     expect(showFieldIf({ empty_array: 'empty' })).toBe(true);
     expect(showFieldIf({ empty_object: 'empty' })).toBe(true);


### PR DESCRIPTION
This pull request fixes an issue where fields with `empty`/`not empty` conditions targeting an integer field would be hidden, even when the target field had a value.

This was happening because the validator's `isEmpty` helper falls through to `Object.keys(value).length === 0`, and `Object.keys()` of a number is always an empty array — so any number was considered empty. It only ever appeared to work while typing, since text inputs produce strings (whose `Object.keys()` are their character indexes).

This PR fixes it by treating numbers as never empty — including `0`, since a saved zero is a value rather than an absence.
