### PR TITLE
[6.x] Fix global set sites array being ordered by file modification time

### DIFF
--- a/src/UpdateScripts/UpdateGlobalVariables.php
+++ b/src/UpdateScripts/UpdateGlobalVariables.php
@@ -38,15 +38,19 @@ class UpdateGlobalVariables extends UpdateScript
      */
     private function buildSitesArray(): void
     {
-        GlobalSet::all()->each(function ($globalSet) {
+        $siteOrder = Site::all()->keys()->flip();
+
+        GlobalSet::all()->each(function ($globalSet) use ($siteOrder) {
             $variables = GlobalVariables::whereSet($globalSet->handle());
 
-            $sites = $variables->mapWithKeys(function ($variable) {
-                $contents = YAML::file($variable->path())->parse();
-                $origin = Arr::get($contents, 'origin');
+            $sites = $variables
+                ->sortBy(fn ($variable) => $siteOrder->get($variable->locale(), $siteOrder->count()))
+                ->mapWithKeys(function ($variable) {
+                    $contents = YAML::file($variable->path())->parse();
+                    $origin = Arr::get($contents, 'origin');
 
-                return [$variable->locale() => $origin];
-            });
+                    return [$variable->locale() => $origin];
+                });
 
             $globalSet->sites($sites)->save();
 

--- a/tests/UpdateScripts/UpdateGlobalVariablesTest.php
+++ b/tests/UpdateScripts/UpdateGlobalVariablesTest.php
@@ -120,9 +120,12 @@ YAML;
         File::ensureDirectoryExists($this->globalsPath.'/de');
 
         File::put($this->globalsPath.'/test.yaml', Yaml::dump(['title' => 'Test']));
-        File::put($this->globalsPath.'/en/test.yaml', Yaml::dump(['foo' => 'Bar', 'baz' => 'Qux']));
-        File::put($this->globalsPath.'/fr/test.yaml', Yaml::dump(['origin' => 'en', 'foo' => 'Bar']));
+
+        // Written out of order on purpose. The Stache indexes variables by modification
+        // time, but the sites array should follow the order of the sites config.
         File::put($this->globalsPath.'/de/test.yaml', Yaml::dump(['origin' => 'fr']));
+        File::put($this->globalsPath.'/fr/test.yaml', Yaml::dump(['origin' => 'en', 'foo' => 'Bar']));
+        File::put($this->globalsPath.'/en/test.yaml', Yaml::dump(['foo' => 'Bar', 'baz' => 'Qux']));
 
         $this->runUpdateScript(UpdateGlobalVariables::class);
 
@@ -130,9 +133,9 @@ YAML;
         $expected = <<<'YAML'
 title: Test
 sites:
-  de: fr
   en: null
   fr: en
+  de: fr
 
 YAML;
 


### PR DESCRIPTION
This pull request fixes an issue where the `UpdateGlobalVariables` update script built the global set's `sites` array in a non-deterministic order.

This was happening because `Stache\Traverser::traverse()` sorts paths by their file modification time, not by name, so the update script wrote the sites out in whatever order the variable files happened to have been written in. When the mtimes tie, the traverser's name ordering survives, which is why it looked stable locally and only showed up on the slower Windows CI runners, where the writes straddle a second boundary.

This PR fixes it by ordering the sites by their position in the sites config, which is the same order the Control Panel writes when a global set is saved. Variables for sites that aren't in the config are already excluded upstream by `GlobalVariables::whereSet()`, so they never reach this method — the sort's fallback ordering is just a safety net, not what prevents deletion.

The test now writes its fixture files in a different order than it expects them back, so it catches the ordering on every platform rather than passing by accident on Linux and macOS.

Related: #15297
