### PR TITLE
[6.x] Only add site view paths for directories that exist

### DIFF
--- a/src/Http/Middleware/AddViewPaths.php
+++ b/src/Http/Middleware/AddViewPaths.php
@@ -36,11 +36,9 @@ class AddViewPaths
 
     private function updatePaths()
     {
-        $site = $this->site;
-
-        $paths = collect($this->paths)->flatMap(function ($path) use ($site) {
+        $paths = collect($this->paths)->flatMap(function ($path) {
             return [
-                $path.'/'.$site,
+                $this->sitePath($path),
                 $path,
             ];
         })->filter()->values()->all();
@@ -53,13 +51,20 @@ class AddViewPaths
         foreach ($this->hints as $namespace => $paths) {
             $paths = collect($paths)->flatMap(function ($path) {
                 return [
-                    $path.'/'.$this->site,
+                    $this->sitePath($path),
                     $path,
                 ];
-            })->values();
+            })->filter()->values();
 
             $this->finder->replaceNamespace($namespace, $paths->all());
         }
+    }
+
+    private function sitePath($path)
+    {
+        $sitePath = $path.'/'.$this->site;
+
+        return is_dir($sitePath) ? $sitePath : null;
     }
 
     private function restore()

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -8,16 +8,30 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Site;
 use Statamic\Http\Middleware\AddViewPaths;
 use Statamic\Support\Arr;
-use Statamic\Support\Str;
 use Symfony\Component\HttpFoundation\Request as SymfonyRequest;
 use Symfony\Component\HttpFoundation\Response;
 use Tests\TestCase;
 
 class AddViewPathsTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        mkdir(__DIR__.'/tmp/views/french', 0755, true);
+        mkdir(__DIR__.'/tmp/other/views/english', 0755, true);
+    }
+
+    public function tearDown(): void
+    {
+        app('files')->deleteDirectory(__DIR__.'/tmp');
+
+        parent::tearDown();
+    }
+
     #[Test]
     #[DataProvider('viewPathProvider')]
-    public function adds_view_paths($isAmpEnabled, $requestUrl, $expectedPaths)
+    public function adds_view_paths($requestUrl, $expectedPaths)
     {
         $this->setSites([
             'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
@@ -25,11 +39,9 @@ class AddViewPathsTest extends TestCase
         ]);
 
         view()->getFinder()->setPaths($originalPaths = [
-            '/path/to/views',
-            '/path/to/other/views',
+            __DIR__.'/tmp/views',
+            __DIR__.'/tmp/other/views',
         ]);
-
-        config(['statamic.amp.enabled' => $isAmpEnabled]);
 
         $this->setCurrentSiteBasedOnUrl($requestUrl);
 
@@ -57,8 +69,8 @@ class AddViewPathsTest extends TestCase
         ]);
 
         view()->getFinder()->replaceNamespace('foo', [
-            '/path/to/views',
-            '/path/to/other',
+            __DIR__.'/tmp/views',
+            __DIR__.'/tmp/other/views',
         ]);
         $originalHints = view()->getFinder()->getHints()['foo'];
 
@@ -78,10 +90,58 @@ class AddViewPathsTest extends TestCase
         $this->assertEquals($originalHints, Arr::get(view()->getFinder()->getHints(), 'foo'));
     }
 
