### PR TITLE
[6.x] Multisite bulk localize entries

### DIFF
--- a/resources/js/components/ui/Publish/Field.vue
+++ b/resources/js/components/ui/Publish/Field.vue
@@ -180,8 +180,7 @@ const shouldShowLabelText = computed(() => !props.config.hide_display);
 // screen-reader-only label to the control below.
 const shouldShowLabel = computed(
     () =>
-        shouldShowLabelText.value || // Need to see the text
-        isRequired.value || // Need to see the required asterisk
+        shouldShowLabelText.value || // Need to see the text (and required asterisk, when shown)
         isLocked.value || // Need to see the avatar
         isSyncable.value, // Need to see the icon
 );

--- a/src/Actions/Localize.php
+++ b/src/Actions/Localize.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Statamic\Actions;
+
+use Statamic\Contracts\Entries\Entry;
+use Statamic\Facades\Site;
+use Statamic\Facades\User;
+
+use function Statamic\trans as __;
+use function Statamic\trans_choice;
+
+class Localize extends Action
+{
+    protected $icon = 'earth';
+
+    public static function title()
+    {
+        return __('Localize');
+    }
+
+    public function visibleTo($item)
+    {
+        return $this->context['view'] === 'list'
+            && $item instanceof Entry
+            && Site::multiEnabled()
+            && $item->collection()->sites()->count() > 1
+            && $this->missingSites($item)->isNotEmpty();
+    }
+
+    public function visibleToBulk($items)
+    {
+        if ($items->whereInstanceOf(Entry::class)->count() !== $items->count()) {
+            return false;
+        }
+
+        if (! Site::multiEnabled()) {
+            return false;
+        }
+
+        if ($items->map->collectionHandle()->unique()->count() !== 1) {
+            return false;
+        }
+
+        $collection = $items->first()->collection();
+
+        if ($collection->sites()->count() <= 1) {
+            return false;
+        }
+
+        return $items->contains(fn (Entry $entry) => $this->missingSites($entry)->isNotEmpty());
+    }
+
+    public function authorize($user, $entry)
+    {
+        return $user->can('edit', $entry);
+    }
+
+    public function confirmationText()
+    {
+        /** @translation */
+        return 'Localize this entry?|Localize these :count entries?';
+    }
+
+    public function buttonText()
+    {
+        /** @translation */
+        return 'Localize|Localize :count entries';
+    }
+
+    public function run($entries, $values)
+    {
+        $site = $values['site'];
+        $created = 0;
+        $skipped = 0;
+
+        $entries->each(function (Entry $entry) use ($site, &$created, &$skipped) {
+            if ($entry->locale() === $site || $entry->existsIn($site)) {
+                $skipped++;
+
+                return;
+            }
+
+            if (! User::current()->can('edit', $entry)) {
+                $skipped++;
+
+                return;
+            }
+
+            $entry->makeLocalization($site)->store(['user' => User::current()]);
+            $created++;
+        });
+
+        if ($created === 0) {
+            /** @translation */
+            return __('No localizations were created.');
+        }
+
+        if ($skipped > 0) {
+            return __('Created :created localization(s), skipped :skipped.', [
+                'created' => $created,
+                'skipped' => $skipped,
+            ]);
+        }
+
+        return trans_choice('Created :count localization|Created :count localizations', $created, [
+            'count' => $created,
+        ]);
+    }
+
+    protected function fieldItems()
+    {
+        return [
+            'site' => [
+                'display' => __('Site'),
+                'instructions' => __('Only entries that are missing this localization will be created.'),
+                'type' => 'select',
+                'options' => $this->siteOptions(),
+                'validate' => 'required',
+            ],
+        ];
+    }
+
+    private function siteOptions(): array
+    {
+        $collection = $this->items->first()?->collection();
+
+        if (! $collection) {
+            return [];
+        }
+
+        return $collection->sites()
+            ->filter(fn ($handle) => $this->items->contains(
+                fn (Entry $entry) => $entry->locale() !== $handle && ! $entry->existsIn($handle)
+            ))
+            ->mapWithKeys(fn ($handle) => [
+                $handle => Site::get($handle)?->name() ?? $handle,
+            ])
+            ->all();
+    }
+
+    private function missingSites(Entry $entry)
+    {
+        return $entry->collection()->sites()
+            ->reject($entry->locale())
+            ->reject(fn ($site) => $entry->existsIn($site))
+            ->values();
+    }
+}

