### PR TITLE
[6.x] Add --connection and --queue options to search:update

### DIFF
--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -16,7 +16,8 @@ class Update extends Command
     protected $signature = 'statamic:search:update
         { index? : The handle of the index to update. }
         { --all : Update all indexes. }
-        { --connection= : The queue connection used for indexing jobs. }';
+        { --connection= : The queue connection used for indexing jobs. }
+        { --queue= : The queue name used for indexing jobs. }';
 
     protected $description = 'Update a search index';
 
@@ -27,6 +28,10 @@ class Update extends Command
         foreach ($this->getIndexes() as $index) {
             if ($connection = $this->option('connection')) {
                 $index->onConnection($connection);
+            }
+
+            if ($queue = $this->option('queue')) {
+                $index->onQueue($queue);
             }
 
             $index->update();

--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -16,7 +16,7 @@ class Update extends Command
     protected $signature = 'statamic:search:update
         { index? : The handle of the index to update. }
         { --all : Update all indexes. }
-        { --sync : Index the documents immediately instead of queueing them. }';
+        { --queue= : The queue connection used for indexing jobs. }';
 
     protected $description = 'Update a search index';
 
@@ -25,8 +25,8 @@ class Update extends Command
     public function handle()
     {
         foreach ($this->getIndexes() as $index) {
-            if ($this->option('sync')) {
-                $index->withoutQueue();
+            if ($queue = $this->option('queue')) {
+                $index->onConnection($queue);
             }
 
             $index->update();

--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -15,7 +15,8 @@ class Update extends Command
 
     protected $signature = 'statamic:search:update
         { index? : The handle of the index to update. }
-        { --all : Update all indexes. }';
+        { --all : Update all indexes. }
+        { --sync : Index the documents immediately instead of queueing them. }';
 
     protected $description = 'Update a search index';
 
@@ -24,6 +25,10 @@ class Update extends Command
     public function handle()
     {
         foreach ($this->getIndexes() as $index) {
+            if ($this->option('sync')) {
+                $index->withoutQueue();
+            }
+
             $index->update();
 
             SearchIndexUpdated::dispatch($index);

--- a/src/Search/Commands/Update.php
+++ b/src/Search/Commands/Update.php
@@ -16,7 +16,7 @@ class Update extends Command
     protected $signature = 'statamic:search:update
         { index? : The handle of the index to update. }
         { --all : Update all indexes. }
-        { --queue= : The queue connection used for indexing jobs. }';
+        { --connection= : The queue connection used for indexing jobs. }';
 
     protected $description = 'Update a search index';
 
@@ -25,8 +25,8 @@ class Update extends Command
     public function handle()
     {
         foreach ($this->getIndexes() as $index) {
-            if ($queue = $this->option('queue')) {
-                $index->onConnection($queue);
+            if ($connection = $this->option('connection')) {
+                $index->onConnection($connection);
             }
 
             $index->update();

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -12,6 +12,7 @@ abstract class Index
     protected $handle;
     protected $locale;
     protected $config;
+    protected bool $shouldQueue = true;
     protected static ?Closure $nameCallback = null;
 
     abstract public function search($query);
@@ -98,11 +99,22 @@ abstract class Index
     {
         $documents
             ->chunk(config('statamic.search.chunk_size'))
-            ->each(fn ($documents) => InsertMultipleJob::dispatch(
-                name: $this->handle,
-                locale: $this->locale,
-                documents: $documents
-            ));
+            ->each(function ($documents) {
+                $job = new InsertMultipleJob(
+                    name: $this->handle,
+                    locale: $this->locale,
+                    documents: $documents
+                );
+
+                $this->shouldQueue ? dispatch($job) : dispatch_sync($job);
+            });
+
+        return $this;
+    }
+
+    public function withoutQueue()
+    {
+        $this->shouldQueue = false;
 
         return $this;
     }

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -12,7 +12,7 @@ abstract class Index
     protected $handle;
     protected $locale;
     protected $config;
-    protected bool $shouldQueue = true;
+    protected ?string $queueConnection = null;
     protected static ?Closure $nameCallback = null;
 
     abstract public function search($query);
@@ -106,15 +106,19 @@ abstract class Index
                     documents: $documents
                 );
 
-                $this->shouldQueue ? dispatch($job) : dispatch_sync($job);
+                if ($this->queueConnection) {
+                    $job->onConnection($this->queueConnection);
+                }
+
+                dispatch($job);
             });
 
         return $this;
     }
 
-    public function withoutQueue()
+    public function onConnection(string $connection)
     {
-        $this->shouldQueue = false;
+        $this->queueConnection = $connection;
 
         return $this;
     }

--- a/src/Search/Index.php
+++ b/src/Search/Index.php
@@ -12,6 +12,7 @@ abstract class Index
     protected $handle;
     protected $locale;
     protected $config;
+    protected ?string $queue = null;
     protected ?string $queueConnection = null;
     protected static ?Closure $nameCallback = null;
 
@@ -110,6 +111,10 @@ abstract class Index
                     $job->onConnection($this->queueConnection);
                 }
 
+                if ($this->queue) {
+                    $job->onQueue($this->queue);
+                }
+
                 dispatch($job);
             });
 
@@ -119,6 +124,13 @@ abstract class Index
     public function onConnection(string $connection)
     {
         $this->queueConnection = $connection;
+
+        return $this;
+    }
+
+    public function onQueue(string $queue)
+    {
+        $this->queue = $queue;
 
         return $this;
     }

--- a/tests/Search/Commands/UpdateTest.php
+++ b/tests/Search/Commands/UpdateTest.php
@@ -83,12 +83,12 @@ class UpdateTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_the_queue_connection_from_the_queue_option()
+    public function it_uses_the_queue_connection_from_the_connection_option()
     {
         $index = $this->fakeIndex();
         $index->shouldReceive('onConnection')->once()->with('sync')->andReturnSelf();
 
-        $this->artisan(Update::class, ['index' => 'test', '--queue' => 'sync'])->assertExitCode(0);
+        $this->artisan(Update::class, ['index' => 'test', '--connection' => 'sync'])->assertExitCode(0);
     }
 
     #[Test]

--- a/tests/Search/Commands/UpdateTest.php
+++ b/tests/Search/Commands/UpdateTest.php
@@ -74,21 +74,21 @@ class UpdateTest extends TestCase
     }
 
     #[Test]
-    public function it_queues_the_indexing_by_default()
+    public function it_uses_the_configured_queue_connection_by_default()
     {
         $index = $this->fakeIndex();
-        $index->shouldReceive('withoutQueue')->never();
+        $index->shouldReceive('onConnection')->never();
 
         $this->artisan(Update::class, ['index' => 'test'])->assertExitCode(0);
     }
 
     #[Test]
-    public function it_indexes_immediately_when_using_the_sync_option()
+    public function it_uses_the_queue_connection_from_the_queue_option()
     {
         $index = $this->fakeIndex();
-        $index->shouldReceive('withoutQueue')->once()->andReturnSelf();
+        $index->shouldReceive('onConnection')->once()->with('sync')->andReturnSelf();
 
-        $this->artisan(Update::class, ['index' => 'test', '--sync' => true])->assertExitCode(0);
+        $this->artisan(Update::class, ['index' => 'test', '--queue' => 'sync'])->assertExitCode(0);
     }
 
     #[Test]

--- a/tests/Search/Commands/UpdateTest.php
+++ b/tests/Search/Commands/UpdateTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Search\Commands;
 
+use Mockery;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Search;
 use Statamic\Search\Commands\Update;
 use Statamic\Search\Index;
 use Tests\TestCase;
@@ -15,6 +17,17 @@ class UpdateTest extends TestCase
         Index::resolveNameUsing(null);
 
         parent::tearDown();
+    }
+
+    private function fakeIndex()
+    {
+        $index = Mockery::mock(Index::class);
+        $index->shouldReceive('name')->andReturn('test');
+        $index->shouldReceive('update')->once();
+
+        Search::shouldReceive('indexes')->andReturn(collect(['test' => $index]));
+
+        return $index;
     }
 
     private function setUpIndexes()
