### PR TITLE
[6.x] REST API: collection, taxonomy, nav, and asset-container metadata

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -11,12 +11,14 @@ use Statamic\Http\Controllers\API\NavigationTreeController;
 use Statamic\Http\Controllers\API\NotFoundController;
 use Statamic\Http\Controllers\API\PingController;
 use Statamic\Http\Controllers\API\SitesController;
+use Statamic\Http\Controllers\API\TaxonomiesController;
 use Statamic\Http\Controllers\API\TaxonomyTermEntriesController;
 use Statamic\Http\Controllers\API\TaxonomyTermsController;
 use Statamic\Http\Controllers\API\UsersController;
 
 Route::resource('collections', CollectionsController::class)->only('index', 'show');
 Route::resource('collections.entries', CollectionEntriesController::class)->only('index', 'show');
+Route::resource('taxonomies', TaxonomiesController::class)->only('index', 'show');
 Route::resource('taxonomies.terms', TaxonomyTermsController::class)->only('index', 'show');
 Route::resource('taxonomies.terms.entries', TaxonomyTermEntriesController::class)->only('index');
 Route::resource('globals', GlobalsController::class)->only('index', 'show');

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Support\Facades\Route;
 use Statamic\Http\Controllers\API\AssetsController;
 use Statamic\Http\Controllers\API\CollectionEntriesController;
+use Statamic\Http\Controllers\API\CollectionsController;
 use Statamic\Http\Controllers\API\CollectionTreeController;
 use Statamic\Http\Controllers\API\FormsController;
 use Statamic\Http\Controllers\API\GlobalsController;
@@ -14,6 +15,7 @@ use Statamic\Http\Controllers\API\TaxonomyTermEntriesController;
 use Statamic\Http\Controllers\API\TaxonomyTermsController;
 use Statamic\Http\Controllers\API\UsersController;
 
+Route::resource('collections', CollectionsController::class)->only('index', 'show');
 Route::resource('collections.entries', CollectionEntriesController::class)->only('index', 'show');
 Route::resource('taxonomies.terms', TaxonomyTermsController::class)->only('index', 'show');
 Route::resource('taxonomies.terms.entries', TaxonomyTermEntriesController::class)->only('index');

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Statamic\Http\Controllers\API\AssetContainersController;
 use Statamic\Http\Controllers\API\AssetsController;
 use Statamic\Http\Controllers\API\CollectionEntriesController;
 use Statamic\Http\Controllers\API\CollectionsController;
@@ -28,6 +29,7 @@ Route::resource('users', UsersController::class)->only('index', 'show');
 Route::resource('sites', SitesController::class)->only('index');
 Route::resource('navs', NavsController::class)->only('index', 'show');
 
+Route::resource('asset-containers', AssetContainersController::class)->only('index', 'show')->parameters(['asset-containers' => 'asset_container']);
 Route::name('assets.index')->get('assets/{asset_container}', [AssetsController::class, 'index']);
 Route::name('assets.show')->get('assets/{asset_container}/{asset}', [AssetsController::class, 'show'])->where('asset', '.*');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,7 @@ use Statamic\Http\Controllers\API\CollectionTreeController;
 use Statamic\Http\Controllers\API\FormsController;
 use Statamic\Http\Controllers\API\GlobalsController;
 use Statamic\Http\Controllers\API\NavigationTreeController;
+use Statamic\Http\Controllers\API\NavsController;
 use Statamic\Http\Controllers\API\NotFoundController;
 use Statamic\Http\Controllers\API\PingController;
 use Statamic\Http\Controllers\API\SitesController;
@@ -25,6 +26,7 @@ Route::resource('globals', GlobalsController::class)->only('index', 'show');
 Route::resource('forms', FormsController::class)->only('index', 'show');
 Route::resource('users', UsersController::class)->only('index', 'show');
 Route::resource('sites', SitesController::class)->only('index');
+Route::resource('navs', NavsController::class)->only('index', 'show');
 
 Route::name('assets.index')->get('assets/{asset_container}', [AssetsController::class, 'index']);
 Route::name('assets.show')->get('assets/{asset_container}/{asset}', [AssetsController::class, 'show'])->where('asset', '.*');

