### PR TITLE
[6.x] Pass validation replacements when storing and updating terms

### DIFF
--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -167,14 +167,21 @@ class TermsController extends CpController
 
         $fields = $term->blueprint()->fields()->addValues($request->except('id'));
 
-        $fields->validate([
-            'title' => 'required',
-            'slug' => [
-                'required',
-                new Slug,
-                new UniqueTermValue(taxonomy: $taxonomy->handle(), except: $term->id(), site: $site->handle()),
-            ],
-        ]);
+        $fields
+            ->validator()
+            ->withRules([
+                'title' => 'required',
+                'slug' => [
+                    'required',
+                    new Slug,
+                    new UniqueTermValue(taxonomy: $taxonomy->handle(), except: $term->id(), site: $site->handle()),
+                ],
+            ])
+            ->withReplacements([
+                'id' => $term->id(),
+                'taxonomy' => $taxonomy->handle(),
+                'site' => $site->handle(),
+            ])->validate();
 
         $values = $fields->process()->values();
 
@@ -274,10 +281,16 @@ class TermsController extends CpController
 
         $fields = $blueprint->fields()->addValues($request->all());
 
-        $fields->validate([
-            'title' => 'required',
-            'slug' => ['required', new UniqueTermValue(taxonomy: $taxonomy->handle(), site: $site->handle())],
-        ]);
+        $fields
+            ->validator()
+            ->withRules([
+                'title' => 'required',
+                'slug' => ['required', new UniqueTermValue(taxonomy: $taxonomy->handle(), site: $site->handle())],
+            ])
+            ->withReplacements([
+                'taxonomy' => $taxonomy->handle(),
+                'site' => $site->handle(),
+            ])->validate();
 
         $values = $fields->process()->values()->except(['slug', 'blueprint']);
 

--- a/tests/Feature/Taxonomies/StoreTermTest.php
+++ b/tests/Feature/Taxonomies/StoreTermTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Feature\Taxonomies;
+
+use Facades\Statamic\Fields\BlueprintRepository;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blueprint;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
+use Statamic\Facades\User;
+use Tests\FakesRoles;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class StoreTermTest extends TestCase
+{
+    use FakesRoles, PreventSavingStacheItemsToDisk;
+
+    #[Test]
+    public function term_gets_created()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create tags terms']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        Taxonomy::make('tags')->save();
+
+        $this
+            ->actingAs($user)
+            ->store('tags', ['title' => 'Alfa', 'slug' => 'alfa'])
+            ->assertOk();
+
+        $this->assertEquals('Alfa', Term::find('tags::alfa')->title);
+    }
+
+    #[Test]
+    public function it_replaces_placeholders_in_blueprint_validation_rules()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'create tags terms']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        Taxonomy::make('tags')->save();
+        Taxonomy::make('categories')->save();
+        Term::make()->taxonomy('categories')->inDefaultLocale()->slug('alfa')->data(['title' => 'alfa'])->save();
+
+        $blueprint = Blueprint::makeFromFields([
+            'slug' => ['type' => 'slug', 'validate' => 'new \\Statamic\\Rules\\UniqueTermValue({taxonomy}, {id}, {site})'],
+        ]);
+
+        BlueprintRepository::partialMock();
+        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect([$blueprint]));
+
+        $this
+            ->actingAs($user)
+            ->store('tags', ['title' => 'Alfa', 'slug' => 'alfa'])
+            ->assertOk();
+
+        $this->assertEquals('Alfa', Term::find('tags::alfa')->title);
+    }
+
+    private function store($taxonomy, $attrs = [])
+    {
+        $payload = array_merge([
+            'title' => 'New term',
+            'slug' => 'new-term',
+        ], $attrs);
+
+        return $this->postJson(cp_route('taxonomies.terms.store', [$taxonomy, 'en']), $payload);
+    }
+}

--- a/tests/Feature/Taxonomies/UpdateTermTest.php
+++ b/tests/Feature/Taxonomies/UpdateTermTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Taxonomies;
 
+use Facades\Statamic\Fields\BlueprintRepository;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
@@ -71,6 +73,31 @@ class UpdateTermTest extends TestCase
         $this
             ->actingAs($user)
             ->update($term, ['title' => 'Updated alfa'])
+            ->assertOk();
+
+        $term = $term->fresh();
+        $this->assertEquals('Updated alfa', $term->title);
+    }
+
+    #[Test]
+    public function it_replaces_placeholders_in_blueprint_validation_rules()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'edit tags terms']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        Taxonomy::make('tags')->save();
+        $term = tap(Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alfa')->data(['title' => 'alfa']))->save();
+
+        $blueprint = Blueprint::makeFromFields([
+            'slug' => ['type' => 'slug', 'validate' => 'new \\Statamic\\Rules\\UniqueTermValue({taxonomy}, {id}, {site})'],
+        ]);
+
+        BlueprintRepository::partialMock();
+        BlueprintRepository::shouldReceive('in')->with('taxonomies/tags')->andReturn(collect([$blueprint]));
+
+        $this
+            ->actingAs($user)
+            ->update($term, ['title' => 'Updated alfa', 'slug' => 'alfa'])
             ->assertOk();
 
         $term = $term->fresh();


### PR DESCRIPTION
This pull request fixes an issue where a term blueprint using the `new \Statamic\Rules\UniqueTermValue({taxonomy}, {id}, {site})` rule would always fail validation with "This value has already been taken" when saving an existing term.

Statamic already enforces slug uniqueness itself in `TermsController`, with the real taxonomy, term ID and site passed to the rule. However, you might want to use the rule yourself on a custom field, and the `{taxonomy}`, `{id}` and `{site}` placeholders are the documented way to do that. Those placeholders are swapped in via `withReplacements()`, which `TermsController@update` and `store` never called, so they all resolved to `null`. With no `except` value, the rule matched the term being edited and failed. `EntriesController` and `UsersController` already pass their own replacements.

This PR fixes it by having `TermsController@update` and `store` build their validators via `$fields->validator()->withRules([...])->withReplacements([...])`, passing `id`, `taxonomy` and `site` on update, and `taxonomy` and `site` on store.

Fixes #10078