### PR TITLE
[6.x] Fix entries accepting a cyclic origin

### DIFF
--- a/src/Data/HasOrigin.php
+++ b/src/Data/HasOrigin.php
@@ -113,12 +113,28 @@ trait HasOrigin
 
     public function root()
     {
-        $entry = $this;
+        $chain = $this->originChain();
 
-        while ($entry->hasOrigin()) {
-            $entry = $entry->origin();
+        return empty($chain) ? $this : end($chain);
+    }
+
+    protected function originChain()
+    {
+        $chain = [];
+        $seen = [$this->originChainKey($this)];
+        $item = $this->origin();
+
+        while ($item && ! in_array($key = $this->originChainKey($item), $seen, true)) {
+            $chain[] = $item;
+            $seen[] = $key;
+            $item = $item->origin();
         }
 
-        return $entry;
+        return $chain;
+    }
+
+    private function originChainKey($item)
+    {
+        return method_exists($item, 'id') && ($id = $item->id()) ? $id : spl_object_id($item);
     }
 }

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -235,7 +235,7 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
         return array_merge([
             'collection' => $this->collectionHandle(),
             'locale' => $this->locale(),
-            'origin' => $this->hasOrigin() ? $this->origin()->id() : null,
+            'origin' => $this->origin,
             'slug' => $this->slug(),
             'date' => optional($this->date())->format('Y-m-d-Hi'),
             'published' => $this->published(),

--- a/src/Entries/Entry.php
+++ b/src/Entries/Entry.php
@@ -38,6 +38,7 @@ use Statamic\Events\EntryDeleting;
 use Statamic\Events\EntrySaved;
 use Statamic\Events\EntrySaving;
 use Statamic\Exceptions\BlueprintNotFoundException;
+use Statamic\Exceptions\EntryOriginRecursionException;
 use Statamic\Facades;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Blink;
@@ -399,6 +400,8 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
 
     public function save()
     {
+        $this->ensureOriginIsNotRecursive();
+
         $isNew = is_null(Facades\Entry::find($this->id()));
 
         $withEvents = $this->withEvents;
@@ -847,16 +850,22 @@ class Entry implements Arrayable, ArrayAccess, Augmentable, BulkAugmentable, Con
 
     public function ancestors()
     {
-        $ancestors = collect();
+        return collect($this->originChain());
+    }
 
-        $origin = $this->origin();
-
-        while ($origin) {
-            $ancestors->push($origin);
-            $origin = $origin->origin();
+    private function ensureOriginIsNotRecursive()
+    {
+        if (! $this->origin) {
+            return;
         }
 
-        return $ancestors;
+        $last = collect($this->originChain())->last() ?? $this;
+
+        if ($last->origin() === null) {
+            return;
+        }
+
+        throw new EntryOriginRecursionException($this->id(), $this->origin);
     }
 
     public function directDescendants()

--- a/src/Exceptions/EntryOriginRecursionException.php
+++ b/src/Exceptions/EntryOriginRecursionException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Statamic\Exceptions;
+
+use Exception;
+use Spatie\ErrorSolutions\Contracts\BaseSolution;
+use Spatie\ErrorSolutions\Contracts\ProvidesSolution;
+use Spatie\ErrorSolutions\Contracts\Solution;
+
+class EntryOriginRecursionException extends Exception implements ProvidesSolution
+{
+    public function __construct(private ?string $entry, private ?string $origin)
+    {
+        parent::__construct("Entry [$entry] cannot use origin [$origin] because it would create a loop.");
+    }
+
+    public function getEntry()
+    {
+        return $this->entry;
+    }
+
+    public function getOrigin()
+    {
+        return $this->origin;
+    }
+
+    public function getSolution(): Solution
+    {
+        return BaseSolution::create('Avoid infinite recursion')
+            ->setSolutionDescription("The entry `$this->origin` already originates from `$this->entry`, directly or through another entry. Pick an origin that isn't a descendant of this entry.");
+    }
+}

--- a/tests/Data/Entries/EntryTest.php
+++ b/tests/Data/Entries/EntryTest.php
@@ -29,6 +29,7 @@ use Statamic\Events\EntryDeleted;
 use Statamic\Events\EntryDeleting;
 use Statamic\Events\EntrySaved;
 use Statamic\Events\EntrySaving;
+use Statamic\Exceptions\EntryOriginRecursionException;
 use Statamic\Facades;
 use Statamic\Facades\Blink;
 use Statamic\Fields\Blueprint;
@@ -1655,6 +1656,109 @@ class EntryTest extends TestCase
         $this->assertSame($de, $descendants->get('de'));
     }
 
+    #[Test]
+    public function the_root_of_an_entry_in_an_origin_cycle_does_not_recurse()
+    {
+        $collection = tap(Collection::make('test'))->save();
+
+        $a = (new CyclicOriginEntry)->id('a')->locale('en')->collection($collection);
+        $b = (new CyclicOriginEntry)->id('b')->locale('fr')->collection($collection);
+
+        CyclicOriginEntry::$entries = ['a' => $a, 'b' => $b];
+
+        $a->origin('b');
+        $b->origin('a');
+
+        // The walk stops where the cycle closes rather than looping forever.
+        $this->assertSame($b, $a->root());
+        $this->assertSame($a, $b->root());
+    }
+
+    #[Test]
+    public function it_walks_a_valid_origin_chain_to_the_root()
+    {
+        $collection = tap(Collection::make('test'))->save();
+
+        $a = (new CyclicOriginEntry)->id('a')->locale('en')->collection($collection);
+        $b = (new CyclicOriginEntry)->id('b')->locale('fr')->collection($collection);
+        $c = (new CyclicOriginEntry)->id('c')->locale('de')->collection($collection);
+
+        CyclicOriginEntry::$entries = ['a' => $a, 'b' => $b, 'c' => $c];
+
+        // a -> b -> c, no cycle.
+        $a->origin('b');
+        $b->origin('c');
+
+        $this->assertSame($c, $a->root());
+        $this->assertSame([$b, $c], $a->ancestors()->all());
+    }
+
+    #[Test]
+    public function it_cannot_be_saved_with_an_origin_that_points_back_at_it()
+    {
+        tap(Collection::make('test')->sites(['en', 'fr']))->save();
+
+        $a = EntryFactory::id('a')->collection('test')->locale('en')->create();
+        $b = EntryFactory::id('b')->collection('test')->locale('fr')->origin('a')->create();
+
+        $this->expectException(EntryOriginRecursionException::class);
+        $this->expectExceptionMessage('Entry [a] cannot use origin [b] because it would create a loop.');
+
+        $a->origin($b)->save();
+    }
+
+    #[Test]
+    public function it_cannot_be_saved_with_an_origin_further_up_its_own_chain()
+    {
+        tap(Collection::make('test')->sites(['en', 'fr', 'de']))->save();
+
+        $a = EntryFactory::id('a')->collection('test')->locale('en')->create();
+        $b = EntryFactory::id('b')->collection('test')->locale('fr')->origin('a')->create();
+        $c = EntryFactory::id('c')->collection('test')->locale('de')->origin('b')->create();
+
+        $this->expectException(EntryOriginRecursionException::class);
+
+        $a->origin($c)->save();
+    }
+
+    #[Test]
+    public function it_cannot_be_saved_with_itself_as_origin()
+    {
+        tap(Collection::make('test')->sites(['en']))->save();
+
+        $a = EntryFactory::id('a')->collection('test')->locale('en')->create();
+
+        $this->expectException(EntryOriginRecursionException::class);
+
+        $a->origin('a')->save();
+    }
+
+    #[Test]
+    public function it_can_be_saved_when_an_origin_further_up_the_chain_no_longer_exists()
+    {
+        tap(Collection::make('test')->sites(['en', 'fr', 'de']))->save();
+
+        $b = EntryFactory::id('b')->collection('test')->locale('fr')->origin('missing')->create();
+        $c = EntryFactory::id('c')->collection('test')->locale('de')->create();
+
+        $c->origin($b)->save();
+
+        $this->assertSame('b', $c->origin()->id());
+    }
+
+    #[Test]
+    public function it_can_be_saved_with_an_origin_that_does_not_loop()
+    {
+        tap(Collection::make('test')->sites(['en', 'fr']))->save();
+
+        $a = EntryFactory::id('a')->collection('test')->locale('en')->create();
+        $b = EntryFactory::id('b')->collection('test')->locale('fr')->create();
+
+        $b->origin($a)->save();
+
+        $this->assertSame($a->id(), $b->origin()->id());
+    }
+
     private function fakeDescendantsQuery($results, ?array $whereInOrigins = null): QueryBuilder
     {
         $query = Mockery::mock(QueryBuilder::class);
@@ -2952,6 +3056,16 @@ class EntryTest extends TestCase
         $unserialized = unserialize($serialized);
 
         $this->assertSame('entry-slug', $unserialized->slug);
+    }
+}
+
+class CyclicOriginEntry extends Entry
+{
+    public static $entries = [];
+
+    protected function getOriginByString($origin)
+    {
+        return static::$entries[$origin] ?? null;
     }
 }
 


### PR DESCRIPTION
An entry's origin can be pointed at an entry that already originates from it. Nothing rejects this, the cycle is written to disk, and from then on loading either entry, or saving anything else in that collection, recurses until PHP dies. `stache:clear` doesn't recover from it either: the markdown needs hand editing plus removing the cached Stache files.

Reproduced on 6.29.0, file driver, multi-site, PHP 8.4:

```php
$en = Entry::make()->collection('pages')->locale('en')->slug('a')->data(['title' => 'A']);
$en->save();

$nl = Entry::make()->collection('pages')->locale('nl')->slug('b')->data(['title' => 'B']);
$nl->save();

$nl->origin($en)->save(); // fine
$en->origin($nl)->save(); // memory exhausted, but the cycle is already on disk
```

The control panel can't produce this, but the API accepts it, so imports and content sync scripts can.

**Cause**

Resolving an origin runs a query, and the Stache calls `syncOriginal()` on every item it hands out, which resolved the origin again through `getCurrentDirtyStateAttributes()`. For a cyclic pair that never bottoms out:

```
BasicStore::getItem()        syncOriginal()
HasDirtyState                getCurrentDirtyStateAttributes()
Entry                        $this->origin()->id()
Entry::getOriginByString()   queryEntries()->where('id', ...)->first()
BasicStore::getItem()        syncOriginal() ...
```

`root()` and `ancestors()` also loop forever on a cycle.

**Fix**

- `Entry::save()` throws `EntryOriginRecursionException` when the origin would close a loop: directly, through another entry, or on itself. An origin pointing at an entry that no longer exists still saves, as before.
- `getCurrentDirtyStateAttributes()` uses the origin id it already holds instead of resolving it, so dirty state tracking no longer queries from inside the store.
- `root()` and `ancestors()` walk the chain with a visited set instead of following `origin()` blindly. `descendants()` already does this for the other direction.

The check lives in `save()` rather than in `origin()` on purpose. The Stache calls the setter when hydrating from disk, so rejecting there would make an already broken site throw on load instead of letting you repair it.

**Not in this PR**

This keeps new cycles from being written. It doesn't make a site that already has one on disk usable again: `value()`, `blueprint()`, `template()`, `layout()` and `date()` each follow `origin()` recursively, and `blueprint()` is called for every entry whenever an index is rebuilt. Happy to do that in a follow-up, but I'd like to hear first whether you'd rather guard each of those reads or normalise bad origins when the Stache loads them.

Tests cover the three rejection cases, the dangling origin case, and `root()`/`ancestors()` on a cycle.
