### PR TITLE
[6.x] Make `Composer::isInstalled()` fail gracefully when the lock file is missing

### DIFF
--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -48,7 +48,9 @@ class Composer extends Process
      */
     public function isInstalled(string $package)
     {
-        return Lock::file($this->basePath.'composer.lock')->isPackageInstalled($package);
+        $lock = Lock::file($this->basePath.'composer.lock');
+
+        return $lock->exists() && $lock->isPackageInstalled($package);
     }
 
     /**

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -106,6 +106,7 @@ class ComposerTest extends TestCase
         $this->assertInstanceOf(\Illuminate\Support\Collection::class, $installed);
         $this->assertEmpty($installed);
         $this->assertNull(Composer::installedVersion('statamic/composer-test-example-dependency'));
+        $this->assertFalse(Composer::isInstalled('statamic/composer-test-example-dependency'));
     }
 
     #[Group('integration')]


### PR DESCRIPTION
This pull request fixes an issue where `Composer::isInstalled()` throws a `ComposerLockFileNotFoundException` when the `composer.lock` file doesn't exist.

This was happening because it reads the lock file without checking it exists first, unlike `Composer::installed()` and `Composer::installedVersion()`, which already fail gracefully when the lock file is missing.

This PR fixes it by returning `false` when there's no lock file, since we can't know whether a package is installed without one. This is mostly an issue in addon test suites, where the Testbench skeleton doesn't include a `composer.lock` file, forcing addons to create a stub lock file whenever something in core calls `Composer::isInstalled()`. With the Forms 2 changes, that'll happen on every front-end form request via `Statamic::formsProInstalled()`.