### PR TITLE
[6.x] Forms 2: Add `appendConfigFields` to form fieldtypes

### DIFF
--- a/src/Fields/Fieldtype.php
+++ b/src/Fields/Fieldtype.php
@@ -303,7 +303,7 @@ abstract class Fieldtype implements Arrayable
         return $this->configFields;
     }
 
-    protected function extraConfigFieldItems(): array
+    public function extraConfigFieldItems(): array
     {
         return array_merge(
             self::$extraConfigFields[static::class] ?? [],

--- a/src/Forms/Fields/FormFieldtype.php
+++ b/src/Forms/Fields/FormFieldtype.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\Forms\Fields;
 
+use Facades\Statamic\Fields\FieldtypeRepository;
 use Facades\Statamic\Forms\Fields\FormFieldtypeRepository;
 use Illuminate\Contracts\Support\Arrayable;
 use Statamic\Extend\HasHandle;
@@ -121,9 +122,8 @@ abstract class FormFieldtype implements Arrayable
             return $cached;
         }
 
-        $fields = collect($this->configFieldItems());
-
-        $fields = $fields
+        $fields = collect($this->configFieldItems())
+            ->merge($this->extraConfigFieldItems())
             ->map(function ($field, $handle) {
                 return compact('handle', 'field');
             });
@@ -140,6 +140,20 @@ abstract class FormFieldtype implements Arrayable
         return $this->configFields;
     }
 
