### PR TITLE
[6.x] Fix `startRegistration()` warning when registering passkeys

### DIFF
--- a/resources/js/pages/users/Passkeys.vue
+++ b/resources/js/pages/users/Passkeys.vue
@@ -54,7 +54,7 @@ async function createPasskey() {
 
     let startRegistrationResponse;
     try {
-        startRegistrationResponse = await startRegistration(await authOptionsResponse.json());
+        startRegistrationResponse = await startRegistration({ optionsJSON: await authOptionsResponse.json() });
     } catch (e) {
         console.error(e);
         passkeyWaiting.value = false;


### PR DESCRIPTION
This pull request fixes an issue where passkey registration emits an incorrect call warning from SimpleWebAuthn.

This was happening because `startRegistration()` was being passed registration options directly, using the API shape discontinued in SimpleWebAuthn 11. The library continues through a backwards-compatibility path, but [logs a warning](https://simplewebauthn.dev/docs/packages/browser#typeerror-cannot-read-properties-of-undefined-reading-challenge).

This PR fixes it by passing the registration options through the documented `optionsJSON` property.

Related: #15212