### PR TITLE
[6.x] Fix Glide tag erroring when an asset cannot be resolved

### DIFF
--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -15,6 +15,7 @@ use Statamic\Facades\Glide as GlideManager;
 use Statamic\Facades\Image;
 use Statamic\Facades\Path;
 use Statamic\Facades\URL;
+use Statamic\Imaging\AssetNotFoundException;
 use Statamic\Imaging\ImageGenerator;
 use Statamic\Support\Str;
 
@@ -177,7 +178,15 @@ class Glide extends Tags
                 : $this->getGenerator()->generateByPath($item, $params);
         }
 
-        return $this->getGenerator()->generateByAsset(Asset::find($item), $params);
+        $asset = $item instanceof AssetContract ? $item : Asset::find((string) $item);
+
+        if (! $asset) {
+            throw new AssetNotFoundException(
+                sprintf('Could not generate a manipulated image from asset [%s]', $item)
+            );
+        }
+
+        return $this->getGenerator()->generateByAsset($asset, $params);
     }
 
     /**

--- a/src/Tags/Glide.php
+++ b/src/Tags/Glide.php
@@ -178,7 +178,7 @@ class Glide extends Tags
                 : $this->getGenerator()->generateByPath($item, $params);
         }
 
-        $asset = $item instanceof AssetContract ? $item : Asset::find((string) $item);
+        $asset = $item instanceof AssetContract ? $item : Asset::find($item);
 
         if (! $asset) {
             throw new AssetNotFoundException(
@@ -299,7 +299,7 @@ class Glide extends Tags
 
         // Double colons indicate an asset ID.
         if (Str::contains($item, '::')) {
-            return Asset::find($item);
+            return Asset::find($item) ?? $item;
         }
 
         // In a subfolder installation, the subfolder will likely be passed in

--- a/tests/Tags/GlideTest.php
+++ b/tests/Tags/GlideTest.php
@@ -56,6 +56,26 @@ class GlideTest extends TestCase
     }
 
     #[Test]
+    public function it_doesnt_error_when_an_asset_url_cannot_be_resolved()
+    {
+        $tag = <<<'EOT'
+{{ glide src="http://external.com/bar (1).jpg" width="100" }}{{ url }}{{ /glide }}
+EOT;
+
+        $this->assertSame('', (string) Parse::template($tag, trusted: true));
+    }
+
+    #[Test]
+    public function it_doesnt_error_when_an_asset_id_cannot_be_resolved()
+    {
+        $tag = <<<'EOT'
+{{ glide src="test::bar.jpg" width="100" }}{{ url }}{{ /glide }}
+EOT;
+
+        $this->assertSame('', (string) Parse::template($tag, trusted: true));
+    }
+
+    #[Test]
     public function it_outputs_a_data_url()
     {
         $this->createImageInPublicDirectory();

--- a/tests/Tags/GlideTest.php
+++ b/tests/Tags/GlideTest.php
@@ -56,11 +56,9 @@ class GlideTest extends TestCase
     }
 
     #[Test]
-    public function it_doesnt_error_when_an_asset_url_cannot_be_resolved()
+    public function it_doesnt_error_when_a_url_cannot_be_resolved_to_an_asset()
     {
-        $tag = <<<'EOT'
-{{ glide src="http://external.com/bar (1).jpg" width="100" }}{{ url }}{{ /glide }}
-EOT;
+        $tag = '{{ glide src="http://external.com/bar (1).jpg" width="100" }}{{ url }}{{ /glide }}';
 
         $this->assertSame('', (string) Parse::template($tag, trusted: true));
     }
@@ -68,9 +66,16 @@ EOT;
     #[Test]
     public function it_doesnt_error_when_an_asset_id_cannot_be_resolved()
     {
-        $tag = <<<'EOT'
-{{ glide src="test::bar.jpg" width="100" }}{{ url }}{{ /glide }}
-EOT;
+        $tag = '{{ glide src="test::bar.jpg" width="100" fit="crop_focal" }}{{ url }}{{ /glide }}';
+
+        $this->assertSame('', (string) Parse::template($tag, trusted: true));
+    }
+
+    #[Test]
+    #[DefineEnvironment('relativeRouteUrl')]
+    public function it_doesnt_error_when_an_asset_id_cannot_be_resolved_and_images_are_served_directly()
+    {
+        $tag = '{{ glide src="test::bar.jpg" width="100" }}{{ url }}{{ /glide }}';
 
         $this->assertSame('', (string) Parse::template($tag, trusted: true));
     }


### PR DESCRIPTION
When the Glide tag is given an asset that can't be resolved, the tag 500s the whole page instead of skipping the image. `normalizeItem()` returns null for an unresolvable asset ID, and that null then reaches `ImageGenerator::generateByAsset()`, which calls `isVideo()` on it, or `Asset::find()`, which rejects it against its `string` signature. Both are an `\Error` rather than an `\Exception`, so they slip past the `catch (\Exception)` in `Glide::generate()`. There are three ways to hit this today: the plain unresolvable ID, the same ID with `fit="crop_focal"`, and the same ID when the cache disk has a URL so images are served directly.

Every other failure inside that closure degrades gracefully, so these should too. `normalizeItem()` now keeps the original ID when it can't resolve it, which is what it already does for the URL branch a few lines down, and `generateImage()` throws an `AssetNotFoundException` when there's still no asset. The existing catch logs it and the image is skipped. That mirrors the guard `StaticUrlBuilder::generatePath()` already has for the same situation.

Keeping the ID also cleans up the single tag form, `{{ glide src="..." }}` without a closing tag. That one only builds a URL, so it never crashed, but it was passing the null down into `rawurlencode()` and triggering a deprecation on the way to a `/img?w=100` URL with no image in it.

Fixes #15359
