### PR TITLE
[6.x] Prevent deleted entries from being restored

### DIFF
--- a/src/Stache/Indexes/Value.php
+++ b/src/Stache/Indexes/Value.php
@@ -8,7 +8,7 @@ class Value extends Index
 {
     public function getItems()
     {
-        return $this->store->getItemsFromFiles()->map(function ($item) {
+        return $this->store->getItemsFromFiles()->filter()->map(function ($item) {
             return $this->getItemValue($item);
         })->all();
     }

--- a/src/Stache/Stores/BasicStore.php
+++ b/src/Stache/Stores/BasicStore.php
@@ -31,6 +31,10 @@ abstract class BasicStore extends Store
             return $item;
         }
 
+        if (! File::exists($path)) {
+            return null;
+        }
+
         $item = $this->makeItemFromFile($path, File::get($path));
 
         $this->cacheItem($item);

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -313,6 +313,32 @@ class FeatureTest extends TestCase
     }
 
     #[Test]
+    public function it_excludes_deleted_entries_when_building_a_value_index()
+    {
+        config(['statamic.stache.watcher' => false]);
+
+        $entry = tap(Entry::make()
+            ->locale('en')
+            ->id('stale-entry')
+            ->collection(Collection::findByHandle('blog'))
+            ->slug('stale-entry')
+            ->date('2017-07-04')
+            ->data(['title' => 'Stale Entry', 'foo' => 'bar'])
+        )->save();
+
+        $path = $entry->path();
+
+        Entry::all();
+
+        File::delete($path);
+        $this->stache->cacheStore()->forget('stache::items::entries::blog::'.$entry->id());
+
+        $entries = Entry::query()->where('foo', 'bar')->get();
+
+        $this->assertCount(0, $entries);
+    }
+
+    #[Test]
     public function saving_an_entry_with_a_closure_based_slug_resolves_it_before_writing_to_file()
     {
         $entry = tap(Entry::make()

--- a/tests/Stache/FeatureTest.php
+++ b/tests/Stache/FeatureTest.php
@@ -7,6 +7,7 @@ use Statamic\Facades\AssetContainer;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Data;
 use Statamic\Facades\Entry;
+use Statamic\Facades\File;
 use Statamic\Facades\GlobalSet;
 use Statamic\Facades\Nav;
 use Statamic\Facades\Nav as NavRepository;
@@ -282,6 +283,33 @@ class FeatureTest extends TestCase
         $this->assertFileExists(__DIR__.'/__fixtures__/content/collections/blog/2017-07-04.test-entry.md');
 
         $entry->delete();
+    }
+
+    #[Test]
+    public function it_does_not_restore_a_deleted_entry_when_its_cached_item_is_missing()
+    {
+        config(['statamic.stache.watcher' => false]);
+
+        $entry = tap(Entry::make()
+            ->locale('en')
+            ->id('stale-entry')
+            ->collection(Collection::findByHandle('blog'))
+            ->slug('stale-entry')
+            ->date('2017-07-04')
+            ->data(['title' => 'Stale Entry'])
+        )->save();
+
+        $path = $entry->path();
+
+        Entry::all();
+
+        File::delete($path);
+        $this->stache->cacheStore()->forget('stache::items::entries::blog::'.$entry->id());
+
+        $entries = Entry::all();
+
+        $this->assertCount(14, $entries);
+        $this->assertFileDoesNotExist($path);
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where a long-lived worker could recreate a deleted entry as an empty stub file.

This was happening because a stale in-memory Stache path could outlive the shared cached entry. A cache miss then attempted to parse the removed file, which generated and wrote a new entry.

This PR fixes it by returning no item when the path no longer exists.

Fixes #15225