### PR TITLE
[6.x] Fix: `statamic:static:warm` drops `--header` values on paginated pages

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -133,7 +133,9 @@ class StaticWarm extends Command
             return $url;
         });
 
-        $requests = $urls->map(fn (string $url) => new Request('GET', $url))->all();
+        $headers = $this->parseHeaders($this->option('header'));
+        
+        $requests = $urls->map(fn (string $url) => new Request('GET', $url, $headers))->all();
 
         $pool = new Pool($this->client(), $requests, [
             'concurrency' => $this->concurrency(),

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -134,7 +134,7 @@ class StaticWarm extends Command
         });
 
         $headers = $this->parseHeaders($this->option('header'));
-        
+
         $requests = $urls->map(fn (string $url) => new Request('GET', $url, $headers))->all();
 
         $pool = new Pool($this->client(), $requests, [


### PR DESCRIPTION
`statamic:static:warm` attaches `--header` values to its main request pass:

```php
// requests(), line ~221
return new Request('GET', $uri, $headers);
```

but `warmPaginatedPages()` — which follows an index page's `X-Statamic-Pagination` header to warm pages 2..n builds its requests without them:

```php
// warmPaginatedPages(), line ~136
$requests = $urls->map(fn (string $url) => new Request('GET', $url))->all();
```

So a warm run with `--header "X-My-Token: …"` identifies `/tags` to whatever is in front of the origin and does not identify `/tags?page=2`. Anything keyed on that header (eg a CDN/WAF skip rule, an origin allowlist, basic-auth-by-header on a staging site) applies to page 1 of every paginated URL and nothing else.

### The fix

Parse the headers the same way the main pass does and pass them into the paginated requests.

No behaviour change for anyone not passing `--header`.

### Note

I'm an inexperienced contributor. I've tried to make sure I follow the contributor guide, but please do point out anything I missed or could improve on.