### PR TITLE
[6.x] Forms 2: Respect min/max when generating fake integer values

### DIFF
--- a/src/Forms/FakeSubmissionGenerator.php
+++ b/src/Forms/FakeSubmissionGenerator.php
@@ -40,7 +40,7 @@ class FakeSubmissionGenerator
             'text', 'revealer', 'hidden' => $this->textValueFor($field),
             'slug' => IlluminateStr::slug($this->textValueFor($field)),
             'textarea', 'markdown' => $this->paragraph(),
-            'integer', 'range' => $this->number(1, 5000),
+            'integer', 'range' => $this->integerValueFor($field),
             'float' => $this->decimalNumber(),
             'toggle' => $this->boolean(),
             'date' => $this->date(),
@@ -61,6 +61,14 @@ class FakeSubmissionGenerator
             'list' => [$this->word(), $this->word(), $this->word()],
             default => $field->fieldtype()->fakeValue() ?? $default,
         };
+    }
+
+    private function integerValueFor(Field $field): int
+    {
+        $min = (int) ($field->get('min') ?? 1);
+        $max = (int) ($field->get('max') ?? 5000);
+
+        return $this->number(min($min, $max), max($min, $max));
     }
 
     private function randomOptionKey(Field $field): mixed

--- a/tests/Forms/FakeSubmissionGeneratorTest.php
+++ b/tests/Forms/FakeSubmissionGeneratorTest.php
@@ -182,6 +182,39 @@ class FakeSubmissionGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function it_respects_number_min_and_max()
+    {
+        $form = $this->makeForm('ages', [
+            ['handle' => 'age', 'field' => [
+                'type' => 'number',
+                'display' => 'Age',
+                'min' => 16,
+                'max' => 80,
+            ]],
+        ]);
+
+        foreach (range(1, 20) as $_) {
+            $value = (new FakeSubmissionGenerator)->generate($form)['age'];
+            $this->assertGreaterThanOrEqual(16, $value);
+            $this->assertLessThanOrEqual(80, $value);
+        }
+    }
+
+    #[Test]
+    public function it_generates_numbers_without_min_and_max()
+    {
+        $form = $this->makeForm('quantities', [
+            ['handle' => 'quantity', 'field' => ['type' => 'number', 'display' => 'Quantity']],
+        ]);
+
+        $value = (new FakeSubmissionGenerator)->generate($form)['quantity'];
+
+        $this->assertIsInt($value);
+        $this->assertGreaterThanOrEqual(1, $value);
+        $this->assertLessThanOrEqual(5000, $value);
+    }
+
+    #[Test]
     public function it_respects_star_rating_half_steps()
     {
         $form = $this->makeForm('stars', [


### PR DESCRIPTION
This pull request fixes an issue where the fake submission generator would ignore a field's `min`/`max` config when generating values for integer fields.

This was happening because the `integer`/`range` match arm in `FakeSubmissionGenerator` always generated a number between a hardcoded 1 and 5000.

This PR fixes it by reading the field's `min` and `max` config when generating integer values, falling back to the previous 1–5000 range when they aren't set.