### PR TITLE
[6.x] Fix focal point editor performance with large images

### DIFF
--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -168,6 +168,7 @@
                 v-if="showFocalPointEditor && isFocalPointEditorEnabled"
                 :data="values.focus"
                 :image="asset.preview"
+                :thumbnail="asset.thumbnail"
                 @selected="selectFocalPoint"
                 @closed="closeFocalPointEditor"
             />

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -168,7 +168,6 @@
                 v-if="showFocalPointEditor && isFocalPointEditorEnabled"
                 :data="values.focus"
                 :image="asset.preview"
-                :thumbnail="asset.thumbnail"
                 @selected="selectFocalPoint"
                 @closed="closeFocalPointEditor"
             />

--- a/resources/js/components/assets/Editor/Editor.vue
+++ b/resources/js/components/assets/Editor/Editor.vue
@@ -167,7 +167,7 @@
             <focal-point-editor
                 v-if="showFocalPointEditor && isFocalPointEditorEnabled"
                 :data="values.focus"
-                :image="asset.preview"
+                :image="asset.large_thumbnail"
                 @selected="selectFocalPoint"
                 @closed="closeFocalPointEditor"
             />

--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -55,7 +55,7 @@
                     :x="x"
                     :y="y"
                     :z="z"
-                    :image-url="image"
+                    :image-url="thumbnail || image"
                     :image-dimensions="imageDimensions"
                 />
             </div>
