### PR TITLE
[6.x] Don't add per-site view paths when there's only one site

### DIFF
--- a/src/Http/Middleware/AddViewPaths.php
+++ b/src/Http/Middleware/AddViewPaths.php
@@ -14,6 +14,10 @@ class AddViewPaths
 
     public function handle($request, Closure $next)
     {
+        if (! Site::hasMultiple()) {
+            return $next($request);
+        }
+
         $this->update();
 
         $response = $next($request);

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -78,6 +78,37 @@ class AddViewPathsTest extends TestCase
         $this->assertEquals($originalHints, Arr::get(view()->getFinder()->getHints(), 'foo'));
     }
 
+    #[Test]
+    public function doesnt_add_view_paths_when_theres_only_one_site()
+    {
+        $this->setSites([
+            'english' => ['url' => 'http://localhost/', 'locale' => 'en'],
+        ]);
+
+        view()->getFinder()->setPaths($originalPaths = [
+            '/path/to/views',
+            '/path/to/other/views',
+        ]);
+
+        view()->getFinder()->replaceNamespace('foo', $originalHints = [
+            '/path/to/views',
+            '/path/to/other',
+        ]);
+
+        $request = $this->createRequest('/test');
+        $handled = false;
+
+        (new AddViewPaths())->handle($request, function () use ($originalPaths, $originalHints, &$handled) {
+            $this->assertEquals($originalPaths, view()->getFinder()->getPaths());
+            $this->assertEquals($originalHints, Arr::get(view()->getFinder()->getHints(), 'foo'));
+            $handled = true;
+
+            return new Response;
+        });
+
+        $this->assertTrue($handled);
+    }
+
     private function setCurrentSiteBasedOnUrl($requestUrl)
     {
         $url = 'http://localhost'.Str::removeLeft($requestUrl, '/amp');

--- a/tests/Http/Middleware/AddViewPathsTest.php
+++ b/tests/Http/Middleware/AddViewPathsTest.php
@@ -107,6 +107,8 @@ class AddViewPathsTest extends TestCase
         });
 
         $this->assertTrue($handled);
+        $this->assertEquals($originalPaths, view()->getFinder()->getPaths());
+        $this->assertEquals($originalHints, Arr::get(view()->getFinder()->getHints(), 'foo'));
     }
 
     private function setCurrentSiteBasedOnUrl($requestUrl)


### PR DESCRIPTION
The `AddViewPaths` middleware prefixes every view path and namespace hint with a `/<site>` sibling directory so a multi-site install can override templates per site. It does that on every front-end request, whether or not the install actually has more than one site.

On a single-site install those directories don't exist, so every prefixed entry is a guaranteed miss and the finder probes twice as many paths as it needs to. It's much worse on hosts that set `open_basedir`, since PHP can't cache a negative realpath lookup and each miss re-walks the whole path on every call. Counting the finder's `file_exists()` calls on a single-site install, a lookup went from 56 probes to 28 with the render unchanged.

This skips the middleware when there's only one site. Worth flagging: anyone on a one-site install who kept templates in `resources/views/<site>` would need to move them up a level. The issue also suggests filtering on `is_dir()` instead, which would help multi-site installs too, but that stats every path on every request, so I've kept this to the case that was reported.

Fixes #15323
