### PR TITLE
[6.x] Invalidate moved entries' new URLs when a collection tree is saved

### DIFF
--- a/src/StaticCaching/DefaultInvalidator.php
+++ b/src/StaticCaching/DefaultInvalidator.php
@@ -10,6 +10,7 @@ use Statamic\Contracts\Forms\Form;
 use Statamic\Contracts\Globals\Variables;
 use Statamic\Contracts\Structures\Nav;
 use Statamic\Contracts\Structures\NavTree;
+use Statamic\Facades;
 use Statamic\Facades\Antlers;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
@@ -270,6 +271,8 @@ class DefaultInvalidator implements Invalidator
     {
         $rules = $this->parseInvalidationRules(Arr::get($this->rules, "collections.{$tree->collection()->handle()}.urls", []));
 
+        $urls = $this->getMovedEntryUrls($tree);
+
         $absoluteUrls = $rules->filter(fn (string $rule) => URL::isAbsolute($rule))->all();
 
         $prefixedRelativeUrls = $rules
@@ -278,9 +281,22 @@ class DefaultInvalidator implements Invalidator
             ->all();
 
         return [
+            ...$urls,
             ...$absoluteUrls,
             ...$prefixedRelativeUrls,
         ];
+    }
+
+    private function getMovedEntryUrls($tree)
+    {
+        return collect($tree->diff()->ancestryChanged())
+            ->map(fn ($id) => Facades\Entry::find($id))
+            ->filter()
+            ->reject(fn ($entry) => $entry->isRedirect())
+            ->map->absoluteUrl()
+            ->filter()
+            ->values()
+            ->all();
     }
 
     private function parseInvalidationRules(array $rules, array $context = []): IlluminateCollection

--- a/tests/StaticCaching/DefaultInvalidatorTest.php
+++ b/tests/StaticCaching/DefaultInvalidatorTest.php
@@ -13,12 +13,14 @@ use Statamic\Contracts\Globals\GlobalSet;
 use Statamic\Contracts\Structures\Nav;
 use Statamic\Contracts\Taxonomies\Taxonomy;
 use Statamic\Contracts\Taxonomies\Term;
+use Statamic\Facades\Entry as EntryFacade;
 use Statamic\Facades\Site;
 use Statamic\Facades\URL;
 use Statamic\Globals\Variables;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\DefaultInvalidator as Invalidator;
 use Statamic\Structures\CollectionTree;
+use Statamic\Structures\CollectionTreeDiff;
 use Statamic\Structures\NavTree;
 use Statamic\Structures\Structure;
 use Statamic\Taxonomies\LocalizedTerm;
@@ -224,6 +226,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('structure')->andReturn($structure);
             $m->shouldReceive('collection')->andReturn($collection);
             $m->shouldReceive('site')->andReturn(Site::default());
