### PR TITLE
[6.x] Fix `whereDate()` and `whereTime()` when the app timezone is not UTC

### DIFF
--- a/src/Query/IteratorBuilder.php
+++ b/src/Query/IteratorBuilder.php
@@ -259,7 +259,9 @@ abstract class IteratorBuilder extends Builder
                 return false;
             }
 
-            return $value->copy()->startOfDay()->$method($where['value']);
+            $value = $value->copy()->setTimezone(config('app.timezone'));
+
+            return $value->startOfDay()->$method($where['value']);
         });
     }
 
@@ -318,6 +320,8 @@ abstract class IteratorBuilder extends Builder
             if (is_null($value)) {
                 return false;
             }
+
+            $value = $value->copy()->setTimezone(config('app.timezone'));
 
             $compareValue = $value->copy()->setTimeFromTimeString($where['value']);
 

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -206,7 +206,7 @@ abstract class Builder extends BaseBuilder
                 return false;
             }
 
-            return $value->copy()->startOfDay()->$method($where['value']);
+            return $value->copy()->setTimezone(config('app.timezone'))->startOfDay()->$method($where['value']);
         });
     }
 
@@ -257,6 +257,8 @@ abstract class Builder extends BaseBuilder
             if (is_null($value)) {
                 return false;
             }
+
+            $value = $value->copy()->setTimezone(config('app.timezone'));
 
             $compareValue = $value->copy()->setTimeFromTimeString($where['value']);
 

--- a/src/Stache/Query/Builder.php
+++ b/src/Stache/Query/Builder.php
@@ -206,7 +206,9 @@ abstract class Builder extends BaseBuilder
                 return false;
             }
 