--- a/src/Http/Controllers/API/AssetContainersController.php
+++ b/src/Http/Controllers/API/AssetContainersController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Statamic\Http\Controllers\API;
+
+use Statamic\Facades\AssetContainer;
+use Statamic\Http\Resources\API\AssetContainerResource;
+
+class AssetContainersController extends ApiController
+{
+    protected $resourceConfigKey = 'assets';
+    protected $routeResourceKey = 'asset_container';
+
+    public function index()
+    {
+        $this->abortIfDisabled();
+
+        return app(AssetContainerResource::class)::collection(
+            $this->filterAllowedResources(AssetContainer::all())->values()
+        );
+    }
+
+    public function show($assetContainer)
+    {
+        $this->abortIfDisabled();
+
+        return app(AssetContainerResource::class)::make($assetContainer);
+    }
+}

--- a/src/Http/Controllers/API/CollectionsController.php
+++ b/src/Http/Controllers/API/CollectionsController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Statamic\Http\Controllers\API;
+
+use Statamic\Facades\Collection;
+use Statamic\Http\Resources\API\CollectionResource;
+
+class CollectionsController extends ApiController
+{
+    protected $resourceConfigKey = 'collections';
+    protected $routeResourceKey = 'collection';
+
+    public function index()
+    {
+        $this->abortIfDisabled();
+
+        return app(CollectionResource::class)::collection(
+            $this->filterAllowedResources(Collection::all())->values()
+        );
+    }
+
+    public function show($collection)
+    {
+        $this->abortIfDisabled();
+
+        return app(CollectionResource::class)::make($collection);
+    }
+}

--- a/src/Http/Controllers/API/NavsController.php
+++ b/src/Http/Controllers/API/NavsController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Statamic\Http\Controllers\API;
+
+use Statamic\Exceptions\NotFoundHttpException;
+use Statamic\Facades\Nav;
+use Statamic\Http\Resources\API\NavResource;
+
+class NavsController extends ApiController
+{
+    protected $resourceConfigKey = 'navs';
+    protected $routeResourceKey = 'nav';
+
+    public function index()
+    {
+        $this->abortIfDisabled();
+
+        return app(NavResource::class)::collection(
+            $this->filterAllowedResources(Nav::all())->values()
+        );
+    }
+
+    public function show($handle)
+    {
+        $this->abortIfDisabled();
+
+        throw_unless($nav = Nav::find($handle), new NotFoundHttpException("Navigation [{$handle}] not found"));
+
+        return app(NavResource::class)::make($nav);
+    }
+}

--- a/src/Http/Controllers/API/TaxonomiesController.php
+++ b/src/Http/Controllers/API/TaxonomiesController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Statamic\Http\Controllers\API;
+
+use Statamic\Facades\Taxonomy;
+use Statamic\Http\Resources\API\TaxonomyResource;
+
+class TaxonomiesController extends ApiController
+{
+    protected $resourceConfigKey = 'taxonomies';
+    protected $routeResourceKey = 'taxonomy';
+
+    public function index()
+    {
+        $this->abortIfDisabled();
+
+        return app(TaxonomyResource::class)::collection(
+            $this->filterAllowedResources(Taxonomy::all())->values()
+        );
+    }
+
+    public function show($taxonomy)
+    {
+        $this->abortIfDisabled();
+
+        return app(TaxonomyResource::class)::make($taxonomy);
+    }
+}

--- a/src/Http/Resources/API/AssetContainerResource.php
+++ b/src/Http/Resources/API/AssetContainerResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Statamic\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Statamic;
+
+class AssetContainerResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'handle' => $this->resource->handle(),
+            'title' => $this->resource->title(),
+            'api_url' => Statamic::apiRoute('asset-containers.show', [$this->resource->handle()]),
+        ];
+    }
+}

--- a/src/Http/Resources/API/CollectionResource.php
+++ b/src/Http/Resources/API/CollectionResource.php
@@ -18,7 +18,10 @@ class CollectionResource extends JsonResource
         return [
             'handle' => $this->resource->handle(),
             'title' => $this->resource->title(),
-            'structure' => $this->resource->structureHandle(),
+            'structure' => $this->resource->hasStructure() ? [
+                'max_depth' => $this->resource->structure()->maxDepth(),
+                'expects_root' => (bool) $this->resource->structure()->expectsRoot(),
+            ] : null,
             'mount' => $this->resource->mount()?->id(),
             'api_url' => Statamic::apiRoute('collections.show', [$this->resource->handle()]),
         ];

