### PR TITLE
[6.x] REST API: ping and sites endpoints

### DIFF
--- a/config/api.php
+++ b/config/api.php
@@ -24,6 +24,7 @@ return [
         'assets' => false,
         'globals' => false,
         'forms' => false,
+        'sites' => false,
         'users' => false,
     ],
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use Statamic\Http\Controllers\API\FormsController;
 use Statamic\Http\Controllers\API\GlobalsController;
 use Statamic\Http\Controllers\API\NavigationTreeController;
 use Statamic\Http\Controllers\API\NotFoundController;
+use Statamic\Http\Controllers\API\PingController;
 use Statamic\Http\Controllers\API\TaxonomyTermEntriesController;
 use Statamic\Http\Controllers\API\TaxonomyTermsController;
 use Statamic\Http\Controllers\API\UsersController;
@@ -24,5 +25,7 @@ Route::name('assets.show')->get('assets/{asset_container}/{asset}', [AssetsContr
 
 Route::get('collections/{collection}/tree', [CollectionTreeController::class, 'show']);
 Route::get('navs/{nav}/tree', [NavigationTreeController::class, 'show']);
+
+Route::get('ping', PingController::class);
 
 Route::get('{path?}', NotFoundController::class)->where('path', '.*');

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,7 @@ use Statamic\Http\Controllers\API\GlobalsController;
 use Statamic\Http\Controllers\API\NavigationTreeController;
 use Statamic\Http\Controllers\API\NotFoundController;
 use Statamic\Http\Controllers\API\PingController;
+use Statamic\Http\Controllers\API\SitesController;
 use Statamic\Http\Controllers\API\TaxonomyTermEntriesController;
 use Statamic\Http\Controllers\API\TaxonomyTermsController;
 use Statamic\Http\Controllers\API\UsersController;
@@ -19,6 +20,7 @@ Route::resource('taxonomies.terms.entries', TaxonomyTermEntriesController::class
 Route::resource('globals', GlobalsController::class)->only('index', 'show');
 Route::resource('forms', FormsController::class)->only('index', 'show');
 Route::resource('users', UsersController::class)->only('index', 'show');
+Route::resource('sites', SitesController::class)->only('index');
 
 Route::name('assets.index')->get('assets/{asset_container}', [AssetsController::class, 'index']);
 Route::name('assets.show')->get('assets/{asset_container}/{asset}', [AssetsController::class, 'show'])->where('asset', '.*');

--- a/src/Http/Controllers/API/PingController.php
+++ b/src/Http/Controllers/API/PingController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Statamic\Http\Controllers\API;
+
+class PingController
+{
+    public function __invoke()
+    {
+        return ['ping' => 'pong'];
+    }
+}

--- a/src/Http/Controllers/API/SitesController.php
+++ b/src/Http/Controllers/API/SitesController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Statamic\Http\Controllers\API;
+
+use Statamic\Facades\Site;
+use Statamic\Http\Resources\API\SiteResource;
+
+class SitesController extends ApiController
+{
+    protected $resourceConfigKey = 'sites';
+
+    public function index()
+    {
+        $this->abortIfDisabled();
+
+        return app(SiteResource::class)::collection(Site::all()->values());
+    }
+}

--- a/src/Http/Resources/API/Resource.php
+++ b/src/Http/Resources/API/Resource.php
@@ -17,6 +17,7 @@ class Resource
         EntryResource::class,
         FormResource::class,
         GlobalSetResource::class,
+        SiteResource::class,
         TermResource::class,
         UserResource::class,
         TreeResource::class,

--- a/src/Http/Resources/API/SiteResource.php
+++ b/src/Http/Resources/API/SiteResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class SiteResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'handle' => $this->resource->handle(),
+            'name' => $this->resource->name(),
+            'locale' => $this->resource->locale(),
+            'short_locale' => $this->resource->shortLocale(),
+            'url' => $this->resource->url(),
+        ];
+    }
+}

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -19,6 +19,15 @@ class APITest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     #[Test]
+    public function it_pongs_when_pinged()
+    {
+        $this
+            ->get('/api/ping')
+            ->assertSuccessful()
+            ->assertExactJson(['ping' => 'pong']);
+    }
+
+    #[Test]
     public function not_found_responses_are_formatted_with_json()
     {
         $this

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -19,6 +19,33 @@ class APITest extends TestCase
     use PreventSavingStacheItemsToDisk;
 
     #[Test]
+    public function it_cannot_query_sites_by_default()
+    {
+        $this->assertEndpointNotFound('/api/sites');
+    }
+
+    #[Test]
+    public function it_queries_sites()
+    {
+        Facades\Config::set('statamic.api.resources.sites', true);
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://test.com/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://fr.test.com/'],
+            'de' => ['name' => 'German', 'locale' => 'de_DE', 'url' => 'http://test.com/de/'],
+        ]);
+
+        $this
+            ->get('/api/sites')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                ['handle' => 'en', 'name' => 'English', 'locale' => 'en_US', 'short_locale' => 'en', 'url' => 'http://test.com'],
+                ['handle' => 'fr', 'name' => 'French', 'locale' => 'fr_FR', 'short_locale' => 'fr', 'url' => 'http://fr.test.com'],
+                ['handle' => 'de', 'name' => 'German', 'locale' => 'de_DE', 'short_locale' => 'de', 'url' => 'http://test.com/de'],
+            ]]);
+    }
+
+    #[Test]
     public function it_pongs_when_pinged()
     {
         $this

--- a/tests/API/ConfigTest.php
+++ b/tests/API/ConfigTest.php
@@ -347,6 +347,23 @@ class ConfigTest extends TestCase
     }
 
     #[Test]
+    public function config_can_enable_sites()
+    {
+        Facades\Config::set('statamic.api.resources.sites', true);
+
+        $this->assertEndpointSuccessful('/api/sites');
+        $this->assertEndpointDataCount('/api/sites', 1);
+    }
+
+    #[Test]
+    public function config_can_disable_sites()
+    {
+        Facades\Config::set('statamic.api.resources.sites', false);
+
+        $this->assertEndpointNotFound('/api/sites');
+    }
+
+    #[Test]
     public function config_can_enable_all_users()
     {
         Facades\User::make()->id('one')->save();


### PR DESCRIPTION
## Summary
- Add `GET /api/ping` (`{ "ping": "pong" }`) when the Content API is enabled.
- Add `GET /api/sites` (handle, name, locale, short_locale, url), gated by `resources.sites` (off by default).

Bottom of the REST API completeness stack.

## Test plan
- [ ] `GET /api/ping` returns pong
- [ ] `GET /api/sites` is 404 until `statamic.api.resources.sites` is true
- [ ] Enabled sites match GraphQL site fields
- [ ] Existing collection/entry routes still work