+    // TODO: Remove in v7. Only exists so config fields appended to the wrapped fieldtype keep working.
+    public function extraConfigFieldItems(): array
+    {
+        if (! $handle = static::fieldtype()) {
+            return [];
+        }
+
+        if (! $class = FieldtypeRepository::classes()->get($handle)) {
+            return [];
+        }
+
+        return app($class)->extraConfigFieldItems();
+    }
+
     public function configBlueprint(): Blueprint
     {
         return (new Blueprint)->setContents([
@@ -148,6 +162,7 @@ abstract class FormFieldtype implements Arrayable
                     'sections' => [
                         [
                             'fields' => collect($this->configFieldItems())
+                                ->merge($this->extraConfigFieldItems())
                                 ->map(fn ($field, $handle) => compact('handle', 'field'))
                                 ->values()->all(),
                         ],

--- a/src/Forms/Fields/FormFieldtype.php
+++ b/src/Forms/Fields/FormFieldtype.php
@@ -24,6 +24,7 @@ abstract class FormFieldtype implements Arrayable
 
     protected static $title;
     protected static $fieldtype;
+    protected static $extraConfigFields = [];
 
     protected $field;
     protected $selectable = true;
@@ -140,8 +141,17 @@ abstract class FormFieldtype implements Arrayable
         return $this->configFields;
     }
 
-    // TODO: Remove in v7. Only exists so config fields appended to the wrapped fieldtype keep working.
     public function extraConfigFieldItems(): array
+    {
+        return array_merge(
+            $this->configFieldItemsFromWrappedFieldtype(),
+            self::$extraConfigFields[static::class] ?? [],
+            self::$extraConfigFields[FormFieldtype::class] ?? [],
+        );
+    }
+
+    // TODO: Remove this bridge in v7, once addons have migrated to FormFieldtype::appendConfigField.
+    private function configFieldItemsFromWrappedFieldtype(): array
     {
         if (! $handle = static::fieldtype()) {
             return [];
@@ -152,6 +162,18 @@ abstract class FormFieldtype implements Arrayable
         }
 
         return app($class)->extraConfigFieldItems();
+    }
+
+    public static function appendConfigFields(array $config): void
+    {
+        $existingConfig = self::$extraConfigFields[static::class] ?? [];
+
+        self::$extraConfigFields[static::class] = array_merge($existingConfig, $config);
+    }
+
+    public static function appendConfigField(string $field, array $config): void
+    {
+        self::appendConfigFields([$field => $config]);
     }
 
     public function configBlueprint(): Blueprint

--- a/tests/Forms/Fields/FormFieldtypeTest.php
+++ b/tests/Forms/Fields/FormFieldtypeTest.php
@@ -18,6 +18,7 @@ class FormFieldtypeTest extends TestCase
     public function tearDown(): void
     {
         (new \ReflectionProperty(Fieldtype::class, 'extraConfigFields'))->setValue(null, []);
+        (new \ReflectionProperty(FormFieldtype::class, 'extraConfigFields'))->setValue(null, []);
 
         parent::tearDown();
     }
@@ -186,5 +187,78 @@ class FormFieldtypeTest extends TestCase
 
         $this->assertEquals('textarea', $shortAnswer->configFields()->get('placeholder')->type());
         $this->assertEquals('textarea', $shortAnswer->configBlueprint()->fields()->get('placeholder')->type());
+    }
+
+    #[Test]
+    public function it_can_append_a_single_config_field()
+    {
+        ShortAnswer::appendConfigField('some_extra', ['type' => 'toggle']);
+
+        $shortAnswer = new ShortAnswer;
+
+        $this->assertEquals('toggle', $shortAnswer->configFields()->get('some_extra')->type());
+        $this->assertTrue($shortAnswer->configBlueprint()->hasField('some_extra'));
+    }
+
+    #[Test]
+    public function it_can_append_multiple_config_fields()
+    {
+        ShortAnswer::appendConfigFields([
+            'some_extra' => ['type' => 'toggle'],
+            'another_extra' => ['type' => 'textarea'],
+        ]);
+
+        $shortAnswer = new ShortAnswer;
+
+        $this->assertEquals('toggle', $shortAnswer->configFields()->get('some_extra')->type());
+        $this->assertEquals('textarea', $shortAnswer->configFields()->get('another_extra')->type());
+    }
+
+    #[Test]
+    public function it_wont_override_previously_appended_config_fields()
+    {
+        ShortAnswer::appendConfigFields([
+            'some_extra' => ['type' => 'toggle'],
+            'another_extra' => ['type' => 'textarea'],
+        ]);
+
+        ShortAnswer::appendConfigField('yet_another_extra', ['type' => 'text']);
+
+        $shortAnswer = new ShortAnswer;
+
+        $this->assertEquals('toggle', $shortAnswer->configFields()->get('some_extra')->type());
+        $this->assertEquals('textarea', $shortAnswer->configFields()->get('another_extra')->type());
+        $this->assertEquals('text', $shortAnswer->configFields()->get('yet_another_extra')->type());
+    }
+
+    #[Test]
+    public function appended_config_fields_exclude_those_appended_to_other_form_fieldtypes()
+    {
+        ShortAnswer::appendConfigField('some_extra', ['type' => 'toggle']);
+
+        $dropdown = new Dropdown;
+
+        $this->assertNull($dropdown->configFields()->get('some_extra'));
+        $this->assertFalse($dropdown->configBlueprint()->hasField('some_extra'));
+    }
+
+    #[Test]
+    public function config_fields_can_be_appended_to_every_form_fieldtype()
+    {
+        FormFieldtype::appendConfigField('some_extra', ['type' => 'toggle']);
+
+        $this->assertEquals('toggle', (new ShortAnswer)->configFields()->get('some_extra')->type());
+        $this->assertEquals('toggle', (new Dropdown)->configFields()->get('some_extra')->type());
+    }
+
+    #[Test]
+    public function appended_config_fields_override_extras_appended_to_the_wrapped_fieldtype()
+    {
+        Text::appendConfigField('some_extra', ['type' => 'toggle']);
+        ShortAnswer::appendConfigField('some_extra', ['type' => 'textarea']);
+
+        $shortAnswer = new ShortAnswer;
+
+        $this->assertEquals('textarea', $shortAnswer->configFields()->get('some_extra')->type());
     }
 }

--- a/tests/Forms/Fields/FormFieldtypeTest.php
+++ b/tests/Forms/Fields/FormFieldtypeTest.php
@@ -6,11 +6,22 @@ use Facades\Statamic\Forms\Fields\FormFieldtypeRepository;
 use Illuminate\Support\Facades\View;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Fields\Fieldtype;
+use Statamic\Fieldtypes\Text;
 use Statamic\Forms\Fields\FormFieldtype;
+use Statamic\Forms\Fieldtypes\Dropdown;
+use Statamic\Forms\Fieldtypes\ShortAnswer;
 use Tests\TestCase;
 
 class FormFieldtypeTest extends TestCase
 {
+    public function tearDown(): void
+    {
+        (new \ReflectionProperty(Fieldtype::class, 'extraConfigFields'))->setValue(null, []);
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function it_can_make_a_fieldtype_selectable_in_forms()
     {
@@ -142,5 +153,38 @@ class FormFieldtypeTest extends TestCase
             'information alongside another category' => [['text', 'information'], false],
             'no categories' => [[], true],
         ];
+    }
+
+    #[Test]
+    public function config_fields_include_extras_appended_to_the_wrapped_fieldtype()
+    {
+        Text::appendConfigField('some_extra', ['type' => 'toggle']);
+
+        $shortAnswer = new ShortAnswer;
+
+        $this->assertEquals('toggle', $shortAnswer->configFields()->get('some_extra')->type());
+        $this->assertTrue($shortAnswer->configBlueprint()->hasField('some_extra'));
+    }
+
+    #[Test]
+    public function config_fields_exclude_extras_appended_to_other_fieldtypes()
+    {
+        Text::appendConfigField('some_extra', ['type' => 'toggle']);
+
+        $dropdown = new Dropdown;
+
+        $this->assertNull($dropdown->configFields()->get('some_extra'));
+        $this->assertFalse($dropdown->configBlueprint()->hasField('some_extra'));
+    }
+
+    #[Test]
+    public function extras_appended_to_the_wrapped_fieldtype_override_curated_config_fields()
+    {
+        Text::appendConfigField('placeholder', ['type' => 'textarea']);
+
+        $shortAnswer = new ShortAnswer;
+
+        $this->assertEquals('textarea', $shortAnswer->configFields()->get('placeholder')->type());
+        $this->assertEquals('textarea', $shortAnswer->configBlueprint()->fields()->get('placeholder')->type());
     }
 }


### PR DESCRIPTION
This pull request adds a way for addons to append config fields to form fieldtypes.

Form fields use dedicated form fieldtypes (eg. Short Answer, Dropdown) which wrap a regular fieldtype under the hood (Short Answer wraps `text`).

These build their config fields from their own curated `configFieldItems()`, so addons appending config fields to a regular fieldtype via `Fieldtype::appendConfigField()` never showed up in the Form Builder.

`FormFieldtype` now has its own `appendConfigFields()` and `appendConfigField()` methods, mirroring the existing `Fieldtype` API. You can append to a specific form fieldtype, or to every form fieldtype by calling it on the `FormFieldtype` base class:

```php
use Statamic\Forms\Fieldtypes\ShortAnswer;

ShortAnswer::appendConfigField('character_limit', [
    'display' => 'Character Limit',
    'type' => 'integer',
]);
```

## Backwards compatibility

This PR also bridges config fields appended to a *wrapped* fieldtype (eg. `Text::appendConfigField()`) onto the form fieldtypes that wrap it, so addons written against the old API keep working without changes. If both APIs append a field with the same handle, the form fieldtype's own append wins.

This "bridge" is temporary and marked with a TODO to be removed in v7. Appending to the wrapped fieldtype is indirect — the addon is really targeting `text` fields everywhere (entries, globals, etc.), and only reaches forms because form fieldtypes happen to wrap regular fieldtypes as an implementation detail. 

The bridge exists purely because Forms 2 ships in a minor release where existing addons can't be broken. By v7, addons should append to form fieldtypes directly using the new API.