--- a/src/Http/Resources/API/CollectionResource.php
+++ b/src/Http/Resources/API/CollectionResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Statamic;
+
+class CollectionResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'handle' => $this->resource->handle(),
+            'title' => $this->resource->title(),
+            'structure' => $this->resource->structureHandle(),
+            'mount' => $this->resource->mount()?->id(),
+            'api_url' => Statamic::apiRoute('collections.show', [$this->resource->handle()]),
+        ];
+    }
+}

--- a/src/Http/Resources/API/NavResource.php
+++ b/src/Http/Resources/API/NavResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Statamic;
+
+class NavResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'handle' => $this->resource->handle(),
+            'title' => $this->resource->title(),
+            'max_depth' => $this->resource->maxDepth(),
+            'expects_root' => (bool) $this->resource->expectsRoot(),
+            'api_url' => Statamic::apiRoute('navs.show', [$this->resource->handle()]),
+        ];
+    }
+}

--- a/src/Http/Resources/API/Resource.php
+++ b/src/Http/Resources/API/Resource.php
@@ -13,6 +13,7 @@ class Resource
      * @var array
      */
     const STATAMIC_RESOURCES = [
+        AssetContainerResource::class,
         AssetResource::class,
         CollectionResource::class,
         EntryResource::class,

--- a/src/Http/Resources/API/Resource.php
+++ b/src/Http/Resources/API/Resource.php
@@ -14,6 +14,7 @@ class Resource
      */
     const STATAMIC_RESOURCES = [
         AssetResource::class,
+        CollectionResource::class,
         EntryResource::class,
         FormResource::class,
         GlobalSetResource::class,

--- a/src/Http/Resources/API/Resource.php
+++ b/src/Http/Resources/API/Resource.php
@@ -19,6 +19,7 @@ class Resource
         FormResource::class,
         GlobalSetResource::class,
         SiteResource::class,
+        TaxonomyResource::class,
         TermResource::class,
         UserResource::class,
         TreeResource::class,

--- a/src/Http/Resources/API/Resource.php
+++ b/src/Http/Resources/API/Resource.php
@@ -18,6 +18,7 @@ class Resource
         EntryResource::class,
         FormResource::class,
         GlobalSetResource::class,
+        NavResource::class,
         SiteResource::class,
         TaxonomyResource::class,
         TermResource::class,

--- a/src/Http/Resources/API/TaxonomyResource.php
+++ b/src/Http/Resources/API/TaxonomyResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Statamic\Http\Resources\API;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Statamic\Statamic;
+
+class TaxonomyResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return [
+            'handle' => $this->resource->handle(),
+            'title' => $this->resource->title(),
+            'api_url' => Statamic::apiRoute('taxonomies.show', [$this->resource->handle()]),
+        ];
+    }
+}

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -224,6 +224,58 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function it_queries_asset_container_metadata()
+    {
+        Facades\Config::set('statamic.api.resources.assets', true);
+
+        Facades\AssetContainer::make('main')->title('Main')->save();
+        Facades\AssetContainer::make('avatars')->title('Avatars')->save();
+
+        $this
+            ->get('/api/asset-containers')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                [
+                    'handle' => 'main',
+                    'title' => 'Main',
+                    'api_url' => 'http://localhost/api/asset-containers/main',
+                ],
+                [
+                    'handle' => 'avatars',
+                    'title' => 'Avatars',
+                    'api_url' => 'http://localhost/api/asset-containers/avatars',
+                ],
+            ]]);
+
+        $this
+            ->get('/api/asset-containers/main')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                'handle' => 'main',
+                'title' => 'Main',
+                'api_url' => 'http://localhost/api/asset-containers/main',
+            ]]);
+    }
+
+    #[Test]
+    public function it_only_queries_allowed_asset_containers()
+    {
+        Facades\Config::set('statamic.api.resources.assets', ['avatars']);
+
+        Facades\AssetContainer::make('main')->save();
+        Facades\AssetContainer::make('avatars')->title('Avatars')->save();
+
+        $this
+            ->get('/api/asset-containers')
+            ->assertSuccessful()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.handle', 'avatars');
+
+        $this->assertEndpointNotFound('/api/asset-containers/main');
+        $this->assertEndpointSuccessful('/api/asset-containers/avatars');
+    }
+
+    #[Test]
     public function it_pongs_when_pinged()
     {
         $this

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -166,6 +166,64 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function it_queries_nav_metadata()
+    {
+        Facades\Config::set('statamic.api.resources.navs', true);
+
+        Facades\Nav::make('footer')->title('Footer')->maxDepth(2)->expectsRoot(false)->save();
+        Facades\Nav::make('docs')->title('Docs')->save();
+
+        $this
+            ->get('/api/navs')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                [
+                    'handle' => 'footer',
+                    'title' => 'Footer',
+                    'max_depth' => 2,
+                    'expects_root' => false,
+                    'api_url' => 'http://localhost/api/navs/footer',
+                ],
+                [
+                    'handle' => 'docs',
+                    'title' => 'Docs',
+                    'max_depth' => null,
+                    'expects_root' => false,
+                    'api_url' => 'http://localhost/api/navs/docs',
+                ],
+            ]]);
+
+        $this
+            ->get('/api/navs/footer')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                'handle' => 'footer',
+                'title' => 'Footer',
+                'max_depth' => 2,
+                'expects_root' => false,
+                'api_url' => 'http://localhost/api/navs/footer',
+            ]]);
+    }
+
+    #[Test]
+    public function it_only_queries_allowed_navs()
+    {
+        Facades\Config::set('statamic.api.resources.navs', ['footer']);
+
+        Facades\Nav::make('footer')->save();
+        Facades\Nav::make('docs')->save();
+
+        $this
+            ->get('/api/navs')
+            ->assertSuccessful()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.handle', 'footer');
+
+        $this->assertEndpointSuccessful('/api/navs/footer');
+        $this->assertEndpointNotFound('/api/navs/docs');
+    }
+
+    #[Test]
     public function it_pongs_when_pinged()
     {
         $this

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -114,6 +114,58 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function it_queries_taxonomy_metadata()
+    {
+        Facades\Config::set('statamic.api.resources.taxonomies', true);
+
+        Facades\Taxonomy::make('topics')->title('Topics')->save();
+        Facades\Taxonomy::make('tags')->title('Tags')->save();
+
+        $this
+            ->get('/api/taxonomies')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                [
+                    'handle' => 'topics',
+                    'title' => 'Topics',
+                    'api_url' => 'http://localhost/api/taxonomies/topics',
+                ],
+                [
+                    'handle' => 'tags',
+                    'title' => 'Tags',
+                    'api_url' => 'http://localhost/api/taxonomies/tags',
+                ],
+            ]]);
+
+        $this
+            ->get('/api/taxonomies/topics')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                'handle' => 'topics',
+                'title' => 'Topics',
+                'api_url' => 'http://localhost/api/taxonomies/topics',
+            ]]);
+    }
+
+    #[Test]
+    public function it_only_queries_allowed_taxonomies()
+    {
+        Facades\Config::set('statamic.api.resources.taxonomies', ['tags']);
+
+        Facades\Taxonomy::make('topics')->save();
+        Facades\Taxonomy::make('tags')->title('Tags')->save();
+
+        $this
+            ->get('/api/taxonomies')
+            ->assertSuccessful()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.handle', 'tags');
+
+        $this->assertEndpointNotFound('/api/taxonomies/topics');
+        $this->assertEndpointSuccessful('/api/taxonomies/tags');
+    }
+
+    #[Test]
     public function it_pongs_when_pinged()
     {
         $this

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -46,6 +46,74 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function it_cannot_query_collections_by_default()
+    {
+        Facades\Collection::make('pages')->save();
+
+        $this->assertEndpointNotFound('/api/collections');
+        $this->assertEndpointNotFound('/api/collections/pages');
+    }
+
+    #[Test]
+    public function it_queries_collection_metadata()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        Facades\Collection::make('pages')->title('Pages')->structureContents(['expects_root' => false])->mount('home')->save();
+        Facades\Entry::make()->collection('pages')->id('home')->slug('home')->published(true)->save();
+        Facades\Collection::make('articles')->title('Articles')->save();
+
+        $this
+            ->get('/api/collections')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                [
+                    'handle' => 'pages',
+                    'title' => 'Pages',
+                    'structure' => 'pages',
+                    'mount' => 'home',
+                    'api_url' => 'http://localhost/api/collections/pages',
+                ],
+                [
+                    'handle' => 'articles',
+                    'title' => 'Articles',
+                    'structure' => null,
+                    'mount' => null,
+                    'api_url' => 'http://localhost/api/collections/articles',
+                ],
+            ]]);
+
+        $this
+            ->get('/api/collections/pages')
+            ->assertSuccessful()
+            ->assertExactJson(['data' => [
+                'handle' => 'pages',
+                'title' => 'Pages',
+                'structure' => 'pages',
+                'mount' => 'home',
+                'api_url' => 'http://localhost/api/collections/pages',
+            ]]);
+    }
+
+    #[Test]
+    public function it_only_queries_allowed_collections()
+    {
+        Facades\Config::set('statamic.api.resources.collections', ['articles']);
+
+        Facades\Collection::make('pages')->save();
+        Facades\Collection::make('articles')->title('Articles')->save();
+
+        $this
+            ->get('/api/collections')
+            ->assertSuccessful()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.handle', 'articles');
+
+        $this->assertEndpointNotFound('/api/collections/pages');
+        $this->assertEndpointSuccessful('/api/collections/articles');
+    }
+
+    #[Test]
     public function it_pongs_when_pinged()
     {
         $this

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -59,7 +59,7 @@ class APITest extends TestCase
     {
         Facades\Config::set('statamic.api.resources.collections', true);
 
-        Facades\Collection::make('pages')->title('Pages')->structureContents(['expects_root' => false])->mount('home')->save();
+        Facades\Collection::make('pages')->title('Pages')->structureContents(['root' => true, 'max_depth' => 3])->mount('home')->save();
         Facades\Entry::make()->collection('pages')->id('home')->slug('home')->published(true)->save();
         Facades\Collection::make('articles')->title('Articles')->save();
 
@@ -70,7 +70,10 @@ class APITest extends TestCase
                 [
                     'handle' => 'pages',
                     'title' => 'Pages',
-                    'structure' => 'pages',
+                    'structure' => [
+                        'max_depth' => 3,
+                        'expects_root' => true,
+                    ],
                     'mount' => 'home',
                     'api_url' => 'http://localhost/api/collections/pages',
                 ],
@@ -89,7 +92,10 @@ class APITest extends TestCase
             ->assertExactJson(['data' => [
                 'handle' => 'pages',
                 'title' => 'Pages',
-                'structure' => 'pages',
+                'structure' => [
+                    'max_depth' => 3,
+                    'expects_root' => true,
+                ],
                 'mount' => 'home',
                 'api_url' => 'http://localhost/api/collections/pages',
             ]]);

--- a/tests/API/ConfigTest.php
+++ b/tests/API/ConfigTest.php
@@ -289,6 +289,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.assets', true);
 
+        $this->assertEndpointSuccessful('/api/asset-containers');
+        $this->assertEndpointSuccessful('/api/asset-containers/main');
+        $this->assertEndpointSuccessful('/api/asset-containers/avatars');
         $this->assertEndpointSuccessful('/api/assets/main');
         $this->assertEndpointSuccessful('/api/assets/avatars');
 
@@ -304,6 +307,8 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.assets', false);
 
+        $this->assertEndpointNotFound('/api/asset-containers');
+        $this->assertEndpointNotFound('/api/asset-containers/main');
         $this->assertEndpointNotFound('/api/assets/main');
         $this->assertEndpointNotFound('/api/assets/avatars');
 
@@ -319,6 +324,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.assets', ['avatars']);
 
+        $this->assertEndpointSuccessful('/api/asset-containers');
+        $this->assertEndpointNotFound('/api/asset-containers/main');
+        $this->assertEndpointSuccessful('/api/asset-containers/avatars');
         $this->assertEndpointNotFound('/api/assets/main');
         $this->assertEndpointSuccessful('/api/assets/avatars');
 

--- a/tests/API/ConfigTest.php
+++ b/tests/API/ConfigTest.php
@@ -142,6 +142,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.navs', true);
 
+        $this->assertEndpointSuccessful('/api/navs');
+        $this->assertEndpointSuccessful('/api/navs/footer');
+        $this->assertEndpointSuccessful('/api/navs/docs');
         $this->assertEndpointSuccessful('/api/navs/footer/tree');
         $this->assertEndpointSuccessful('/api/navs/docs/tree');
     }
@@ -154,6 +157,8 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.navs', false);
 
+        $this->assertEndpointNotFound('/api/navs');
+        $this->assertEndpointNotFound('/api/navs/footer');
         $this->assertEndpointNotFound('/api/navs/footer/tree');
         $this->assertEndpointNotFound('/api/navs/docs/tree');
     }
