### PR TITLE
[6.x] Forms 2: Expose form sections, pages and access restrictions in the REST & GraphQL APIs

### DIFF
--- a/src/Forms/AugmentedForm.php
+++ b/src/Forms/AugmentedForm.php
@@ -11,7 +11,7 @@ class AugmentedForm extends AbstractAugmented
 {
     public function keys()
     {
-        $keys = ['handle', 'title', 'fields', 'sections', 'pages', 'status', 'api_url'];
+        $keys = ['handle', 'title', 'fields', 'sections', 'pages', 'status', 'require_login', 'restriction_message', 'api_url'];
 
         if (! Statamic::isApiRoute()) {
             $keys[] = 'honeypot';
@@ -44,5 +44,15 @@ class AugmentedForm extends AbstractAugmented
             'instructions' => $section->instructions(),
             'fields' => $section->fields()->all()->map->toArray()->all(),
         ];
+    }
+
+    public function requireLogin(): bool
+    {
+        return (bool) $this->data->get('require_login');
+    }
+
+    public function restrictionMessage(): ?string
+    {
+        return $this->data->status() === 'open' ? null : $this->data->restrictionMessage();
     }
 }

--- a/src/Forms/AugmentedForm.php
+++ b/src/Forms/AugmentedForm.php
@@ -3,18 +3,46 @@
 namespace Statamic\Forms;
 
 use Statamic\Data\AbstractAugmented;
+use Statamic\Fields\Section;
+use Statamic\Fields\Tab;
 use Statamic\Statamic;
 
 class AugmentedForm extends AbstractAugmented
 {
     public function keys()
     {
-        $keys = ['handle', 'title', 'fields', 'status', 'api_url'];
+        $keys = ['handle', 'title', 'fields', 'sections', 'pages', 'status', 'api_url'];
 
         if (! Statamic::isApiRoute()) {
             $keys[] = 'honeypot';
         }
 
         return $keys;
+    }
+
+    public function sections(): array
+    {
+        return $this->data->sections()
+            ->map(fn (Section $section) => $this->sectionToArray($section))
+            ->all();
+    }
+
+    public function pages(): array
+    {
+        return $this->data->pages()->map(fn (Tab $page) => [
+            'id' => $page->handle(),
+            'display' => $page->display(),
+            'instructions' => $page->instructions(),
+            'sections' => $page->sections()->map(fn (Section $section) => $this->sectionToArray($section))->all(),
+        ])->all();
+    }
+
+    private function sectionToArray(Section $section): array
+    {
+        return [
+            'display' => $section->display(),
+            'instructions' => $section->instructions(),
+            'fields' => $section->fields()->all()->map->toArray()->all(),
+        ];
     }
 }

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -4,6 +4,7 @@ namespace Statamic\Forms;
 
 use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Data\Augmented;
 use Statamic\Contracts\Forms\Form as FormContract;
@@ -27,6 +28,7 @@ use Statamic\Facades\FormSubmission;
 use Statamic\Facades\User;
 use Statamic\Facades\YAML;
 use Statamic\Fields\Blueprint;
+use Statamic\Fields\Tab;
 use Statamic\Forms\Exporters\Exporter;
 use Statamic\Forms\Fields\FormFields;
 use Statamic\Statamic;
@@ -302,14 +304,19 @@ class Form implements Arrayable, Augmentable, ContainsQueryableValues, FormContr
         return $this->fluentlyGetOrSet('email')->args(func_get_args());
     }
 