--- a/src/Actions/Localize.php
+++ b/src/Actions/Localize.php
@@ -58,7 +58,7 @@ class Localize extends Action
     public function confirmationText()
     {
         /** @translation */
-        return 'Create missing localizations for this entry? (Existing localizations will be skipped).|Create missing localizations for these :count entries? (Existing localizations will be skipped).';
+        return 'Localize this entry to the selected site? Existing localizations will be skipped.|Localize these :count entries to the selected site? Existing localizations will be skipped.';
     }
 
     public function buttonText()

--- a/src/Actions/Localize.php
+++ b/src/Actions/Localize.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Actions;
 
+use Illuminate\Validation\Rule;
 use Statamic\Contracts\Entries\Entry;
 use Statamic\Facades\Site;
 use Statamic\Facades\User;
@@ -80,12 +81,6 @@ class Localize extends Action
                 return;
             }
 
-            if (! User::current()->can('edit', $entry)) {
-                $skipped++;
-
-                return;
-            }
-
             $entry->makeLocalization($site)->store(['user' => User::current()]);
             $created++;
         });
@@ -115,8 +110,8 @@ class Localize extends Action
                 'hide_display' => true,
                 'type' => 'select',
                 'placeholder' => __('Choose a site...'),
-                'options' => $this->siteOptions(),
-                'validate' => 'required',
+                'options' => $options = $this->siteOptions(),
+                'validate' => ['required', Rule::in(array_keys($options))],
             ],
         ];
     }

--- a/src/Actions/Localize.php
+++ b/src/Actions/Localize.php
@@ -58,13 +58,13 @@ class Localize extends Action
     public function confirmationText()
     {
         /** @translation */
-        return 'Localize this entry?|Localize these :count entries?';
+        return 'Create missing localizations for this entry? (Existing localizations will be skipped).|Create missing localizations for these :count entries? (Existing localizations will be skipped).';
     }
 
     public function buttonText()
     {
         /** @translation */
-        return 'Localize|Localize :count entries';
+        return 'Localize|Localize :count Entries';
     }
 
     public function run($entries, $values)
