### PR TITLE
[6.x] Move nocache views to Statamic temporary storage

### DIFF
--- a/src/Providers/ViewServiceProvider.php
+++ b/src/Providers/ViewServiceProvider.php
@@ -425,7 +425,7 @@ PHP;
 
     public function boot()
     {
-        ViewFactory::addNamespace('compiled__views', storage_path('framework/views'));
+        ViewFactory::addNamespace('compiled__views', storage_path('statamic/tmp/nocache'));
 
         Region::preserveContextKeys(IncludeTag::VIEW_DATA_KEYS);
 

--- a/src/StaticCaching/NoCache/StringFragment.php
+++ b/src/StaticCaching/NoCache/StringFragment.php
@@ -20,7 +20,7 @@ class StringFragment
         $this->contents = $contents;
         $this->extension = $extension;
         $this->data = $data;
-        $this->directory = config('view.compiled').'/nocache';
+        $this->directory = storage_path('statamic/tmp/nocache');
     }
 
     public function render(): string

--- a/src/View/Blade/AntlersBladePrecompiler.php
+++ b/src/View/Blade/AntlersBladePrecompiler.php
@@ -3,6 +3,7 @@
 namespace Statamic\View\Blade;
 
 use Illuminate\Support\Str;
+use Statamic\Facades\File;
 
 class AntlersBladePrecompiler
 {
@@ -27,7 +28,7 @@ class AntlersBladePrecompiler
             $contentHash = sha1($innerContent);
             $fileName = 'antlers_'.$contentHash;
 
-            file_put_contents(storage_path('framework/views/'.$fileName.'.antlers.html'), $innerContent);
+            File::put(storage_path('statamic/tmp/nocache/'.$fileName.'.antlers.html'), $innerContent);
 
             $content = str_replace($original, '@include(\'compiled__views::'.$fileName.'\')', $content);
         }

--- a/src/View/Blade/Concerns/CompilesNocache.php
+++ b/src/View/Blade/Concerns/CompilesNocache.php
@@ -2,6 +2,7 @@
 
 namespace Statamic\View\Blade\Concerns;
 
+use Statamic\Facades\File;
 use Statamic\View\Blade\StatamicTagCompiler;
 use Stillat\BladeParser\Nodes\Components\ComponentNode;
 
@@ -11,8 +12,8 @@ trait CompilesNocache
     {
         $compiled = (new StatamicTagCompiler())->compile($component->innerDocumentContent);
         $viewName = '_nocache'.sha1($compiled);
-        $path = storage_path('framework/views/'.$viewName.'.blade.php');
-        file_put_contents($path, $compiled);
+        $path = storage_path('statamic/tmp/nocache/'.$viewName.'.blade.php');
+        File::put($path, $compiled);
 
         return '@nocache(\'compiled__views::'.$viewName.'\')';
     }

--- a/tests/StaticCaching/IncludeNocacheTest.php
+++ b/tests/StaticCaching/IncludeNocacheTest.php
@@ -39,11 +39,13 @@ class IncludeNocacheTest extends TestCase
 
     private function setUpBladeViews(array $views)
     {
+        app('files')->cleanDirectory(config('view.compiled'));
+
         foreach ($views as $name => $contents) {
             $this->viewShouldReturnRaw($name, $contents, 'blade.php');
         }
 
-        view()->addNamespace('compiled__views', storage_path('framework/views'));
+        view()->addNamespace('compiled__views', storage_path('statamic/tmp/nocache'));
     }
 
     private function renderTwice(string $layout, array $views): array

--- a/tests/StaticCaching/StringFragmentTest.php
+++ b/tests/StaticCaching/StringFragmentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\StaticCaching;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\StaticCaching\NoCache\StringFragment;
+use Tests\TestCase;
+
+class StringFragmentTest extends TestCase
+{
+    #[Test]
+    public function it_writes_temporary_views_to_statamic_storage()
+    {
+        $compiledViewDirectory = storage_path('framework/views/string-fragment-'.uniqid());
+
+        config()->set('view.compiled', $compiledViewDirectory);
+
+        try {
+            $fragment = new StringFragment('test-region', 'Hello {{ name }}', 'antlers.html', ['name' => 'World']);
+
+            $this->assertSame('Hello World', $fragment->render());
+            $this->assertDirectoryExists(storage_path('statamic/tmp/nocache'));
+            $this->assertDirectoryDoesNotExist($compiledViewDirectory.'/nocache');
+        } finally {
+            app('files')->deleteDirectory($compiledViewDirectory);
+        }
+    }
+}

--- a/tests/View/Blade/NocacheStorageTest.php
+++ b/tests/View/Blade/NocacheStorageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\View\Blade;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\View\Blade\AntlersBladePrecompiler;
+use Statamic\View\Blade\StatamicTagCompiler;
+use Tests\TestCase;
+
+class NocacheStorageTest extends TestCase
+{
+    #[Test]
+    public function it_stores_compiled_nocache_components_in_statamic_storage()
+    {
+        $compiled = (new StatamicTagCompiler())->compile('<s:nocache>Hello</s:nocache>');
+        $viewName = '_nocache'.sha1('Hello');
+
+        $this->assertSame("@nocache('compiled__views::{$viewName}')", $compiled);
+        $this->assertSame('Hello', file_get_contents(storage_path("statamic/tmp/nocache/{$viewName}.blade.php")));
+    }
+
+    #[Test]
+    public function it_stores_precompiled_antlers_views_in_statamic_storage()
+    {
+        $antlers = 'Hello {{ name }}';
+        $viewName = 'antlers_'.sha1($antlers);
+
+        $compiled = AntlersBladePrecompiler::compile("@antlers{$antlers}@endantlers");
+
+        $this->assertSame("@include('compiled__views::{$viewName}')", $compiled);
+        $this->assertSame($antlers, file_get_contents(storage_path("statamic/tmp/nocache/{$viewName}.antlers.html")));
+    }
+}


### PR DESCRIPTION
## What this changes

Statamic generates temporary views for Antlers nocache regions, Blade nocache components, and `@antlers` blocks. These files were stored alongside Laravel’s compiled views, with two paths writing directly to `storage/framework/views`.

All three types of generated view now live in `storage/statamic/tmp/nocache`. This keeps Statamic’s temporary files together in the application’s normal writable storage directory and gives Vite one consistent location to ignore.

The companion change in statamic/statamic#152 updates the default Vite configuration so these generated files do not trigger browser refreshes during `npm run dev`.

Related to #13158.

## Testing

- Added coverage for all three generated view types and their new storage location.
- Static-caching suite: 201 tests, 502 assertions.
- Blade suite: 96 tests, 152 assertions.
- Pint passed.