@@ -58,6 +71,24 @@ class UpdateTest extends TestCase
             ->expectsOutputToContain('Index local_test_fr updated.')
             ->doesntExpectOutputToContain('Index local_cp_ updated.')
             ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_queues_the_indexing_by_default()
+    {
+        $index = $this->fakeIndex();
+        $index->shouldReceive('withoutQueue')->never();
+
+        $this->artisan(Update::class, ['index' => 'test'])->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_indexes_immediately_when_using_the_sync_option()
+    {
+        $index = $this->fakeIndex();
+        $index->shouldReceive('withoutQueue')->once()->andReturnSelf();
+
+        $this->artisan(Update::class, ['index' => 'test', '--sync' => true])->assertExitCode(0);
     }
 
     #[Test]

--- a/tests/Search/Commands/UpdateTest.php
+++ b/tests/Search/Commands/UpdateTest.php
@@ -78,6 +78,7 @@ class UpdateTest extends TestCase
     {
         $index = $this->fakeIndex();
         $index->shouldReceive('onConnection')->never();
+        $index->shouldReceive('onQueue')->never();
 
         $this->artisan(Update::class, ['index' => 'test'])->assertExitCode(0);
     }
@@ -89,6 +90,25 @@ class UpdateTest extends TestCase
         $index->shouldReceive('onConnection')->once()->with('sync')->andReturnSelf();
 
         $this->artisan(Update::class, ['index' => 'test', '--connection' => 'sync'])->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_uses_the_queue_from_the_queue_option()
+    {
+        $index = $this->fakeIndex();
+        $index->shouldReceive('onQueue')->once()->with('indexing')->andReturnSelf();
+
+        $this->artisan(Update::class, ['index' => 'test', '--queue' => 'indexing'])->assertExitCode(0);
+    }
+
+    #[Test]
+    public function it_uses_the_connection_and_queue_together()
+    {
+        $index = $this->fakeIndex();
+        $index->shouldReceive('onConnection')->once()->with('redis')->andReturnSelf();
+        $index->shouldReceive('onQueue')->once()->with('indexing')->andReturnSelf();
+
+        $this->artisan(Update::class, ['index' => 'test', '--connection' => 'redis', '--queue' => 'indexing'])->assertExitCode(0);
     }
 
     #[Test]

--- a/tests/Search/IndexTests.php
+++ b/tests/Search/IndexTests.php
@@ -70,4 +70,19 @@ trait IndexTests
             fn (InsertMultipleJob $job) => $job->name === 'test' && $job->locale === 'en'
         );
     }
