### PR TITLE
[6.x] Bard server-side performance improvements

### DIFF
--- a/.phpstan/baseline.neon
+++ b/.phpstan/baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: ../src/Facades/Endpoint/Parse.php
 
 		-
-			message: '#^Method Illuminate\\Contracts\\Validation\\DataAwareRule@anonymous/Fieldtypes/Bard\.php\:934\:\:setData\(\) should return \$this\(Illuminate\\Contracts\\Validation\\DataAwareRule@anonymous/Fieldtypes/Bard\.php\:934\) but return statement is missing\.$#'
-			identifier: return.missing
-			count: 1
-			path: ../src/Fieldtypes/Bard.php
-
-		-
 			message: '#^Access to an undefined property Statamic\\Filesystem\\AbstractAdapter\:\:\$filesystem\.$#'
 			identifier: property.notFound
 			count: 13

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -13,6 +13,7 @@ use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Facades\GraphQL;
 use Statamic\Facades\Site;
+use Statamic\Facades\User;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Value;
@@ -837,31 +838,42 @@ class Bard extends Replicator
     {
         $field = $this->linkTypeField();
 
-        return collect(Link::types())
-            ->filter(fn (LinkType $type): bool => $type->visible($field))
-            ->map(function (LinkType $type, string $handle) use ($field): ?array {
-                if (! $config = $type->fieldtype($field)) {
-                    return null;
-                }
+        // The cached payload contains site-dependent config (an entry link type falls back
+        // to the current site's routable collections) and user-dependent meta (asset link
+        // type permissions), so both need to be part of the key.
+        $key = vsprintf('bard-link-types-%s-%s-%s', [
+            Site::current()->handle(),
+            User::current()?->id() ?? 'guest',
+            md5(json_encode($field->config())),
+        ]);
 
-                $nestedField = new Field($handle, $config);
-                $nestedFieldtype = $nestedField->fieldtype();
+        return Blink::once($key, function () use ($field) {
+            return collect(Link::types())
+                ->filter(fn (LinkType $type): bool => $type->visible($field))
+                ->map(function (LinkType $type, string $handle) use ($field): ?array {
+                    if (! $config = $type->fieldtype($field)) {
+                        return null;
+                    }
 
-                try {
-                    $meta = $nestedFieldtype->preload();
-                } catch (CollectionNotFoundException) {
-                    $meta = [];
-                }
+                    $nestedField = new Field($handle, $config);
+                    $nestedFieldtype = $nestedField->fieldtype();
 
-                return [
-                    'title' => $type->title(),
-                    'component' => $nestedFieldtype->component(),
-                    'config' => $nestedFieldtype->config(),
-                    'meta' => $meta,
-                ];
-            })
-            ->filter()
-            ->all();
+                    try {
+                        $meta = $nestedFieldtype->preload();
+                    } catch (CollectionNotFoundException) {
+                        $meta = [];
+                    }
+
+                    return [
+                        'title' => $type->title(),
+                        'component' => $nestedFieldtype->component(),
+                        'config' => $nestedFieldtype->config(),
+                        'meta' => $meta,
+                    ];
+                })
+                ->filter()
+                ->all();
+        });
     }
 
     private function wrapInlineValue($value)

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -673,9 +673,11 @@ class Bard extends Replicator
                 'folder' => $this->config('folder'),
             ]));
 
+            $assetMeta = $assetField->meta();
+
             $data['assets'] = [
-                'container' => $assetField->meta()['container'],
-                'columns' => $assetField->meta()['columns'],
+                'container' => $assetMeta['container'],
+                'columns' => $assetMeta['columns'],
             ];
         }
 

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -16,6 +16,7 @@ use Statamic\Facades\Site;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Assets\Assets as AssetsFieldtype;
 use Statamic\Fieldtypes\Bard\Augmentor;
 use Statamic\Fieldtypes\Link\LinkType;
 use Statamic\GraphQL\Types\BardSetsType;
@@ -811,8 +812,16 @@ class Bard extends Replicator
 
         $nestedField = new Field($handle, $config);
         $nestedField->setValue([$id]);