-            return $value->copy()->setTimezone(config('app.timezone'))->startOfDay()->$method($where['value']);
+            $value = $value->copy()->setTimezone(config('app.timezone'));
+
+            return $value->startOfDay()->$method($where['value']);
         });
     }
 

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -189,6 +189,19 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function entries_are_found_using_where_date_when_the_app_timezone_is_not_utc()
+    {
+        config()->set('app.timezone', 'Europe/Zurich');
+
+        $this->createWhereDateTestEntries();
+
+        $entries = Entry::query()->whereDate('test_date', Carbon::parse('2021-11-15', 'Europe/Zurich'))->get();
+
+        $this->assertCount(2, $entries);
+        $this->assertEquals(['Post 1', 'Post 3'], $entries->map->title->all());
+    }
+
+    #[Test]
     public function entries_are_found_using_where_month()
     {
         $this->createWhereDateTestEntries();
@@ -276,6 +289,19 @@ class EntryQueryBuilderTest extends TestCase
         $value = Carbon::create(2021, 11, 13, 12, 0, 0, 'Europe/Moscow');
 
         $entries = Entry::query()->whereTime('test_date', $value)->get();
+
+        $this->assertCount(1, $entries);
+        $this->assertEquals(['Post 2'], $entries->map->title->all());
+    }
+
+    #[Test]
+    public function entries_are_found_using_where_time_when_the_app_timezone_is_not_utc()
+    {
+        config()->set('app.timezone', 'Europe/Zurich');
+
+        $this->createWhereDateTestEntries();
+
+        $entries = Entry::query()->whereTime('test_date', Carbon::parse('2021-11-13 09:00', 'Europe/Zurich'))->get();
 
         $this->assertCount(1, $entries);
         $this->assertEquals(['Post 2'], $entries->map->title->all());

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -195,6 +195,8 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->createWhereDateTestEntries();
 
+        // The entries are indexed in UTC, so Post 3 (2021-11-15 00:00 in Zurich) is stored
+        // as 2021-11-14 23:00. It should still be found when querying for the 15th.
         $entries = Entry::query()->whereDate('test_date', Carbon::parse('2021-11-15', 'Europe/Zurich'))->get();
 
         $this->assertCount(2, $entries);
@@ -301,6 +303,8 @@ class EntryQueryBuilderTest extends TestCase
 
         $this->createWhereDateTestEntries();
 
+        // Post 2's 09:00 in Zurich (+01:00) is indexed as 08:00 in UTC, so it should
+        // still be found when querying for 09:00.
         $entries = Entry::query()->whereTime('test_date', Carbon::parse('2021-11-13 09:00', 'Europe/Zurich'))->get();
 
         $this->assertCount(1, $entries);

--- a/tests/Search/QueryBuilderTest.php
+++ b/tests/Search/QueryBuilderTest.php
@@ -137,6 +137,25 @@ class QueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function results_are_found_using_where_date_when_the_app_timezone_is_not_utc()
+    {
+        config()->set('app.timezone', 'Europe/Zurich');
+
+        // The indexed values are in UTC, so 'b' (2021-11-15 00:00 in Zurich) is stored
+        // as 2021-11-14 23:00. It should still be found when querying for the 15th.
+        $items = collect([
+            ['reference' => 'a', 'test_date' => Carbon::parse('2021-11-15 20:31:04', 'Europe/Zurich')->utc()],
+            ['reference' => 'b', 'test_date' => Carbon::parse('2021-11-15 00:00:00', 'Europe/Zurich')->utc()],
+            ['reference' => 'c', 'test_date' => Carbon::parse('2021-11-14 09:00:00', 'Europe/Zurich')->utc()],
+        ]);
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->whereDate('test_date', Carbon::parse('2021-11-15', 'Europe/Zurich'))->get();
+
+        $this->assertCount(2, $results);
+        $this->assertEquals(['a', 'b'], $results->map->reference->all());
+    }
+
+    #[Test]
     public function results_are_found_using_where_month()
     {
         $items = $this->createWhereDateTestItems();
@@ -198,6 +217,24 @@ class QueryBuilderTest extends TestCase
 
         $this->assertCount(2, $results);
         $this->assertEquals(['a', 'd'], $results->map->reference->all());
+    }
+
+    #[Test]
+    public function results_are_found_using_where_time_when_the_app_timezone_is_not_utc()
+    {
+        config()->set('app.timezone', 'Europe/Zurich');
+
+        // 'a' is at 09:00 in Zurich (+01:00), so it is indexed as 08:00 in UTC.
+        // It should still be found when querying for 09:00.
+        $items = collect([
+            ['reference' => 'a', 'test_date' => Carbon::parse('2021-11-14 09:00:00', 'Europe/Zurich')->utc()],
+            ['reference' => 'b', 'test_date' => Carbon::parse('2021-11-15 20:31:04', 'Europe/Zurich')->utc()],
+        ]);
+
+        $results = (new FakeQueryBuilder($items))->withoutData()->whereTime('test_date', Carbon::parse('2021-11-14 09:00', 'Europe/Zurich'))->get();
+
+        $this->assertCount(1, $results);
+        $this->assertEquals(['a'], $results->map->reference->all());
     }
 
     private function createWhereDateTestItems()


### PR DESCRIPTION
The Stache query builder never matches anything with `whereDate()` or `whereTime()` when `app.timezone` is set to something other than UTC. A knock-on effect is that scheduled entries stop getting published, since `MinuteEntries` is built on both of those methods.

The comparison value is normalised into the app timezone in `Statamic\Query\Builder`, but the indexed values are augmented dates and therefore in UTC. `filterWhereDate()` then calls `startOfDay()` on the UTC value, which lands on midnight UTC, while the comparison value sits at midnight in the app timezone. Those are two different instants, so with any non-zero offset the two sides can never line up. `filterWhereTime()` has the same problem: it applies the app timezone `H:i:s` string to a UTC value.

Converting the indexed value into the app timezone before comparing puts both sides on the same wall clock. `Statamic\Query\IteratorBuilder` carries a copy of the same logic, so search and item queries were affected too and are fixed alongside it.

Fixes #15336
