### PR TITLE
[6.x] Fixed php error if oauth is enabled and cp is on top level

### DIFF
--- a/src/Http/Controllers/CP/Auth/LoginController.php
+++ b/src/Http/Controllers/CP/Auth/LoginController.php
@@ -52,7 +52,7 @@ class LoginController extends CpController
 
     private function oauthProviders()
     {
-        $redirect = parse_url(cp_route('index'))['path'];
+        $redirect = parse_url(cp_route('index'))['path'] ?? '/';
 
         return OAuth::providers()->map(fn (Provider $provider) => [
             'name' => $provider->name(),

--- a/tests/Auth/LoginTest.php
+++ b/tests/Auth/LoginTest.php
@@ -223,6 +223,31 @@ class LoginTest extends TestCase
         $this->assertGuest();
     }
 
+    #[Test]
+    #[DefineEnvironment('cpOnTopLevel')]
+    #[DefineEnvironment('addOauthProvider')]
+    public function it_shows_oauth_providers_even_if_cp_is_on_top_level()
+    {
+        $this
+            ->get(cp_route('login'))
+            ->assertInertia(fn ($page) => $page
+                ->component('auth/Login')
+                ->has('providers', 1)
+                ->where('oauthEnabled', true)
+            );
+    }
+
+    protected function cpOnTopLevel($app)
+    {
+        $app['config']->set('statamic.cp.route', '');
+    }
+
+    protected function addOauthProvider($app)
+    {
+        $app['config']->set('statamic.oauth.enabled', true);
+        $app['config']->set('statamic.oauth.providers', ['github']);
+    }
+
     protected function disableTwoFactor($app)
     {
         $app['config']->set('statamic.users.two_factor_enabled', false);


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/11290

I read that you don't recommend placing the CP on the top level domain, but as it's an easy fix i thought its worth a shot.