### PR TITLE
[6.x] Fix/antlers interpolation selection

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -735,14 +735,19 @@ class DocumentParser
                     $docParser->setIsInterpolatedParser(true);
 
                     $parseResults = $docParser->parse($content);
+                    $interpolationNode = null;
 
-                    if (count($parseResults) > 1 && $parseResults[1] instanceof AntlersNode) {
-                        $parseResults = [$parseResults[1]];
-                    } elseif (count($parseResults) == 1 && ($parseResults[0] instanceof AntlersNode) == false) {
-                        $parseResults = [];
+                    foreach ($parseResults as $parseResult) {
+                        if ($parseResult instanceof DirectiveNode) {
+                            continue;
+                        }
+
+                        if ($parseResult instanceof AntlersNode || $parseResult instanceof PhpExecutionNode) {
+                            $interpolationNode = $parseResult;
+                        }
                     }
 
-                    $node->processedInterpolationRegions[$varName] = $parseResults;
+                    $node->processedInterpolationRegions[$varName] = $interpolationNode === null ? [] : [$interpolationNode];
                 }
                 $node->hasProcessedInterpolationRegions = true;
             }

--- a/tests/Antlers/Parser/BasicNodeTest.php
+++ b/tests/Antlers/Parser/BasicNodeTest.php
@@ -12,6 +12,7 @@ use Statamic\View\Antlers\Language\Nodes\Operators\LogicalOrOperator;
 use Statamic\View\Antlers\Language\Nodes\Paths\PathNode;
 use Statamic\View\Antlers\Language\Nodes\Paths\VariableReference;
 use Statamic\View\Antlers\Language\Nodes\Structures\LogicGroup;
+use Statamic\View\Antlers\Language\Nodes\Structures\PhpExecutionNode;
 use Statamic\View\Antlers\Language\Nodes\Structures\SemanticGroup;
 use Statamic\View\Antlers\Language\Nodes\VariableNode;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
@@ -29,6 +30,36 @@ class BasicNodeTest extends ParserTestCase
         $this->assertInstanceOf(LiteralNode::class, $nodes[1]);
         $this->assertInstanceOf(AntlersNode::class, $nodes[2]);
         $this->assertInstanceOf(LiteralNode::class, $nodes[3]);
+    }
+
+    public function test_interpolations_after_a_directive_skip_the_directive_node()
+    {
+        $nodes = $this->parseNodes("@props(['a' => 1])\n{{ tag x=\"{{ y }}\" }}");
+
+        $regions = array_values($nodes[2]->processedInterpolationRegions);
+        $this->assertCount(1, $regions[0]);
+        $first = $regions[0][0];
+        $this->assertInstanceOf(AntlersNode::class, $first);
+        $this->assertSame('int_c', $first->content);
+        $this->assertSame(27, $first->startPosition->offset);
+        $this->assertSame(2, $first->startPosition->line);
+        $this->assertSame(9, $first->startPosition->char);
+
+        $inner = array_values($first->processedInterpolationRegions)[0][0];
+        $this->assertSame(' y ', $inner->content);
+        $this->assertSame(27, $inner->startPosition->offset);
+    }
+
+    public function test_php_nodes_inside_interpolations_are_kept()
+    {
+        $nodes = $this->parseNodes('<div>{{ tag value="{{$ \'hi\' $}}" }}</div>');
+
+        $outer = array_values($nodes[1]->processedInterpolationRegions)[0][0];
+        $php = array_values($outer->processedInterpolationRegions)[0][0];
+
+        $this->assertInstanceOf(PhpExecutionNode::class, $php);
+        $this->assertSame(" 'hi' ", $php->content);
+        $this->assertTrue($php->isEchoNode);
     }
 
     public function test_it_doesnt_trim_off_content_start()

--- a/tests/Antlers/Parser/DirectivesTest.php
+++ b/tests/Antlers/Parser/DirectivesTest.php
@@ -65,6 +65,71 @@ EOT;
         $this->assertSame($expected, $this->renderString($template, ['title' => 'The Title']));
     }
 