+            $m->shouldReceive('diff')->andReturn(new CollectionTreeDiff);
         });
 
         $invalidator = new Invalidator($cacher, [
@@ -273,6 +276,7 @@ class DefaultInvalidatorTest extends TestCase
             $m->shouldReceive('structure')->andReturn($structure);
             $m->shouldReceive('collection')->andReturn($collection);
             $m->shouldReceive('site')->andReturn(Site::get('fr'));
+            $m->shouldReceive('diff')->andReturn(new CollectionTreeDiff);
         });
 
         $invalidator = new Invalidator($cacher, [
@@ -285,6 +289,56 @@ class DefaultInvalidatorTest extends TestCase
                         '/test/{test}',
                         '{{ if favourite_color == "purple" }}/purple{{ /if }}',
                         '{{ if favourite_color == "red" }}/red{{ /if }}',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertNull($invalidator->invalidate($tree));
+    }
+
+    #[Test]
+    public function moved_entry_urls_can_be_invalidated_by_a_tree()
+    {
+        $cacher = tap(Mockery::mock(Cacher::class), function ($cacher) {
+            $cacher->shouldReceive('invalidateUrls')->with([
+                'http://localhost/parent/child',
+                'http://localhost/blog/one',
+            ])->once();
+        });
+
+        $movedEntry = tap(Mockery::mock(Entry::class), function ($m) {
+            $m->shouldReceive('isRedirect')->andReturn(false);
+            $m->shouldReceive('absoluteUrl')->andReturn('http://localhost/parent/child');
+        });
+
+        $redirectEntry = tap(Mockery::mock(Entry::class), function ($m) {
+            $m->shouldReceive('isRedirect')->andReturn(true);
+        });
+
+        EntryFacade::shouldReceive('find')->with('child')->andReturn($movedEntry);
+        EntryFacade::shouldReceive('find')->with('redirect')->andReturn($redirectEntry);
+        EntryFacade::shouldReceive('find')->with('missing')->andReturnNull();
+
+        $diff = tap(Mockery::mock(CollectionTreeDiff::class), function ($m) {
+            $m->shouldReceive('ancestryChanged')->andReturn(['child', 'redirect', 'missing']);
+        });
+
+        $collection = tap(Mockery::mock(Collection::class), function ($m) {
+            $m->shouldReceive('handle')->andReturn('blog');
+        });
+
+        $tree = tap(Mockery::mock(CollectionTree::class), function ($m) use ($collection, $diff) {
+            $m->shouldReceive('collection')->andReturn($collection);
+            $m->shouldReceive('site')->andReturn(Site::default());
+            $m->shouldReceive('diff')->andReturn($diff);
+        });
+
+        $invalidator = new Invalidator($cacher, [
+            'collections' => [
+                'blog' => [
+                    'urls' => [
+                        '/blog/one',
                     ],
                 ],
             ],

--- a/tests/StaticCaching/HalfMeasureStaticCachingTest.php
+++ b/tests/StaticCaching/HalfMeasureStaticCachingTest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Queue;
 use Orchestra\Testbench\Attributes\DefineEnvironment;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Commands\StaticWarmJob;
+use Statamic\Facades\Collection;
 use Statamic\StaticCaching\Cacher;
 use Statamic\StaticCaching\Replacer;
 use Symfony\Component\HttpFoundation\Response;
@@ -293,6 +294,31 @@ class HalfMeasureStaticCachingTest extends TestCase
 
         // ...so the new page is served instead of the stale 404.
         $this->get('/about')->assertOk()->assertSee('The About Page');
+    }
+
+    #[Test]
+    public function moving_an_entry_in_the_tree_invalidates_the_cached_404_at_its_new_url()
+    {
+        \Illuminate\Support\Facades\Cache::flush();
+
+        $this->withStandardFakeViews();
+        $this->viewShouldReturnRaw('default', '{{ title }}');
+        $this->viewShouldReturnRaw('errors.404', '404 not found');
+
+        $collection = tap(Collection::make('pages')->routes('{parent_uri}/{slug}')->template('default'))->save();
+        $this->createPage('parent', ['with' => ['title' => 'The Parent Page']]);
+        $this->createPage('child', ['with' => ['title' => 'The Child Page']]);
+        $collection->structureContents(['root' => false])->save();
+        $collection->structure()->makeTree('en', [['entry' => 'parent'], ['entry' => 'child']])->save();
+
+        // Both pages are top level, so this URL 404s and the 404 gets cached.
+        $this->get('/parent/child')->assertNotFound();
+
+        // Moving the child page below the parent page makes the URL valid...
+        $collection->structure()->in('en')->tree([['entry' => 'parent', 'children' => [['entry' => 'child']]]])->save();
+
+        // ...so the page is served instead of the stale 404.
+        $this->get('/parent/child')->assertOk()->assertSee('The Child Page');
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where a statically cached 404 would keep being served after the collection tree was changed so that the URL became valid. For example, with half-measure static caching, visiting `/parent/child` while both pages are top level caches a 404, and moving `child` below `parent` in the tree leaves that 404 in place.

This was happening because #14386 only invalidates the URLs moved entries are leaving behind, which is done during `CollectionTreeSaving` while the old URLs can still be resolved. Nothing invalidated the URLs the entries are moving to, so any cached 404 at the new URL stuck around.

This PR fixes it by having the invalidator also invalidate the URLs of any entries whose ancestry changed when the tree is saved. By the time the `CollectionTreeSaved` event is handled, the entry URIs have already been updated, so the new URLs resolve correctly.

Fixes #10758