### PR TITLE
[6.x] Honour the COMPOSER env var when locating composer.json and its lock file

### DIFF
--- a/src/Console/Commands/MakeAddon.php
+++ b/src/Console/Commands/MakeAddon.php
@@ -3,6 +3,7 @@
 namespace Statamic\Console\Commands;
 
 use Facades\Statamic\Console\Processes\Composer;
+use Statamic\Console\Composer\Json as ComposerJson;
 use Statamic\Console\EnhancesCommands;
 use Statamic\Console\Processes\Exceptions\ProcessException;
 use Statamic\Console\RunsInPlease;
@@ -226,7 +227,7 @@ class MakeAddon extends GeneratorCommand
      */
     protected function addRepositoryPath()
     {
-        $decoded = json_decode($this->files->get(base_path('composer.json')), true);
+        $decoded = json_decode($this->files->get(ComposerJson::path()), true);
 
         $decoded['repositories'][] = [
             'type' => 'path',
@@ -235,7 +236,7 @@ class MakeAddon extends GeneratorCommand
 
         $json = json_encode($decoded, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
 
-        $this->files->put(base_path('composer.json'), $json);
+        $this->files->put(ComposerJson::path(), $json);
 
         $this->components->info("Repository added to your app's composer.json.");
         $this->components->bulletList([

--- a/src/Console/Composer/Json.php
+++ b/src/Console/Composer/Json.php
@@ -2,14 +2,28 @@
 
 namespace Statamic\Console\Composer;
 
+use Illuminate\Support\Env;
 use Statamic\Facades\File;
+use Statamic\Facades\Path;
 use Statamic\Support\Arr;
 
 class Json
 {
+    public static function filename(): string
+    {
+        return trim((string) Env::get('COMPOSER')) ?: 'composer.json';
+    }
+
+    public static function path(): string
+    {
+        $filename = static::filename();
+
+        return Path::isAbsolute($filename) ? $filename : base_path($filename);
+    }
+
     public static function isMissingPreUpdateCmd()
     {
-        $composerJson = json_decode(File::get(base_path('composer.json')), true);
+        $composerJson = json_decode(File::get(static::path()), true);
 
         $scripts = Arr::get($composerJson, 'scripts.pre-update-cmd', []);
 
@@ -22,7 +36,7 @@ class Json
             return false;
         }
 
-        $composerJson = File::get($path = base_path('composer.json'));
+        $composerJson = File::get($path = static::path());
 
         $preUpdateCmdScript = str_replace('\\', '\\\\\\', Scripts::class.'::preUpdateCmd');
 

--- a/src/Console/Composer/Lock.php
+++ b/src/Console/Composer/Lock.php
@@ -7,6 +7,7 @@ use Illuminate\Filesystem\Filesystem;
 use Statamic\Exceptions\ComposerLockFileNotFoundException;
 use Statamic\Exceptions\ComposerLockPackageNotFoundException;
 use Statamic\Facades\Path;
+use Statamic\Support\Str;
 use Statamic\UpdateScripts\UpdateScript;
 
 /**
@@ -20,11 +21,25 @@ class Lock
     /**
      * Instantiate lock file helper.
      */
-    public function __construct(string $file = 'composer.lock')
+    public function __construct(?string $file = null)
     {
+        $file ??= static::filename();
+
         $this->files = app(Filesystem::class);
 
         $this->path = Path::isAbsolute($file) ? $file : base_path($file);
+    }
+
+    /**
+     * Get the lock filename Composer derives from its configured composer.json filename.
+     */
+    public static function filename(): string
+    {
+        $json = Json::filename();
+
+        return Str::endsWith($json, '.json')
+            ? Str::replaceLast('.json', '.lock', $json)
+            : $json.'.lock';
     }
 
     /**
@@ -32,16 +47,26 @@ class Lock
      *
      * @return static
      */
-    public static function file(string $file = 'composer.lock')
+    public static function file(?string $file = null)
     {
         return new static($file);
     }
 
     /**
+     * Get the resolved lock file path.
+     */
+    public function path(): string
+    {
+        return $this->path;
+    }
+
+    /**
      * Backup lock file, using vanilla PHP so that this can be run in a Composer hook.
      */
-    public static function backup(string $file = 'composer.lock')
+    public static function backup(?string $file = null)
     {
+        $file ??= static::filename();
+
         if (! is_file($file)) {
             return;
         }

--- a/src/Console/Processes/Composer.php
+++ b/src/Console/Processes/Composer.php
@@ -4,6 +4,7 @@ namespace Statamic\Console\Processes;
 
 use Illuminate\Support\Facades\Cache;
 use Statamic\Console\Composer\Lock;
+use Statamic\Facades\Path;
 use Statamic\Jobs\RunComposer;
 use Statamic\Support\Str;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
@@ -48,7 +49,7 @@ class Composer extends Process
      */
     public function isInstalled(string $package)
     {
-        $lock = Lock::file($this->basePath.'composer.lock');
+        $lock = $this->lock();
 
         return $lock->exists() && $lock->isPackageInstalled($package);
     }
@@ -60,7 +61,7 @@ class Composer extends Process
      */
     public function installed()
     {
-        $lock = Lock::file($this->basePath.'composer.lock');
+        $lock = $this->lock();
 
         if (! $lock->exists()) {
             return collect();
@@ -83,7 +84,7 @@ class Composer extends Process
      */
     public function installedVersion(string $package)
     {
-        $lock = Lock::file($this->basePath.'composer.lock');
+        $lock = $this->lock();
 
         if (! $lock->exists()) {
             return null;
@@ -92,6 +93,13 @@ class Composer extends Process
         $version = $lock->getInstalledVersion($package);
 
         return $this->normalizeVersion($version);
+    }
+
+    private function lock(): Lock
+    {
+        $filename = Lock::filename();
+
+        return Lock::file(Path::isAbsolute($filename) ? $filename : $this->basePath.$filename);
     }
 
     /**

--- a/src/StarterKits/ExportableModule.php
+++ b/src/StarterKits/ExportableModule.php
@@ -4,6 +4,7 @@ namespace Statamic\StarterKits;
 
 use Exception;
 use Illuminate\Support\Collection;
+use Statamic\Console\Composer\Json as ComposerJson;
 use Statamic\StarterKits\Exceptions\StarterKitException;
 use Statamic\Support\Str;
 
@@ -78,7 +79,7 @@ class ExportableModule extends Module
      */
     protected function exportDependenciesFromComposerRequire(string $requireKey, Collection $exportableDependencies): mixed
     {
-        $composerJson = json_decode($this->files->get(base_path('composer.json')), true);
+        $composerJson = json_decode($this->files->get(ComposerJson::path()), true);
 
         $dependencies = collect($composerJson[$requireKey] ?? [])
             ->filter(function ($version, $dependency) use ($exportableDependencies) {
@@ -134,7 +135,7 @@ class ExportableModule extends Module
      */
     protected function ensureExportableDependenciesExist(): self
     {
-        $installedDependencies = collect(json_decode($this->files->get(base_path('composer.json')), true))
+        $installedDependencies = collect(json_decode($this->files->get(ComposerJson::path()), true))
             ->only(['require', 'require-dev'])
             ->map(fn ($dependencies) => array_keys($dependencies))
             ->flatten();

--- a/src/StarterKits/Installer.php
+++ b/src/StarterKits/Installer.php
@@ -8,6 +8,7 @@ use Facades\Statamic\StarterKits\Hook;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Http;
+use Statamic\Console\Composer\Json as ComposerJson;
 use Statamic\Console\NullConsole;
 use Statamic\Console\Please\Application as PleaseApplication;
 use Statamic\Console\Processes\Exceptions\ProcessException;
@@ -184,7 +185,7 @@ final class Installer
      */
     protected function backupComposerJson(): self
     {
-        $this->files->copy(base_path('composer.json'), base_path('composer.json.bak'));
+        $this->files->copy(ComposerJson::path(), ComposerJson::path().'.bak');
 
         return $this;
     }
@@ -222,7 +223,7 @@ final class Installer
             return $this;
         }
 
-        $composerJson = json_decode($this->files->get(base_path('composer.json')), true);
+        $composerJson = json_decode($this->files->get(ComposerJson::path()), true);
 
         $composerJson['repositories'][] = [
             'type' => 'vcs',
@@ -230,7 +231,7 @@ final class Installer
         ];
 
         $this->files->put(
-            base_path('composer.json'),
+            ComposerJson::path(),
             json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
         );
 
@@ -588,7 +589,7 @@ EOT;
      */
     protected function removeComposerJsonBackup(): self
     {
-        $this->files->delete(base_path('composer.json.bak'));
+        $this->files->delete(ComposerJson::path().'.bak');
 
         return $this;
     }
@@ -612,7 +613,7 @@ EOT;
             return $this;
         }
 
-        $composerJson = json_decode($this->files->get(base_path('composer.json')), true);
+        $composerJson = json_decode($this->files->get(ComposerJson::path()), true);
 
         $repositories = collect($composerJson['repositories'])->reject(function ($repository) {
             return isset($repository['url']) && $repository['url'] === $this->url;
@@ -625,7 +626,7 @@ EOT;
         }
 
         $this->files->put(
-            base_path('composer.json'),
+            ComposerJson::path(),
             json_encode($composerJson, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
         );
 
@@ -637,7 +638,7 @@ EOT;
      */
     protected function restoreComposerJson(): self
     {
-        $this->files->copy(base_path('composer.json.bak'), base_path('composer.json'));
+        $this->files->copy(ComposerJson::path().'.bak', ComposerJson::path());
 
         return $this;
     }

--- a/src/UpdateScripts/Manager.php
+++ b/src/UpdateScripts/Manager.php
@@ -40,7 +40,7 @@ class Manager
      */
     public function runUpdatesForSpecificPackageVersion($package, $oldVersion, $console = null)
     {
-        Lock::backup(base_path('composer.lock'));
+        Lock::backup(Lock::file()->path());
 
         $newLockFile = Lock::file();
         $oldLockFile = Lock::file(UpdateScript::BACKUP_PATH)->overridePackageVersion($package, $oldVersion);

--- a/tests/Composer/ComposerJsonTest.php
+++ b/tests/Composer/ComposerJsonTest.php
@@ -34,6 +34,10 @@ class ComposerJsonTest extends TestCase
     {
         $this->restore();
 
+        unset($_ENV['COMPOSER']);
+
+        $this->files->delete(base_path('composer.testing.json'));
+
         parent::tearDown();
     }
 
@@ -52,6 +56,64 @@ class ComposerJsonTest extends TestCase
         ]));
 
         $this->assertFalse(Json::isMissingPreUpdateCmd());
+    }
+
+    #[Test]
+    public function it_reads_the_composer_json_named_by_the_composer_env_var()
+    {
+        $_ENV['COMPOSER'] = 'composer.testing.json';
+
+        $this->assertEquals(base_path('composer.testing.json'), Json::path());
+        $this->assertTrue(Json::isMissingPreUpdateCmd());
+
+        $this->files->put(base_path('composer.testing.json'), json_encode([
+            'scripts' => [
+                'pre-update-cmd' => [
+                    Scripts::class.'::preUpdateCmd',
+                ],
+            ],
+        ]));
+
+        $this->assertFalse(Json::isMissingPreUpdateCmd());
+    }
+
+    #[Test]
+    public function it_adds_pre_update_cmd_to_the_composer_json_named_by_the_composer_env_var()
+    {
+        $_ENV['COMPOSER'] = 'composer.testing.json';
+
+        $original = $this->files->get($this->path);
+
+        $this->files->put(base_path('composer.testing.json'), <<<'EOT'
+{
+    "scripts": {
+        "post-autoload-dump": [
+            "@php artisan package:discover --ansi"
+        ]
+    }
+}
+EOT
+        );
+
+        Json::addPreUpdateCmd();
+
+        $this->assertFalse(Json::isMissingPreUpdateCmd());
+        $this->assertEquals($original, $this->files->get($this->path));
+
+        $expected = <<<'EOT'
+{
+    "scripts": {
+        "pre-update-cmd": [
+            "Statamic\\Console\\Composer\\Scripts::preUpdateCmd"
+        ],
+        "post-autoload-dump": [
+            "@php artisan package:discover --ansi"
+        ]
+    }
+}
+EOT;
+
+        $this->assertEquals($expected, $this->files->get(base_path('composer.testing.json')));
     }
 
     #[Test]

--- a/tests/Composer/ComposerLockBackupTest.php
+++ b/tests/Composer/ComposerLockBackupTest.php
@@ -11,6 +11,7 @@ use Statamic\Console\Composer\Lock;
 class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
 {
     protected $lockPath = './composer.lock';
+    protected $envLockPath = './composer.testing.lock';
     protected $customLockPath = './custom/composer.lock';
     protected $backupLockPath = './storage/statamic/updater/composer.lock.bak';
     protected $customBackupLockPath = './custom/storage/statamic/updater/composer.lock.bak';
@@ -26,6 +27,8 @@ class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
     {
         $this->removeLockFiles();
 
+        unset($_ENV['COMPOSER']);
+
         parent::tearDown();
     }
 
@@ -36,6 +39,20 @@ class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFileExists($this->lockPath);
         $this->assertFileDoesNotExist($this->backupLockPath);
+
+        Lock::backup();
+
+        $this->assertFileExists($this->backupLockPath);
+        $this->assertEquals($content, file_get_contents($this->backupLockPath));
+    }
+
+    #[Test]
+    public function it_backs_up_the_lock_file_named_by_the_composer_env_var()
+    {
+        $_ENV['COMPOSER'] = 'composer.testing.json';
+
+        file_put_contents($this->lockPath, 'default lock file content');
+        file_put_contents($this->envLockPath, $content = 'env lock file content');
 
         Lock::backup();
 
@@ -73,6 +90,7 @@ class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
     {
         $files = [
             $this->lockPath,
+            $this->envLockPath,
             $this->customLockPath,
             $this->backupLockPath,
             $this->customBackupLockPath,

--- a/tests/Composer/ComposerLockTest.php
+++ b/tests/Composer/ComposerLockTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Composer;
 
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Composer\Lock;
 use Statamic\Exceptions\ComposerLockFileNotFoundException;
@@ -15,6 +16,7 @@ class ComposerLockTest extends TestCase
 {
     private $files;
     private $lockPath;
+    private $envLockPath;
     private $previousLockPath;
 
     public function setUp(): void
@@ -24,6 +26,7 @@ class ComposerLockTest extends TestCase
         $this->files = app(Filesystem::class);
 
         $this->lockPath = base_path('composer.lock');
+        $this->envLockPath = base_path('composer.testing.lock');
         $this->previousLockPath = storage_path('statamic/updater/composer.lock.bak');
 
         $this->removeLockFiles();
@@ -32,6 +35,8 @@ class ComposerLockTest extends TestCase
     public function tearDown(): void
     {
         $this->removeLockFiles();
+
+        unset($_ENV['COMPOSER']);
 
         parent::tearDown();
     }
@@ -44,6 +49,41 @@ class ComposerLockTest extends TestCase
         PackToTheFuture::generateComposerLock('package/one', '1.0.0', $this->lockPath);
 
         $this->assertTrue(Lock::file()->exists());
+    }
+
+    #[Test]
+    #[DataProvider('composerEnvProvider')]
+    public function it_derives_lock_filename_from_composer_env_var($composerEnv, $expectedFilename)
+    {
+        if ($composerEnv) {
+            $_ENV['COMPOSER'] = $composerEnv;
+        }
+
+        $this->assertEquals($expectedFilename, Lock::filename());
+        $this->assertEquals(base_path($expectedFilename), Lock::file()->path());
+    }
+
+    public static function composerEnvProvider()
+    {
+        return [
+            'unset' => [null, 'composer.lock'],
+            'json extension' => ['composer.testing.json', 'composer.testing.lock'],
+            'no extension' => ['composer-testing', 'composer-testing.lock'],
+        ];
+    }
+
+    #[Test]
+    public function it_reads_the_lock_file_named_by_the_composer_env_var()
+    {
+        $_ENV['COMPOSER'] = 'composer.testing.json';
+
+        $this->assertFalse(Lock::file()->exists());
+
+        PackToTheFuture::generateComposerLock('package/one', '2.0.0', $this->lockPath);
+        PackToTheFuture::generateComposerLock('package/one', '1.0.0', $this->envLockPath);
+
+        $this->assertTrue(Lock::file()->exists());
+        $this->assertEquals('1.0.0', Lock::file()->getInstalledVersion('package/one'));
     }
 
     #[Test]
@@ -192,7 +232,7 @@ class ComposerLockTest extends TestCase
 
     private function removeLockFiles()
     {
-        foreach ([$this->lockPath, $this->previousLockPath] as $lockFile) {
+        foreach ([$this->lockPath, $this->envLockPath, $this->previousLockPath] as $lockFile) {
             if ($this->files->exists($lockFile)) {
                 $this->files->delete($lockFile);
             }

--- a/tests/Composer/ComposerTest.php
+++ b/tests/Composer/ComposerTest.php
@@ -43,10 +43,13 @@ class ComposerTest extends TestCase
             return;
         }
 
+        unset($_ENV['COMPOSER']);
+
         $this->files->deleteDirectory($this->basePath('tmp'));
         $this->files->deleteDirectory($this->basePath('vendor'));
         $this->files->delete($this->basePath('composer.json'));
         $this->files->delete($this->basePath('composer.lock'));
+        $this->files->delete($this->basePath('composer.testing.lock'));
         $this->files->move($this->basePath('composer.lock.bak'), $this->basePath('composer.lock'));
         $this->files->move($this->basePath('composer.json.bak'), $this->basePath('composer.json'));
 
@@ -74,6 +77,19 @@ class ComposerTest extends TestCase
     #[Test]
     public function it_can_get_installed_version_of_a_package_directly_from_composer_lock()
     {
+        $this->assertEquals('1.2.3', Composer::installedVersion('statamic/composer-test-example-dependency'));
+    }
+
+    #[Group('integration')]
+    #[Test]
+    public function it_gets_installed_version_from_the_lock_file_named_by_the_composer_env_var()
+    {
+        $_ENV['COMPOSER'] = 'composer.testing.json';
+
+        $this->assertNull(Composer::installedVersion('statamic/composer-test-example-dependency'));
+
+        $this->files->move($this->basePath('composer.lock'), $this->basePath('composer.testing.lock'));
+
         $this->assertEquals('1.2.3', Composer::installedVersion('statamic/composer-test-example-dependency'));
     }
 


### PR DESCRIPTION
This pull request fixes an issue where Statamic would error when the `COMPOSER` environment variable points Composer at a different `composer.json` file (eg. `COMPOSER=composer.local.json`).

This was happening because Statamic hard-coded `composer.json` and `composer.lock` paths. Composer names the lock file after the configured JSON file (`composer.local.json` → `composer.local.lock`), so `Version::get()` couldn't find a lock file and threw on every request, and `statamic:install` reported a missing `pre-update-cmd` hook because it was reading a `composer.json` that no longer existed.

This PR fixes it by resolving the filenames the same way Composer does. `Json::filename()` reads the `COMPOSER` environment variable (falling back to `composer.json`) and `Lock::filename()` derives the lock filename from it. Everywhere Statamic previously assumed `composer.json` or `composer.lock` now goes through these, including the update scripts, starter kit installer/exporter and `make:addon`.

Fixes #10592
