### PR TITLE
[6.x] Avoid layout thrashing from Reka's aria-label fallback

### DIFF
--- a/resources/js/components/fieldtypes/ToggleFieldtype.vue
+++ b/resources/js/components/fieldtypes/ToggleFieldtype.vue
@@ -4,6 +4,7 @@
             @update:model-value="update"
             :disabled="config.disabled || isReadOnly"
             :id="fieldId"
+            :aria-label="__(config.display)"
             :model-value="value"
             :read-only="isReadOnly"
         />

--- a/resources/js/components/ui/Checkbox/Item.vue
+++ b/resources/js/components/ui/Checkbox/Item.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { CheckboxIndicator, CheckboxRoot } from 'reka-ui';
-import { computed, useAttrs, useId } from 'vue';
+import { computed, useAttrs, useId, useSlots } from 'vue';
 import { cva } from 'cva';
 import { twMerge } from 'tailwind-merge';
 import { injectCheckboxContext } from './Group.vue';
@@ -8,6 +8,7 @@ import { injectCheckboxContext } from './Group.vue';
 defineOptions({ inheritAttrs: false });
 
 const attrs = useAttrs();
+const slots = useSlots();
 
 const props = defineProps({
     /** Optional ID for the checkbox input */
@@ -100,7 +101,8 @@ const conditionalProps = computed(() => {
         props_obj['aria-describedby'] = `${props.id}-description`;
     }
 
-    if (props.solo && (props.label || props.value)) {
+    // Providing the name ourselves stops Reka from deriving it from the label's innerText, which forces a layout.
+    if ((props.solo || !slots.default) && (props.label || props.value)) {
         props_obj['aria-label'] = props.label || props.value;
     }
 

--- a/resources/js/tests/components/CheckboxItem.test.js
+++ b/resources/js/tests/components/CheckboxItem.test.js
@@ -30,3 +30,21 @@ test('aria-describedby and the description element share the custom id', () => {
     expect(wrapper.find('[role="checkbox"]').attributes('aria-describedby')).toBe('custom-checkbox-id-description');
     expect(wrapper.find('p').attributes('id')).toBe('custom-checkbox-id-description');
 });
+
+test('the label prop is rendered as the aria-label', () => {
+    const wrapper = mount(Checkbox, {
+        props: { label: 'Subscribe' },
+    });
+
+    expect(wrapper.find('[role="checkbox"]').attributes('aria-label')).toBe('Subscribe');
+});
+
+test('no aria-label is rendered when the label comes from the slot', () => {
+    const wrapper = mount(Checkbox, {
+        props: { value: 'subscribe' },
+        slots: { default: () => 'Subscribe' },
+    });
+
+    expect(wrapper.find('[role="checkbox"]').attributes('aria-label')).toBeUndefined();
+});
+

--- a/resources/js/tests/components/Switch.test.js
+++ b/resources/js/tests/components/Switch.test.js
@@ -1,0 +1,17 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+import Switch from '@/components/ui/Switch.vue';
+
+test('an aria-label attribute falls through to the switch element', () => {
+    const wrapper = mount(Switch, {
+        attrs: { 'aria-label': 'Publish this entry' },
+    });
+
+    expect(wrapper.find('[role="switch"]').attributes('aria-label')).toBe('Publish this entry');
+});
+
+test('no aria-label is rendered when no aria-label attribute is given', () => {
+    const wrapper = mount(Switch);
+
+    expect(wrapper.find('[role="switch"]').attributes('aria-label')).toBeUndefined();
+});


### PR DESCRIPTION
Reka UI's `SwitchRoot` and `CheckboxRoot` compute a fallback `aria-label` via `document.querySelector('[for="<id>"]').innerText`, on mount and again whenever their `id` changes. `innerText` forces a full synchronous layout, so on large publish forms this runs once per toggle.

On a 105-set Bard entry that was ~10.5s of the page load, and ~21s when pressing Enter near the top of the Bard field — inserting a node renumbers every following set, which changes every nested field's id.

Reka skips that computed when a truthy `aria-label` attribute is supplied, so we now pass the real accessible name ourselves:

- The Toggle fieldtype passes `__(config.display)`, the same text as its `<label for>`.
- `Checkbox/Item.vue` passes `label || value` when no custom slot is rendered.

Measured on the same entry: Enter-at-start 21s → 1.1s, page-load `innerText` cost 10.5s → 0.

Radio is intentionally not covered here: Reka's `Radio` overrides a caller-supplied `aria-label`, so it needs an upstream fix.
