### PR TITLE
[6.x] Fix recache token leaking into pagination links

### DIFF
--- a/src/Extensions/Pagination/LengthAwarePaginator.php
+++ b/src/Extensions/Pagination/LengthAwarePaginator.php
@@ -4,6 +4,8 @@ namespace Statamic\Extensions\Pagination;
 
 use Illuminate\Http\Resources\Json\PaginatedResourceResponse;
 use Illuminate\Pagination\LengthAwarePaginator as BasePaginator;
+use Illuminate\Support\Arr;
+use Statamic\Facades\StaticCache;
 
 class LengthAwarePaginator extends BasePaginator
 {
@@ -64,7 +66,9 @@ class LengthAwarePaginator extends BasePaginator
 
     public function withQueryString()
     {
-        $this->appends(request()->query());
+        $query = static::resolveQueryString(request()->query());
+
+        $this->appends(Arr::except($query, StaticCache::recacheTokenParameter()));
 
         return $this;
     }

--- a/tests/Extensions/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Extensions/Pagination/LengthAwarePaginatorTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Extensions\Pagination;
+
+use Illuminate\Pagination\Paginator;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Extensions\Pagination\LengthAwarePaginator;
+use Tests\TestCase;
+
+class LengthAwarePaginatorTest extends TestCase
+{
+    #[Test]
+    public function it_appends_the_query_string()
+    {
+        $this->get('/?foo=bar');
+
+        $paginator = $this->paginator()->withQueryString();
+
+        $this->assertEquals('/?foo=bar&page=2', $paginator->url(2));
+    }
+
+    #[Test]
+    public function it_doesnt_append_the_recache_token()
+    {
+        $this->get('/?foo=bar&__recache=abc');
+
+        $paginator = $this->paginator()->withQueryString();
+
+        $this->assertEquals('/?foo=bar&page=2', $paginator->url(2));
+    }
+
+    #[Test]
+    public function it_uses_the_query_string_resolver()
+    {
+        Paginator::queryStringResolver(fn () => ['foo' => 'bar']);
+
+        $paginator = $this->paginator()->withQueryString();
+
+        $this->assertEquals('/?foo=bar&page=2', $paginator->url(2));
+    }
+
+    private function paginator()
+    {
+        return new LengthAwarePaginator(collect(['a', 'b', 'c']), 3, 1, 1, ['path' => '/']);
+    }
+}


### PR DESCRIPTION
With background recache enabled, pages rendered by a recache request emitted pagination links containing the `__recache` token, and that HTML got written to the static cache, so the token was served to everyone until the page was regenerated by an ordinary request.

The paginator's `withQueryString()` appended the raw request query string, token included. It also bypassed Laravel's `Paginator::queryStringResolver()`, so the usual way of filtering pagination query params never got called. It now goes through the resolver and drops the recache token.

Fixes #15294