+    public function test_interpolated_parameters_after_directives_receive_their_values()
+    {
+        (new class extends \Statamic\Tags\Tags
+        {
+            protected static $handle = 'directive_param_echo';
+
+            public function index()
+            {
+                return '['.$this->params->get('value').']';
+            }
+        })::register();
+
+        $templates = [
+            "@props(['a' => 1])\n<div>{{ directive_param_echo value=\"{{ title }}\" }}</div>",
+            "@@props\n@props(['a' => 1])\n<div>{{ directive_param_echo value=\"{{ title }}\" }}</div>",
+            "@props(['a' => 1])\n@props(['b' => 2])\n<div>{{ directive_param_echo value=\"{{ title | upper }}\" }}</div>",
+            "café\n@props(['a' => 1])\n<div>{{ directive_param_echo value=\"{{ title }}\" }}</div>",
+        ];
+
+        $expected = [
+            "\n<div>[The Title]</div>",
+            "@props\n\n<div>[The Title]</div>",
+            "\n\n<div>[THE TITLE]</div>",
+            "café\n\n<div>[The Title]</div>",
+        ];
+
+        foreach ($templates as $index => $template) {
+            $this->assertSame(
+                $expected[$index],
+                $this->renderString($template, ['title' => 'The Title'], true),
+                "Template #{$index}"
+            );
+        }
+    }
+
+    public function test_templates_with_interpolated_parameters_render_after_directives()
+    {
+        (new class extends \Statamic\Tags\Tags
+        {
+            protected static $handle = 'directive_param_echo';
+
+            public function index()
+            {
+                return '['.$this->params->get('value').']';
+            }
+        })::register();
+
+        $template = <<<'EOT'
+@props(['heading' => 'Default'])
+<h1>{{ heading }}</h1>
+{{ items }}<li class="{{ if value == "{{ selected }}" }}on{{ else }}off{{ /if }}">{{ directive_param_echo value="{{ value | upper }}" }}</li>{{ /items }}
+EOT;
+
+        $expected = <<<'EOT'
+
+<h1>Default</h1>
+<li class="off">[A]</li><li class="on">[B]</li>
+EOT;
+
+        $this->assertSame(
+            $expected,
+            $this->renderString($template, ['items' => ['a', 'b'], 'selected' => 'b'], true)
+        );
+    }
+
     public function test_directives_args_must_be_finished()
     {
         $this->expectExceptionMessage('Incomplete arguments for @props directive');

--- a/tests/Antlers/Runtime/PhpDisabledTest.php
+++ b/tests/Antlers/Runtime/PhpDisabledTest.php
@@ -54,10 +54,23 @@ class PhpDisabledTest extends TestCase
         $this->assertSame('[THE TITLE]', (string) Antlers::parse($template, $data, true));
         $this->assertSame('<li>[a:A]</li><li>[b:B]</li>', (string) Antlers::parse($loop, $data, true));
 
-        $this->assertSame('', (string) Antlers::parse($template, $data, false));
-        $this->assertSame('', (string) Antlers::parse($template, $data));
-        $this->assertSame('<li></li><li></li>', (string) Antlers::parse($loop, $data, false));
-        $this->assertSame('', (string) Antlers::parse('{{ php_param_echo value="a{{? $x = 1; ?}}b" }}', $data, false));
+        $condition = '{{ if title == "{{$ \'The Title\' $}}" }}yes{{ else }}no{{ /if }}';
+        $phpBlockCondition = '{{ if title == "{{? echo \'The Title\'; ?}}" }}yes{{ else }}no{{ /if }}';
+        $modifier = '{{ title | ensure_right:"{{$ \'!\' $}}" }}';
+        $loopCondition = '{{ items }}{{ if value == "{{$ strtolower($value) $}}" }}y{{ else }}n{{ /if }}{{ /items }}';
+
+        $this->assertSame('yes', (string) Antlers::parse($condition, $data, true));
+        $this->assertSame('no', (string) Antlers::parse($condition, $data, false));
+        $this->assertSame('no', (string) Antlers::parse($condition, $data));
+
+        $this->assertSame('yes', (string) Antlers::parse($phpBlockCondition, $data, true));
+        $this->assertSame('no', (string) Antlers::parse($phpBlockCondition, $data, false));
+
+        $this->assertSame('The Title!', (string) Antlers::parse($modifier, $data, true));
+        $this->assertSame('The Title', (string) Antlers::parse($modifier, $data, false));
+
+        $this->assertSame('yy', (string) Antlers::parse($loopCondition, $data, true));
+        $this->assertSame('nn', (string) Antlers::parse($loopCondition, $data, false));
     }
 
     public function test_it_allows_inline_echo_blocks_when_enabled()

