### PR TITLE
[6.x] REST API: honor fields param on entries and assets

### DIFF
--- a/src/Http/Resources/API/AssetResource.php
+++ b/src/Http/Resources/API/AssetResource.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class AssetResource extends JsonResource
 {
+    use ResolvesRequestedFields;
+
     /**
      * Transform the resource into an array.
      *
@@ -19,7 +21,7 @@ class AssetResource extends JsonResource
             ->filter->isRelationship()->keys()->all();
 
         return $this->resource
-            ->toAugmentedCollection()
+            ->toAugmentedCollection($this->requestedFields($request))
             ->withRelations($with)
             ->withShallowNesting()
             ->toArray();

--- a/src/Http/Resources/API/EntryResource.php
+++ b/src/Http/Resources/API/EntryResource.php
@@ -6,6 +6,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
 
 class EntryResource extends JsonResource
 {
+    use ResolvesRequestedFields;
+
     /**
      * Transform the resource into an array.
      *
@@ -19,7 +21,7 @@ class EntryResource extends JsonResource
             ->filter->isRelationship()->keys()->all();
 
         return $this->resource
-            ->toAugmentedCollection()
+            ->toAugmentedCollection($this->requestedFields($request))
             ->withRelations($with)
             ->withShallowNesting()
             ->toArray();

--- a/src/Http/Resources/API/ResolvesRequestedFields.php
+++ b/src/Http/Resources/API/ResolvesRequestedFields.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Statamic\Http\Resources\API;
+
+trait ResolvesRequestedFields
+{
+    protected function requestedFields($request): ?array
+    {
+        if ($selected = $this->resource->selectedQueryColumns()) {
+            return $selected;
+        }
+
+        $fields = $request->input('fields');
+
+        if (! $fields || $fields === '*') {
+            return null;
+        }
+
+        return collect(explode(',', $fields))
+            ->map(fn ($field) => trim($field))
+            ->filter()
+            ->values()
+            ->all();
+    }
+}

--- a/src/Http/Resources/API/ResolvesRequestedFields.php
+++ b/src/Http/Resources/API/ResolvesRequestedFields.php
@@ -12,7 +12,7 @@ trait ResolvesRequestedFields
 
         $fields = $request->input('fields');
 
-        if (! $fields || $fields === '*') {
+        if (! is_string($fields) || $fields === '*') {
             return null;
         }
 

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -309,6 +309,14 @@ class APITest extends TestCase
             ->assertJsonPath('data.id', 'about')
             ->assertJsonPath('data.title', 'About')
             ->assertJsonMissingPath('data.slug');
+
+        $arrayForm = $this
+            ->get('/api/collections/pages/entries/about?fields[]=id&fields[]=title')
+            ->assertSuccessful()
+            ->json('data');
+
+        $this->assertArrayHasKey('title', $arrayForm);
+        $this->assertArrayHasKey('slug', $arrayForm);
     }
 
     #[Test]

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -4,6 +4,7 @@ namespace Tests\API;
 
 use Facades\Statamic\CP\LivePreview;
 use Facades\Statamic\Fields\BlueprintRepository;
+use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades;
@@ -279,6 +280,72 @@ class APITest extends TestCase
 
         $this->assertEndpointNotFound('/api/asset-containers/main');
         $this->assertEndpointSuccessful('/api/asset-containers/avatars');
+    }
+
+    #[Test]
+    public function it_selects_entry_fields()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        Facades\Collection::make('pages')->save();
+        Facades\Entry::make()->collection('pages')->id('about')->slug('about')->published(true)->data(['title' => 'About'])->save();
+
+        $full = $this->get('/api/collections/pages/entries/about')->assertSuccessful()->json('data');
+
+        $this->assertArrayHasKey('title', $full);
+        $this->assertArrayHasKey('slug', $full);
+        $this->assertGreaterThan(2, count($full));
+
+        $this
+            ->get('/api/collections/pages/entries?fields=id,title')
+            ->assertSuccessful()
+            ->assertJsonPath('data.0.id', 'about')
+            ->assertJsonPath('data.0.title', 'About')
+            ->assertJsonMissingPath('data.0.slug');
+
+        $this
+            ->get('/api/collections/pages/entries/about?fields=id,title')
+            ->assertSuccessful()
+            ->assertJsonPath('data.id', 'about')
+            ->assertJsonPath('data.title', 'About')
+            ->assertJsonMissingPath('data.slug');
+    }
+
+    #[Test]
+    public function it_selects_asset_fields()
+    {
+        Facades\Config::set('statamic.api.resources.assets', true);
+
+        config(['filesystems.disks.test' => [
+            'driver' => 'local',
+            'root' => __DIR__.'/tmp',
+        ]]);
+
+        Storage::fake('test');
+        Storage::disk('test')->put('foo.jpg', '');
+
+        Facades\AssetContainer::make('main')->disk('test')->save();
+        Facades\Asset::make()->container('main')->path('foo.jpg')->data(['alt' => 'A picture'])->save();
+
+        $full = $this->get('/api/assets/main/foo.jpg')->assertSuccessful()->json('data');
+
+        $this->assertArrayHasKey('alt', $full);
+        $this->assertArrayHasKey('url', $full);
+        $this->assertGreaterThan(2, count($full));
+
+        $this
+            ->get('/api/assets/main?fields=id,alt')
+            ->assertSuccessful()
+            ->assertJsonPath('data.0.id', 'main::foo.jpg')
+            ->assertJsonPath('data.0.alt', 'A picture')
+            ->assertJsonMissingPath('data.0.url');
+
+        $this
+            ->get('/api/assets/main/foo.jpg?fields=id,alt')
+            ->assertSuccessful()
+            ->assertJsonPath('data.id', 'main::foo.jpg')
+            ->assertJsonPath('data.alt', 'A picture')
+            ->assertJsonMissingPath('data.url');
     }
 
     #[Test]


### PR DESCRIPTION
## Summary
- `?fields=id,title` now shapes entry and asset JSON on list and show.
- Omitting `fields` (or `fields=*`) still returns the full augmented payload.

Stacked on #15318.

Closes https://github.com/statamic/ideas/issues/1078

## Test plan
- [ ] `GET /api/collections/pages/entries?fields=id,title` only includes those keys
- [ ] Same for a single entry show and for assets
- [ ] Requests without `fields` are unchanged