+        $fieldtype = $nestedField->fieldtype();
 
-        return $nestedField->fieldtype()->preload()['data'][0] ?? null;
+        // Both of these build their preload `data` from getItemData(), so we can get the
+        // item without paying for the rest of the preload payload. Anything else may only
+        // implement preload(), so it gets the original treatment.
+        if ($fieldtype instanceof Relationship || $fieldtype instanceof AssetsFieldtype) {
+            return $fieldtype->getItemData([$id])->first();
+        }
+
+        return $fieldtype->preload()['data'][0] ?? null;
     }
 
     private function linkTypeField(): Field

--- a/src/Fieldtypes/Bard.php
+++ b/src/Fieldtypes/Bard.php
@@ -938,6 +938,8 @@ class Bard extends Replicator
             public function setData(array $data)
             {
                 $this->data = $data;
+
+                return $this;
             }
 
             public function validate(string $attribute, mixed $value, Closure $fail): void

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -12,6 +12,7 @@ use Statamic\Facades;
 use Statamic\Fields\Field;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
+use Statamic\Fieldtypes\Assets\Assets as AssetsFieldtype;
 use Statamic\Fieldtypes\Bard;
 use Statamic\Fieldtypes\Bard\Augmentor;
 use Statamic\Fieldtypes\Link;
@@ -1572,6 +1573,36 @@ EOT;
         $this->assertArrayNotHasKey('bard-test-hidden', $this->bard()->preload()['linkTypes']);
     }
 
+    #[Test]
+    public function it_preloads_the_asset_container_and_columns()
+    {
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
+        Facades\AssetContainer::make('main')->disk('local')->save();
+
+        $assets = $this->bard(['container' => 'main'])->preload()['assets'];
+
+        $this->assertEquals(['container', 'columns'], array_keys($assets));
+        $this->assertEquals('main', $assets['container']['id']);
+        $this->assertEquals('Main', $assets['container']['title']);
+        $this->assertTrue($assets['container']['can_upload']);
+        $this->assertContains('basename', collect($assets['columns'])->map->field()->all());
+    }
+
+    #[Test]
+    public function it_only_generates_the_asset_fields_meta_once_when_preloading()
+    {
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
+        Facades\AssetContainer::make('main')->disk('local')->save();
+
+        TestCountingAssetsFieldtype::register();
+        TestCountingAssetsFieldtype::$preloads = 0;
+
+        $this->bard(['container' => 'main'])->preload();
+
+        // Once for the asset link type in the toolbar, once for the field's own asset meta.
+        $this->assertEquals(2, TestCountingAssetsFieldtype::$preloads);
+    }
+
     private function bard($config = [])
     {
         return (new Bard)->setField(new Field('test', array_merge(['type' => 'bard', 'sets' => ['one' => []]], $config)));
@@ -1641,5 +1672,18 @@ class TestCustomLinkFieldtype extends Fieldtype
     public function preload()
     {
         return ['data' => [['title' => 'Custom Title']]];
+    }
+}
+
+class TestCountingAssetsFieldtype extends AssetsFieldtype
+{
+    public static $handle = 'assets';
+    public static int $preloads = 0;
+
+    public function preload()
+    {
+        static::$preloads++;
+
+        return parent::preload();
     }
 }

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -1574,6 +1574,67 @@ EOT;
     }
 
     #[Test]