+
+    #[Test]
+    public function it_dispatches_the_insert_job_synchronously_when_queueing_is_disabled()
+    {
+        Bus::fake();
+
+        $index = $this->getIndex('test', [], 'en');
+
+        $index->withoutQueue()->insertMultiple(collect(['foo::bar']));
+
+        Bus::assertDispatchedSync(
+            InsertMultipleJob::class,
+            fn (InsertMultipleJob $job) => $job->name === 'test' && $job->locale === 'en'
+        );
+    }
 }

--- a/tests/Search/IndexTests.php
+++ b/tests/Search/IndexTests.php
@@ -85,4 +85,19 @@ trait IndexTests
             fn (InsertMultipleJob $job) => $job->name === 'test' && $job->locale === 'en' && $job->connection === 'sync'
         );
     }
+
+    #[Test]
+    public function it_dispatches_the_insert_job_on_the_given_queue()
+    {
+        Bus::fake();
+
+        $index = $this->getIndex('test', [], 'en');
+
+        $index->onQueue('indexing')->insertMultiple(collect(['foo::bar']));
+
+        Bus::assertDispatched(
+            InsertMultipleJob::class,
+            fn (InsertMultipleJob $job) => $job->name === 'test' && $job->locale === 'en' && $job->queue === 'indexing'
+        );
+    }
 }

--- a/tests/Search/IndexTests.php
+++ b/tests/Search/IndexTests.php
@@ -72,17 +72,17 @@ trait IndexTests
     }
 
     #[Test]
-    public function it_dispatches_the_insert_job_synchronously_when_queueing_is_disabled()
+    public function it_dispatches_the_insert_job_on_the_given_queue_connection()
     {
         Bus::fake();
 
         $index = $this->getIndex('test', [], 'en');
 
-        $index->withoutQueue()->insertMultiple(collect(['foo::bar']));
+        $index->onConnection('sync')->insertMultiple(collect(['foo::bar']));
 
-        Bus::assertDispatchedSync(
+        Bus::assertDispatched(
             InsertMultipleJob::class,
-            fn (InsertMultipleJob $job) => $job->name === 'test' && $job->locale === 'en'
+            fn (InsertMultipleJob $job) => $job->name === 'test' && $job->locale === 'en' && $job->connection === 'sync'
         );
     }
 }


### PR DESCRIPTION
## Summary

We use the local search driver with zero-downtime deploys, and we run `statamic:search:update` on each deployment. If indexing stays on the default queue, the new release can go live before the search index is ready, so search is broken until a worker catches up.

`--connection` and `--queue` override the queue connection and queue name for that run. `--connection=sync` indexes inline, so when the deploy finishes, search is already ready. You can also send jobs to another connection and/or named queue without changing config.

Queueing on the configured connection and queue is still the default. Docs for the new flags belong in the statamic.dev repo.

## Test plan

- [ ] `php artisan statamic:search:update --connection=sync` rebuilds the index before the command exits
- [ ] `php artisan statamic:search:update --queue=indexing` puts jobs on that queue name
- [ ] Both flags can be used together
- [ ] With neither flag, indexing jobs still use the configured search connection and queue