### PR TITLE
[6.x] Multisite - configuration improvements

### DIFF
--- a/lang/en/validation.php
+++ b/lang/en/validation.php
@@ -174,6 +174,7 @@ return [
     'email_available' => 'A user with this email already exists.',
     'fieldset_imported_recursively' => 'Fieldset :handle is being imported recursively.',
     'one_site_without_origin' => 'At least one site must not have an origin.',
+    'at_least_one_site_enabled' => 'At least one site must be enabled.',
     'options_require_keys' => 'All options must have keys.',
     'origin_cannot_be_disabled' => 'Cannot select a disabled origin.',
     'parent_cannot_be_itself' => 'Cannot be its own parent.',

--- a/resources/js/components/collections/OneOrManySitesField.vue
+++ b/resources/js/components/collections/OneOrManySitesField.vue
@@ -60,9 +60,20 @@ export default {
         },
 
         sites() {
-            if (!this.publishContainer.values.value.sites) return [];
+            const sites = this.publishContainer.values.value.sites;
 
-            return this.publishContainer.values.value.sites.map((handle, i) => {
+            if (!sites?.length) return [];
+
+            if (typeof sites[0] === 'object') {
+                return sites
+                    .filter((site) => site.enabled)
+                    .map((site) => ({
+                        handle: site.handle,
+                        name: site.name,
+                    }));
+            }
+
+            return sites.map((handle, i) => {
                 return {
                     handle,
                     name: this.publishContainer.meta.value.sites.data[i].title,

--- a/resources/js/components/globals/Sites.vue
+++ b/resources/js/components/globals/Sites.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="flex flex-col gap-3">
-        <div class="flex flex-wrap items-center gap-3 rounded-xl border border-gray-200 bg-gray-50 px-3 pr-2 py-2 dark:border-gray-700 dark:bg-gray-800">
+        <div
+            v-if="showOrigins"
+            class="flex flex-wrap items-center gap-3 rounded-xl border border-gray-200 bg-gray-50 px-3 pr-2 py-2 dark:border-gray-700 dark:bg-gray-800"
+        >
             <Checkbox
                 size="sm"
                 solo
@@ -53,7 +56,7 @@
         <table class="grid-table">
             <thead>
                 <tr>
-                    <th scope="col" class="checkbox-column w-8">
+                    <th v-if="showOrigins" scope="col" class="checkbox-column w-8">
                         <span class="sr-only">{{ __('Select') }}</span>
                     </th>
                     <th scope="col">
@@ -61,7 +64,7 @@
                             {{ __('Site') }}
                         </div>
                     </th>
-                    <th scope="col">
+                    <th v-if="showOrigins" scope="col">
                         <div class="flex items-center justify-between">
                             {{ __('Origin') }}
                         </div>
@@ -71,9 +74,10 @@
             <tbody>
                 <template v-for="group in siteGroups" :key="group.key">
                     <tr v-if="hasNamedGroups">
-                        <td colspan="3" class="sticky top-[calc(--spacing(7)+1px)] z-(--z-index-above) bg-gray-50 py-2! dark:bg-gray-800">
+                        <td :colspan="columnCount" class="sticky top-[calc(--spacing(7)+1px)] z-(--z-index-above) bg-gray-50 py-2! dark:bg-gray-800">
                             <div class="flex items-center gap-4 ps-1!">
                                 <Checkbox
+                                    v-if="showOrigins"
                                     size="sm"
                                     solo
                                     :model-value="isGroupSelected(group)"
@@ -90,7 +94,7 @@
                         </td>
                     </tr>
                     <tr v-for="site in group.items" :key="site.handle">
-                        <td class="checkbox-column ps-3!">
+                        <td v-if="showOrigins" class="checkbox-column ps-3!">
                             <Checkbox
                                 size="sm"
                                 class="pt-2.5"
@@ -106,7 +110,7 @@
                                 <Heading :text="__(site.name)" />
                             </div>
                         </td>
-                        <td class="grid-cell">
+                        <td v-if="showOrigins" class="grid-cell">
                             <Select
                                 class="w-full"
                                 :options="siteOriginOptions(site)"
@@ -180,6 +184,14 @@ export default {
     },
 
     computed: {
+        showOrigins() {
+            return this.config.origins !== false;
+        },
+
+        columnCount() {
+            return this.showOrigins ? 3 : 1;
+        },
+
         hasNamedGroups() {
             return hasNamedSiteGroups(this.sites);
         },

--- a/src/Fieldtypes/GlobalSetSites.php
+++ b/src/Fieldtypes/GlobalSetSites.php
@@ -22,6 +22,20 @@ class GlobalSetSites extends Fieldtype
         ];
     }
 
+    public function process($data)
+    {
+        if ($this->config('origins', true)) {
+            return $data;
+        }
+
+        return collect($data ?? [])
+            ->filter(fn ($site) => is_string($site) ? filled($site) : ($site['enabled'] ?? false))
+            ->map(fn ($site) => is_string($site) ? $site : $site['handle'])
+            ->filter()
+            ->values()
+            ->all();
+    }
+
     public function rules(): array
     {
         $rules = [
@@ -42,7 +56,9 @@ class GlobalSetSites extends Fieldtype
         {
             public function passes($attribute, $value)
             {
-                return collect($value)->filter->enabled->isNotEmpty();
+                return collect($value)->contains(function ($site) {
+                    return is_string($site) ? filled($site) : ($site['enabled'] ?? false);
+                });
             }
 
             public function message()

--- a/src/Fieldtypes/GlobalSetSites.php
+++ b/src/Fieldtypes/GlobalSetSites.php
@@ -11,12 +11,45 @@ class GlobalSetSites extends Fieldtype
 {
     protected $selectable = false;
 
-    public function rules(): array
+    protected function configFieldItems(): array
     {
         return [
-            $this->cannotAllHaveOriginsRule(),
-            $this->originsMustBeEnabledRule(),
+            'origins' => [
+                'display' => __('Origins'),
+                'type' => 'toggle',
+                'default' => true,
+            ],
         ];
+    }
+
+    public function rules(): array
+    {
+        $rules = [
+            $this->atLeastOneSiteEnabledRule(),
+        ];
+
+        if ($this->config('origins', true)) {
+            $rules[] = $this->cannotAllHaveOriginsRule();
+            $rules[] = $this->originsMustBeEnabledRule();
+        }
+
+        return $rules;
+    }
+
+    private function atLeastOneSiteEnabledRule()
+    {
+        return new class implements ValidationRule
+        {
+            public function passes($attribute, $value)
+            {
+                return collect($value)->filter->enabled->isNotEmpty();
+            }
+
+            public function message()
+            {
+                return __('statamic::validation.at_least_one_site_enabled');
+            }
+        };
     }
 
     private function cannotAllHaveOriginsRule()

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -354,14 +354,6 @@ class CollectionsController extends CpController
             ->previewTargets($values['preview_targets']);
 
         if ($sites = Arr::get($values, 'sites')) {
-            if (Site::multiEnabled()) {
-                $sites = collect($sites)
-                    ->filter(fn ($site) => $site['enabled'] ?? false)
-                    ->map(fn ($site) => $site['handle'])
-                    ->values()
-                    ->all();
-            }
-
             $collection
                 ->sites($sites)
                 ->originBehavior($values['origin_behavior']);

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -258,7 +258,18 @@ class CollectionsController extends CpController
             'default_publish_state' => $collection->defaultPublishState(),
             'template' => $collection->template(),
             'layout' => $collection->layout(),
-            'sites' => $collection->sites()->all(),
+            'sites' => Site::multiEnabled()
+                ? Site::all()->map(function ($site) use ($collection) {
+                    return [
+                        'name' => $site->name(),
+                        'handle' => $site->handle(),
+                        'group' => $site->group(),
+                        'group_handle' => $site->groupHandle(),
+                        'enabled' => $collection->sites()->contains($site->handle()),
+                        'origin' => null,
+                    ];
+                })->values()->all()
+                : $collection->sites()->all(),
             'propagate' => $collection->propagate(),
             'routes' => $collection->routes()->unique()->count() === 1
                 ? $collection->routes()->first()
@@ -343,6 +354,14 @@ class CollectionsController extends CpController
             ->previewTargets($values['preview_targets']);
 
         if ($sites = Arr::get($values, 'sites')) {
+            if (Site::multiEnabled()) {
+                $sites = collect($sites)
+                    ->filter(fn ($site) => $site['enabled'] ?? false)
+                    ->map(fn ($site) => $site['handle'])
+                    ->values()
+                    ->all();
+            }
+
             $collection
                 ->sites($sites)
                 ->originBehavior($values['origin_behavior']);
@@ -598,8 +617,8 @@ class CollectionsController extends CpController
                 'display' => __('Localizations'),
                 'fields' => [
                     'sites' => [
-                        'type' => 'sites',
-                        'mode' => 'select',
+                        'type' => 'global_set_sites',
+                        'origins' => false,
                         'required' => true,
                     ],
                     'propagate' => [

--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -595,7 +595,7 @@ class CollectionsController extends CpController
 
         if (Site::multiEnabled()) {
             $fields['sites'] = [
-                'display' => __('Sites'),
+                'display' => __('Localizations'),
                 'fields' => [
                     'sites' => [
                         'type' => 'sites',

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -201,14 +201,6 @@ class TaxonomiesController extends CpController
             ->layout($values['layout'] ?? null);
 
         if ($sites = Arr::get($values, 'sites')) {
-            if (Site::multiEnabled()) {
-                $sites = collect($sites)
-                    ->filter(fn ($site) => $site['enabled'] ?? false)
-                    ->map(fn ($site) => $site['handle'])
-                    ->values()
-                    ->all();
-            }
-
             $taxonomy->sites($sites);
         }
 

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -287,7 +287,7 @@ class TaxonomiesController extends CpController
 
         if (Site::multiEnabled()) {
             $fields['sites'] = [
-                'display' => __('Sites'),
+                'display' => __('Localizations'),
                 'fields' => [
                     'sites' => [
                         'type' => 'sites',

--- a/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TaxonomiesController.php
@@ -156,7 +156,18 @@ class TaxonomiesController extends CpController
             'title' => $taxonomy->title(),
             'blueprints' => $taxonomy->termBlueprints()->map->handle()->all(),
             'collections' => $taxonomy->collections()->map->handle()->all(),
-            'sites' => $taxonomy->sites()->all(),
+            'sites' => Site::multiEnabled()
+                ? Site::all()->map(function ($site) use ($taxonomy) {
+                    return [
+                        'name' => $site->name(),
+                        'handle' => $site->handle(),
+                        'group' => $site->group(),
+                        'group_handle' => $site->groupHandle(),
+                        'enabled' => $taxonomy->sites()->contains($site->handle()),
+                        'origin' => null,
+                    ];
+                })->values()->all()
+                : $taxonomy->sites()->all(),
             'preview_targets' => $taxonomy->basePreviewTargets(),
             'term_template' => $taxonomy->hasCustomTermTemplate() ? $taxonomy->termTemplate() : null,
             'template' => $taxonomy->hasCustomTemplate() ? $taxonomy->template() : null,
@@ -190,6 +201,14 @@ class TaxonomiesController extends CpController
             ->layout($values['layout'] ?? null);
 
         if ($sites = Arr::get($values, 'sites')) {
+            if (Site::multiEnabled()) {
+                $sites = collect($sites)
+                    ->filter(fn ($site) => $site['enabled'] ?? false)
+                    ->map(fn ($site) => $site['handle'])
+                    ->values()
+                    ->all();
+            }
+
             $taxonomy->sites($sites);
         }
 
@@ -290,8 +309,8 @@ class TaxonomiesController extends CpController
                 'display' => __('Localizations'),
                 'fields' => [
                     'sites' => [
-                        'type' => 'sites',
-                        'mode' => 'select',
+                        'type' => 'global_set_sites',
+                        'origins' => false,
                         'required' => true,
                     ],
                 ],

--- a/tests/Feature/Collections/UpdateCollectionTest.php
+++ b/tests/Feature/Collections/UpdateCollectionTest.php
@@ -187,6 +187,32 @@ class UpdateCollectionTest extends TestCase
         $this->assertTrue($updated->propagate());
     }
 
+    #[Test]
+    public function it_updates_collection_sites_from_legacy_handle_array()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://de.test.com/'],
+        ]);
+
+        $collection = Collection::make('test')->sites(['en', 'fr'])->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($collection, [
+                'sites' => ['en', 'de'],
+                'origin_behavior' => 'root',
+                'propagate' => false,
+                'structured' => false,
+                'require_slugs' => true,
+                'preview_targets' => [],
+            ])
+            ->assertOk();
+
+        $this->assertEquals(['en', 'de'], Collection::findByHandle('test')->sites()->all());
+    }
+
     private function userWithoutPermission()
     {
         $this->setTestRoles(['test' => ['access cp']]);

--- a/tests/Feature/Collections/UpdateCollectionTest.php
+++ b/tests/Feature/Collections/UpdateCollectionTest.php
@@ -153,6 +153,40 @@ class UpdateCollectionTest extends TestCase
         $this->assertEquals(['test', 'link'], $blueprints->map->handle()->values()->all());
     }
 
+    #[Test]
+    public function it_updates_collection_sites_from_enabled_rows_and_ignores_origins()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://de.test.com/'],
+        ]);
+
+        $collection = Collection::make('test')->sites(['en', 'fr'])->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($collection, [
+                'sites' => [
+                    ['name' => 'English', 'handle' => 'en', 'enabled' => true, 'origin' => null],
+                    ['name' => 'French', 'handle' => 'fr', 'enabled' => false, 'origin' => 'en'],
+                    ['name' => 'German', 'handle' => 'de', 'enabled' => true, 'origin' => 'en'],
+                ],
+                'origin_behavior' => 'root',
+                'propagate' => true,
+                'structured' => false,
+                'require_slugs' => true,
+                'preview_targets' => [],
+            ])
+            ->assertOk();
+
+        $updated = Collection::findByHandle('test');
+
+        $this->assertEquals(['en', 'de'], $updated->sites()->all());
+        $this->assertEquals('root', $updated->originBehavior());
+        $this->assertTrue($updated->propagate());
+    }
+
     private function userWithoutPermission()
     {
         $this->setTestRoles(['test' => ['access cp']]);

--- a/tests/Feature/Taxonomies/UpdateTaxonomyTest.php
+++ b/tests/Feature/Taxonomies/UpdateTaxonomyTest.php
@@ -75,6 +75,33 @@ class UpdateTaxonomyTest extends TestCase
         $this->assertTrue($collectionThree->taxonomies()->contains($taxonomy));
     }
 
+    #[Test]
+    public function it_updates_taxonomy_sites_from_enabled_rows_and_ignores_origins()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://de.test.com/'],
+        ]);
+
+        $taxonomy = tap(Taxonomy::make('test')->sites(['en', 'fr']))->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($taxonomy, [
+                'sites' => [
+                    ['name' => 'English', 'handle' => 'en', 'enabled' => true, 'origin' => null],
+                    ['name' => 'French', 'handle' => 'fr', 'enabled' => false, 'origin' => 'en'],
+                    ['name' => 'German', 'handle' => 'de', 'enabled' => true, 'origin' => 'en'],
+                ],
+                'preview_targets' => [],
+                'collections' => [],
+            ])
+            ->assertOk();
+
+        $this->assertEquals(['en', 'de'], Taxonomy::findByHandle('test')->sites()->all());
+    }
+
     private function userWithoutPermission()
     {
         $this->setTestRoles(['test' => ['access cp']]);

--- a/tests/Feature/Taxonomies/UpdateTaxonomyTest.php
+++ b/tests/Feature/Taxonomies/UpdateTaxonomyTest.php
@@ -102,6 +102,29 @@ class UpdateTaxonomyTest extends TestCase
         $this->assertEquals(['en', 'de'], Taxonomy::findByHandle('test')->sites()->all());
     }
 
+    #[Test]
+    public function it_updates_taxonomy_sites_from_legacy_handle_array()
+    {
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://de.test.com/'],
+        ]);
+
+        $taxonomy = tap(Taxonomy::make('test')->sites(['en', 'fr']))->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($taxonomy, [
+                'sites' => ['en', 'de'],
+                'preview_targets' => [],
+                'collections' => [],
+            ])
+            ->assertOk();
+
+        $this->assertEquals(['en', 'de'], Taxonomy::findByHandle('test')->sites()->all());
+    }
+
     private function userWithoutPermission()
     {
         $this->setTestRoles(['test' => ['access cp']]);


### PR DESCRIPTION
## Description of the Problem

We have different interfaces for the global configuration and collections/taxonomies configuration. While we have a different mechanism for deciding the origin for globals, it would be better if they more closely aligned.

## What this PR Does

### Before

<img width="3420" height="2146" alt="2026-08-26 at 14 12 06@2x" src="https://github.com/user-attachments/assets/bf11b88d-428a-4b52-a0fd-0df396468f44" />

### After

<img width="3420" height="2146" alt="2026-08-26 at 14 10 05@2x" src="https://github.com/user-attachments/assets/dc39c660-3a49-4e59-8542-f17211baf5e6" />

## How to Reproduce

1. Edit a collection or taxonomy config