### PR TITLE
[6.x] Prevent Bard sets from selecting form controls

### DIFF
--- a/resources/js/components/fieldtypes/bard/Set.vue
+++ b/resources/js/components/fieldtypes/bard/Set.vue
@@ -17,6 +17,7 @@
             @paste.stop
             @cut.stop
             @dragstart="preventNodeSelectionDrag"
+            @mousedown="preventFormControlNodeSelection"
         >
             <div ref="content" hidden />
             <header
@@ -351,6 +352,12 @@ export default {
         disableDragging() {
             this.$el.setAttribute('draggable', false);
             this._draggableObserver?.observe(this.$el, { attributes: true, attributeFilter: ['draggable'] });
+        },
+
+        preventFormControlNodeSelection(event) {
+            const target = event.target instanceof Element ? event.target : event.target.parentElement;
+
+            if (target?.closest('[data-ui-combobox], [data-ui-input], [data-interactive]')) event.stopPropagation();
         },
 
         preventNodeSelectionDrag(event) {

--- a/resources/js/tests/components/fieldtypes/bard/Set.test.js
+++ b/resources/js/tests/components/fieldtypes/bard/Set.test.js
@@ -90,3 +90,21 @@ test('dragging a draggable element inside the set is allowed', async () => {
 
     expect(event.defaultPrevented).toBe(false);
 });
+
+test('clicking a custom select field does not bubble its mousedown to ProseMirror', () => {
+    const wrapper = mountSet();
+    const parent = document.createElement('div');
+    const combobox = document.createElement('div');
+    const selectedOption = document.createElement('div');
+    const mousedown = vi.fn();
+
+    combobox.dataset.uiCombobox = '';
+    combobox.append(selectedOption);
+    wrapper.find('[data-type]').element.append(combobox);
+    parent.append(wrapper.element);
+    parent.addEventListener('mousedown', mousedown);
+
+    selectedOption.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+
+    expect(mousedown).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
This pull request fixes an issue where interacting with a form control in a Bard set selects the whole set.

This was happening because custom form controls emit their mousedown from non-native elements, which Tiptap does not recognise as inputs.

This PR fixes it by preventing form-control mousedown events from reaching ProseMirror.

## Before


https://github.com/user-attachments/assets/372d9740-b75f-4087-b8ec-dc28166d89fc



## After

https://github.com/user-attachments/assets/d569e78b-944b-4115-bda4-bdcbf2566eb0



---

Fixes #15207