+    public function it_reuses_the_link_types_for_the_toolbar_within_a_request()
+    {
+        TestCustomLinkFieldtype::register();
+        Link::extend('bard-test-counted', TestCountedLinkType::class);
+        TestCountedLinkType::$fieldtypeCalls = 0;
+
+        $bard = $this->bard();
+
+        $first = $bard->preload()['linkTypes'];
+        $second = $bard->preload()['linkTypes'];
+
+        $this->assertEquals($first, $second);
+        $this->assertEquals(1, TestCountedLinkType::$fieldtypeCalls);
+    }
+
+    #[Test]
+    public function it_does_not_share_cached_link_types_between_sites()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
+
+        Facades\Collection::make('blog')->sites(['en'])->routes(['en' => 'blog/{slug}'])->save();
+        Facades\Collection::make('actus')->sites(['fr'])->routes(['fr' => 'actus/{slug}'])->save();
+
+        $bard = $this->bard();
+
+        Facades\Site::setCurrent('en');
+        $en = $bard->preload()['linkTypes']['entry']['config']['collections'];
+
+        Facades\Site::setCurrent('fr');
+        $fr = $bard->preload()['linkTypes']['entry']['config']['collections'];
+
+        $this->assertEquals(['blog'], $en);
+        $this->assertEquals(['actus'], $fr);
+    }
+
+    #[Test]
+    public function it_does_not_share_cached_link_types_between_users()
+    {
+        Facades\AssetContainer::make('main')->disk('local')->save();
+
+        $super = tap(Facades\User::make()->makeSuper())->save();
+        $peon = tap(Facades\User::make())->save();
+
+        $bard = $this->bard(['container' => 'main']);
+
+        $this->actingAs($super);
+        $superMeta = $bard->preload()['linkTypes']['asset']['meta']['container'];
+
+        $this->actingAs($peon);
+        $peonMeta = $bard->preload()['linkTypes']['asset']['meta']['container'];
+
+        $this->assertTrue($superMeta['can_upload']);
+        $this->assertFalse($peonMeta['can_upload']);
+    }
+
+    #[Test]
     public function it_gets_link_data_for_an_entry_link()
     {
         $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
@@ -1753,6 +1814,25 @@ class TestCountingAssetsFieldtype extends AssetsFieldtype
         static::$preloads++;
 
         return parent::preload();
+    }
+}
+
+class TestCountedLinkType extends LinkType
+{
+    public static int $fieldtypeCalls = 0;
+
+    protected static ?string $title = 'Counted Type';
+
+    public function resolve(string $id, $parent = null, bool $localize = false): mixed
+    {
+        return null;
+    }
+
+    public function fieldtype(Field $field): ?array
+    {
+        static::$fieldtypeCalls++;
+
+        return ['type' => 'test_custom_link'];
     }
 }
 

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -1574,6 +1574,74 @@ EOT;
     }
 
     #[Test]
