### PR TITLE
[6.x] Fix: pagination warm failures are reported against the wrong URL

### DIFF
--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -140,7 +140,7 @@ class StaticWarm extends Command
             'fulfilled' => function (Response $response, $index) use ($urls) {
                 $this->components->twoColumnDetail($this->getRelativeUri($urls->get($index)), '<info>✓ Cached</info>');
             },
-            rejected' => function ($exception, $index) use ($urls) {
+            'rejected' => function ($exception, $index) use ($urls) {
                 $this->outputFailureLineFor($urls->get($index), $exception);
             },
         ]);

--- a/src/Console/Commands/StaticWarm.php
+++ b/src/Console/Commands/StaticWarm.php
@@ -140,7 +140,9 @@ class StaticWarm extends Command
             'fulfilled' => function (Response $response, $index) use ($urls) {
                 $this->components->twoColumnDetail($this->getRelativeUri($urls->get($index)), '<info>✓ Cached</info>');
             },
-            'rejected' => [$this, 'outputFailureLine'],
+            rejected' => function ($exception, $index) use ($urls) {
+                $this->outputFailureLineFor($urls->get($index), $exception);
+            },
         ]);
 
         $promise = $pool->promise();
@@ -183,7 +185,12 @@ class StaticWarm extends Command
 
     public function outputFailureLine($exception, $index): void
     {
-        $uri = $this->getRelativeUri($this->uris()->get($index));
+        $this->outputFailureLineFor($this->uris()->get($index), $exception);
+    }
+
+    private function outputFailureLineFor(string $url, $exception): void
+    {
+        $uri = $this->getRelativeUri($url);
 
         if ($exception instanceof RequestException && $exception->hasResponse()) {
             $response = $exception->getResponse();


### PR DESCRIPTION
The pagination pool reuses the main pass's rejection handler:

```php
$pool = new Pool($this->client(), $requests, [
    'concurrency' => $this->concurrency(),
    'fulfilled' => function (Response $response, $index) use ($urls) {
        $this->components->twoColumnDetail($this->getRelativeUri($urls->get($index)), '<info>✓ Cached</info>');
    },
    'rejected' => [$this, 'outputFailureLine'],
]);
```

but `outputFailureLine()` resolves its URI from the **compiled URI list**:

```php
public function outputFailureLine($exception, $index): void
{
    $uri = $this->getRelativeUri($this->uris()->get($index));
    ...
```

`$index` here is an index into the *pagination* pool — `0` for the first page being warmed, `1` for the second — not into `uris()`. So a failed paginated request is reported under whatever unrelated URL happens to sit at that offset in
the main list. The `fulfilled` handler two lines above gets this right, which is what makes the asymmetry look unintentional.

Two consequences:

- The output names a URL that did not fail, and stays silent about the one that did. That is the exact output someone reads when working out why pagination is not caching, so it actively misleads during the investigation it exists for.
- When the pagination pool has more entries than the compiled list has left at that offset, `uris()->get($index)` returns `null` and `getRelativeUri(string $uri)` is called with it — a deprecation on PHP 8.1+, fatal under stricter settings.

### The fix — two edits

**1. Let the failure line be produced for a given URL**, by splitting the message formatting out of the index lookup. No behaviour change to the existing method:

**2. Point the pagination pool at it**, resolving the index against `$urls` the way `fulfilled` already does.

### Notes

- Pure output correctness; nothing about what gets warmed changes.
- The status line is the useful part of that message — a paginated page turned away at the edge reports `403 Forbidden` — which is why it is worth keeping the existing formatting rather than falling back to `$exception->getMessage()`.