@@ -166,6 +171,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.navs', ['footer']);
 
+        $this->assertEndpointSuccessful('/api/navs');
+        $this->assertEndpointSuccessful('/api/navs/footer');
+        $this->assertEndpointNotFound('/api/navs/docs');
         $this->assertEndpointSuccessful('/api/navs/footer/tree');
         $this->assertEndpointNotFound('/api/navs/docs/tree');
     }

--- a/tests/API/ConfigTest.php
+++ b/tests/API/ConfigTest.php
@@ -37,6 +37,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.collections', true);
 
+        $this->assertEndpointSuccessful('/api/collections');
+        $this->assertEndpointSuccessful('/api/collections/pages');
+        $this->assertEndpointSuccessful('/api/collections/articles');
         $this->assertEndpointSuccessful('/api/collections/pages/tree');
         $this->assertEndpointSuccessful('/api/collections/pages/entries');
         $this->assertEndpointSuccessful('/api/collections/articles/entries');
@@ -55,6 +58,8 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.collections', false);
 
+        $this->assertEndpointNotFound('/api/collections');
+        $this->assertEndpointNotFound('/api/collections/pages');
         $this->assertEndpointNotFound('/api/collections/pages/tree');
         $this->assertEndpointNotFound('/api/collections/pages/entries');
         $this->assertEndpointNotFound('/api/collections/articles/entries');
