### PR TITLE
[6.x] Memoize the Replicator flattened sets config Blink key

### DIFF
--- a/src/Fieldtypes/Replicator.php
+++ b/src/Fieldtypes/Replicator.php
@@ -7,6 +7,7 @@ use Statamic\Contracts\Data\Localization;
 use Statamic\Data\NestedFieldUpdater;
 use Statamic\Facades\Blink;
 use Statamic\Facades\GraphQL;
+use Statamic\Fields\Field;
 use Statamic\Fields\Fields;
 use Statamic\Fields\Fieldtype;
 use Statamic\Fields\Values;
@@ -25,6 +26,14 @@ class Replicator extends Fieldtype
     protected $categories = ['structured'];
     protected $keywords = ['builder', 'page builder', 'content'];
     protected $rules = ['array'];
+    protected ?string $flattenedSetsConfigBlinkKey = null;
+
+    public function setField(Field $field)
+    {
+        $this->flattenedSetsConfigBlinkKey = null;
+
+        return parent::setField($field);
+    }
 
     protected function configFieldItems(): array
     {
@@ -276,9 +285,12 @@ class Replicator extends Fieldtype
 
     public function flattenedSetsConfig()
     {
-        $blink = md5($this->field?->handle().json_encode($this->field?->config()));
+        // Re-serializing the config on every call is expensive on fields with lots
+        // of sets, and this gets hit repeatedly by fields(), preload() and augment().
+        // Invalidated in setField(), which is the only thing that replaces the field.
+        $this->flattenedSetsConfigBlinkKey ??= md5($this->field?->handle().json_encode($this->field?->config()));
 
-        return Blink::once($blink, function () {
+        return Blink::once($this->flattenedSetsConfigBlinkKey, function () {
             $sets = collect($this->config('sets'));
 
             // If the first set doesn't have a nested "set" key, it would be the legacy format.

--- a/tests/Fieldtypes/BardTest.php
+++ b/tests/Fieldtypes/BardTest.php
@@ -1577,6 +1577,46 @@ EOT;
         return (new Bard)->setField(new Field('test', array_merge(['type' => 'bard', 'sets' => ['one' => []]], $config)));
     }
 
+    #[Test]
+    public function it_gets_flattened_sets_config_for_each_field_it_is_given()
+    {
+        $fieldtype = new Bard;
+
+        $fieldtype->setField($this->fieldWithSet('alpha'));
+        $this->assertSame(['alpha'], $fieldtype->flattenedSetsConfig()->keys()->all());
+
+        $fieldtype->setField($this->fieldWithSet('bravo'));
+        $this->assertSame(['bravo'], $fieldtype->flattenedSetsConfig()->keys()->all());
+    }
+
+    #[Test]
+    public function it_gets_flattened_sets_config_when_the_field_is_replaced_without_being_read()
+    {
+        $fieldtype = new Bard;
+
+        $fieldtype->setField($this->fieldWithSet('alpha'));
+        $fieldtype->flattenedSetsConfig();
+
+        $fieldtype->setField($this->fieldWithSet('bravo'));
+        $fieldtype->setField($this->fieldWithSet('charlie'));
+
+        $this->assertSame(['charlie'], $fieldtype->flattenedSetsConfig()->keys()->all());
+    }
+
+    private function fieldWithSet(string $set)
+    {
+        return new Field($set.'_field', [
+            'type' => 'bard',
+            'sets' => [
+                'main' => [
+                    'sets' => [
+                        $set => ['fields' => [['handle' => 'words', 'field' => ['type' => 'text']]]],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public static function groupedSetsProvider()
     {
         return [

--- a/tests/Fieldtypes/ReplicatorTest.php
+++ b/tests/Fieldtypes/ReplicatorTest.php
@@ -1232,6 +1232,61 @@ class ReplicatorTest extends TestCase
         $this->assertSame('Add Set', $configFields['button_label']['placeholder']);
     }
 
+    #[Test]
+    public function it_gets_flattened_sets_config_for_each_field_it_is_given()
+    {
+        $fieldtype = new Replicator;
+
+        $fieldtype->setField($this->fieldWithSet('alpha'));
+        $this->assertSame(['alpha'], $fieldtype->flattenedSetsConfig()->keys()->all());
+
+        $fieldtype->setField($this->fieldWithSet('bravo'));
+        $this->assertSame(['bravo'], $fieldtype->flattenedSetsConfig()->keys()->all());
+    }
+
+    #[Test]
+    public function it_gets_flattened_sets_config_when_the_field_is_replaced_without_being_read()
+    {
+        // The field is cloned into the fieldtype, so replacing it frees the previous
+        // clone and its spl_object_id becomes available to the next one.
+        $fieldtype = new Replicator;
+
+        $fieldtype->setField($this->fieldWithSet('alpha'));
+        $fieldtype->flattenedSetsConfig();
+
+        $fieldtype->setField($this->fieldWithSet('bravo'));
+        $fieldtype->setField($this->fieldWithSet('charlie'));
+
+        $this->assertSame(['charlie'], $fieldtype->flattenedSetsConfig()->keys()->all());
+    }
+
+    #[Test]
+    public function it_doesnt_use_another_fields_flattened_sets_config_when_cloned()
+    {
+        $fieldtype = new Replicator;
+        $fieldtype->setField($this->fieldWithSet('alpha'));
+        $fieldtype->flattenedSetsConfig();
+
+        $clone = (clone $fieldtype)->setField($this->fieldWithSet('bravo'));
+
+        $this->assertSame(['bravo'], $clone->flattenedSetsConfig()->keys()->all());
+        $this->assertSame(['alpha'], $fieldtype->flattenedSetsConfig()->keys()->all());
+    }
+
+    private function fieldWithSet(string $set)
+    {
+        return new Field($set.'_field', [
+            'type' => 'replicator',
+            'sets' => [
+                'main' => [
+                    'sets' => [
+                        $set => ['fields' => [['handle' => 'words', 'field' => ['type' => 'text']]]],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public static function groupedSetsProvider()
     {
         return [


### PR DESCRIPTION
`Replicator::flattenedSetsConfig()` rebuilt its Blink key on every call by `json_encode`-ing the entire field config. It's called repeatedly from `fields()`, `preload()` and `augment()`, so on a field with a lot of sets that serialization runs many times per request for a config that hasn't changed. Bard inherits it too.

The key is now built once and cached on the fieldtype, and reset in `setField()` — the only thing that replaces the field it's derived from. That keeps the key's lifetime tied to the field it was built for.

Caching it against `spl_object_id($this->field)` instead wouldn't be safe. `setField()` stores a `clone` of the field, so the fieldtype is its sole owner and the field is freed as soon as it's replaced, and PHP reuses object ids — 300 fields through `Field::fieldtype()` reused just 4. Replace the field twice without reading the config in between and the third can land on the first's id, and you'd get the wrong set config back. There's a test covering that, for both Replicator and Bard.

Extracted from #15158 