### PR TITLE
[6.x] Fix Glide throwing when proc_open is disabled

### DIFF
--- a/src/Console/Processes/Ffmpeg.php
+++ b/src/Console/Processes/Ffmpeg.php
@@ -75,6 +75,10 @@ class Ffmpeg extends Process
             return is_executable($binary) ? $binary : null;
         }
 
+        if (! $this->procOpenAvailable()) {
+            return null;
+        }
+
         $output = $this->run($this->isWindows() ? 'where ffmpeg' : 'which ffmpeg');
 
         // Laravel Herd doesn't inherit the user's PATH, so we need to check the Homebrew path manually
@@ -95,6 +99,11 @@ class Ffmpeg extends Process
         }
 
         return $resolved;
+    }
+
+    protected function procOpenAvailable(): bool
+    {
+        return function_exists('proc_open');
     }
 
     public static function clearBinaryCache(): void

--- a/src/Console/Processes/Ffmpeg.php
+++ b/src/Console/Processes/Ffmpeg.php
@@ -71,12 +71,12 @@ class Ffmpeg extends Process
 
     private function resolveFfmpegBinary(): ?string
     {
-        if ($binary = config('statamic.assets.ffmpeg.binary')) {
-            return is_executable($binary) ? $binary : null;
-        }
-
         if (! $this->procOpenAvailable()) {
             return null;
+        }
+
+        if ($binary = config('statamic.assets.ffmpeg.binary')) {
+            return is_executable($binary) ? $binary : null;
         }
 
         $output = $this->run($this->isWindows() ? 'where ffmpeg' : 'which ffmpeg');

--- a/src/Imaging/ImageGenerator.php
+++ b/src/Imaging/ImageGenerator.php
@@ -155,7 +155,7 @@ class ImageGenerator
      */
     public function generateByAsset($asset, array $params)
     {
-        if (ThumbnailExtractor::available() && $asset->isVideo()) {
+        if ($asset->isVideo() && ThumbnailExtractor::available()) {
             return $this->generateVideoThumbnail($asset, $params);
         }
 

--- a/tests/Console/FfmpegTest.php
+++ b/tests/Console/FfmpegTest.php
@@ -78,6 +78,29 @@ class FfmpegTest extends TestCase
     }
 
     #[Test]
+    public function it_treats_ffmpeg_as_unavailable_when_proc_open_is_disabled_even_with_a_configured_binary()
+    {
+        Ffmpeg::clearBinaryCache();
+        config(['statamic.assets.ffmpeg.binary' => PHP_BINARY]);
+
+        $ffmpeg = new class extends Ffmpeg
+        {
+            protected function procOpenAvailable(): bool
+            {
+                return false;
+            }
+
+            public function run($command, $cacheKey = null)
+            {
+                throw new \LogicException('The Process class relies on proc_open, which is not available on your PHP installation.');
+            }
+        };
+
+        $this->assertNull($ffmpeg->ffmpegBinary());
+        $this->assertFalse($ffmpeg->available());
+    }
+
+    #[Test]
     public function it_ignores_a_path_discovered_binary_that_is_not_executable()
     {
         Ffmpeg::clearBinaryCache();

--- a/tests/Console/FfmpegTest.php
+++ b/tests/Console/FfmpegTest.php
@@ -55,6 +55,29 @@ class FfmpegTest extends TestCase
     }
 
     #[Test]
+    public function it_treats_ffmpeg_as_unavailable_when_proc_open_is_disabled()
+    {
+        Ffmpeg::clearBinaryCache();
+        config(['statamic.assets.ffmpeg.binary' => null]);
+
+        $ffmpeg = new class extends Ffmpeg
+        {
+            protected function procOpenAvailable(): bool
+            {
+                return false;
+            }
+
+            public function run($command, $cacheKey = null)
+            {
+                throw new \LogicException('The Process class relies on proc_open, which is not available on your PHP installation.');
+            }
+        };
+
+        $this->assertNull($ffmpeg->ffmpegBinary());
+        $this->assertFalse($ffmpeg->available());
+    }
+
+    #[Test]
     public function it_ignores_a_path_discovered_binary_that_is_not_executable()
     {
         Ffmpeg::clearBinaryCache();

--- a/tests/Imaging/ImageGeneratorTest.php
+++ b/tests/Imaging/ImageGeneratorTest.php
@@ -99,6 +99,30 @@ class ImageGeneratorTest extends TestCase
     }
 
     #[Test]
+    public function it_does_not_check_ffmpeg_availability_for_non_video_assets()
+    {
+        // Regression test: non-video assets shouldn't trigger ffmpeg detection, since
+        // that shells out via Symfony Process and can throw on hosts where proc_open
+        // is disabled, breaking every image request instead of just video thumbnails.
+        $this->mock(\Statamic\Console\Processes\Ffmpeg::class, function ($mock) {
+            $mock->shouldNotReceive('available');
+            $mock->shouldNotReceive('ffmpegBinary');
+        });
+
+        Storage::fake('test');
+        $file = UploadedFile::fake()->image('foo/hoff.jpg', 30, 60);
+        Storage::disk('test')->putFileAs('foo', $file, 'hoff.jpg');
+        $container = tap(AssetContainer::make('test_container')->disk('test'))->save();
+        $asset = tap($container->makeAsset('foo/hoff.jpg'))->save();
+
+        ImageValidator::shouldReceive('isValidImage')->andReturnTrue();
+
+        $this->makeGenerator()->generateByAsset($asset, ['w' => 100]);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
     public function it_throws_unable_to_read_file_when_asset_is_not_a_valid_image()
     {
         Storage::fake('test');


### PR DESCRIPTION
## Description of the Problem

#15291 fixed video thumbnails showing as broken images when ffmpeg isn't installed, but introduced a regression on hosts where `proc_open` is disabled. `ImageGenerator::generateByAsset()` checked `ThumbnailExtractor::available() && $asset->isVideo()`, and PHP evaluates conditions left to right — so ffmpeg detection (which shells out via Symfony Process) ran for *every* image request, not just videos. With `proc_open` disabled, that threw a `LogicException` and broke all Glide requests, including plain JPEGs.

Reported in https://github.com/statamic/cms/pull/15291#issuecomment-5496723078.

## What this PR Does

- Reorders the check to `$asset->isVideo() && ThumbnailExtractor::available()` so non-video assets never trigger ffmpeg detection
- Makes `Ffmpeg::resolveFfmpegBinary()` bail out gracefully when `proc_open` is unavailable, so even video assets fall back to the file icon instead of throwing