@@ -118,6 +123,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.collections', ['pages']);
 
+        $this->assertEndpointSuccessful('/api/collections');
+        $this->assertEndpointSuccessful('/api/collections/pages');
+        $this->assertEndpointNotFound('/api/collections/articles');
         $this->assertEndpointSuccessful('/api/collections/pages/tree');
         $this->assertEndpointSuccessful('/api/collections/pages/entries');
         $this->assertEndpointNotFound('/api/collections/articles/entries');

--- a/tests/API/ConfigTest.php
+++ b/tests/API/ConfigTest.php
@@ -180,6 +180,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.taxonomies', true);
 
+        $this->assertEndpointSuccessful('/api/taxonomies');
+        $this->assertEndpointSuccessful('/api/taxonomies/topics');
+        $this->assertEndpointSuccessful('/api/taxonomies/colours');
         $this->assertEndpointSuccessful('/api/taxonomies/topics/terms');
         $this->assertEndpointSuccessful('/api/taxonomies/colours/terms');
 
@@ -197,6 +200,8 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.taxonomies', false);
 
+        $this->assertEndpointNotFound('/api/taxonomies');
+        $this->assertEndpointNotFound('/api/taxonomies/topics');
         $this->assertEndpointNotFound('/api/taxonomies/topics/terms');
         $this->assertEndpointNotFound('/api/taxonomies/colours/terms');
 
@@ -214,6 +219,9 @@ class ConfigTest extends TestCase
 
         Facades\Config::set('statamic.api.resources.taxonomies', ['topics']);
 
+        $this->assertEndpointSuccessful('/api/taxonomies');
+        $this->assertEndpointSuccessful('/api/taxonomies/topics');
+        $this->assertEndpointNotFound('/api/taxonomies/colours');
         $this->assertEndpointSuccessful('/api/taxonomies/topics/terms');
         $this->assertEndpointNotFound('/api/taxonomies/colours/terms');
 


### PR DESCRIPTION
## Summary
- `GET /api/collections` + `/{handle}` — handle, title, structure, mount, api_url
- `GET /api/taxonomies` + `/{handle}` — handle, title, api_url
- `GET /api/navs` + `/{handle}` — handle, title, max_depth, expects_root, api_url
- `GET /api/asset-containers` + `/{handle}` — handle, title, api_url

Same resource allowlists as existing content endpoints. `/navs/{nav}/tree` and `/assets/{container}` unchanged.

Stacked on #15317.

## Test plan
- [ ] Disabled resources 404 on the new list/show routes
- [ ] Allowlists hide unlisted collections/taxonomies/navs/containers
- [ ] Existing entries/terms/tree/asset routes still work