### PR TITLE
[6.x] Remove dead fluid publish-fields CSS and unused selectedWidth computed

### DIFF
--- a/resources/css/components/publish.css
+++ b/resources/css/components/publish.css
@@ -45,40 +45,6 @@
 }
 
 
-/* GROUP PUBLISH COMPONENT / FIELDS / FLUID
-=================================================== */
-/* =Jay. Use this class if the fields should be fluid and fill the remaining space e.g. /cp/collections/pages/edit.
-Here flexbox is much better suited to create a layout that grows to fill space. */
-.publish-fields-fluid {
-    @apply gap-2;
-
-    display: flex;
-    flex-wrap: wrap;
-    > * {
-        flex-grow: 1;
-    }
-
-    @variant lg {
-        /* Here we have to cut short the proper width very slightly to account for the gap value. Because we're using flex-grow it should be pretty unnoticeable */
-        .field-w-25  { flex-basis: 24.5%; }
-        .field-w-33  { flex-basis: 32.5%; }
-        .field-w-50  { flex-basis: 49.4%; }
-        .field-w-66  { flex-basis: 66.1%; }
-        .field-w-75  { flex-basis: 74.5%; }
-        .field-w-undefined, .field-w-100 { flex-basis: 100%; }
-    }
-}
-
-.publish-fields-fluid--xl-only {
-    /* A modifier that prevents the fields from being fluid on smaller screens to help legibility, for example on the Blueprints builder */
-    @media (width < 1400px) {
-        [class*="field-w-"] {
-            flex-basis: 100%;
-        }
-    }
-}
-
-
 /* GROUP PUBLISH COMPONENT / FIELD
 =================================================== */
 .publish-field {

--- a/resources/css/core/animation.css
+++ b/resources/css/core/animation.css
@@ -69,8 +69,7 @@
 @media (prefers-reduced-motion: no-preference) {
     .starting-style-transition,
     .starting-style-transition-children > *,
-    .publish-fields > *,
-    .publish-fields-fluid > *  {
+    .publish-fields > * {
         transition: opacity var(--starting-style-transition-duration);
         @starting-style {
             opacity: 0;

--- a/resources/js/components/fields/Settings.vue
+++ b/resources/js/components/fields/Settings.vue
@@ -154,12 +154,6 @@ export default {
             return blueprint;
         },
 
-        selectedWidth: function () {
-            var width = this.config.width || 100;
-            var found = this.widths.find((w) => w.value === width);
-            return found.text;
-        },
-
         fieldtypeConfig() {
             return this.fieldtype.config;
         },


### PR DESCRIPTION
This clean up will be helpful in some upcoming changes regarding field widths and dashboard widget ui. #14690 

- `.publish-fields-fluid` (publish.css) was introduced in `07202fe133` for the old
  `resources/js/components/publish/Fields.vue`, applied broadly across the CP. That whole
  component tree was deleted in #11968 in favor of `ui/Publish/Fields.vue`, which never
  reintroduced the class. The one screen named in the class's own comment
  (`/cp/collections/pages/edit`, i.e. Configure Collection) now renders via `asConfig()` /
  a stacked `divide-y` layout instead — confirmed in `CollectionsController::edit()`. Dead
  since 2025-07-18.

- `.publish-fields-fluid--xl-only` (publish.css) was added for the Blueprint Builder's
  Title/Hidden fields on 2025-09-01, then removed 5 weeks later in #12700 ("Go back to v5
  style config fields"), which replaced it with the same stacked `as-config` pattern. A
  deliberate UI-direction reversal, not an accidental casualty. Dead since 2025-10-09.

- `.publish-fields-fluid > *` (animation.css) was added alongside the Blueprint Builder
  usage above and never removed when that markup changed. A later cleanup (#13658) touched
  a near-duplicate selector list elsewhere in the same file but missed this one — evidence
  nobody's relied on it since, not that it's still needed. The still-live `.publish-fields > *`
  selector in the same rule is untouched.

- `selectedWidth` (`resources/js/components/fields/Settings.vue`) is an unused computed
  property. It's also broken dead code — it references `this.widths`, which isn't defined
  anywhere in that component, so it would throw if ever evaluated.

These are all internal implementation details that were never exposed as CP extension points
— no Blade view, config option, or documented customization hook ever emitted these classes,
and the computed was never referenced — so there's no addon-facing breaking-change risk.