### PR TITLE
[6.x] Fix Antlers directives being ignored after multibyte text/escape sequences

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -364,13 +364,11 @@ class DocumentParser
                 if (in_array($antlersRegion, ['@props', '@aware', '@cascade'])) {
                     $offset = mb_strpos($this->content, $antlersRegion, $lastAntlersOffset);
 
-                    if ($antlersMatch[1] > 0) {
-                        if (mb_substr($this->content, $antlersMatch[1] - 1, 1) === '@') {
-                            $lastAntlersOffset = mb_strpos($this->content, $antlersRegion, $lastAntlersOffset);
-                            $lastWasEscaped = true;
+                    if ($antlersMatch[1] > 0 && $this->content[$antlersMatch[1] - 1] === '@') {
+                        $lastAntlersOffset = $offset + mb_strlen($antlersRegion);
+                        $lastWasEscaped = false;
 
-                            continue;
-                        }
+                        continue;
                     }
 
                     if (in_array($antlersRegion, ['@props', '@aware'])) {

--- a/tests/Antlers/Parser/DirectivesTest.php
+++ b/tests/Antlers/Parser/DirectivesTest.php
@@ -31,6 +31,40 @@ EXECTED;
         );
     }
 
+    public function test_directives_are_detected_after_multibyte_content()
+    {
+        $template = <<<'EOT'
+café
+@props(['title' => 'Default'])
+{{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+café
+
+The Title
+EOT;
+
+        $this->assertSame($expected, $this->renderString($template, ['title' => 'The Title']));
+    }
+
+    public function test_directives_are_detected_after_an_escaped_directive()
+    {
+        $template = <<<'EOT'
+@@props
+@props(['title' => 'Default'])
+{{ title }}
+EOT;
+
+        $expected = <<<'EOT'
+@props
+
+The Title
+EOT;
+
+        $this->assertSame($expected, $this->renderString($template, ['title' => 'The Title']));
+    }
+
     public function test_directives_args_must_be_finished()
     {
         $this->expectExceptionMessage('Incomplete arguments for @props directive');


### PR DESCRIPTION
This PR corrects an issue where directives (for authoring Blade components using Antlers views) would be ignored if they followed multibyte text or an escaped directive.