### PR TITLE
[6.x] Add safe option to to_json for HTML-embedded JSON

### DIFF
--- a/src/Modifiers/CoreModifiers.php
+++ b/src/Modifiers/CoreModifiers.php
@@ -2802,7 +2802,15 @@ class CoreModifiers extends Modifier
      */
     public function toJson($value, $params)
     {
-        $options = Arr::get($params, 0) === 'pretty' ? JSON_PRETTY_PRINT : 0;
+        $options = 0;
+
+        if (in_array('pretty', $params)) {
+            $options |= JSON_PRETTY_PRINT;
+        }
+
+        if (in_array('safe', $params)) {
+            $options |= JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT;
+        }
 
         if (Compare::isQueryBuilder($value)) {
             $value = $value->get();

--- a/tests/Modifiers/ToJsonTest.php
+++ b/tests/Modifiers/ToJsonTest.php
@@ -32,6 +32,43 @@ class ToJsonTest extends TestCase
         $this->assertEquals(json_encode(json_decode($expected, true), JSON_PRETTY_PRINT), $modified);
     }
 
+    #[Test]
+    public function it_hex_encodes_html_sensitive_characters_when_safe(): void
+    {
+        $value = '</script><script>alert(1)</script>';
+        $modified = $this->modify($value, ['safe']);
+
+        $this->assertSame(
+            json_encode($value, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT),
+            $modified,
+        );
+        $this->assertStringNotContainsString('</script>', $modified);
+        $this->assertSame($value, json_decode($modified));
+    }
+
+    #[Test]
+    #[DataProvider('safeParamOrderProvider')]
+    public function it_can_combine_pretty_and_safe(array $params): void
+    {
+        $value = ['html' => '</script>'];
+        $modified = $this->modify($value, $params);
+
+        $this->assertSame(
+            json_encode($value, JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT),
+            $modified,
+        );
+        $this->assertStringNotContainsString('</script>', $modified);
+        $this->assertSame($value, json_decode($modified, true));
+    }
+
+    public static function safeParamOrderProvider(): array
+    {
+        return [
+            'pretty then safe' => [['pretty', 'safe']],
+            'safe then pretty' => [['safe', 'pretty']],
+        ];
+    }
+
     private function modify($value, $options = [])
     {
         return Modify::value($value)->toJson($options)->fetch();


### PR DESCRIPTION
## Summary

Bare `json_encode` output (what `to_json` uses today) can allow strings containing `</script>` to break out of HTML `<script>` elements, including `application/ld+json`. Laravel’s `@json` / `Js::from()` already apply the JSON HEX flags; Antlers had no equivalent.

This adds an opt-in `safe` parameter so existing `to_json` output stays unchanged:

- `{{ value | to_json:safe }}`
- Combinable in either order: `{{ value | to_json:pretty:safe }}` or `{{ value | to_json:safe:pretty }}`

When `safe` is present, encoding uses `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT`.

Modifier docs live in the separate docs repo and need a follow-up update.

## Test plan

- [x] Existing `to_json` / `to_json:pretty` output unchanged
- [x] `to_json:safe` hex-encodes HTML-sensitive characters and does not contain raw `</script>`
- [x] Safe output `json_decode`s back to the original value
- [x] `pretty` and `safe` work together in either param order