### PR TITLE
[6.x] Multisite - make it clearer when globals have/haven't been translated

### DIFF
--- a/lang/en/messages.php
+++ b/lang/en/messages.php
@@ -94,6 +94,7 @@ return [
     'field_conditions_instructions' => 'When to show or hide this field.',
     'field_desynced_from_origin' => 'Desynced from origin. Click to sync and revert to the origin\'s value.',
     'field_synced_with_origin' => 'Synced with origin. Click or edit the field to desync.',
+    'localization_fully_synced_with_origin' => 'All fields synced with origin.',
     'field_validation_advanced_instructions' => 'Add more advanced validation to this field.',
     'field_validation_required_instructions' => 'Make this field required or optional.',
     'field_validation_sometimes_instructions' => 'Only validate when this field is visible or submitted.',

--- a/resources/js/components/SiteSelector.vue
+++ b/resources/js/components/SiteSelector.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { computed } from 'vue';
-import { Icon, Select, Subheading } from '@/components/ui';
+import { Badge, Icon, Select, Subheading } from '@/components/ui';
 import {
     flatOptionsFromSiteGroups,
     groupItemsBySiteGroup,
@@ -49,6 +49,31 @@ function groupLabel(option) {
                     <Icon name="chevron-right" class="size-3.5! shrink-0 text-gray-700 dark:text-white/70" aria-hidden="true" />
                 </template>
                 <span class="truncate">{{ __(option.name) }}</span>
+                <span
+                    v-if="option.fully_synced === true"
+                    class="inline-flex shrink-0 ps-0.5"
+                    v-tooltip="__('messages.localization_fully_synced_with_origin')"
+                >
+                    <Icon name="synced" class="size-3! text-gray-600 dark:text-gray-400" />
+                </span>
+            </span>
+        </template>
+
+        <template #option="option">
+            <span class="flex min-w-0 flex-1 items-center gap-x-2">
+                <span class="flex min-w-0 items-center gap-1.5">
+                    <span class="truncate">{{ __(option.name) }}</span>
+                    <span
+                        v-if="option.fully_synced === true"
+                        class="inline-flex shrink-0"
+                        v-tooltip="__('messages.localization_fully_synced_with_origin')"
+                    >
+                        <Icon name="synced" class="size-3! text-gray-600 dark:text-gray-400" />
+                    </span>
+                </span>
+                <Badge size="sm" color="orange" v-if="option.origin === true" :text="__('Origin')" />
+                <Badge size="sm" color="blue" v-if="option.active === true" :text="__('Active')" />
+                <Badge size="sm" color="purple" v-if="option.root === true && option.origin !== true && option.active !== true" :text="__('Root')" />
             </span>
         </template>
 

--- a/resources/js/components/SiteSelector.vue
+++ b/resources/js/components/SiteSelector.vue
@@ -54,7 +54,7 @@ function groupLabel(option) {
                     class="inline-flex shrink-0 ps-0.5"
                     v-tooltip="__('messages.localization_fully_synced_with_origin')"
                 >
-                    <Icon name="synced" class="size-3! text-gray-600 dark:text-gray-400" />
+                    <Icon name="synced" class="size-3.5! text-gray-400 dark:text-gray-600" />
                 </span>
             </span>
         </template>
@@ -68,7 +68,7 @@ function groupLabel(option) {
                         class="inline-flex shrink-0"
                         v-tooltip="__('messages.localization_fully_synced_with_origin')"
                     >
-                        <Icon name="synced" class="size-3! text-gray-600 dark:text-gray-400" />
+                        <Icon name="synced" class="size-3.5! text-gray-400 dark:text-gray-600" />
                     </span>
                 </span>
                 <Badge size="sm" color="orange" v-if="option.origin === true" :text="__('Origin')" />

--- a/resources/js/components/globals/PublishForm.vue
+++ b/resources/js/components/globals/PublishForm.vue
@@ -233,9 +233,33 @@ export default {
         saving(saving) {
             this.$progress.loading(`${this.publishContainer}-global-publish-form`, saving);
         },
+
+        localizedFields: {
+            handler() {
+                this.refreshActiveLocalizationSyncState();
+            },
+            deep: true,
+        },
+
+        hasOrigin() {
+            this.refreshActiveLocalizationSyncState();
+        },
     },
 
     methods: {
+        refreshActiveLocalizationSyncState() {
+            this.localizations = this.localizations.map((localization) => {
+                if (localization.handle !== this.site) {
+                    return localization;
+                }
+
+                return {
+                    ...localization,
+                    fully_synced: this.hasOrigin && this.localizedFields.length === 0,
+                };
+            });
+        },
+
         save() {
             if (!this.canSave) return;
 
@@ -262,6 +286,7 @@ export default {
                 .then((response) => {
                     if (!this.isCreating) this.$toast.success(__('Saved'));
 
+                    this.refreshActiveLocalizationSyncState();
                     this.$nextTick(() => this.$emit('saved', response));
                 })
                 .catch((e) => {

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -54,6 +54,7 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Statamic\View\Cascade;
+
 use function Statamic\trans as __;
 
 class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, ContainsQueryableValues, Contract, Localization, Protectable, ResolvesValuesContract, Responsable, SearchableContract

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -54,7 +54,6 @@ use Statamic\Support\Arr;
 use Statamic\Support\Str;
 use Statamic\Support\Traits\FluentlyGetsAndSets;
 use Statamic\View\Cascade;
-
 use function Statamic\trans as __;
 
 class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, ContainsQueryableValues, Contract, Localization, Protectable, ResolvesValuesContract, Responsable, SearchableContract

--- a/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
+++ b/src/Http/Controllers/CP/Globals/GlobalVariablesController.php
@@ -63,7 +63,9 @@ class GlobalVariablesController extends CpController
                     'group' => $site->group(),
                     'group_handle' => $site->groupHandle(),
                     'active' => $localized->locale() === $variables->locale(),
-                    'origin' => ! $localized->hasOrigin(),
+                    'root' => $localized->isRoot(),
+                    'origin' => optional($variables->origin())->locale() === $localized->locale(),
+                    'fully_synced' => $localized->hasOrigin() && $localized->data()->isEmpty(),
                     'url' => $localized->editUrl(),
                 ];
             })->values()->all(),
@@ -137,9 +139,12 @@ class GlobalVariablesController extends CpController
 
     protected function getAuthorizedLocalizationsForVariables($variables)
     {
-        return $variables
-            ->globalSet()
-            ->localizations()
-            ->filter(fn ($set) => User::current()->can('edit', $set));
+        $localizations = $variables->globalSet()->localizations();
+
+        return Site::all()
+            ->map(fn ($site) => $localizations->get($site->handle()))
+            ->filter()
+            ->filter(fn ($set) => User::current()->can('edit', $set))
+            ->values();
     }
 }

--- a/tests/Feature/Globals/EditGlobalVariablesTest.php
+++ b/tests/Feature/Globals/EditGlobalVariablesTest.php
@@ -112,6 +112,185 @@ class EditGlobalVariablesTest extends TestCase
     }
 
     #[Test]
+    public function it_marks_localizations_as_fully_synced_when_they_have_no_localized_data()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+        ]);
+
+        $blueprint = Blueprint::make()->setContents(['fields' => [
+            ['handle' => 'foo', 'field' => ['type' => 'text']],
+        ]]);
+        Blueprint::partialMock();
+        Blueprint::shouldReceive('find')->with('globals.test')->andReturn($blueprint);
+
+        $this->setTestRoles(['test' => [
+            'access cp',
+            'edit test globals',
+            'access en site',
+            'access fr site',
+        ]]);
+        $user = User::make()->assignRole('test')->save();
+
+        $global = GlobalSet::make('test')->sites(['en', 'fr' => 'en'])->save();
+        $global->in('en')->data(['foo' => 'bar'])->save();
+        $global->in('fr')->data(['foo' => 'baz'])->save();
+
+        $this
+            ->actingAs($user)
+            ->get($global->in('en')->editUrl())
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('globals/Edit')
+                ->where('localizations.0.handle', 'en')
+                ->where('localizations.0.active', true)
+                ->where('localizations.0.root', true)
+                ->where('localizations.0.origin', false)
+                ->where('localizations.0.fully_synced', false)
+                ->where('localizations.1.handle', 'fr')
+                ->where('localizations.1.active', false)
+                ->where('localizations.1.root', false)
+                ->where('localizations.1.origin', false)
+                ->where('localizations.1.fully_synced', false)
+            );
+
+        $this
+            ->actingAs($user)
+            ->get($global->in('fr')->editUrl())
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('globals/Edit')
+                ->where('localizations.0.handle', 'en')
+                ->where('localizations.0.active', false)
+                ->where('localizations.0.root', true)
+                ->where('localizations.0.origin', true)
+                ->where('localizations.1.handle', 'fr')
+                ->where('localizations.1.active', true)
+                ->where('localizations.1.root', false)
+                ->where('localizations.1.origin', false)
+                ->where('localizations.1.fully_synced', false)
+            );
+
+        $global->in('fr')->data([])->save();
+
+        $this
+            ->actingAs($user)
+            ->get($global->in('en')->editUrl())
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('globals/Edit')
+                ->where('localizations.0.handle', 'en')
+                ->where('localizations.0.fully_synced', false)
+                ->where('localizations.1.handle', 'fr')
+                ->where('localizations.1.fully_synced', true)
+            );
+
+        // Matching origin values still counts as unsynced once data is stored locally.
+        $global->in('fr')->data(['foo' => 'bar'])->save();
+
+        $this
+            ->actingAs($user)
+            ->get($global->in('en')->editUrl())
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('globals/Edit')
+                ->where('localizations.1.handle', 'fr')
+                ->where('localizations.1.fully_synced', false)
+            );
+    }
+
+    #[Test]
+    public function it_marks_root_when_the_origin_is_not_the_root()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://de.test.com/'],
+        ]);
+
+        $blueprint = Blueprint::make()->setContents(['fields' => [
+            ['handle' => 'foo', 'field' => ['type' => 'text']],
+        ]]);
+        Blueprint::partialMock();
+        Blueprint::shouldReceive('find')->with('globals.test')->andReturn($blueprint);
+
+        $this->setTestRoles(['test' => [
+            'access cp',
+            'edit test globals',
+            'access en site',
+            'access fr site',
+            'access de site',
+        ]]);
+        $user = User::make()->assignRole('test')->save();
+
+        $global = GlobalSet::make('test')->sites(['en', 'fr' => 'en', 'de' => 'fr'])->save();
+        $global->in('en')->data(['foo' => 'bar'])->save();
+        $global->in('fr')->data([])->save();
+        $global->in('de')->data([])->save();
+
+        $this
+            ->actingAs($user)
+            ->get($global->in('de')->editUrl())
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('globals/Edit')
+                ->where('localizations.0.handle', 'en')
+                ->where('localizations.0.root', true)
+                ->where('localizations.0.origin', false)
+                ->where('localizations.0.active', false)
+                ->where('localizations.1.handle', 'fr')
+                ->where('localizations.1.root', false)
+                ->where('localizations.1.origin', true)
+                ->where('localizations.1.active', false)
+                ->where('localizations.2.handle', 'de')
+                ->where('localizations.2.root', false)
+                ->where('localizations.2.origin', false)
+                ->where('localizations.2.active', true)
+            );
+    }
+
+    #[Test]
+    public function it_orders_localizations_by_configured_site_order()
+    {
+        $this->setSites([
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/', 'group' => 'EU', 'group_handle' => 'eu'],
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/', 'group' => 'UK', 'group_handle' => 'uk'],
+        ]);
+
+        $blueprint = Blueprint::make()->setContents(['fields' => [
+            ['handle' => 'foo', 'field' => ['type' => 'text']],
+        ]]);
+        Blueprint::partialMock();
+        Blueprint::shouldReceive('find')->with('globals.test')->andReturn($blueprint);
+
+        $this->setTestRoles(['test' => [
+            'access cp',
+            'edit test globals',
+            'access en site',
+            'access fr site',
+        ]]);
+        $user = User::make()->assignRole('test')->save();
+
+        // Global set sites() keys start with en, but Site::all() starts with fr.
+        $global = GlobalSet::make('test')->sites(['en', 'fr' => 'en'])->save();
+        $global->in('en')->data(['foo' => 'bar'])->save();
+        $global->in('fr')->data([])->save();
+
+        $this
+            ->actingAs($user)
+            ->get($global->in('en')->editUrl())
+            ->assertSuccessful()
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('globals/Edit')
+                ->where('localizations.0.handle', 'fr')
+                ->where('localizations.0.group', 'EU')
+                ->where('localizations.1.handle', 'en')
+                ->where('localizations.1.group', 'UK')
+            );
+    }
+
+    #[Test]
     public function it_404s_if_invalid_site()
     {
         $this->setSites([


### PR DESCRIPTION
## Description of the Problem

When editing a multisite globals, it's not clear what's been translated and what hasn't.
It would be useful to tell at a glance which localizations still fully inherit vs which have local data.

This problem is reported here https://github.com/statamic/ideas/issues/657
This, along with https://github.com/statamic/cms/pull/15253, should close https://github.com/statamic/ideas/issues/657

## What this PR Does

- Adds a synced icon on localizations that fully inherit from their origin (`data()` empty — same rule as field-level sync)
- Shows Origin / Active / Root badges in the site dropdown options, as a helpful addition, like entries do
- Refreshes the active localization’s synced state after save
- Order globals localizations by configured site order so things match up. The stache order made site groups appear differently than on the configure page.

### Before

What's been translated? It's not clear

<img width="3420" height="2146" alt="2026-08-25 at 12 32 07@2x" src="https://github.com/user-attachments/assets/9e8b3b91-ae0d-441a-ad24-980fa7847cc1" />

### After

It's now easy to understand which globals have been modified (they do not still have the sync icon), and we can clearly see the origin of the current global (as a side note, the group order here now also follows the config page)

<img width="3420" height="2146" alt="2026-08-25 at 12 40 23@2x" src="https://github.com/user-attachments/assets/e8ec6901-2b14-4005-b7e3-8a453c3813d0" />

## How to Reproduce

1. Open a multisite global with at least one localization that has an origin (e.g. `/cp/globals/company`)
2. Open the site dropdown — Origin / Active / Root badges should appear like on entries
3. Clear all localized field data on a child site and reload — that site should show the synced icon
4. Store local values on that site again (even if they match the origin) — the synced icon should disappear