### PR TITLE
[6.x] Align the maximum items badge to the top

### DIFF
--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -71,7 +71,7 @@
                         v-if="selectedFilesText"
                         size="sm"
                         pill
-                        class="ms-auto shrink-0 tabular-nums px-1.5!"
+                        class="ms-auto self-start shrink-0 tabular-nums px-1.5!"
                         :text="`${assets.length}/${maxFiles}`"
                         :aria-label="selectedFilesText"
                     />


### PR DESCRIPTION
## Description of the Problem

For the "maximum items" badge e.g. on an Assets field the badge looked a bit out of place vertically, in the middle

<img width="3420" height="2146" alt="image" src="https://github.com/user-attachments/assets/09cfd536-5c20-4eca-81a9-d6ce14ca31ac" />

## What this PR Does

Effectively tucks the badge into the corner

<img width="3420" height="2146" alt="2026-08-28 at 10 52 39@2x" src="https://github.com/user-attachments/assets/341735bd-5827-44b6-b9f3-fcd7dd1b1b13" />

## How to Reproduce

1. Add an assets field with a maximum number of files