-    /**
-     * Get the form fields off the blueprint.
-     *
-     * @return \Illuminate\Support\Collection
-     */
-    public function fields()
+    public function fields(): Collection
     {
         return $this->blueprint()->fields()->all();
+    }
+
+    public function sections(): Collection
+    {
+        return $this->pages()->flatMap(fn (Tab $page) => $page->sections());
+    }
+
+    public function pages(): Collection
+    {
+        return $this->blueprint()->tabs()->values();
     }
 
     /**

--- a/src/GraphQL/TypeRegistrar.php
+++ b/src/GraphQL/TypeRegistrar.php
@@ -13,6 +13,7 @@ use Statamic\GraphQL\Types\CollectionType;
 use Statamic\GraphQL\Types\DateRangeType;
 use Statamic\GraphQL\Types\EntryInterface;
 use Statamic\GraphQL\Types\FieldType;
+use Statamic\GraphQL\Types\FormPageType;
 use Statamic\GraphQL\Types\FormType;
 use Statamic\GraphQL\Types\GlobalSetInterface;
 use Statamic\GraphQL\Types\JsonArgument;
@@ -66,6 +67,7 @@ class TypeRegistrar
         GraphQL::addType(GlobalSetInterface::class);
         GraphQL::addType(FieldType::class);
         GraphQL::addType(SectionType::class);
+        GraphQL::addType(FormPageType::class);
         GraphQL::addType(LinkValueType::class);
 
         PageInterface::addTypes();

--- a/src/GraphQL/Types/FormPageType.php
+++ b/src/GraphQL/Types/FormPageType.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Statamic\GraphQL\Types;
+
+use Statamic\Facades\GraphQL;
+
+class FormPageType extends \Rebing\GraphQL\Support\Type
+{
+    const NAME = 'FormPage';
+
+    protected $attributes = [
+        'name' => self::NAME,
+    ];
+
+    public function fields(): array
+    {
+        return [
+            'id' => [
+                'type' => GraphQL::nonNull(GraphQL::string()),
+                'resolve' => function ($page) {
+                    return $page->handle();
+                },
+            ],
+            'display' => [
+                'type' => GraphQL::string(),
+                'resolve' => function ($page) {
+                    return $page->display();
+                },
+            ],
+            'instructions' => [
+                'type' => GraphQL::string(),
+                'resolve' => function ($page) {
+                    return $page->instructions();
+                },
+            ],
+            'sections' => [
+                'type' => GraphQL::listOf(GraphQL::type(SectionType::NAME)),
+                'resolve' => function ($page) {
+                    return $page->sections()->all();
+                },
+            ],
+        ];
+    }
+}

--- a/src/GraphQL/Types/FormType.php
+++ b/src/GraphQL/Types/FormType.php
@@ -59,7 +59,13 @@ class FormType extends \Rebing\GraphQL\Support\Type
             'sections' => [
                 'type' => GraphQL::listOf(GraphQL::type(SectionType::NAME)),
                 'resolve' => function ($form, $args, $context, $info) {
-                    return $form->blueprint()->tabs()->first()->sections()->all();
+                    return $form->sections()->all();
+                },
+            ],
+            'pages' => [
+                'type' => GraphQL::listOf(GraphQL::type(FormPageType::NAME)),
+                'resolve' => function ($form, $args, $context, $info) {
+                    return $form->pages()->all();
                 },
             ],
         ])->map(function (array $arr) {

--- a/src/GraphQL/Types/FormType.php
+++ b/src/GraphQL/Types/FormType.php
@@ -30,6 +30,12 @@ class FormType extends \Rebing\GraphQL\Support\Type
             'status' => [
                 'type' => GraphQL::nonNull(GraphQL::string()),
             ],
+            'require_login' => [
+                'type' => GraphQL::nonNull(GraphQL::boolean()),
+            ],
+            'restriction_message' => [
+                'type' => GraphQL::string(),
+            ],
             'fields' => [
                 'type' => GraphQL::listOf(GraphQL::type(FieldType::NAME)),
                 'resolve' => function ($form, $args, $context, $info) {

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -5,6 +5,7 @@ namespace Tests\API;
 use Facades\Statamic\Console\Processes\Composer;
 use Facades\Statamic\CP\LivePreview;
 use Facades\Statamic\Fields\BlueprintRepository;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Storage;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
@@ -395,6 +396,40 @@ class APITest extends TestCase
                 ],
             ])
             ->assertJsonPath('data.sections.*.display', ['Your Details', null]);
+    }
+
+    #[Test]
+    public function it_queries_form_access_restrictions()
+    {
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(true);
+        Carbon::setTestNow('2026-07-06 12:00:00');
+
+        Facades\Config::set('statamic.api.resources.forms', true);
+
+        Facades\Form::make('contact')->save();
+        Facades\Form::make('members')->data(['require_login' => true])->save();
+        Facades\Form::make('applications')->data(['close_date' => '2026-07-01 09:00', 'closed_message' => 'Applications have closed.'])->save();
+
+        $this
+            ->get('/api/forms/contact')
+            ->assertSuccessful()
+            ->assertJsonPath('data.status', 'open')
+            ->assertJsonPath('data.require_login', false)
+            ->assertJsonPath('data.restriction_message', null);
+
+        $this
+            ->get('/api/forms/members')
+            ->assertSuccessful()
+            ->assertJsonPath('data.status', 'open')
+            ->assertJsonPath('data.require_login', true)
+            ->assertJsonPath('data.restriction_message', null);
+
+        $this
+            ->get('/api/forms/applications')
+            ->assertSuccessful()
+            ->assertJsonPath('data.status', 'closed')
+            ->assertJsonPath('data.require_login', false)
+            ->assertJsonPath('data.restriction_message', 'Applications have closed.');
     }
 
     #[Test]

--- a/tests/API/APITest.php
+++ b/tests/API/APITest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\API;
 
+use Facades\Statamic\Console\Processes\Composer;
 use Facades\Statamic\CP\LivePreview;
 use Facades\Statamic\Fields\BlueprintRepository;
 use Illuminate\Support\Facades\Storage;
@@ -280,6 +281,120 @@ class APITest extends TestCase
 
         $this->assertEndpointNotFound('/api/asset-containers/main');
         $this->assertEndpointSuccessful('/api/asset-containers/avatars');
+    }
+
+    #[Test]
+    public function it_queries_form_sections()
+    {
+        Facades\Config::set('statamic.api.resources.forms', true);
+
+        Facades\Form::make('contact')->title('Contact Us')->formFields([
+            'sections' => [
+                [
+                    'display' => 'Your Details',
+                    'instructions' => 'Tell us who you are',
+                    'fields' => [
+                        ['handle' => 'name', 'field' => ['type' => 'short_answer', 'display' => 'Your Name']],
+                    ],
+                ],
+                [
+                    'fields' => [
+                        ['handle' => 'message', 'field' => ['type' => 'long_answer', 'display' => 'Message', 'width' => 50]],
+                    ],
+                ],
+            ],
+        ])->save();
+
+        $this
+            ->get('/api/forms/contact')
+            ->assertSuccessful()
+            ->assertJsonPath('data.sections', [
+                [
+                    'display' => 'Your Details',
+                    'instructions' => 'Tell us who you are',
+                    'fields' => [
+                        'name' => ['type' => 'text', 'display' => 'Your Name', 'handle' => 'name', 'width' => 100],
+                    ],
+                ],
+                [
+                    'display' => null,
+                    'instructions' => null,
+                    'fields' => [
+                        'message' => ['type' => 'textarea', 'display' => 'Message', 'width' => 50, 'handle' => 'message'],
+                    ],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function it_queries_form_pages()
+    {
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(true);
+
+        Facades\Config::set('statamic.api.resources.forms', true);
+
+        Facades\Form::make('contact')->title('Contact Us')->formFields([
+            'pages' => [
+                [
+                    'id' => 'about_you',
+                    'display' => 'About You',
+                    'instructions' => 'Tell us who you are',
+                    'sections' => [
+                        [
+                            'display' => 'Your Details',
+                            'fields' => [
+                                ['handle' => 'name', 'field' => ['type' => 'short_answer', 'display' => 'Your Name']],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'your_message',
+                    'sections' => [
+                        [
+                            'fields' => [
+                                ['handle' => 'message', 'field' => ['type' => 'long_answer', 'display' => 'Message']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->save();
+
+        $this
+            ->get('/api/forms/contact')
+            ->assertSuccessful()
+            ->assertJsonPath('data.pages', [
+                [
+                    'id' => 'about_you',
+                    'display' => 'About You',
+                    'instructions' => 'Tell us who you are',
+                    'sections' => [
+                        [
+                            'display' => 'Your Details',
+                            'instructions' => null,
+                            'fields' => [
+                                'name' => ['type' => 'text', 'display' => 'Your Name', 'handle' => 'name', 'width' => 100],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'your_message',
+                    'display' => 'Page 2 of 2',
+                    'instructions' => null,
+                    'sections' => [
+                        [
+                            'display' => null,
+                            'instructions' => null,
+                            'fields' => [
+                                'message' => ['type' => 'textarea', 'display' => 'Message', 'handle' => 'message', 'width' => 100],
+                            ],
+                        ],
+                    ],
+                ],
+            ])
+            ->assertJsonPath('data.sections.*.display', ['Your Details', null]);
     }
 
     #[Test]

--- a/tests/Feature/GraphQL/FormTest.php
+++ b/tests/Feature/GraphQL/FormTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\GraphQL;
 
 use Facades\Statamic\API\ResourceAuthorizer;
+use Facades\Statamic\Console\Processes\Composer;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\GraphQL\CastableToValidationString;
@@ -308,6 +309,106 @@ GQL;
                                     'instructions' => null,
                                     'width' => 33,
                                     'config' => [],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]]);
+    }
+
+    #[Test]
+    public function it_queries_the_pages()
+    {
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(true);
+
+        Form::make('contact')->title('Contact Us')->formFields([
+            'pages' => [
+                [
+                    'id' => 'about_you',
+                    'display' => 'About You',
+                    'instructions' => 'Tell us who you are',
+                    'sections' => [
+                        [
+                            'display' => 'Your Details',
+                            'fields' => [
+                                ['handle' => 'name', 'field' => ['type' => 'short_answer', 'display' => 'Your Name']],
+                            ],
+                        ],
+                    ],
+                ],
+                [
+                    'id' => 'your_message',
+                    'sections' => [
+                        [
+                            'fields' => [
+                                ['handle' => 'message', 'field' => ['type' => 'long_answer', 'display' => 'Message']],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->save();
+
+        $query = <<<'GQL'
+{
+    form(handle: "contact") {
+        sections {
+            display
+        }
+        pages {
+            id
+            display
+            instructions
+            sections {
+                display
+                instructions
+                fields {
+                    handle
+                    type
+                }
+            }
+        }
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'form' => [
+                    'sections' => [
+                        ['display' => 'Your Details'],
+                        ['display' => null],
+                    ],
+                    'pages' => [
+                        [
+                            'id' => 'about_you',
+                            'display' => 'About You',
+                            'instructions' => 'Tell us who you are',
+                            'sections' => [
+                                [
+                                    'display' => 'Your Details',
+                                    'instructions' => null,
+                                    'fields' => [
+                                        ['handle' => 'name', 'type' => 'text'],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            'id' => 'your_message',
+                            'display' => 'Page 2 of 2',
+                            'instructions' => null,
+                            'sections' => [
+                                [
+                                    'display' => null,
+                                    'instructions' => null,
+                                    'fields' => [
+                                        ['handle' => 'message', 'type' => 'textarea'],
+                                    ],
                                 ],
                             ],
                         ],

--- a/tests/Feature/GraphQL/FormTest.php
+++ b/tests/Feature/GraphQL/FormTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\GraphQL;
 
 use Facades\Statamic\API\ResourceAuthorizer;
 use Facades\Statamic\Console\Processes\Composer;
+use Illuminate\Support\Carbon;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Contracts\GraphQL\CastableToValidationString;
@@ -413,6 +414,40 @@ GQL;
                             ],
                         ],
                     ],
+                ],
+            ]]);
+    }
+
+    #[Test]
+    public function it_queries_the_access_restrictions()
+    {
+        Composer::shouldReceive('isInstalled')->with('statamic/forms-pro')->andReturn(true);
+        Carbon::setTestNow('2026-07-06 12:00:00');
+
+        Form::make('contact')->save();
+        Form::make('members')->data(['require_login' => true])->save();
+        Form::make('applications')->data(['close_date' => '2026-07-01 09:00', 'closed_message' => 'Applications have closed.'])->save();
+
+        $query = <<<'GQL'
+{
+    forms {
+        handle
+        status
+        require_login
+        restriction_message
+    }
+}
+GQL;
+
+        $this
+            ->withoutExceptionHandling()
+            ->post('/graphql', ['query' => $query])
+            ->assertGqlOk()
+            ->assertExactJson(['data' => [
+                'forms' => [
+                    ['handle' => 'applications', 'status' => 'closed', 'require_login' => false, 'restriction_message' => 'Applications have closed.'],
+                    ['handle' => 'contact', 'status' => 'open', 'require_login' => false, 'restriction_message' => null],
+                    ['handle' => 'members', 'status' => 'open', 'require_login' => true, 'restriction_message' => null],
                 ],
             ]]);
     }


### PR DESCRIPTION
This pull request implements support for form `sections` in the REST API, and `pages` in both the REST and GraphQL APIs. The GraphQL API has had `sections` since #11466 but the REST API never got them, and neither API exposed pages.

`sections` returns every section across all pages, so it's the easy way to render a single-page form with the same structure as the Control Panel. `pages` returns each page's `id`, `display`, `instructions` and its `sections`, for rendering multi-page forms. Single-page forms return a single page.

This PR also fixes the GraphQL `sections` field only returning the first page's sections on multi-page forms.

## Access restrictions

This PR also exposes `require_login` and `restriction_message` alongside the existing `status`, so headless frontends can tell whether a form is currently accepting submissions and what to show when it isn't.

`restriction_message` only covers the closed and limit reached cases. The login case is deliberately left out, since the API can't know who is visiting a headless frontend. `require_login` is exposed as a plain boolean instead so the frontend can make that call itself.

## REST API

`GET /api/forms/contact`

```json
{
  "data": {
    "handle": "contact",
    "title": "Contact",
    "fields": { "name": {...}, "email": {...} },
    "sections": [
      { "display": "Your Details", "instructions": null, "fields": { "name": {...}, "email": {...} } }
    ],
    "pages": [
      { "id": "main", "display": "Page 1 of 1", "instructions": null, "sections": [...] }
    ],
    "status": "open",
    "require_login": false,
    "restriction_message": null,
    "api_url": "http://example.com/api/forms/contact"
  }
}
```

## GraphQL

```graphql
{
    form(handle: "contact") {
        status
        require_login
        restriction_message
        pages {
            id
            display
            instructions
            sections {
                display
                instructions
                fields { handle display }
            }
        }
    }
}
```

---

Closes statamic/ideas#1320
