### PR TITLE
[6.x] Fix user wizard breaking when blueprint has conditional fields

### DIFF
--- a/resources/js/components/users/Wizard.vue
+++ b/resources/js/components/users/Wizard.vue
@@ -28,6 +28,11 @@
                     :blueprint="blueprint"
                     v-model="values"
                     :meta="meta"
+                    :extra-values="{
+                        roles: user.roles,
+                        groups: user.groups,
+                        super: user.super,
+                    }"
                     :track-dirty-state="false"
                     :errors="errors"
                 >

--- a/src/Http/Controllers/CP/Users/UsersController.php
+++ b/src/Http/Controllers/CP/Users/UsersController.php
@@ -160,7 +160,7 @@ class UsersController extends CpController
             ->keys();
 
         $viewData = [
-            'values' => (object) $fields->values()->only($additional)->all(),
+            'initialValues' => (object) $fields->values()->only($additional)->all(),
             'meta' => (object) $fields->meta()->all(),
             'fields' => collect($blueprint->fields()->toPublishArray())->filter(fn ($field) => $additional->contains($field['handle']))->values()->all(),
             'blueprint' => $blueprint->toPublishArray(),

--- a/tests/Feature/Users/CreateUserTest.php
+++ b/tests/Feature/Users/CreateUserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Users;
 
+use Inertia\Testing\AssertableInertia as Assert;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
@@ -27,6 +28,23 @@ class CreateUserTest extends TestCase
             ->actingAsWithElevatedSession($me)
             ->get(route('statamic.cp.users.create'))
             ->assertOk();
+    }
+
+    #[Test]
+    public function it_provides_the_initial_values()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create users']]);
+        $me = tap(User::make()->email('admin@domain.com')->assignRole('test'))->save();
+
+        $this
+            ->actingAsWithElevatedSession($me)
+            ->get(route('statamic.cp.users.create'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('users/Create')
+                ->has('initialValues')
+                ->where('initialValues.email', null)
+                ->missing('initialValues.roles')
+                ->missing('initialValues.groups'));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where adding a field condition to the user blueprint could break the "create user" wizard — clicking Next wouldn't advance, and Vue would log "Unhandled error during execution of component update" and "Cannot destructure property 'type' of 'vnode' as it is null" errors.

This was happening because the create controller passes the pre-processed values under a `values` key, while the `users/Create` page expects an `initialValues` prop. The wizard's publish container ended up running on an empty object, so every field's value resolved to `null` instead of its pre-processed default. Fieldtypes that expect an array value (like `user_roles` or `entries`) then throw while computing their field actions, leaving a half-rendered component that crashes Vue when the step is unmounted — freezing the wizard.

This PR fixes it by passing the values under the `initialValues` key the page expects, so field defaults reach the wizard and field conditions evaluate against real values.

This PR also provides the wizard's `roles`, `groups` and `super` selections as extra values to the publish container, so conditions referencing them behave the same as on the Edit User page (e.g. a field with "show when `roles` contains `editor`" will appear on the first step after assigning the role and navigating back).

Fixes #15316

Caused by #12942