### PR TITLE
[6.x] Prevent recache tokens from leaking into pagination URLs

### DIFF
--- a/src/Extensions/Pagination/LengthAwarePaginator.php
+++ b/src/Extensions/Pagination/LengthAwarePaginator.php
@@ -4,6 +4,7 @@ namespace Statamic\Extensions\Pagination;
 
 use Illuminate\Http\Resources\Json\PaginatedResourceResponse;
 use Illuminate\Pagination\LengthAwarePaginator as BasePaginator;
+use Statamic\Facades\StaticCache;
 
 class LengthAwarePaginator extends BasePaginator
 {
@@ -64,7 +65,9 @@ class LengthAwarePaginator extends BasePaginator
 
     public function withQueryString()
     {
-        $this->appends(request()->query());
+        parent::withQueryString();
+
+        unset($this->query[StaticCache::recacheTokenParameter()]);
 
         return $this;
     }

--- a/tests/Extensions/Pagination/LengthAwarePaginatorTest.php
+++ b/tests/Extensions/Pagination/LengthAwarePaginatorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Extensions\Pagination;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Extensions\Pagination\LengthAwarePaginator;
+use Tests\TestCase;
+
+class LengthAwarePaginatorTest extends TestCase
+{
+    public function tearDown(): void
+    {
+        LengthAwarePaginator::queryStringResolver(fn () => request()->query());
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_excludes_the_recache_token_from_urls()
+    {
+        request()->query->replace([
+            '__recache' => 'test-token',
+            'filter' => 'news',
+        ]);
+
+        $paginator = $this->paginator()->withQueryString();
+
+        $this->assertSame('https://example.com/resources?filter=news&page=2', $paginator->url(2));
+    }
+
+    #[Test]
+    public function it_uses_the_query_string_resolver()
+    {
+        LengthAwarePaginator::queryStringResolver(fn () => [
+            '__recache' => 'test-token',
+            'filter' => 'news',
+        ]);
+
+        $paginator = $this->paginator()->withQueryString();
+
+        $this->assertSame('https://example.com/resources?filter=news&page=2', $paginator->url(2));
+    }
+
+    private function paginator()
+    {
+        return new LengthAwarePaginator([], 30, 10, 1, [
+            'path' => 'https://example.com/resources',
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes #15294.

Background recache requests include Statamic's reserved recache token in the query string. The custom paginator was appending the raw request query, causing that token to appear in generated pagination links and become part of the static cache.

This delegates query-string handling to Laravel's resolver, then removes Statamic's configured recache token while preserving legitimate query parameters. It also restores support for custom query-string resolvers.

## Testing

- `./vendor/bin/phpunit tests/Extensions/Pagination/LengthAwarePaginatorTest.php tests/StaticCaching/RecacheTokenTest.php`
- `./vendor/bin/phpunit tests/StaticCaching/HalfMeasureStaticCachingTest.php`
- `./vendor/bin/phpunit tests/StaticCaching/FullMeasureStaticCachingTest.php`
- `./vendor/bin/pint --test src/Extensions/Pagination/LengthAwarePaginator.php tests/Extensions/Pagination/LengthAwarePaginatorTest.php`
- `./vendor/bin/phpstan analyse --memory-limit=2G src/Extensions/Pagination/LengthAwarePaginator.php`