### PR TITLE
[6.x] Fix "Can't clear fields on user when storing users in a database"

### DIFF
--- a/src/Auth/Eloquent/User.php
+++ b/src/Auth/Eloquent/User.php
@@ -295,7 +295,15 @@ class User extends BaseUser
         }
 
         if ($value === null) {
-            unset($this->model()->$key);
+            // Only keep a null when the key is a real database column (i.e. it
+            // was loaded from the database). This lets an existing value be
+            // cleared out, while preventing non-column fields from being added
+            // as attributes, which would error when the model is saved.
+            if ($this->model()->exists && array_key_exists($key, $this->model()->getRawOriginal())) {
+                $this->model()->$key = null;
+            } else {
+                unset($this->model()->$key);
+            }
 
             return $this;
         }
@@ -316,7 +324,7 @@ class User extends BaseUser
     {
         $merged = $this->data()
             ->except(['roles', 'groups'])
-            ->merge(collect($data)->filter(fn ($v) => $v !== null)->all());
+            ->merge($data);
 
         $this->data($merged->all());
 

--- a/tests/Auth/Eloquent/EloquentUserTest.php
+++ b/tests/Auth/Eloquent/EloquentUserTest.php
@@ -355,6 +355,32 @@ class EloquentUserTest extends TestCase
     }
 
     #[Test]
+    public function it_clears_an_existing_database_column_when_set_to_null()
+    {
+        $user = $this->makeUser();
+        $user->set('avatar', 'hendrix.jpg')->save();
+
+        $this->assertSame('hendrix.jpg', Facades\User::find($user->id())->get('avatar'));
+
+        $user->set('avatar', null)->save();
+
+        $this->assertNull(Facades\User::find($user->id())->get('avatar'));
+    }
+
+    #[Test]
+    public function it_clears_an_existing_database_column_when_merged_with_null()
+    {
+        $user = $this->makeUser();
+        $user->set('avatar', 'hendrix.jpg')->save();
+
+        $this->assertSame('hendrix.jpg', Facades\User::find($user->id())->get('avatar'));
+
+        $user->merge(['avatar' => null])->save();
+
+        $this->assertNull(Facades\User::find($user->id())->get('avatar'));
+    }
+
+    #[Test]
     public function merge_does_not_set_roles_and_groups_as_model_attributes()
     {
         $user = $this->user();


### PR DESCRIPTION
Fix the bug that I introduced where eloquent user values can no longer be nulled.

Closes https://github.com/statamic/cms/issues/11921