### PR TITLE
[6.x] Save asset folders on blur

### DIFF
--- a/resources/js/components/assets/Browser/Grid.vue
+++ b/resources/js/components/assets/Browser/Grid.vue
@@ -64,7 +64,7 @@
                         ref="newFolderInput"
                         v-model:modelValue="newFolderName"
                         :start-with-edit-mode="true"
-                        submit-mode="enter"
+                        submit-mode="both"
                         :placeholder="__('Name')"
                         :class="[
                             'flex w-[80px] items-center placeholder:lowercase justify-center overflow-hidden mt-2 text-center text-xs text-ellipsis whitespace-nowrap placeholder:text-gray-400 dark:placeholder:text-gray-500 text-gray-500',

--- a/resources/js/components/assets/Browser/Table.vue
+++ b/resources/js/components/assets/Browser/Table.vue
@@ -70,7 +70,7 @@
                                 ref="newFolderInput"
                                 v-model:modelValue="newFolderName"
                                 :start-with-edit-mode="true"
-                                submit-mode="enter"
+                                submit-mode="both"
                                 :placeholder="__('Name')"
                                 :class="[
                                     'placeholder:lowercase',


### PR DESCRIPTION
This pull request fixes an issue where new asset folders disappear when their name input loses focus. This was happening because the input only submitted on Enter and cancelled when blurred.

This PR fixes it by submitting creation on either Enter or blur in grid and table views.

## Before

https://github.com/user-attachments/assets/5a481983-612a-4947-8878-e604d4330779


## After

https://github.com/user-attachments/assets/69ce1a7d-ad1d-4308-9959-47742d15ea26


---

Fixes #15226