### PR TITLE
[6.x] Fix Comb returning 500 when matched search token is longer than the configured snippet_length

### DIFF
--- a/src/Search/Comb/Comb.php
+++ b/src/Search/Comb/Comb.php
@@ -1077,13 +1077,13 @@ class Comb
             [, $before, $chunk, $after] = $match;
             $before = $surplus.$before;
             $surplus = '';
-            $half = floor(($length - Str::length($chunk)) / 2);
+            $half = max(0, floor(($length - Str::length($chunk)) / 2));
             if (Str::length($after) < $half) {
                 $snippet = $chunk.$after;
-                $snippet = Str::safeTruncateReverse($before, $length - Str::length($snippet)).$snippet;
+                $snippet = Str::safeTruncateReverse($before, max(0, $length - Str::length($snippet))).$snippet;
             } else {
                 $snippet = Str::safeTruncateReverse($before, $half).$chunk;
-                $trimmed = Str::safeTruncate($after, $length - Str::length($snippet));
+                $trimmed = Str::safeTruncate($after, max(0, $length - Str::length($snippet)));
                 $surplus = Str::substr($after, Str::length($trimmed));
                 $snippet = $snippet.$trimmed;
             }

--- a/tests/Search/CombTest.php
+++ b/tests/Search/CombTest.php
@@ -203,6 +203,36 @@ EOT;
     }
 
     #[Test]
+    public function it_extracts_snippets_when_the_term_is_longer_than_the_snippet_length()
+    {
+        // https://github.com/statamic/cms/issues/12951
+        $content = <<<'EOT'
+        We know, it was a long wait, but now we finally have it, support for OpenID
+        Connect front and back-channel logout. The backchannel_logout_session_required
+        flag can be set on a client. See backchannel_logout_uri too. The
+        frontchannel_logout_session_required flag is the front-channel equivalent, and
+        backchannel_logout_session_required appears once more right here.
+        EOT;
+
+        $comb = new Comb([
+            ['content' => $content],
+        ], ['snippet_length' => 30]);
+
+        try {
+            $results = $comb->lookUp('backchannel_logout_session_required');
+        } catch (NoResultsFound $e) {
+            $results = [];
+        }
+
+        $expected = [[
+            'backchannel_logout_session_required',
+            'backchannel_logout_session_required',
+        ]];
+
+        $this->assertEquals($expected, collect($results['data'] ?? [])->pluck('snippets.content')->all());
+    }
+
+    #[Test]
     public function it_can_search_for_plus_signs()
     {
         $comb = new Comb([


### PR DESCRIPTION
Fixes https://github.com/statamic/cms/issues/12951

### Background

  The offending token here is backchannel_logout_session_required — exactly 35 characters. The index sets snippet_length => 30.                                                                                                                        
                                                                                                                                                                                                                                                       
  Chain of events:                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                       
  1. Line 1080: $half = floor(($length - Str::length($chunk)) / 2) → floor((30 - 35) / 2) = -3 (negative).                                                                                                                                             
  2. Line 1085: Str::safeTruncateReverse($before, -3). A negative length defeats Stringy's safeTruncate — internally it does mb_substr($str, 0, $negativeLength), which keeps almost the whole string instead of trimming it. So $snippet is never bounded to snippet_length.                                                                                                                                                                                                                        
  3. Line 1087: $surplus = Str::substr($after, Str::length($trimmed)). Because $trimmed collapses to almost nothing, $surplus ends up being nearly the full $after (~31 chars), and it gets prepended to $before on the next loop iteration            
     (line 1078).                                                                                                                                                                                                                                      
  4. With the token recurring through the document (plus stemming/alternates), $snippet grows by ~one snippet-width per match — unbounded. In the reporter's content it reached ~2435 chars.                                                           
  5. Line 1086: Str::safeTruncate($after, $length - Str::length($snippet)) → safeTruncate($after, 30 - 2435) = safeTruncate($after, -2405). Stringy then calls mb_strpos($after, ' ', -2406, 'UTF-8'). $after is only " : true, ... } (~14 chars), so  the offset -2406 is way out of range → PHP 8's mb_strpos throws ValueError: Argument 3 ($offset) must be contained in argument 1. (On PHP 7 this only emitted a warning and returned false, so it wouldn't have 500'd.)                         
                                                                                                                                                                                                                                                       
  Why snippet_length = 35 fixed it: the token is 35 chars, so floor((35 - 35) / 2) = 0 — no longer negative, truncation works normally, $snippet stays bounded, surplus doesn't run away. Any snippet_length ≥ token length works; 34 would still break (floor(-0.5) = -1).


### Fix

Although this fixes it in Comb, there is an argument that it should be fixed in Stringy instead and negative truncates get clamped to 0.