### PR TITLE
[6.x] Fix item actions on the term edit page

### DIFF
--- a/resources/js/pages/terms/Edit.vue
+++ b/resources/js/pages/terms/Edit.vue
@@ -26,6 +26,7 @@ defineProps([
     'listingUrl',
     'previewTargets',
     'itemActions',
+    'itemActionUrl',
     'hasTemplate',
 ]);
 </script>
@@ -59,6 +60,7 @@ defineProps([
         :listing-url="listingUrl"
         :preview-targets="previewTargets"
         :initial-item-actions="itemActions"
+        :item-action-url="itemActionUrl"
         :has-template="hasTemplate"
     />
 </template>


### PR DESCRIPTION
Running an item action like Delete or Duplicate from a taxonomy term's edit page did nothing and threw a JSON parse error in the console.

The terms Edit page never declared `itemActionUrl`, so it was never forwarded to the publish form. The action runner then posted to `undefined` instead of the terms action route. The entries and users pages already declare and forward it.

Fixes #15289