@@ -96,7 +96,7 @@ class Localize extends Action
         }
 
         if ($skipped > 0) {
-            return __('Created :created localization(s), skipped :skipped.', [
+            return __('Created :created, skipped :skipped.', [
                 'created' => $created,
                 'skipped' => $skipped,
             ]);
@@ -112,8 +112,9 @@ class Localize extends Action
         return [
             'site' => [
                 'display' => __('Site'),
-                'instructions' => __('Only entries that are missing this localization will be created.'),
+                'hide_display' => true,
                 'type' => 'select',
+                'placeholder' => __('Choose a site...'),
                 'options' => $this->siteOptions(),
                 'validate' => 'required',
             ],

--- a/src/Providers/ExtensionServiceProvider.php
+++ b/src/Providers/ExtensionServiceProvider.php
@@ -50,6 +50,7 @@ class ExtensionServiceProvider extends ServiceProvider
         Actions\MoveAssetFolder::class,
         Actions\RenameAssetFolder::class,
         Actions\Impersonate::class,
+        Actions\Localize::class,
     ];
 
     protected $dictionaries = [

--- a/tests/Actions/LocalizeTest.php
+++ b/tests/Actions/LocalizeTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Actions;
+
+use Facades\Tests\Factories\EntryFactory;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Actions\Localize;
+use Statamic\Facades\Collection;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class LocalizeTest extends TestCase
+{
+    use FakesRoles;
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => '/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => '/fr/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => '/de/'],
+        ]);
+
+        Collection::make('test')->sites(['en', 'fr', 'de'])->save();
+    }
+
+    #[Test]
+    public function it_is_visible_for_multisite_entries_missing_localizations()
+    {
+        $entry = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+
+        $action = (new Localize)->context(['view' => 'list'])->items([$entry]);
+
+        $this->assertTrue($action->visibleTo($entry));
+    }
+
+    #[Test]
+    public function it_is_hidden_when_all_localizations_exist()
+    {
+        $en = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        EntryFactory::id('alfa-fr')->collection('test')->slug('alfa')->locale('fr')->origin('alfa')->create();
+        EntryFactory::id('alfa-de')->collection('test')->slug('alfa')->locale('de')->origin('alfa')->create();
+
+        $action = (new Localize)->context(['view' => 'list'])->items([$en]);
+
+        $this->assertFalse($action->visibleTo($en));
+    }
+
+    #[Test]
+    public function it_is_hidden_for_single_site_collections()
+    {
+        Collection::make('single')->sites(['en'])->save();
+        $entry = EntryFactory::id('alfa')->collection('single')->slug('alfa')->locale('en')->create();
+
+        $action = (new Localize)->context(['view' => 'list'])->items([$entry]);
+
+        $this->assertFalse($action->visibleTo($entry));
+    }
+
+    #[Test]
+    public function it_localizes_entries_missing_the_selected_site()
+    {
+        $this->actingAs(User::make()->makeSuper()->save());
+
+        $alfa = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->data(['title' => 'Alfa'])->create();
+        $bravo = EntryFactory::id('bravo')->collection('test')->slug('bravo')->locale('en')->data(['title' => 'Bravo'])->create();
+        EntryFactory::id('bravo-fr')->collection('test')->slug('bravo')->locale('fr')->origin('bravo')->create();
+
+        $message = (new Localize)->run(collect([$alfa, $bravo]), ['site' => 'fr']);
+
+        $this->assertTrue($alfa->fresh()->existsIn('fr'));
+        $this->assertEquals('bravo-fr', $bravo->fresh()->in('fr')->id());
+        $this->assertEquals('alfa', $alfa->fresh()->in('fr')->origin()->id());
+        $this->assertStringContainsString('Created 1', $message);
+        $this->assertStringContainsString('skipped 1', $message);
+    }
+
+    #[Test]
+    public function it_only_offers_sites_that_are_missing_for_selected_entries()
+    {
+        $en = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        EntryFactory::id('alfa-fr')->collection('test')->slug('alfa')->locale('fr')->origin('alfa')->create();
+
+        $action = (new Localize)->context(['view' => 'list'])->items([$en]);
+        $siteField = $action->fields()->get('site');
+
+        $this->assertEquals([
+            'de' => 'German',
+        ], $siteField->get('options'));
+    }
+}

--- a/tests/Actions/LocalizeTest.php
+++ b/tests/Actions/LocalizeTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Actions;
 
 use Facades\Tests\Factories\EntryFactory;
+use Illuminate\Support\Facades\Config;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Actions\Localize;
 use Statamic\Facades\Collection;
@@ -63,6 +64,95 @@ class LocalizeTest extends TestCase
     }
 
     #[Test]