--- a/tests/Antlers/Runtime/PhpDisabledTest.php
+++ b/tests/Antlers/Runtime/PhpDisabledTest.php
@@ -35,6 +35,31 @@ class PhpDisabledTest extends TestCase
         $this->assertSame('Before &lt;?php echo "hello"; ?> After', $result);
     }
 
+    public function test_php_nodes_inside_interpolated_parameters_are_not_evaluated_when_disabled()
+    {
+        (new class extends \Statamic\Tags\Tags
+        {
+            protected static $handle = 'php_param_echo';
+
+            public function index()
+            {
+                return '['.$this->params->get('value').']';
+            }
+        })::register();
+
+        $data = ['title' => 'The Title', 'items' => ['a', 'b']];
+        $template = '{{ php_param_echo value="{{$ strtoupper($title) $}}" }}';
+        $loop = '{{ items }}<li>{{ php_param_echo value="{{ value }}:{{$ strtoupper($value) $}}" }}</li>{{ /items }}';
+
+        $this->assertSame('[THE TITLE]', (string) Antlers::parse($template, $data, true));
+        $this->assertSame('<li>[a:A]</li><li>[b:B]</li>', (string) Antlers::parse($loop, $data, true));
+
+        $this->assertSame('', (string) Antlers::parse($template, $data, false));
+        $this->assertSame('', (string) Antlers::parse($template, $data));
+        $this->assertSame('<li></li><li></li>', (string) Antlers::parse($loop, $data, false));
+        $this->assertSame('', (string) Antlers::parse('{{ php_param_echo value="a{{? $x = 1; ?}}b" }}', $data, false));
+    }
+
     public function test_it_allows_inline_echo_blocks_when_enabled()
     {
         $result = (string) Antlers::parse('Before {{$ "hello" $}} After', [], true);

--- a/tests/Antlers/Runtime/PhpEnabledTest.php
+++ b/tests/Antlers/Runtime/PhpEnabledTest.php
@@ -32,6 +32,42 @@ class PhpEnabledTest extends ParserTestCase
         );
     }
 
+    public function test_php_nodes_inside_interpolated_parameters_are_evaluated()
+    {
+        (new class extends \Statamic\Tags\Tags
+        {
+            protected static $handle = 'php_param_echo';
+
+            public function index()
+            {
+                return '['.$this->params->get('value').']';
+            }
+        })::register();
+
+        $data = ['title' => 'The Title', 'items' => ['a', 'b']];
+
+        $templates = [
+            '<div>{{ php_param_echo value="{{$ \'hi\' $}}" }}</div>' => '<div>[hi]</div>',
+            '<div>{{ php_param_echo value="a-{{$ \'hi\' $}}-b" }}</div>' => '<div>[a-hi-b]</div>',
+            "caf\u{00E9} <div>{{ php_param_echo value=\"{{\$ strtoupper('hi') \$}}\" }}</div>" => "caf\u{00E9} <div>[HI]</div>",
+            '{{ php_param_echo value="{{$ $title $}}" }}' => '[The Title]',
+            '{{ php_param_echo value="{{$ strtoupper($title) $}}" }}' => '[THE TITLE]',
+            '{{ php_param_echo value="{{ title }}-{{$ \'x\' $}}-{{ title | upper }}" }}' => '[The Title-x-THE TITLE]',
+            '{{ php_param_echo value="a{{? $x = 1; ?}}b" }}' => '[ab]',
+            '{{ items }}{{ php_param_echo value="{{ value }}:{{$ strtoupper($value) $}}" }}{{ /items }}' => '[a:A][b:B]',
+            '{{ if title == "{{$ \'The Title\' $}}" }}yes{{ else }}no{{ /if }}' => 'yes',
+            "@props(['a' => 1])\n".'{{ php_param_echo value="{{$ strtoupper(\'hi\') $}}" }}' => "\n[HI]",
+        ];
+
+        foreach ($templates as $template => $expected) {
+            $this->assertSame(
+                $expected,
+                (string) $this->parser($data, true, true)->allowPhp()->parse($template, $data),
+                $template
+            );
+        }
+    }
+
     public function test_php_can_be_used_to_output_evaluated_antlers()
     {
         // This test covers existing Antlers + PHP behavior.


### PR DESCRIPTION
The PR fixes issues with interpolated Antlers regions, where interpolations would select the wrong parsed node if the node was preceded by a directive. Additionally, the interpolation logic was expanded to allow for PHP nodes, which were mishandled. Both cases could produce garbage output.