@@ -84,6 +84,7 @@ export default {
     props: [
         'data', // The initial focus point data stored in the asset, if applicable.
         'image', // The url of the image.
+        'thumbnail',
     ],
 
     data() {

--- a/resources/js/components/assets/Editor/FocalPointEditor.vue
+++ b/resources/js/components/assets/Editor/FocalPointEditor.vue
@@ -55,7 +55,7 @@
                     :x="x"
                     :y="y"
                     :z="z"
-                    :image-url="thumbnail || image"
+                    :image-url="image"
                     :image-dimensions="imageDimensions"
                 />
             </div>
@@ -84,7 +84,6 @@ export default {
     props: [
         'data', // The initial focus point data stored in the asset, if applicable.
         'image', // The url of the image.
-        'thumbnail',
     ],
 
     data() {

--- a/src/Http/Resources/CP/Assets/HasThumbnails.php
+++ b/src/Http/Resources/CP/Assets/HasThumbnails.php
@@ -27,6 +27,7 @@ trait HasThumbnails
             'is_image' => true,
             'preview' => $this->previewUrl(),
             'thumbnail' => $this->thumbnailUrl('small'),
+            'large_thumbnail' => $this->thumbnailUrl('large'),
             'can_be_transparent' => $this->isSvg() || $this->extensionIsOneOf(['svg', 'png', 'webp', 'avif']),
             'alt' => $this->alt,
             'orientation' => $this->orientation(),

--- a/src/Imaging/Manager.php
+++ b/src/Imaging/Manager.php
@@ -86,7 +86,7 @@ class Manager
     public function cpManipulationPresets()
     {
         $presets = array_merge(
-            ['small' => 400],
+            ['small' => 400, 'large' => 1600],
             config('statamic.cp.thumbnail_presets', [])
         );
 

--- a/tests/Feature/Assets/ImageThumbnailTest.php
+++ b/tests/Feature/Assets/ImageThumbnailTest.php
@@ -3,8 +3,10 @@
 namespace Tests\Feature\Assets;
 
 use Illuminate\Http\UploadedFile;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\AssetContainer;
+use Statamic\Facades\Glide;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -20,6 +22,8 @@ class ImageThumbnailTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        Glide::cacheStore()->flush();
 
         config(['filesystems.disks.test' => [
             'driver' => 'local',
@@ -49,6 +53,32 @@ class ImageThumbnailTest extends TestCase
             ->actingAs($user)
             ->getJson('/cp/thumbnails/'.base64_encode('test::one.png'))
             ->assertSuccessful();
+    }
+
+    #[Test]
+    #[DataProvider('presetProvider')]
+    public function it_returns_thumbnail_using_a_preset($preset)
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.png')
+            ->upload(UploadedFile::fake()->image('one.png'));
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/thumbnails/'.base64_encode('test::one.png').'/'.$preset)
+            ->assertSuccessful();
+    }
+
+    public static function presetProvider()
+    {
+        return [
+            'small' => ['small'],
+            'large' => ['large'],
+        ];
     }
 
     #[Test]

--- a/tests/Feature/Assets/ShowAssetTest.php
+++ b/tests/Feature/Assets/ShowAssetTest.php
@@ -53,6 +53,29 @@ class ShowAssetTest extends TestCase
     }
 
     #[Test]
+    public function it_returns_thumbnail_urls_for_images()
+    {
+        $container = AssetContainer::make('test')->disk('test')->save();
+        $container
+            ->makeAsset('one.png')
+            ->upload(UploadedFile::fake()->image('one.png'));
+
+        $this->setTestRoles(['test' => ['access cp', 'view test assets']]);
+        $user = User::make()->assignRole('test')->save();
+
+        $encodedAsset = base64_encode('test::one.png');
+
+        $this
+            ->actingAs($user)
+            ->getJson('/cp/assets/'.$encodedAsset)
+            ->assertSuccessful()
+            ->assertJson(['data' => [
+                'thumbnail' => "http://localhost/cp/thumbnails/{$encodedAsset}/small",
+                'large_thumbnail' => "http://localhost/cp/thumbnails/{$encodedAsset}/large",
+            ]]);
+    }
+
+    #[Test]
     public function it_404s_when_the_asset_doesnt_exist()
     {
         $container = AssetContainer::make('test')->disk('test')->save();

--- a/tests/Imaging/ManagerTest.php
+++ b/tests/Imaging/ManagerTest.php
@@ -69,6 +69,9 @@ class ManagerTest extends TestCase
             'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '400', 'fit' => 'contain'],
             'cp_thumbnail_small_portrait' => ['h' => '400', 'fit' => 'contain'],
             'cp_thumbnail_small_square' => ['w' => '400', 'h' => '400'],
+            'cp_thumbnail_large_landscape' => ['w' => '1600', 'h' => '1600', 'fit' => 'contain'],
+            'cp_thumbnail_large_portrait' => ['h' => '1600', 'fit' => 'contain'],
+            'cp_thumbnail_large_square' => ['w' => '1600', 'h' => '1600'],
         ], $this->manager->cpManipulationPresets());
 
         $this->manager->registerCustomManipulationPresets([
@@ -87,6 +90,9 @@ class ManagerTest extends TestCase
             'cp_thumbnail_small_landscape' => ['w' => '400', 'h' => '400', 'fit' => 'contain'],
             'cp_thumbnail_small_portrait' => ['h' => '400', 'fit' => 'contain'],
             'cp_thumbnail_small_square' => ['w' => '400', 'h' => '400'],
+            'cp_thumbnail_large_landscape' => ['w' => '1600', 'h' => '1600', 'fit' => 'contain'],
+            'cp_thumbnail_large_portrait' => ['h' => '1600', 'fit' => 'contain'],
+            'cp_thumbnail_large_square' => ['w' => '1600', 'h' => '1600'],
             'og_image' => ['w' => 1146, 'h' => 600],
             'twitter_image' => ['w' => 1200, 'h' => 600],
         ], $this->manager->manipulationPresets());


### PR DESCRIPTION
This pull request fixes an issue where the Control Panel's focal point editor becomes slow and janky when working with large source images (multi-MB originals).

This was happening because both the picker image and the nine preview crop frames rendered the full-size original image, forcing the browser to decode and paint the huge image ten times over.

This PR fixes it by adding a `large` Control Panel thumbnail preset (1600px, `fit: contain`) alongside the existing `small` one in `Manager::cpManipulationPresets()`. It's exposed on CP asset payloads as `large_thumbnail`, and the focal point editor now uses it for both the picker image and the preview frames, so the original image is never decoded at all. 1600px was chosen to keep the previews sharp at the editor's display size, including the zoomed preview frames. The preset is served through the existing CP thumbnail route, so it works the same for both public and private asset containers.

Note there's a brief one-time wait the first time the editor opens for a given asset, while the 1600px derivative is generated. After that, it loads instantly.

Fixes #15270
