### PR TITLE
[6.x] Fix named slots rendering empty inside nested partials

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -1137,7 +1137,7 @@ class NodeProcessor
         $namedSlots = [];
 
         foreach ($node->children as $child) {
-            if ($child instanceof AntlersNode && ! $child->isComment && $child->name->name == 'slot') {
+            if ($child instanceof AntlersNode && ! $child->isComment && $child->isPaired() && $child->name->name == 'slot') {
                 $namedSlots[$child->name->methodPart] = $child;
             }
         }

--- a/tests/Antlers/Runtime/PartialsTest.php
+++ b/tests/Antlers/Runtime/PartialsTest.php
@@ -95,4 +95,27 @@ EOT;
 
         $this->assertSame('FILTERhi<slot>KEEPME</slot>', $this->renderString($template, [], true));
     }
+
+    public function test_named_slots_render_inside_a_nested_partial_that_uses_the_default_slot()
+    {
+        $template = <<<'EOT'
+{{ partial:accordion index="1" }}
+    {{ slot:title }}<h2>The Title</h2>{{ /slot:title }}
+    {{ slot:icon }}<button>+</button>{{ /slot:icon }}
+    {{ slot:body }}<p>The Body</p>{{ /slot:body }}
+{{ /partial:accordion }}
+EOT;
+
+        $accordion = <<<'EOT'
+<div id="accordion-{{ index }}">{{ partial:flex_column class="p-6" }}<div class="header">{{ slot:title }}{{ slot:icon }}</div><div class="content">{{ slot:body }}</div>{{ /partial:flex_column }}</div>
+EOT;
+
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('accordion', $accordion);
+        $this->viewShouldReturnRaw('flex_column', '<div class="flex flex-col {{ class }}">{{ slot }}</div>');
+
+        $expected = '<div id="accordion-1"><div class="flex flex-col p-6"><div class="header"><h2>The Title</h2><button>+</button></div><div class="content"><p>The Body</p></div></div></div>';
+
+        $this->assertSame($expected, $this->renderString($template, [], true));
+    }
 }


### PR DESCRIPTION
This pull request fixes an issue where named slots passed to a partial would render empty when that partial wrapped its body in another partial that uses `{{ slot }}`.

This was happening because `checkPartialForNamedSlots` treated *any* child node named `slot` as a named slot definition. The non-paired `{{ slot:title }}` output tags inside the inner partial pair were picked up as definitions, reduced to empty strings (they have no children) and overwrote the real slot content in the context passed to the inner partial.

This PR fixes it by only treating paired `{{ slot:name }}...{{ /slot:name }}` tags as named slot definitions.

Fixes #8437