+    public function it_is_visible_to_bulk_when_any_entry_is_missing_a_localization()
+    {
+        $alfa = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        $bravo = EntryFactory::id('bravo')->collection('test')->slug('bravo')->locale('en')->create();
+        EntryFactory::id('bravo-fr')->collection('test')->slug('bravo')->locale('fr')->origin('bravo')->create();
+        EntryFactory::id('bravo-de')->collection('test')->slug('bravo')->locale('de')->origin('bravo')->create();
+
+        $items = collect([$alfa, $bravo]);
+        $action = (new Localize)->context(['view' => 'list'])->items($items);
+
+        $this->assertTrue($action->visibleToBulk($items));
+    }
+
+    #[Test]
+    public function it_is_hidden_from_bulk_when_all_entries_are_fully_localized()
+    {
+        $alfa = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        EntryFactory::id('alfa-fr')->collection('test')->slug('alfa')->locale('fr')->origin('alfa')->create();
+        EntryFactory::id('alfa-de')->collection('test')->slug('alfa')->locale('de')->origin('alfa')->create();
+
+        $items = collect([$alfa]);
+        $action = (new Localize)->context(['view' => 'list'])->items($items);
+
+        $this->assertFalse($action->visibleToBulk($items));
+    }
+
+    #[Test]
+    public function it_is_hidden_from_bulk_when_selection_includes_non_entries()
+    {
+        $entry = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        $items = collect([$entry, 'not-an-entry']);
+        $action = (new Localize)->context(['view' => 'list'])->items($items);
+
+        $this->assertFalse($action->visibleToBulk($items));
+    }
+
+    #[Test]
+    public function it_is_hidden_from_bulk_when_entries_are_from_different_collections()
+    {
+        Collection::make('other')->sites(['en', 'fr', 'de'])->save();
+
+        $alfa = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        $bravo = EntryFactory::id('bravo')->collection('other')->slug('bravo')->locale('en')->create();
+        $items = collect([$alfa, $bravo]);
+        $action = (new Localize)->context(['view' => 'list'])->items($items);
+
+        $this->assertFalse($action->visibleToBulk($items));
+    }
+
+    #[Test]
+    public function it_is_hidden_from_bulk_when_multisite_is_disabled()
+    {
+        Config::set('statamic.system.multisite', false);
+
+        $entry = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        $items = collect([$entry]);
+        $action = (new Localize)->context(['view' => 'list'])->items($items);
+
+        $this->assertFalse($action->visibleToBulk($items));
+    }
+
+    #[Test]
+    public function it_is_hidden_from_bulk_for_single_site_collections()
+    {
+        Collection::make('single')->sites(['en'])->save();
+        $entry = EntryFactory::id('alfa')->collection('single')->slug('alfa')->locale('en')->create();
+        $items = collect([$entry]);
+        $action = (new Localize)->context(['view' => 'list'])->items($items);
+
+        $this->assertFalse($action->visibleToBulk($items));
+    }
+
+    #[Test]
+    public function it_authorizes_users_who_can_edit_the_entry()
+    {
+        $this->setTestRoles([
+            'editor' => ['edit test entries', 'access en site'],
+            'viewer' => ['view test entries', 'access en site'],
+        ]);
+
+        $userWithPermission = tap(User::make()->assignRole('editor'))->save();
+        $userWithoutPermission = tap(User::make()->assignRole('viewer'))->save();
+        $entry = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+
+        $this->assertTrue((new Localize)->authorize($userWithPermission, $entry));
+        $this->assertFalse((new Localize)->authorize($userWithoutPermission, $entry));
+    }
+
+    #[Test]
     public function it_localizes_entries_missing_the_selected_site()
     {
         $this->actingAs(User::make()->makeSuper()->save());
@@ -92,5 +182,22 @@ class LocalizeTest extends TestCase
         $this->assertEquals([
             'de' => 'German',
         ], $siteField->get('options'));
+    }
+
+    #[Test]
+    public function it_rejects_sites_that_are_not_offered()
+    {
+        $en = EntryFactory::id('alfa')->collection('test')->slug('alfa')->locale('en')->create();
+        EntryFactory::id('alfa-fr')->collection('test')->slug('alfa')->locale('fr')->origin('alfa')->create();
+
+        $action = (new Localize)->context(['view' => 'list'])->items([$en]);
+
+        $this->assertFalse(
+            $action->fields()->addValues(['site' => 'fr'])->validator()->validator()->passes()
+        );
+
+        $this->assertTrue(
+            $action->fields()->addValues(['site' => 'de'])->validator()->validator()->passes()
+        );
     }
 }


### PR DESCRIPTION
## Description of the Problem

On multisite entry listings, going through each entry to duplicate them for a new site is slow. There’s no bulk way to add a localization for a selected site across multiple entries.

As per https://github.com/statamic/ideas/issues/613

## What this PR Does

<img width="3420" height="2146" alt="2026-08-26 at 16 33 23@2x" src="https://github.com/user-attachments/assets/98129420-e300-42d0-88bf-34747e48173d" />

- Adds a bulk Localize action on entry listings when multisite is enabled and at least one selected entry is missing a localization:
- Shows a site select with only sites still missing for the selection
- Creates localizations via makeLocalization for entries that don’t already exist in that site
- Skips entries that already have the localization, and reports how many were created vs skipped
- Hides the action when the selection isn’t eligible (mixed collections, fully localized, single-site collections, etc.)
- Fixes Publish Field.vue so hide_display + required fields don’t show a stray asterisk (used by the site select in the modal)

## How to Reproduce

- Enable multisite with a collection available in multiple sites (e.g. en, fr, de).
- Create several entries that exist only in one site.
- Open the collection entry index, select those entries, and choose Localize.
- Pick a missing site and confirm — localizations are created for entries that need them; existing ones are skipped.