+    #[Test]
+    public function adds_no_view_paths_on_single_site_when_site_directory_does_not_exist()
+    {
+        $this->setSites([
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+        ]);
+
+        view()->getFinder()->setPaths($originalPaths = [__DIR__.'/tmp/views']);
+        view()->getFinder()->replaceNamespace('foo', $originalHints = [__DIR__.'/tmp/views']);
+
+        $request = $this->createRequest('/test');
+        $handled = false;
+
+        (new AddViewPaths())->handle($request, function () use ($originalPaths, $originalHints, &$handled) {
+            $this->assertEquals($originalPaths, view()->getFinder()->getPaths());
+            $this->assertEquals($originalHints, Arr::get(view()->getFinder()->getHints(), 'foo'));
+            $handled = true;
+
+            return new Response;
+        });
+
+        $this->assertTrue($handled);
+    }
+
+    #[Test]
+    public function adds_view_paths_on_single_site_when_site_directory_exists()
+    {
+        $this->setSites([
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+        ]);
+
+        view()->getFinder()->setPaths([__DIR__.'/tmp/other/views']);
+
+        $request = $this->createRequest('/test');
+        $handled = false;
+
+        (new AddViewPaths())->handle($request, function () use (&$handled) {
+            $this->assertEquals([
+                __DIR__.'/tmp/other/views/english',
+                __DIR__.'/tmp/other/views',
+            ], view()->getFinder()->getPaths());
+            $handled = true;
+
+            return new Response;
+        });
+
+        $this->assertTrue($handled);
+    }
+
     private function setCurrentSiteBasedOnUrl($requestUrl)
     {
-        $url = 'http://localhost'.Str::removeLeft($requestUrl, '/amp');
-        $site = Site::findByUrl($url);
+        $site = Site::findByUrl('http://localhost'.$requestUrl);
         Site::setCurrent($site->handle());
     }
 
@@ -95,29 +155,15 @@ class AddViewPathsTest extends TestCase
     public static function viewPathProvider()
     {
         return [
-            'amp enabled, amp request' => [true, '/amp/fr/test', [
-                '/path/to/views/french',
-                '/path/to/views',
-                '/path/to/other/views/french',
-                '/path/to/other/views',
+            'site directory exists in first path' => ['/fr/test', [
+                __DIR__.'/tmp/views/french',
+                __DIR__.'/tmp/views',
+                __DIR__.'/tmp/other/views',
             ]],
-            'amp enabled, non-amp request' => [true, '/fr/test', [
-                '/path/to/views/french',
-                '/path/to/views',
-                '/path/to/other/views/french',
-                '/path/to/other/views',
-            ]],
-            'amp disabled, default site' => [false, '/test', [
-                '/path/to/views/english',
-                '/path/to/views',
-                '/path/to/other/views/english',
-                '/path/to/other/views',
-            ]],
-            'amp disabled, second site' => [false, '/fr/test', [
-                '/path/to/views/french',
-                '/path/to/views',
-                '/path/to/other/views/french',
-                '/path/to/other/views',
+            'site directory exists in second path' => ['/test', [
+                __DIR__.'/tmp/views',
+                __DIR__.'/tmp/other/views/english',
+                __DIR__.'/tmp/other/views',
             ]],
         ];
     }
@@ -125,22 +171,20 @@ class AddViewPathsTest extends TestCase
     public static function namespacedViewPathProvider()
     {
         return [
-            'default site' => [
-                '/test',
-                [
-                    '/path/to/views/english',
-                    '/path/to/views',
-                    '/path/to/other/english',
-                    '/path/to/other',
-                ],
-            ],
-            'second site' => [
+            'site directory exists in first path' => [
                 '/fr/test',
                 [
-                    '/path/to/views/french',
-                    '/path/to/views',
-                    '/path/to/other/french',
-                    '/path/to/other',
+                    __DIR__.'/tmp/views/french',
+                    __DIR__.'/tmp/views',
+                    __DIR__.'/tmp/other/views',
+                ],
+            ],
+            'site directory exists in second path' => [
+                '/test',
+                [
+                    __DIR__.'/tmp/views',
+                    __DIR__.'/tmp/other/views/english',
+                    __DIR__.'/tmp/other/views',
                 ],
             ],
         ];


### PR DESCRIPTION
This pull request fixes an issue where the `AddViewPaths` middleware doubles every front-end view lookup, even on single-site installs.

This was happening because the middleware prefixes every view path and namespace hint with a `/<site>` sibling without checking whether the directory exists. On a single-site install, those directories almost never exist, so around half of all view `file_exists()` probes were for directories that have never existed. On hosts with `open_basedir` set (most shared/managed hosting), this is much worse — PHP can't cache negative realpath lookups, so each miss re-walks the whole path on every call of every request.

This PR fixes it by only adding the site-prefixed path when the directory actually exists. This helps multi-site installs too, since even a five-site install usually only has override directories for a handful of its path entries. Site directories that do exist continue to be added ahead of their base path, so per-site template overrides behave exactly as before.

Fixes #15323