### PR TITLE
[6.x] Fix OAuth connections for Eloquent users

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -13,6 +13,7 @@ use Statamic\Exceptions\OAuthEmailExistsException;
 use Statamic\Facades\OAuth;
 use Statamic\Facades\TwoFactor;
 use Statamic\Facades\URL;
+use Statamic\Facades\User;
 use Statamic\Support\Str;
 
 use function Statamic\trans as __;
@@ -83,7 +84,7 @@ class OAuthController
         }
 
         if (Auth::guard($guard)->check()) {
-            return $this->connectProvider($oauth, $providerUser, Auth::guard($guard)->user());
+            return $this->connectProvider($oauth, $providerUser, User::fromUser(Auth::guard($guard)->user()));
         }
 
         if ($user = $oauth->findUser($providerUser)) {
@@ -127,7 +128,7 @@ class OAuthController
             throw new NotFoundHttpException();
         }
 
-        $oauth->forgetUser($request->user());
+        $oauth->forgetUser(User::fromUser($request->user()));
 
         if ($request->wantsJson()) {
             return new JsonResponse([], 204);
@@ -148,7 +149,7 @@ class OAuthController
 
         $existingUserId = $oauth->getUserId($providerUser->getId());
 
-        if ($existingUserId === $user->id()) {
+        if ($existingUserId === (string) $user->id()) {
             return redirect()
                 ->to($this->successRedirectUrl())
                 ->with('success', __('statamic::messages.oauth_already_connected', ['provider' => $oauth->label()]));

--- a/tests/OAuth/EloquentOAuthTest.php
+++ b/tests/OAuth/EloquentOAuthTest.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Tests\OAuth;
+
+use Laravel\Socialite\Facades\Socialite;
+use Laravel\Socialite\Two\User as SocialiteUser;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\User as UserFacade;
+use Statamic\OAuth\Provider;
+use Tests\Auth\Eloquent\User as EloquentUser;
+use Tests\ElevatesSessions;
+use Tests\TestCase;
+
+class EloquentOAuthTest extends TestCase
+{
+    use ElevatesSessions;
+
+    protected function getEnvironmentSetUp($app)
+    {
+        parent::getEnvironmentSetUp($app);
+
+        $app['config']->set('auth.providers.users', [
+            'driver' => 'eloquent',
+            'model' => EloquentUser::class,
+        ]);
+        $app['config']->set('statamic.oauth.enabled', true);
+        $app['config']->set('statamic.oauth.providers', ['test' => 'Test']);
+        $app['config']->set('statamic.users.repository', 'eloquent');
+    }
+
+    protected function defineDatabaseMigrations()
+    {
+        $this->loadMigrationsFrom(__DIR__.'/../Auth/Eloquent/__migrations__');
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory(storage_path('statamic/oauth'));
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function an_authenticated_eloquent_user_can_connect_a_provider()
+    {
+        $user = $this->makeUser();
+
+        $this->assertFalse(method_exists($user, 'id'));
+
+        $this->fakeProvider('sub-1');
+
+        $response = $this
+            ->actingAs($user)
+            ->withElevatedSession()
+            ->withSession(['statamic.oauth.guard' => 'web'])
+            ->get(route('statamic.oauth.callback', 'test'));
+
+        $this->assertSame((string) $user->getKey(), $this->provider()->getUserId('sub-1'));
+        $this->assertAuthenticatedAs($user);
+        $response->assertSessionHas('success', __('statamic::messages.oauth_connected', ['provider' => 'Test']));
+    }
+
+    #[Test]
+    public function reconnecting_a_provider_to_the_same_eloquent_user_is_idempotent()
+    {
+        $user = $this->makeUser();
+        $this->provider()->setUserProviderId(UserFacade::fromUser($user), 'sub-1');
+
+        $this->fakeProvider('sub-1');
+
+        $response = $this
+            ->actingAs($user)
+            ->withElevatedSession()
+            ->withSession(['statamic.oauth.guard' => 'web'])
+            ->get(route('statamic.oauth.callback', 'test'));
+
+        $this->assertSame((string) $user->getKey(), $this->provider()->getUserId('sub-1'));
+        $response->assertSessionHas('success', __('statamic::messages.oauth_already_connected', ['provider' => 'Test']));
+    }
+
+    #[Test]
+    public function an_authenticated_eloquent_user_can_disconnect_a_provider()
+    {
+        $user = $this->makeUser();
+        $this->provider()->setUserProviderId(UserFacade::fromUser($user), 'sub-1');
+
+        $response = $this
+            ->actingAs($user)
+            ->withElevatedSession()
+            ->delete(route('statamic.oauth.disconnect', 'test'));
+
+        $this->assertNull($this->provider()->getUserId('sub-1'));
+        $response->assertSessionHas('success', __('statamic::messages.oauth_disconnected', ['provider' => 'Test']));
+    }
+
+    private function makeUser(): EloquentUser
+    {
+        return EloquentUser::create(['name' => 'Test User', 'email' => 'test@example.com']);
+    }
+
+    private function fakeProvider(string $id): void
+    {
+        Socialite::fake('test', SocialiteUser::fake([
+            'id' => $id,
+            'email' => 'test@example.com',
+            'name' => 'Test User',
+        ]));
+    }
+
+    private function provider(): Provider
+    {
+        return new Provider('test');
+    }
+}


### PR DESCRIPTION
## Problem

The OAuth provider disconnect/connect method currently throws a  `BadMethodCallException: Call to undefined method App\Models\User::id()` error for all eloquent-managed users:
 
<img width="537" height="196" alt="statamic_oauth_error" src="https://github.com/user-attachments/assets/9afdc9d5-a7b7-4e6b-84fd-b67b9c44ca3d" />

Both, the cause and fix for this error is quite similar to #10848: The connect and disconnect methods pass the raw `App\Models\User` model to the vendor code that calls `id()`, which is only available on Statamic user wrappers.

(see [discussion on discourse](https://discord.com/channels/489818810157891584/1526432635209908368))

## Reproduction

1. Configure Statamic to use the `eloquent` user repository and an auth provider as per [statamic docs](https://statamic.dev/knowledge-base/tips/storing-users-in-a-database) (tested with azure & github).
2. Use a standard Eloquent user model (without an `id()` method, obviously).
3. Sign in using email/password.
4. Open the "Profile > Sign-In providers" page and connect (or disconnect) a provider.

The callback throws the 500 exception.

## Fix

- Normalize authenticated models using `User::fromUser()` before connecting or disconnecting providers.
- Adds some tests that cover connecting, reconnecting, and disconnecting with an Eloquent user (generated by Codex 5.6 Sol Ultra).