+    public function it_gets_link_data_for_an_entry_link()
+    {
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
+        tap(Facades\Collection::make('blog')->routes('blog/{slug}'))->save();
+        EntryFactory::collection('blog')->id('123')->slug('my-post')->data(['title' => 'My Post'])->create();
+
+        $linkData = $this->bard()->getLinkData([
+            ['type' => 'text', 'marks' => [['type' => 'link', 'attrs' => ['href' => 'statamic://entry::123']]], 'text' => 'Link'],
+        ]);
+
+        $this->assertEquals([
+            'entry::123' => [
+                'id' => '123',
+                'reference' => 'entry::123',
+                'title' => 'My Post',
+                'status' => 'published',
+                'edit_url' => 'http://localhost/cp/collections/blog/entries/123',
+                'editable' => true,
+                'hint' => '',
+            ],
+        ], $linkData);
+    }
+
+    #[Test]
+    public function it_gets_link_data_for_an_asset_link()
+    {
+        Storage::fake('local');
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
+        Facades\AssetContainer::make('main')->disk('local')->save();
+        Facades\Asset::make()->container('main')->path('foo.txt')->upload(UploadedFile::fake()->create('foo.txt'));
+
+        $linkData = $this->bard(['container' => 'main'])->getLinkData([
+            ['type' => 'text', 'marks' => [['type' => 'link', 'attrs' => ['href' => 'statamic://asset::main::foo.txt']]], 'text' => 'Link'],
+        ]);
+
+        $this->assertEquals(['asset::main::foo.txt'], array_keys($linkData));
+        $this->assertEquals('main::foo.txt', $linkData['asset::main::foo.txt']['id']);
+        $this->assertEquals('foo.txt', $linkData['asset::main::foo.txt']['basename']);
+    }
+
+    #[Test]
+    public function it_gets_link_data_for_an_asset_link_when_no_container_is_configured()
+    {
+        $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
+        Facades\AssetContainer::make('one')->disk('local')->save();
+        Facades\AssetContainer::make('two')->disk('local')->save();
+
+        $linkData = $this->bard()->getLinkData([
+            ['type' => 'text', 'marks' => [['type' => 'link', 'attrs' => ['href' => 'statamic://asset::one::foo.txt']]], 'text' => 'Link'],
+        ]);
+
+        $this->assertEquals(['id' => 'one::foo.txt', 'url' => 'one::foo.txt', 'invalid' => true], $linkData['asset::one::foo.txt']);
+    }
+
+    #[Test]
+    public function it_gets_link_data_for_a_custom_link_type_with_a_non_public_get_item_data_method()
+    {
+        TestPrivateItemDataFieldtype::register();
+        Link::extend('bard-test-private', TestPrivateItemDataLinkType::class);
+
+        $linkData = $this->bard()->getLinkData([
+            ['type' => 'text', 'marks' => [['type' => 'link', 'attrs' => ['href' => 'statamic://bard-test-private::valid']]], 'text' => 'Link'],
+        ]);
+
+        $this->assertEquals(['title' => 'From Preload'], $linkData['bard-test-private::valid']);
+    }
+
+    #[Test]
     public function it_preloads_the_asset_container_and_columns()
     {
         $this->actingAs(tap(Facades\User::make()->makeSuper())->save());
@@ -1685,5 +1753,35 @@ class TestCountingAssetsFieldtype extends AssetsFieldtype
         static::$preloads++;
 
         return parent::preload();
+    }
+}
+
+class TestPrivateItemDataLinkType extends LinkType
+{
+    protected static ?string $title = 'Private Item Data Type';
+
+    public function resolve(string $id, $parent = null, bool $localize = false): mixed
+    {
+        return null;
+    }
+
+    public function fieldtype(Field $field): ?array
+    {
+        return ['type' => 'test_private_item_data'];
+    }
+}
+
+class TestPrivateItemDataFieldtype extends Fieldtype
+{
+    public static $handle = 'test_private_item_data';
+
+    public function preload()
+    {
+        return ['data' => $this->getItemData()];
+    }
+
+    private function getItemData()
+    {
+        return [['title' => 'From Preload']];
     }
 }


### PR DESCRIPTION
Split out of #15158.

### Generate the asset field's meta once

`preload()` called `meta()` twice on the same throwaway asset field, once for `container` and once for `columns`. Each call builds the entire Assets preload payload — container lookup, five permission checks, blueprint columns — so half of that work was thrown away.

### Resolve link data without a full preload payload

`linkDataForType()` called `preload()` on a nested field just to read `['data'][0]`. `Relationship` and `Assets` both build that `data` from `getItemData()`, so it can come straight from there, skipping the selection URLs, columns, creatables and container permissions that were being built and discarded once per link in the content.

It's also a bug fix. When a Bard field has an asset link in its content but no configured container, the old path went through `Assets::preload()` → `container()`, which throws `UndefinedContainerException` and 500s the publish form. The new path returns the usual invalid-item marker instead.

The fast path is guarded with `instanceof` rather than a `method_exists('getItemData')` check. `Dictionary::getItemData()` is private and returns a plain array, so duck-typing would fatal on a link type using it, where today it harmlessly resolves to `null`.

### Cache the toolbar's link types for the request

Every Bard field rebuilt the toolbar's link types from scratch, generating a full preload payload per link type. A page with several Bard fields — or a Replicator whose sets each contain one — repeated that per field. Blink is request-scoped, so there's no cross-request staleness.

The key includes the current site and user as well as the field config, because the payload embeds both. An entry link type with no configured collections falls back to the collections routable in `Site::current()`, and the asset link type's meta carries the current user's container permissions. Keying on the config alone serves one context's toolbar to another — with `blog` routable in `en` only and `actus` in `fr` only, the second site got the first site's collections.

### Return `$this` from the `DataAwareRule`'s `setData()`

The interface declares a `$this` return. Removes the corresponding PHPStan baseline entry.
