### PR TITLE
[6.x] Load installed starter kit config files into the running app

### DIFF
--- a/src/StarterKits/InstallableModule.php
+++ b/src/StarterKits/InstallableModule.php
@@ -74,9 +74,26 @@ final class InstallableModule extends Module
     {
         $this->installableFiles()->each(function ($toPath, $fromPath) {
             $this->installFile($fromPath, $toPath, $this->installer->console());
+            $this->loadInstalledConfig($toPath);
         });
 
         return $this;
+    }
+
+    /**
+     * Load installed config file into the running app, so later install steps see it.
+     */
+    private function loadInstalledConfig(string $path): void
+    {
+        $configPath = Path::tidy(config_path()).'/';
+
+        if (! Str::startsWith($path, $configPath) || ! Str::endsWith($path, '.php')) {
+            return;
+        }
+
+        $key = Str::of($path)->after($configPath)->beforeLast('.php')->replace('/', '.')->toString();
+
+        config()->set($key, array_merge(config($key, []), require $path));
     }
 
     /**

--- a/tests/StarterKits/InstallTest.php
+++ b/tests/StarterKits/InstallTest.php
@@ -119,6 +119,20 @@ class InstallTest extends TestCase
     }
 
     #[Test]
+    public function it_loads_installed_config_files_into_the_running_app()
+    {
+        $this->files->put($this->preparePath($this->kitRepoPath('config/statamic/hockey.php')), "<?php\n\nreturn ['rink' => 'calgary'];");
+
+        $this->assertNull(config('filesystems.disks.bobsled_pics'));
+        $this->assertNull(config('statamic.hockey'));
+
+        $this->installCoolRunnings();
+
+        $this->assertEquals('local', config('filesystems.disks.bobsled_pics.driver'));
+        $this->assertEquals('calgary', config('statamic.hockey.rink'));
+    }
+
+    #[Test]
     public function it_installs_from_github()
     {
         $this->assertFileDoesNotExist($this->kitVendorPath());


### PR DESCRIPTION
This pull request fixes an issue where installing a starter kit that ships extra filesystem disks (like Peak's `favicons` disk) would fail with `Disk [favicons] does not have a configured driver.` when creating the super user or updating the search index.

This was happening because the starter kit's config files are copied into the app mid-install, but the running process still holds the config it loaded at boot. Saving the first user rebuilds the CP search index, which walks every asset container, and the new container's disk isn't in `filesystems.disks` yet. The same thing happens when `search:update` runs after install.

This PR fixes it by loading each installed `config/*.php` file into the config repository as it's copied, using the same dotted key Laravel derives at boot (eg. `config/statamic/search.php` becomes `statamic.search`), so later install steps see the kit's config.

Fixes #9884
Fixes #11972