### PR TITLE
[6.x] Forms 2: Scope submission counts and fake submissions to the selected site

### DIFF
--- a/src/Http/Controllers/CP/Forms/FormsController.php
+++ b/src/Http/Controllers/CP/Forms/FormsController.php
@@ -8,6 +8,7 @@ use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\CP\Column;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
+use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\Http\Controllers\CP\Forms\Concerns\ProvidesFormAbilities;
@@ -43,7 +44,7 @@ class FormsController extends CpController
                     'id' => $form->handle(),
                     'title' => __($form->title()),
                     'status' => $form->status(),
-                    'submissions' => $canViewSubmissions ? $form->querySubmissions()->whereNull('partial')->count() : null,
+                    'submissions' => $canViewSubmissions ? $form->querySubmissions()->where('site', Site::selected())->whereNull('partial')->count() : null,
                     'show_url' => $form->showUrl(),
                     'submissions_url' => $form->submissionsUrl(),
                     'edit_url' => $form->editUrl(),

--- a/src/Http/Controllers/CP/Forms/GenerateFakeSubmissionController.php
+++ b/src/Http/Controllers/CP/Forms/GenerateFakeSubmissionController.php
@@ -29,7 +29,7 @@ class GenerateFakeSubmissionController extends CpController
 
         $values = $generator->generate($form);
         $fields = $form->blueprint()->fields()->addValues($values);
-        $submission = $form->makeSubmission();
+        $submission = $form->makeSubmission()->site(Site::selected());
         $submission->data(
             $fields->process()->values()->merge([
                 '_fake' => true,
@@ -47,7 +47,7 @@ class GenerateFakeSubmissionController extends CpController
         $submission->save();
 
         if ($validated['mode'] === 'full_pipeline') {
-            SendEmails::dispatch($submission, Site::default());
+            SendEmails::dispatch($submission, $submission->site());
         }
 
         return response([

--- a/tests/Feature/Forms/GenerateFakeSubmissionTest.php
+++ b/tests/Feature/Forms/GenerateFakeSubmissionTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 use Statamic\Events\FormSubmitted;
 use Statamic\Facades\Blueprint;
 use Statamic\Facades\Form;
+use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Forms\SendEmails;
 use Tests\FakesRoles;
@@ -71,6 +72,26 @@ class GenerateFakeSubmissionTest extends TestCase
             ->assertSessionHas('error');
 
         $this->assertEquals(0, $form->querySubmissions()->count());
+    }
+
+    #[Test]
+    public function it_assigns_the_selected_site_to_the_fake_submission()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+        Site::setSelected('fr');
+
+        $form = $this->makeForm('contact');
+        $user = $this->userWithConfigureFormsPermission();
+
+        $this
+            ->actingAs($user)
+            ->post(cp_route('forms.submissions.generate-fake', $form->handle()), ['mode' => 'cp_only'])
+            ->assertOk();
+
+        $this->assertEquals('fr', $form->querySubmissions()->first()->site()->handle());
     }
 
     #[Test]

--- a/tests/Feature/Forms/ViewFormListingTest.php
+++ b/tests/Feature/Forms/ViewFormListingTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Forms;
 
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\Form;
+use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Tests\FakesRoles;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -167,6 +168,32 @@ class ViewFormListingTest extends TestCase
     }
 
     #[Test]
+    public function it_only_counts_submissions_in_the_selected_site()
+    {
+        $this->setSites([
+            'en' => ['url' => 'http://localhost/', 'locale' => 'en'],
+            'fr' => ['url' => 'http://localhost/fr/', 'locale' => 'fr'],
+        ]);
+        Site::setSelected('fr');
+
+        $this->setTestRoles(['test' => ['access cp', 'view form submissions']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+        $form = tap(Form::make('test'))->save();
+        $this->makeSubmission($form, 'en');
+        $this->makeSubmission($form, 'en');
+        $this->makeSubmission($form, 'fr');
+
+        $this
+            ->actingAs($user)
+            ->get(cp_route('forms.index'))
+            ->assertSuccessful()
+            ->assertInertia(fn ($page) => $page
+                ->component('forms/Index')
+                ->where('forms.0.submissions', 1)
+            );
+    }
+
+    #[Test]
     public function it_excludes_the_submission_count_when_the_user_cannot_view_submissions()
     {
         $this->setTestRoles(['test' => ['access cp', 'edit test form']]);
@@ -187,9 +214,9 @@ class ViewFormListingTest extends TestCase
             );
     }
 
-    private function makeSubmission($form)
+    private function makeSubmission($form, $site = null)
     {
-        $submission = $form->makeSubmission();
+        $submission = $form->makeSubmission()->site($site);
         $submission->data(['name' => 'John Doe']);
         $submission->save();
     }


### PR DESCRIPTION
This pull request fixes an issue where the forms index could show a submission count, but clicking through to the submissions listing showed nothing.

This was happening because the forms index counted submissions across all sites, while the submissions listing auto-applies the selected site filter. Any submissions belonging to another site were counted but never listed.

This PR fixes it by scoping the count on the forms index to the selected site, the same way the collections index does.

This PR also assigns the selected site to generated fake submissions. Previously they never had a site set, so they always resolved to the default site and disappeared from the listing whenever another site was selected. Emails for full pipeline fake submissions are now sent using the submission's site rather than the default site.