### PR TITLE
[6.x] REST API: site query param and pagination link params

### DIFF
--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -20,6 +20,7 @@ class ApiController extends Controller
     protected $resourceConfigKey;
     protected $routeResourceKey;
     protected $filterPublished = false;
+    protected $siteConstrained = false;
 
     /**
      * Abort if item is unpublished.
@@ -87,10 +88,40 @@ class ApiController extends Controller
     protected function updateAndPaginate($query)
     {
         return $this
+            ->applySiteConstraint($query)
             ->filter($query)
             ->sort($query)
             ->scope($query)
             ->paginate($query);
+    }
+
+    /**
+     * Limit the query to an explicit ?site= handle.
+     *
+     * Unlike queryParam('site'), this does not default to the default site,
+     * so omitting the param keeps existing "all sites" list behavior.
+     */
+    protected function applySiteConstraint($query)
+    {
+        if ($this->siteConstrained && $site = $this->requestedSite()) {
+            $query->where('site', $site);
+        }
+
+        return $this;
+    }
+
+    protected function requestedSite(): ?string
+    {
+        return request()->has('site') ? request()->input('site') : null;
+    }
+
+    protected function localize($item)
+    {
+        if (! $item || ! $site = $this->requestedSite()) {
+            return $item;
+        }
+
+        return $item->in($site);
     }
 
     /**

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -300,7 +300,7 @@ class ApiController extends Controller
 
         return $query
             ->paginate(request()->input('limit', config('statamic.api.pagination_size')), $columns)
-            ->appends(request()->only(['filter', 'limit', 'page', 'sort']));
+            ->appends(request()->only(['filter', 'limit', 'page', 'sort', 'query_scope', 'fields', 'site']));
     }
 
     /**

--- a/src/Http/Controllers/API/ApiController.php
+++ b/src/Http/Controllers/API/ApiController.php
@@ -112,7 +112,15 @@ class ApiController extends Controller
 
     protected function requestedSite(): ?string
     {
-        return request()->has('site') ? request()->input('site') : null;
+        if (! request()->has('site')) {
+            return null;
+        }
+
+        $site = request()->input('site');
+
+        throw_unless(Site::get($site), new NotFoundHttpException);
+
+        return $site;
     }
 
     protected function localize($item)

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -17,6 +17,7 @@ class CollectionEntriesController extends ApiController
     protected $resourceConfigKey = 'collections';
     protected $routeResourceKey = 'collection';
     protected $filterPublished = true;
+    protected $siteConstrained = true;
     protected $collectionHandle;
 
     public function index($collection)
@@ -38,7 +39,7 @@ class CollectionEntriesController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $entry = Entry::find($handle);
+        $entry = $this->localize(Entry::find($handle));
 
         $this->abortIfInvalid($entry, $collection);
         $this->abortIfUnpublished($entry);

--- a/src/Http/Controllers/API/TaxonomyTermEntriesController.php
+++ b/src/Http/Controllers/API/TaxonomyTermEntriesController.php
@@ -13,6 +13,7 @@ use Statamic\Http\Resources\API\EntryResource;
 class TaxonomyTermEntriesController extends ApiController
 {
     protected $filterPublished = true;
+    protected $siteConstrained = true;
     protected $allowedCollections;
 
     protected function abortIfDisabled()

--- a/src/Http/Controllers/API/TaxonomyTermsController.php
+++ b/src/Http/Controllers/API/TaxonomyTermsController.php
@@ -12,6 +12,7 @@ class TaxonomyTermsController extends ApiController
 {
     protected $resourceConfigKey = 'taxonomies';
     protected $routeResourceKey = 'taxonomy';
+    protected $siteConstrained = true;
     protected $taxonomyHandle;
 
     public function index($taxonomy)
@@ -33,7 +34,7 @@ class TaxonomyTermsController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $term = Term::find($taxonomy.'::'.$term);
+        $term = $this->localize(Term::find($taxonomy.'::'.$term));
 
         throw_unless($term, new NotFoundHttpException);
 

--- a/src/Http/Controllers/API/TaxonomyTermsController.php
+++ b/src/Http/Controllers/API/TaxonomyTermsController.php
@@ -34,7 +34,11 @@ class TaxonomyTermsController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $term = $this->localize(Term::find($taxonomy.'::'.$term));
+        if ($site = $this->requestedSite()) {
+            throw_unless($taxonomy->sites()->contains($site), new NotFoundHttpException);
+        }
+
+        $term = $this->localize(Term::find($taxonomy->handle().'::'.$term));
 
         throw_unless($term, new NotFoundHttpException);
 

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -384,6 +384,8 @@ class APITest extends TestCase
             ->assertSuccessful()
             ->assertJsonPath('data.id', 'about-fr')
             ->assertJsonPath('data.title', 'A propos');
+
+        $this->assertEndpointNotFound('/api/collections/pages/entries/about?site=bogus');
     }
 
     #[Test]
@@ -409,6 +411,8 @@ class APITest extends TestCase
             ->get('/api/taxonomies/topics/terms/dance?site=fr')
             ->assertSuccessful()
             ->assertJsonPath('data.title', 'Danse');
+
+        $this->assertEndpointNotFound('/api/taxonomies/topics/terms/dance?site=bogus');
     }
 
     #[Test]

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -771,9 +771,9 @@ class APITest extends TestCase
         Facades\Entry::make()->collection('pages')->id('jazz')->slug('jazz')->published(true)->save();
 
         $this
-            ->get('/api/collections/pages/entries?limit=2&sort=-date&filter[published]=true&unknown=param')
-            ->assertJsonPath('links.first', 'http://localhost/api/collections/pages/entries?filter%5Bpublished%5D=true&limit=2&sort=-date&page=1')
-            ->assertJsonPath('links.next', 'http://localhost/api/collections/pages/entries?filter%5Bpublished%5D=true&limit=2&sort=-date&page=2');
+            ->get('/api/collections/pages/entries?limit=2&sort=-date&filter[published]=true&fields=id,title&site=en&unknown=param')
+            ->assertJsonPath('links.first', 'http://localhost/api/collections/pages/entries?filter%5Bpublished%5D=true&limit=2&sort=-date&fields=id%2Ctitle&site=en&page=1')
+            ->assertJsonPath('links.next', 'http://localhost/api/collections/pages/entries?filter%5Bpublished%5D=true&limit=2&sort=-date&fields=id%2Ctitle&site=en&page=2');
     }
 
     #[Test]

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -357,6 +357,61 @@ class APITest extends TestCase
     }
 
     #[Test]
+    public function it_filters_entries_by_site_query_param()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://localhost/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://localhost/fr/'],
+        ]);
+
+        Facades\Collection::make('pages')->sites(['en', 'fr'])->save();
+        Facades\Entry::make()->collection('pages')->locale('en')->id('about')->slug('about')->published(true)->data(['title' => 'About'])->save();
+        Facades\Entry::make()->collection('pages')->locale('fr')->origin('about')->id('about-fr')->slug('a-propos')->published(true)->data(['title' => 'A propos'])->save();
+
+        $this->assertEndpointDataCount('/api/collections/pages/entries', 2);
+        $this->assertEndpointDataCount('/api/collections/pages/entries?site=fr', 1);
+
+        $this
+            ->get('/api/collections/pages/entries?site=fr')
+            ->assertSuccessful()
+            ->assertJsonPath('data.0.id', 'about-fr')
+            ->assertJsonPath('data.0.title', 'A propos');
+
+        $this
+            ->get('/api/collections/pages/entries/about?site=fr')
+            ->assertSuccessful()
+            ->assertJsonPath('data.id', 'about-fr')
+            ->assertJsonPath('data.title', 'A propos');
+    }
+
+    #[Test]
+    public function it_filters_terms_by_site_query_param()
+    {
+        Facades\Config::set('statamic.api.resources.taxonomies', true);
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://localhost/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://localhost/fr/'],
+        ]);
+
+        Facades\Taxonomy::make('topics')->sites(['en', 'fr'])->save();
+        Facades\Term::make()->taxonomy('topics')->slug('dance')->dataForLocale('en', ['title' => 'Dance'])->save();
+        Facades\Term::find('topics::dance')->in('fr')->data(['title' => 'Danse'])->save();
+
+        $this
+            ->get('/api/taxonomies/topics/terms?site=fr')
+            ->assertSuccessful()
+            ->assertJsonPath('data.0.title', 'Danse');
+
+        $this
+            ->get('/api/taxonomies/topics/terms/dance?site=fr')
+            ->assertSuccessful()
+            ->assertJsonPath('data.title', 'Danse');
+    }
+
+    #[Test]
     public function it_pongs_when_pinged()
     {
         $this


### PR DESCRIPTION
## Summary
- Accept `?site=` on entries, terms, and term-entries (keep `filter[site]`).
- Omitting `site` still returns all sites.
- Pagination next/first links now keep `fields`, `site`, and `query_scope`.

Stacked on #15319.

## Test plan
- [ ] `?site=fr` limits entries/terms to that site
- [ ] Show localizes when `?site=` is present
- [ ] No `site` param still returns all sites
- [ ] Pagination links preserve fields/site