### PR TITLE
[6.x] Fix custom term templates on collection-scoped term URLs

### DIFF
--- a/src/Taxonomies/LocalizedTerm.php
+++ b/src/Taxonomies/LocalizedTerm.php
@@ -341,8 +341,8 @@ class LocalizedTerm implements Arrayable, ArrayAccess, Augmentable, BulkAugmenta
 
             $template = $this->taxonomy()->termTemplate();
 
-            if ($collection = $this->collection()) {
-                $template = $collection->handle().'.'.$template;
+            if ($this->collection() && ! $this->taxonomy()->hasCustomTermTemplate()) {
+                $template = $this->collection()->handle().'.'.$template;
             }
 
             return $template;

--- a/tests/Data/Taxonomies/TermTest.php
+++ b/tests/Data/Taxonomies/TermTest.php
@@ -432,6 +432,25 @@ class TermTest extends TestCase
     }
 
     #[Test]
+    public function it_gets_the_template_when_scoped_to_a_collection()
+    {
+        $taxonomy = tap(Taxonomy::make('tags'))->save();
+        $collection = tap(Facades\Collection::make('blog'))->save();
+        $term = (new Term)->taxonomy('tags')->collection($collection);
+
+        // defaults to collection.taxonomy.show
+        $this->assertEquals('blog.tags.show', $term->template());
+
+        // a custom taxonomy level template is used as-is
+        $taxonomy->termTemplate('foo');
+        $this->assertEquals('foo', $term->template());
+
+        // term level overrides the origin
+        $term->template('baz');
+        $this->assertEquals('baz', $term->template());
+    }
+
+    #[Test]
     public function it_fires_a_deleting_event()
     {
         Event::fake();

--- a/tests/Data/Taxonomies/ViewsTest.php
+++ b/tests/Data/Taxonomies/ViewsTest.php
@@ -200,6 +200,18 @@ class ViewsTest extends TestCase
     }
 
     #[Test]
+    public function it_loads_the_collection_specific_term_url_using_a_custom_term_template()
+    {
+        $this->mountBlogPageToBlogCollection();
+
+        $this->tagsTaxonomy->termTemplate('taxonomy.term')->save();
+
+        $this->viewShouldReturnRaw('taxonomy.term', 'custom {{ title }}');
+
+        $this->get('/the-blog/tags/test')->assertOk()->assertSee('custom Test');
+    }
+
+    #[Test]
     public function it_loads_the_localized_collection_specific_taxonomy_url_if_the_view_exists()
     {
         $this->mountBlogPageToBlogCollection();


### PR DESCRIPTION
This pull request fixes an issue where setting a custom term template on a taxonomy (eg. `term_template: taxonomy/term`) caused collection-scoped term URLs like `/blog/tags/foo` to 404, while `/tags/foo` and `/blog/tags` continued to work.

This was happening because `LocalizedTerm::template()` always prefixed the taxonomy's term template with the collection handle when the term was scoped to a collection, producing `blog.taxonomy/term`. That view never exists, so the `view()->exists()` check in `toResponse()` failed. The taxonomy index didn't have this problem since `Taxonomy::template()` already returns a custom template as-is.

This PR fixes it by only adding the collection prefix when the taxonomy is using its conventional default term template, so a custom `term_template` is used as-is for both `/tags/foo` and `/blog/tags/foo`.

Fixes #10478
