### PR TITLE
[6.x] Use ->getAuthIdentifier() instead of ->id()

### DIFF
--- a/src/Http/Controllers/OAuthController.php
+++ b/src/Http/Controllers/OAuthController.php
@@ -148,7 +148,7 @@ class OAuthController
 
         $existingUserId = $oauth->getUserId($providerUser->getId());
 
-        if ($existingUserId === $user->id()) {
+        if ($existingUserId === $user->getAuthIdentifier()) {
             return redirect()
                 ->to($this->successRedirectUrl())
                 ->with('success', __('statamic::messages.oauth_already_connected', ['provider' => $oauth->label()]));


### PR DESCRIPTION
The `Auth::guard()` function returns `Authenticatable|null`. The Authenticatable contract doesn't have an `id()` function, instead it has `getAuthIdentifier()`.

Note that the getAuthIdentifier function is already overwritten in the default `User` authenticatable class that Statamic uses, so I don't see any issue with changing this to the standard function here.

We ran into an issue with this, as this function was being called upon our own `User` model that we use in our storefront. While that's probably going to be a separate issue to look into, I figured it was at least worth making this change regardless.