### PR TITLE
[6.x] Allow addon settings blueprints to be registered lazily

### DIFF
--- a/src/Addons/Addon.php
+++ b/src/Addons/Addon.php
@@ -350,18 +350,21 @@ final class Addon
 
     public function hasSettingsBlueprint(): bool
     {
-        return $this->settingsBlueprint() !== null;
+        return app()->bound($this->settingsBlueprintBinding());
     }
 
     public function settingsBlueprint()
     {
-        $binding = "statamic.addons.{$this->slug()}.settings_blueprint";
-
-        if (! app()->bound($binding)) {
+        if (! $this->hasSettingsBlueprint()) {
             return null;
         }
 
-        return Blueprint::make("addons.{$this->slug()}")->setContents(app($binding));
+        return Blueprint::make("addons.{$this->slug()}")->setContents(app($this->settingsBlueprintBinding()));
+    }
+
+    private function settingsBlueprintBinding(): string
+    {
+        return "statamic.addons.{$this->slug()}.settings_blueprint";
     }
 
     public function setting($key, $default = null): mixed

--- a/src/Providers/AddonServiceProvider.php
+++ b/src/Providers/AddonServiceProvider.php
@@ -815,9 +815,12 @@ abstract class AddonServiceProvider extends ServiceProvider
         return $this;
     }
 
-    protected function registerSettingsBlueprint(array $blueprint): self
+    protected function registerSettingsBlueprint(array|Closure $blueprint): self
     {
-        $this->app->bind("statamic.addons.{$this->getAddon()->slug()}.settings_blueprint", fn () => $blueprint);
+        $this->app->scoped(
+            "statamic.addons.{$this->getAddon()->slug()}.settings_blueprint",
+            fn () => $blueprint instanceof Closure ? $blueprint() : $blueprint
+        );
 
         return $this;
     }
@@ -829,7 +832,7 @@ abstract class AddonServiceProvider extends ServiceProvider
         }
 
         if (file_exists($path = "{$this->getAddon()->directory()}resources/blueprints/settings.yaml")) {
-            $this->registerSettingsBlueprint(YAML::file($path)->parse());
+            $this->registerSettingsBlueprint(fn () => YAML::file($path)->parse());
         }
 
         return $this;

--- a/tests/Addons/AddonTest.php
+++ b/tests/Addons/AddonTest.php
@@ -227,6 +227,14 @@ class AddonTest extends TestCase
     }
 
     #[Test]
+    public function it_checks_if_addon_has_settings_blueprint_without_resolving_it()
+    {
+        $this->app->bind('statamic.addons.test-addon.settings_blueprint', fn () => $this->fail('The blueprint should not have been resolved.'));
+
+        $this->assertTrue($this->makeFromPackage(['slug' => 'test-addon'])->hasSettingsBlueprint());
+    }
+
+    #[Test]
     public function it_gets_the_settings_blueprint()
     {
         $this->app->bind('statamic.addons.test-addon.settings_blueprint', fn () => [

--- a/tests/Providers/AddonServiceProviderTest.php
+++ b/tests/Providers/AddonServiceProviderTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Tests\Providers;
+
+use Foo\Bar\TestAddonServiceProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Addons\Addon;
+use Statamic\Facades;
+use Tests\TestCase;
+
+#[Group('addons')]
+class AddonServiceProviderTest extends TestCase
+{
+    private $addon;
+    private $provider;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->addon = Addon::makeFromPackage([
+            'id' => 'foo/bar',
+            'name' => 'The Bar',
+            'namespace' => 'Foo\\Bar',
+            'provider' => TestAddonServiceProvider::class,
+            'autoload' => '',
+            'version' => '1.0',
+        ]);
+
+        Facades\Addon::shouldReceive('all')->andReturn(collect([$this->addon]));
+
+        $this->provider = new class($this->app) extends TestAddonServiceProvider
+        {
+            public function callRegisterSettingsBlueprint($blueprint)
+            {
+                return $this->registerSettingsBlueprint($blueprint);
+            }
+        };
+    }
+
+    #[Test]
+    public function it_registers_a_settings_blueprint_from_an_array()
+    {
+        $this->provider->callRegisterSettingsBlueprint($contents = [
+            'tabs' => ['main' => ['sections' => [['fields' => [['handle' => 'api_key', 'field' => ['type' => 'text']]]]]]],
+        ]);
+
+        $this->assertTrue($this->addon->hasSettingsBlueprint());
+        $this->assertTrue($this->addon->settingsBlueprint()->hasField('api_key'));
+        $this->assertEquals($contents, app('statamic.addons.bar.settings_blueprint'));
+    }
+
+    #[Test]
+    public function it_registers_a_settings_blueprint_from_a_closure_without_evaluating_it()
+    {
+        $evaluated = 0;
+
+        $this->provider->callRegisterSettingsBlueprint(function () use (&$evaluated) {
+            $evaluated++;
+
+            return ['tabs' => ['main' => ['sections' => [['fields' => [['handle' => 'api_key', 'field' => ['type' => 'text']]]]]]]];
+        });
+
+        $this->assertTrue($this->addon->hasSettingsBlueprint());
+        $this->assertEquals(0, $evaluated);
+
+        $this->assertTrue($this->addon->settingsBlueprint()->hasField('api_key'));
+        $this->assertEquals(1, $evaluated);
+
+        $this->addon->settingsBlueprint();
+        $this->assertEquals(1, $evaluated);
+    }
+
+    #[Test]
+    public function it_reevaluates_the_settings_blueprint_closure_in_a_new_scope()
+    {
+        $evaluated = 0;
+
+        $this->provider->callRegisterSettingsBlueprint(function () use (&$evaluated) {
+            $evaluated++;
+
+            return [];
+        });
+
+        $this->addon->settingsBlueprint();
+        $this->assertEquals(1, $evaluated);
+
+        // Long lived containers (e.g. Octane, queue workers) forget scoped
+        // instances between requests, so it shouldn't be cached forever.
+        $this->app->forgetScopedInstances();
+
+        $this->addon->settingsBlueprint();
+        $this->assertEquals(2, $evaluated);
+    }
+}


### PR DESCRIPTION
`registerSettingsBlueprint` only accepted an array, so any work needed to build the blueprint happened on every request, whether or not the settings screen was ever visited. An addon passing a container to an assets field might do `AssetContainer::all()->first()`, for instance.

It now accepts a closure too, evaluated only when the blueprint is needed:

```php
$this->registerSettingsBlueprint(fn () => [
    'tabs' => [...],
]);
```

Passing an array still works as before.