### PR TITLE
[6.x] Return a copy from AugmentedEntry::date() instead of the entry's live instance

### DIFF
--- a/src/Entries/AugmentedEntry.php
+++ b/src/Entries/AugmentedEntry.php
@@ -106,8 +106,13 @@ class AugmentedEntry extends AbstractAugmented
 
     public function date()
     {
-        return $this->data->collection()->dated()
-            ? $this->data->date()
-            : $this->wrapValue($this->getFromData('date'), 'date');
+        if (! $this->data->collection()->dated()) {
+            return $this->wrapValue($this->getFromData('date'), 'date');
+        }
+
+        // Return a copy, not the entry's live `date` instance. Carbon is mutable, and this
+        // value gets augmented (and potentially mutated by modifiers, e.g. via `title_format`)
+        // before the entry is saved, which would otherwise corrupt the entry's actual date.
+        return optional($this->data->date())->copy();
     }
 }

--- a/tests/Data/Entries/AugmentedEntryTest.php
+++ b/tests/Data/Entries/AugmentedEntryTest.php
@@ -125,6 +125,33 @@ class AugmentedEntryTest extends AugmentedTestCase
     }
 
     #[Test]
+    public function augmented_date_is_not_the_entrys_live_date_instance()
+    {
+        Blueprint::makeFromFields([
+            'date' => ['type' => 'date'],
+        ])->setHandle('test')->save();
+
+        tap(Collection::make('test')->dated(true))->save();
+
+        $entry = EntryFactory::id('entry-id')
+            ->collection('test')
+            ->slug('entry-slug')
+            ->create();
+
+        $entry->date('2018-01-03');
+
+        $augmented = new AugmentedEntry($entry);
+
+        // Mutating the augmented value (e.g. what a modifier like `setTimezone` would do
+        // when evaluated while rendering `title_format` during save) must not mutate the
+        // entry's own date, since that's read again afterwards to build the file path.
+        $augmented->get('date')->value()->setTimezone('Europe/Zurich')->addDay();
+
+        $this->assertEquals('2018-01-03 00:00:00', $entry->date()->format('Y-m-d H:i:s'));
+        $this->assertEquals('UTC', $entry->date()->timezone->getName());
+    }
+
+    #[Test]
     public function it_gets_the_mount_from_the_value_first_if_it_exists()
     {
         $mount = tap(Collection::make('a'))->save();


### PR DESCRIPTION
Fixes: #15269 