### PR TITLE
[6.x] REST API: resolve entries by slug

### DIFF
--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -39,7 +39,7 @@ class CollectionEntriesController extends ApiController
     {
         $this->abortIfDisabled();
 
-        $entry = $this->localize(Entry::find($handle));
+        $entry = $this->resolveEntry($collection, $handle);
 
         $this->abortIfInvalid($entry, $collection);
         $this->abortIfUnpublished($entry);
@@ -70,6 +70,21 @@ class CollectionEntriesController extends ApiController
         $values = collect(explode(',', $terms))->map(fn ($term) => "$taxonomy::$term");
 
         $this->queryTaxonomyTerms($query, $modifier, $values);
+    }
+
+    private function resolveEntry($collection, $handle)
+    {
+        if ($entry = Entry::find($handle)) {
+            return $this->localize($entry);
+        }
+
+        $query = $collection->queryEntries()->where('slug', $handle);
+
+        if ($site = $this->requestedSite()) {
+            $query->where('site', $site);
+        }
+
+        return $query->first();
     }
 
     private function abortIfInvalid($entry, $collection)

--- a/src/Http/Controllers/API/CollectionEntriesController.php
+++ b/src/Http/Controllers/API/CollectionEntriesController.php
@@ -82,6 +82,8 @@ class CollectionEntriesController extends ApiController
 
         if ($site = $this->requestedSite()) {
             $query->where('site', $site);
+        } elseif ($collection->sites()->count() > 1) {
+            $query->where('site', $collection->sites()->first());
         }
 
         return $query->first();

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -491,6 +491,33 @@ class APITest extends TestCase
             ->assertJsonPath('data.title', 'By ID');
     }
 
+    #[Test]
+    public function it_resolves_duplicate_slugs_to_the_first_collection_site()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        $this->setSites([
+            'en' => ['name' => 'English', 'locale' => 'en_US', 'url' => 'http://localhost/'],
+            'fr' => ['name' => 'French', 'locale' => 'fr_FR', 'url' => 'http://localhost/fr/'],
+        ]);
+
+        Facades\Collection::make('pages')->sites(['en', 'fr'])->save();
+        Facades\Entry::make()->collection('pages')->locale('en')->id('about-en')->slug('about')->published(true)->data(['title' => 'About'])->save();
+        Facades\Entry::make()->collection('pages')->locale('fr')->id('about-fr')->slug('about')->published(true)->data(['title' => 'A propos'])->save();
+
+        $this
+            ->get('/api/collections/pages/entries/about')
+            ->assertSuccessful()
+            ->assertJsonPath('data.id', 'about-en')
+            ->assertJsonPath('data.title', 'About');
+
+        $this
+            ->get('/api/collections/pages/entries/about?site=fr')
+            ->assertSuccessful()
+            ->assertJsonPath('data.id', 'about-fr')
+            ->assertJsonPath('data.title', 'A propos');
+    }
+
     public static function exampleFiltersProvider()
     {
         return [['status:is'], ['published:is'], ['title:is']];

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -460,6 +460,37 @@ class APITest extends TestCase
         ];
     }
 
+    #[Test]
+    public function it_resolves_entries_by_slug()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        Facades\Collection::make('pages')->save();
+        Facades\Entry::make()->collection('pages')->id('123')->slug('about')->published(true)->data(['title' => 'About'])->save();
+
+        $this
+            ->get('/api/collections/pages/entries/about')
+            ->assertSuccessful()
+            ->assertJsonPath('data.id', '123')
+            ->assertJsonPath('data.slug', 'about');
+    }
+
+    #[Test]
+    public function it_prefers_entry_id_over_slug()
+    {
+        Facades\Config::set('statamic.api.resources.collections', true);
+
+        Facades\Collection::make('pages')->save();
+        Facades\Entry::make()->collection('pages')->id('about')->slug('about-page')->published(true)->data(['title' => 'By ID'])->save();
+        Facades\Entry::make()->collection('pages')->id('other')->slug('about')->published(true)->data(['title' => 'By Slug'])->save();
+
+        $this
+            ->get('/api/collections/pages/entries/about')
+            ->assertSuccessful()
+            ->assertJsonPath('data.id', 'about')
+            ->assertJsonPath('data.title', 'By ID');
+    }
+
     public static function exampleFiltersProvider()
     {
         return [['status:is'], ['published:is'], ['title:is']];


### PR DESCRIPTION
## Summary
- `GET /api/collections/{collection}/entries/{id}` also accepts a slug.
- ID still wins if an id and another entry's slug collide.

Stacked on #15320.

## Test plan
- [ ] `/entries/about` works when the id is not `about`
- [ ] If an entry id is `about` and another slug is `about`, the id wins
- [ ] Unpublished slugs still 404
- [ ] Existing id lookups unchanged