### PR TITLE
[6.x] Trim asset border in small spaces

### DIFF
--- a/resources/css/components/assets.css
+++ b/resources/css/components/assets.css
@@ -132,7 +132,7 @@
 
 .asset-tile {
     @apply relative flex min-w-0 cursor-pointer flex-col items-center justify-between rounded-lg;
-    @container (width > 350px) {
+    @container (width > 300px) {
         @apply outline outline-gray-300 dark:outline-gray-700
     }
     /* Localize selection/hover layout work; avoid paint so selection outlines aren't clipped. */

--- a/resources/css/components/assets.css
+++ b/resources/css/components/assets.css
@@ -131,7 +131,10 @@
    ========================================================================== */
 
 .asset-tile {
-    @apply relative flex min-w-0 cursor-pointer flex-col items-center justify-between rounded-lg outline outline-gray-300 dark:outline-gray-700;
+    @apply relative flex min-w-0 cursor-pointer flex-col items-center justify-between rounded-lg;
+    @container (width > 350px) {
+        @apply outline outline-gray-300 dark:outline-gray-700
+    }
     /* Localize selection/hover layout work; avoid paint so selection outlines aren't clipped. */
     contain: layout;
 

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -24,11 +24,11 @@
         </asset-editor>
 
         <div class="flex h-full w-full justify-center rounded-b-md relative" :class="[
-            { 'border-b dark:border-gray-700': showFilename },
+            { '@min-[350px]:border-b dark:border-gray-700': showFilename },
             canBeTransparent && checkerboardMode !== 'transparent' ? `bg-checkerboard bg-checkerboard-${checkerboardMode} rounded-lg` : '',
             canBeTransparent && checkerboardMode === 'transparent' ? `bg-checkerboard before:opacity-0 hover:before:opacity-100 rounded-lg` : '',
         ]">
-            <div class="p-1 flex flex-col items-center justify-center h-full">
+            <div class="pb-1 @min-[350px]:p-1 flex flex-col items-center justify-center h-full">
                 <!-- Solo Bard -->
                 <template v-if="isImage && isInBardField && !isInAssetBrowser">
                     <img :src="asset.url" />

--- a/resources/js/components/fieldtypes/assets/AssetTile.vue
+++ b/resources/js/components/fieldtypes/assets/AssetTile.vue
@@ -24,11 +24,11 @@
         </asset-editor>
 
         <div class="flex h-full w-full justify-center rounded-b-md relative" :class="[
-            { '@min-[350px]:border-b dark:border-gray-700': showFilename },
+            { '@min-[300px]:border-b dark:border-gray-700': showFilename },
             canBeTransparent && checkerboardMode !== 'transparent' ? `bg-checkerboard bg-checkerboard-${checkerboardMode} rounded-lg` : '',
             canBeTransparent && checkerboardMode === 'transparent' ? `bg-checkerboard before:opacity-0 hover:before:opacity-100 rounded-lg` : '',
         ]">
-            <div class="pb-1 @min-[350px]:p-1 flex flex-col items-center justify-center h-full">
+            <div class="pb-1 @min-[300px]:p-1 flex flex-col items-center justify-center h-full">
                 <!-- Solo Bard -->
                 <template v-if="isImage && isInBardField && !isInAssetBrowser">
                     <img :src="asset.url" />

--- a/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
+++ b/resources/js/components/fieldtypes/assets/AssetsFieldtype.vue
@@ -127,10 +127,9 @@
                         @dragstart="$emit('focus')"
                     >
                         <div
-                            class="bg-white relative grid gap-4 2xl:gap-10 p-3 relative rounded-xl border border-gray-300 dark:bg-gray-850 dark:border-gray-700"
+                            class="bg-white relative grid @min-[300px]:grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-4 2xl:gap-10 p-3 relative rounded-xl border border-gray-300 dark:bg-gray-850 dark:border-gray-700"
                             :class="{ 'border-t-0 rounded-t-none': !isReadOnly && (showPicker || uploads.length), 'border-dashed': isReadOnly }"
                             ref="assets"
-                            style="grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));"
                         >
                             <asset-tile
                                 v-for="asset in assets"


### PR DESCRIPTION
## Description of the Problem

Asset borders are usually pleasant, for example here:

<img width="3420" height="1972" alt="2026-09-02 at 14 11 51@2x" src="https://github.com/user-attachments/assets/cfbd08c8-18fb-45bc-8280-db2c7a59e6d0" />

But in _very_ small container spaces they end up causing a lot of noise:

<img width="3420" height="1972" alt="2026-09-02 at 14 13 02@2x" src="https://github.com/user-attachments/assets/df769039-9d86-455f-9c68-ef4a010f0a38" />

## What this PR Does

Removes one the asset borders in small spaces

<img width="3420" height="1972" alt="2026-09-02 at 14 14 35@2x" src="https://github.com/user-attachments/assets/2383d8c1-3db6-4ac1-b847-8aa611bfddc2" />

## How to Reproduce

1. Make the asset container in a publish form very narrow to see before / after

<img width="1194" height="1972" alt="2026-09-02 at 14 19 26@2x" src="https://github.com/user-attachments/assets/7a2a3d97-4490-454a-9dd7-72c878018e2c" />