### PR TITLE
[6.x] Antlers Parser Performance Improvements

### DIFF
--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -20,6 +20,7 @@ use Statamic\View\Antlers\Language\Nodes\TagIdentifier;
 use Statamic\View\Antlers\Language\Nodes\VariableNode;
 use Statamic\View\Antlers\Language\Runtime\GlobalRuntimeState;
 use Statamic\View\Antlers\Language\Runtime\Tracing\NodeVisitorContract;
+use Statamic\View\Antlers\Language\Utilities\CharacterOffsets;
 use Statamic\View\Antlers\Language\Utilities\StringUtilities;
 
 class DocumentParser
@@ -64,6 +65,33 @@ class DocumentParser
     private $interpolationRegions = [];
 
     /**
+     * Character length of each neutralized document prefix handed to an interpolation
+     * sub-parser, keyed by the prefix's byte length, so the sub-parse loop can recover
+     * it from the region text without recounting the prefix.
+     *
+     * @var array<int, int>
+     */
+    private $prefixCharacterLengths = [];
+
+    /**
+     * The document content with every "{" replaced by "~", built on first use and
+     * released once the interpolation regions have been parsed. The replacement is
+     * byte-for-byte, which is what lets a prefix of it share the document's offsets.
+     *
+     * @var string|null
+     */
+    private $neutralizedContent = null;
+
+    /**
+     * Added to every line number read from the newline table. Non-zero only in an
+     * interpolation sub-parser whose inherited table was numbered from a different
+     * seed line than its own.
+     *
+     * @var int
+     */
+    private $lineShift = 0;
+
+    /**
      * @var AntlersNodeParser|null
      */
     private $nodeParser = null;
@@ -90,7 +118,15 @@ class DocumentParser
     private $isInterpolatedParser = false;
 
     private $inputLen = 0;
+    /**
+     * The newline table: character offset of each "\n" => [K_CHAR => column, K_LINE => line],
+     * and the same offsets as a sorted list for binary searching. An interpolation
+     * sub-parser shares its parent's arrays and only the first $newlineCount entries
+     * belong to its own document, so every reader goes through that bound.
+     */
     private $documentOffsets = [];
+    private $documentOffsetKeys = [];
+    private $newlineCount = 0;
     private $isDoubleBrace = false;
     private $interpolationEndOffsets = [];
     private $seedStartLine = 1;
@@ -102,6 +138,16 @@ class DocumentParser
     private $antlersStartPositionIndex = [];
     private $chunkSize = 5;
     private $currentChunkOffset = 0;
+    private $nextChunkOffset = 0;
+
+    /**
+     * Character offset => byte offset for every offset the scanner has touched.
+     * Only maintained for multibyte content; otherwise the two are equal.
+     *
+     * @var array<int, int>
+     */
+    private $sourceByteOffsets = [];
+    private $isMultibyteContent = false;
     private $jumpToIndex = null;
 
     private $interpolatedCollisions = [];
@@ -128,7 +174,7 @@ class DocumentParser
 
     public function getText($start, $end)
     {
-        return StringUtilities::substr($this->content, $start, $end - $start);
+        return $this->sourceSubstr($start, $end - $start);
     }
 
     public function setIsInterpolatedParser($isInterpolation)
@@ -158,19 +204,96 @@ class DocumentParser
     }
 
     /**
-     * Fetches content from the source content without appending characters to the current char list.
+     * Extracts characters from the content by character offset, with mb_substr()
+     * semantics: a negative start counts from the end, a negative length omits that
+     * many characters from the end, and an empty range yields an empty string.
      *
-     * @param  int  $count  The number of characters to fetch.
+     * @param  int  $start
+     * @param  int|null  $length
      * @return string
      */
-    private function fetch($count)
+    private function sourceSubstr($start, $length = null)
     {
-        return mb_substr($this->content, $this->currentChunkOffset + $this->chunkSize - count($this->chars), $count);
+        if (! $this->isMultibyteContent) {
+            return substr($this->content, $start, $length);
+        }
+
+        if ($start < 0) {
+            $start = max(0, $this->inputLen + $start);
+        }
+
+        if ($length === null) {
+            $end = $this->inputLen;
+        } elseif ($length < 0) {
+            $end = $this->inputLen + $length;
+        } else {
+            $end = min($start + $length, $this->inputLen);
+        }
+
+        if ($end <= $start) {
+            return '';
+        }
+
+        $byteStart = $this->sourceByteOffset($start);
+
+        return substr($this->content, $byteStart, $this->sourceByteOffset($end) - $byteStart);
     }
 
-    private function fetchAt($location, $count)
+    /**
+     * Returns the byte offset of a character offset, resolving and memoizing it
+     * when the scanner has not touched that offset yet.
+     *
+     * @param  int  $character
+     * @return int
+     */
+    private function sourceByteOffset($character)
     {
-        return mb_substr($this->content, $location, $count);
+        if (! $this->isMultibyteContent) {
+            return min(max($character, 0), $this->inputLen);
+        }
+
+        if (! isset($this->sourceByteOffsets[$character])) {
+            $this->sourceByteOffsets += CharacterOffsets::toBytes($this->content, [$character], true);
+        }
+
+        return $this->sourceByteOffsets[$character];
+    }
+
+    /** @return array<int, string> */
+    private function sourceChunk($characterOffset)
+    {
+        $byteOffset = $this->sourceByteOffset($characterOffset);
+
+        if ($this->isMultibyteContent) {
+            $chunk = mb_strcut($this->content, $byteOffset, $this->chunkSize * 4, 'UTF-8');
+            $characters = array_slice(mb_str_split($chunk), 0, $this->chunkSize);
+
+            foreach ($characters as $index => $character) {
+                $this->sourceByteOffsets[$characterOffset + $index] = $byteOffset;
+                $byteOffset += strlen($character);
+            }
+
+            $this->sourceByteOffsets[$characterOffset + count($characters)] = $byteOffset;
+        } else {
+            $characters = str_split(substr($this->content, $byteOffset, $this->chunkSize));
+        }
+
+        $this->nextChunkOffset = $characterOffset + count($characters);
+
+        return $characters;
+    }
+
+    private function appendSourceChunk()
+    {
+        $this->currentChunkOffset = $this->nextChunkOffset;
+        $nextChunk = $this->sourceChunk($this->currentChunkOffset);
+
+        foreach ($nextChunk as $nextChar) {
+            $this->chars[] = $nextChar;
+            $this->charLen += 1;
+        }
+
+        return $nextChunk !== [];
     }
 
     public function getParsedContent()
@@ -181,13 +304,7 @@ class DocumentParser
     private function peek($count)
     {
         if ($count == $this->charLen) {
-            $nextChunk = mb_str_split(mb_substr($this->content, $this->currentChunkOffset + $this->chunkSize, $this->chunkSize));
-            $this->currentChunkOffset += $this->chunkSize;
-
-            foreach ($nextChunk as $nextChar) {
-                $this->chars[] = $nextChar;
-                $this->charLen += 1;
-            }
+            $this->appendSourceChunk();
         }
 
         return $this->chars[$count];
@@ -198,7 +315,7 @@ class DocumentParser
         $this->currentContent = [];
         $this->startIndex = 0;
 
-        $this->chars = mb_str_split(mb_substr($this->content, $this->currentChunkOffset, $this->chunkSize));
+        $this->chars = $this->sourceChunk($this->currentChunkOffset);
         $this->charLen = count($this->chars);
 
         for ($this->currentIndex = 0; $this->currentIndex < $this->inputLen; $this->currentIndex += 1) {
@@ -322,60 +439,134 @@ class DocumentParser
         return $this->renderNodes;
     }
 
-    private function processInputText($input)
+    /**
+     * @param  string  $input
+     * @param  array|null  $prefix  Set when parsing an interpolation region for a parent parser; see interpolatedRegionPrefix().
+     * @return bool
+     */
+    private function processInputText($input, ?array $prefix)
     {
-        $this->content = StringUtilities::normalizeLineEndings($input);
-        $this->inputLen = mb_strlen($this->content);
+        if ($prefix === null) {
+            $this->content = StringUtilities::normalizeLineEndings($input);
+            $this->inputLen = mb_strlen($this->content);
+        } else {
+            // Interpolation sub-parse: the input is the parent's already-normalized
+            // document prefix (braces neutralized) followed by the interpolated tail.
+            // The prefix's newline table is inherited from the parent below, so only
+            // the tail is scanned.
+            $this->content = $input;
+            $this->inputLen = $prefix['characters'] + $prefix['tailCharacters'];
+        }
 
-        // The document content was normalized, so we can search for "\n".
-        preg_match_all('/\n/', $this->content, $documentNewLines, PREG_OFFSET_CAPTURE);
-        $newLineCountLen = count($documentNewLines[0]);
+        $this->isMultibyteContent = $this->inputLen !== strlen($this->content);
+        $this->sourceByteOffsets = [
+            0 => 0,
+            $this->inputLen => strlen($this->content),
+        ];
 
         $currentLine = $this->seedStartLine;
-        $lastOffset = null;
-        for ($i = 0; $i < $newLineCountLen; $i++) {
-            $thisNewLine = $documentNewLines[0][$i];
-            $thisIndex = $thisNewLine[1];
-            $indexChar = $thisIndex;
+        $newlineCount = 0;
+        $lastOffset = -1; // A virtual newline just before the document.
+        $scanFromByte = 0;
+        $scanFromCharacter = 0;
 
-            if ($lastOffset != null) {
-                $indexChar = $thisIndex - $lastOffset;
-            } else {
-                $indexChar = $indexChar + 1;
-            }
+        if ($prefix !== null) {
+            $this->sourceByteOffsets[$prefix['characters']] = $prefix['bytes'];
+
+            // The parent's table is shared as-is (only the first $newlineCount entries
+            // fall inside the prefix) and stays numbered from the parent's seed line;
+            // the difference from this parser's seed is applied on read.
+            $this->documentOffsets = $prefix['newlineOffsets'];
+            $this->documentOffsetKeys = $prefix['newlineKeys'];
+            $newlineCount = $prefix['newlineCount'];
+            $this->lineShift = $this->seedStartLine - $prefix['startLine'];
+            $currentLine = $prefix['startLine'] + $newlineCount;
+            $lastOffset = $newlineCount > 0 ? $this->documentOffsetKeys[$newlineCount - 1] : -1;
+            $scanFromByte = $prefix['bytes'];
+            $scanFromCharacter = $prefix['characters'];
+        }
+
+        // The document content was normalized, so we can search for "\n".
+        preg_match_all('/\n/', $this->content, $documentNewLines, PREG_OFFSET_CAPTURE, $scanFromByte);
+        $newLineByteOffsets = array_column($documentNewLines[0], 1);
+        $newLineCharacterOffsets = CharacterOffsets::toCharacters(
+            $this->content,
+            $newLineByteOffsets,
+            $this->isMultibyteContent,
+            $scanFromByte,
+            $scanFromCharacter
+        );
+
+        if ($prefix !== null && $newLineByteOffsets !== []) {
+            // The tail adds entries, so this parser needs its own copy cut at the prefix.
+            $this->documentOffsets = array_slice($this->documentOffsets, 0, $newlineCount, true);
+            $this->documentOffsetKeys = array_slice($this->documentOffsetKeys, 0, $newlineCount);
+        }
+
+        foreach ($newLineByteOffsets as $newLineByteOffset) {
+            $thisIndex = $newLineCharacterOffsets[$newLineByteOffset];
 
             $this->documentOffsets[$thisIndex] = [
-                self::K_CHAR => $indexChar,
+                self::K_CHAR => $thisIndex - $lastOffset,
                 self::K_LINE => $currentLine,
             ];
+            $this->documentOffsetKeys[] = $thisIndex;
 
+            $newlineCount += 1;
             $currentLine += 1;
             $lastOffset = $thisIndex;
         }
 
-        preg_match_all('/(@?{{|@(props|aware|cascade))/u', $this->content, $antlersStartCandidates, PREG_OFFSET_CAPTURE);
+        $this->newlineCount = $newlineCount;
 
-        $lastAntlersOffset = 0;
+        // An inherited prefix contains no "{" and any directive in it would be discarded
+        // by the sub-parse loop, so only the tail is scanned for candidates. The byte
+        // before the tail is included so that an "@" ending the prefix still escapes
+        // the tail's braces exactly as a scan of the whole text would; that loses the
+        // interpolation (a pre-existing quirk kept for compatibility, see
+        // InterpolationRegionTest::test_an_at_sign_just_before_an_interpolation_escapes_it).
+        $candidateScanFromByte = $scanFromByte;
+
+        if ($candidateScanFromByte > 0 && $this->content[$candidateScanFromByte - 1] === self::AtChar) {
+            $candidateScanFromByte--;
+        }
+
+        preg_match_all('/(@?{{|@(props|aware|cascade))/u', $this->content, $antlersStartCandidates, PREG_OFFSET_CAPTURE, $candidateScanFromByte);
+        $candidateCharacterOffsets = CharacterOffsets::toCharacters(
+            $this->content,
+            array_column($antlersStartCandidates[0], 1),
+            $this->isMultibyteContent,
+            $scanFromByte,
+            $scanFromCharacter
+        );
+
+        $lastAntlersByteOffset = 0;
         $lastWasEscaped = false;
         foreach ($antlersStartCandidates[0] as $antlersMatch) {
             $antlersRegion = $antlersMatch[0];
+            $matchByteOffset = $antlersMatch[1];
+            $offset = $candidateCharacterOffsets[$matchByteOffset];
+
+            if ($this->isMultibyteContent) {
+                $this->sourceByteOffsets[$offset] = $matchByteOffset;
+            }
 
             if (Str::startsWith($antlersRegion, '@')) {
                 if (in_array($antlersRegion, ['@props', '@aware', '@cascade'])) {
-                    $offset = mb_strpos($this->content, $antlersRegion, $lastAntlersOffset);
+                    if ($matchByteOffset > 0) {
+                        if ($this->content[$matchByteOffset - 1] === self::AtChar) {
+                            $lastAntlersByteOffset = $matchByteOffset;
+                            $lastWasEscaped = true;
 
-                    if ($antlersMatch[1] > 0 && $this->content[$antlersMatch[1] - 1] === '@') {
-                        $lastAntlersOffset = $offset + mb_strlen($antlersRegion);
-                        $lastWasEscaped = false;
-
-                        continue;
+                            continue;
+                        }
                     }
 
                     if (in_array($antlersRegion, ['@props', '@aware'])) {
                         $hasArgs = false;
 
-                        for ($k = $offset + mb_strlen($antlersRegion); $k < $this->inputLen; $k++) {
-                            $ch = mb_substr($this->content, $k, 1);
+                        for ($k = $matchByteOffset + strlen($antlersRegion), $byteLen = strlen($this->content); $k < $byteLen; $k++) {
+                            $ch = $this->content[$k];
 
                             if (ctype_space($ch)) {
                                 continue;
@@ -389,7 +580,7 @@ class DocumentParser
                         }
 
                         if (! $hasArgs) {
-                            $lastAntlersOffset = $offset + mb_strlen($antlersRegion);
+                            $lastAntlersByteOffset = $matchByteOffset + strlen($antlersRegion);
                             $lastWasEscaped = false;
 
                             continue;
@@ -400,34 +591,108 @@ class DocumentParser
                     $this->antlersStartPositionIndex[$offset] = 1;
 
                     $lastWasEscaped = false;
-                    $lastAntlersOffset = $offset + mb_strlen($antlersRegion);
+                    $lastAntlersByteOffset = $matchByteOffset + strlen($antlersRegion);
 
                     continue;
                 }
 
-                $lastAntlersOffset = mb_strpos($this->content, $antlersRegion, $lastAntlersOffset) + 2;
+                $lastAntlersByteOffset = $matchByteOffset + 2;
                 $lastWasEscaped = true;
 
                 continue;
             }
 
-            $offset = mb_strpos($this->content, $antlersRegion, $lastAntlersOffset);
-
-            if ($lastWasEscaped) {
-                if ($lastAntlersOffset == $offset) {
-                    $lastAntlersOffset = $offset;
-
-                    continue;
-                }
+            // A "{{" sitting exactly where the last escaped region ended overlaps it
+            // (as in "@{{{"), and every "{{" after it is skipped until the next escape.
+            if ($lastWasEscaped && substr($this->content, $lastAntlersByteOffset, 2) === '{{') {
+                continue;
             }
 
             $this->antlersStartIndex[] = $offset;
             $this->antlersStartPositionIndex[$offset] = 1;
-            $lastAntlersOffset = $offset + 2;
+            $lastAntlersByteOffset = $matchByteOffset + 2;
             $lastWasEscaped = false;
         }
 
         return true;
+    }
+
+    /**
+     * Returns the document content with every left brace replaced by "~". This is
+     * the prefix handed to interpolation sub-parsers so their positions line up
+     * with the document without the prefix producing Antlers nodes.
+     *
+     * @return string
+     */
+    private function neutralizedContent()
+    {
+        if ($this->neutralizedContent === null) {
+            $this->neutralizedContent = str_replace(self::LeftBrace, self::Punctuation_Tilde, $this->content);
+        }
+
+        return $this->neutralizedContent;
+    }
+
+    /**
+     * Describes the document prefix inside an interpolation region's text so that
+     * the sub-parser can inherit this parser's newline table for it instead of
+     * rescanning it: the prefix's lengths, and the table entries that fall inside it.
+     *
+     * @param  string  $regionText
+     * @return array|null
+     */
+    private function interpolatedRegionPrefix($regionText)
+    {
+        // The prefix is brace-neutralized, so the first "{" is where the tail starts.
+        $prefixBytes = strpos($regionText, self::LeftBrace);
+
+        // Regions this parser did not build (a DirectiveNode carries the regions of
+        // the parser that handled its arguments) belong to another document and are
+        // parsed from scratch, as are any this parser has no record of.
+        if ($prefixBytes === false
+            || ! isset($this->prefixCharacterLengths[$prefixBytes])
+            || strncmp($regionText, $this->neutralizedContent(), $prefixBytes) !== 0) {
+            return null;
+        }
+
+        $prefixCharacters = $this->isMultibyteContent ? $this->prefixCharacterLengths[$prefixBytes] : $prefixBytes;
+
+        return [
+            'characters' => $prefixCharacters,
+            'bytes' => $prefixBytes,
+            // The tail is short; counting it directly keeps a region whose prefix is
+            // empty independent of this parser's own encoding flag.
+            'tailCharacters' => mb_strlen(substr($regionText, $prefixBytes)),
+            // The line the table is numbered from, which may itself be inherited.
+            'startLine' => $this->seedStartLine - $this->lineShift,
+            'newlineCount' => $this->newlineCountBefore($prefixCharacters),
+            'newlineKeys' => $this->documentOffsetKeys,
+            'newlineOffsets' => $this->documentOffsets,
+        ];
+    }
+
+    /**
+     * Counts the newline offsets of this document that fall before $offset.
+     *
+     * @param  int  $offset
+     * @return int
+     */
+    private function newlineCountBefore($offset)
+    {
+        $low = 0;
+        $high = $this->newlineCount;
+
+        while ($low < $high) {
+            $middle = intdiv($low + $high, 2);
+
+            if ($this->documentOffsetKeys[$middle] < $offset) {
+                $low = $middle + 1;
+            } else {
+                $high = $middle;
+            }
+        }
+
+        return $low;
     }
 
     /**
@@ -456,13 +721,25 @@ class DocumentParser
      */
     public function parse($text)
     {
+        return $this->parseDocument($text, null);
+    }
+
+    /**
+     * @param  string  $text
+     * @param  array|null  $interpolationPrefix  Set when $text is an interpolation region of a parent parser: its neutralized document prefix followed by the interpolated tail. See interpolatedRegionPrefix().
+     * @return array
+     */
+    private function parseDocument($text, ?array $interpolationPrefix)
+    {
         $this->resetState();
 
-        if (! $this->processInputText($text)) {
+        if (! $this->processInputText($text, $interpolationPrefix)) {
             return [];
         }
 
-        StringUtilities::prepareSplit($text);
+        StringUtilities::$splitMethod = $this->isMultibyteContent
+            ? StringUtilities::SPLIT_METHOD_MB_STR_SPLIT
+            : StringUtilities::SPLIT_METHOD_STR_SPLIT;
 
         $indexCount = count($this->antlersStartIndex);
         $lastIndex = $indexCount - 1;
@@ -479,11 +756,13 @@ class DocumentParser
                 $offset = $this->antlersStartIndex[$i];
                 $this->seedOffset = $offset;
 
-                if ($i == 0 && $offset > 0) {
-                    // Create a literal node representing the start of the document.
+                if ($i == 0 && $offset > 0 && $interpolationPrefix === null) {
+                    // Create a literal node representing the start of the document. In an
+                    // interpolation sub-parse it would be the neutralized prefix, which the
+                    // parent discards, so it is not built at all.
                     $node = new LiteralNode();
                     $node->isVirtual = $this->isVirtual;
-                    $node->content = $this->prepareLiteralContent(StringUtilities::substr($this->content, 0, $offset));
+                    $node->content = $this->prepareLiteralContent($this->sourceSubstr(0, $offset));
 
                     if (! strlen($node->content) == 0) {
                         $node->startPosition = $this->positionFromOffset(0, 0);
@@ -526,7 +805,7 @@ class DocumentParser
 
                             // Drop a literal node, and break.
                             if ($skipIndex == null) {
-                                $content = $this->prepareLiteralContent(StringUtilities::substr($this->content, $this->lastAntlersNode->endPosition->offset + 1));
+                                $content = $this->prepareLiteralContent($this->sourceSubstr($this->lastAntlersNode->endPosition->offset + 1));
 
                                 if (strlen($content) > 0) {
                                     $node = new LiteralNode();
@@ -556,7 +835,7 @@ class DocumentParser
                                     $spanStart += 1;
                                     $spanEnd -= 1;
 
-                                    $content = StringUtilities::substr($this->content, $spanStart, $spanLen);
+                                    $content = $this->sourceSubstr($spanStart, $spanLen);
 
                                     if (strlen($content) > 0) {
                                         $node = new LiteralNode();
@@ -592,7 +871,7 @@ class DocumentParser
                                     $nextAntlersStart = $this->antlersStartIndex[$i + 2];
                                 } else {
                                     $literalStart = $this->lastAntlersNode->endPosition->offset + 1;
-                                    $finalContent = $this->prepareLiteralContent(StringUtilities::substr($this->content, $literalStart));
+                                    $finalContent = $this->prepareLiteralContent($this->sourceSubstr($literalStart));
 
                                     if (! strlen($finalContent) == 0) {
                                         $finalLiteral = new LiteralNode();
@@ -634,7 +913,7 @@ class DocumentParser
                             } else {
                                 // In this scenario, we will create the last trailing literal node and break.
                                 $thisOffset = $this->currentChunkOffset;
-                                $content = StringUtilities::substr($this->content, $literalStartIndex);
+                                $content = $this->sourceSubstr($literalStartIndex);
 
                                 $node = new LiteralNode();
 
@@ -656,7 +935,7 @@ class DocumentParser
                     if ($i + 1 == $lastIndex && ($nextAntlersStart <= $this->lastAntlersEndIndex)) {
                         // In this scenario, we will create the last trailing literal node and break.
                         $thisOffset = $this->currentChunkOffset;
-                        $content = StringUtilities::substr($this->content, $literalStartIndex);
+                        $content = $this->sourceSubstr($literalStartIndex);
 
                         $node = new LiteralNode();
 
@@ -684,7 +963,7 @@ class DocumentParser
                             $literalLength += 1;
                         }
 
-                        $content = StringUtilities::substr($this->content, $literalStartIndex, $literalLength);
+                        $content = $this->sourceSubstr($literalStartIndex, $literalLength);
 
                         $node = new LiteralNode();
 
@@ -708,7 +987,7 @@ class DocumentParser
                         $node = new LiteralNode();
 
                         $node->isVirtual = $this->isVirtual;
-                        $node->content = $this->prepareLiteralContent(StringUtilities::substr($this->content, $literalStart));
+                        $node->content = $this->prepareLiteralContent($this->sourceSubstr($literalStart));
 
                         if (! strlen($node->content) == 0) {
                             $node->startPosition = $this->positionFromOffset($literalStart, $literalStart);
@@ -734,7 +1013,12 @@ class DocumentParser
                     $docParser = new DocumentParser();
                     $docParser->setIsInterpolatedParser(true);
 
-                    $parseResults = $docParser->parse($content);
+                    $parseResults = $docParser->parseDocument($content, $this->interpolatedRegionPrefix($content));
+
+                    // The interpolated content is parsed with the document prefix in front of it so
+                    // positions line up. The interpolation itself is the final Antlers or PHP node;
+                    // a region that could not be prefixed (parsed from scratch) may also yield the
+                    // prefix's literal and directive nodes, which are skipped.
                     $interpolationNode = null;
 
                     foreach ($parseResults as $parseResult) {
@@ -747,11 +1031,17 @@ class DocumentParser
                         }
                     }
 
-                    $node->processedInterpolationRegions[$varName] = $interpolationNode === null ? [] : [$interpolationNode];
+                    $parseResults = $interpolationNode === null ? [] : [$interpolationNode];
+
+                    $node->processedInterpolationRegions[$varName] = $parseResults;
                 }
                 $node->hasProcessedInterpolationRegions = true;
             }
         }
+
+        // Only the interpolation sub-parses need these; the nodes keep their own copies.
+        $this->neutralizedContent = null;
+        $this->prefixCharacterLengths = [];
 
         $tagPairAnalyzer = new TagPairAnalyzer();
         $this->renderNodes = $tagPairAnalyzer->associate($this->nodes, $this);
@@ -1106,7 +1396,19 @@ class DocumentParser
             $varContent .= str_repeat('x', $padLen);
         }
 
-        $parseContent = str_replace(DocumentParser::LeftBrace, '~', mb_substr($this->content, 0, $this->currentChunkOffset - mb_strlen($content))).'{'.$content.'}';
+        // The sub-parser is handed the document prefix (braces neutralized) followed by
+        // the interpolated content so that its node positions line up with the document.
+        // The cut is chunk-aligned and can fall before the document start, in which case
+        // it counts from the end like mb_substr() would.
+        $prefixLength = $this->currentChunkOffset - $origLen;
+
+        if ($prefixLength < 0) {
+            $prefixLength = max(0, $this->inputLen + $prefixLength);
+        }
+
+        $prefixBytes = $this->sourceByteOffset($prefixLength);
+        $this->prefixCharacterLengths[$prefixBytes] = $prefixLength;
+        $parseContent = substr($this->neutralizedContent(), 0, $prefixBytes).'{'.$content.'}';
 
         return [
             $content,
@@ -1263,7 +1565,7 @@ class DocumentParser
                         // Skips everything in the template until it finds the next {{ /noparse }} closing tag.
                         foreach ($this->antlersStartIndex as $sIndex => $start) {
                             if ($start > $node->endPosition->index) {
-                                $fetchContent = $this->fetchAt($start, 11);
+                                $fetchContent = $this->sourceSubstr($start, 11);
                                 $fetchContent = strtolower(str_replace(' ', '', $fetchContent));
 
                                 if (Str::startsWith($fetchContent, '{{/noparse')) {
@@ -1459,49 +1761,40 @@ class DocumentParser
         $lineToUse = 0;
         $charToUse = 0;
 
-        if (! array_key_exists($offset, $this->documentOffsets)) {
-            if (empty($this->documentOffsets)) {
-                $lineToUse = 1;
-                $charToUse = $offset + 1;
+        if ($this->newlineCount === 0) {
+            $lineToUse = 1;
+            $charToUse = $offset + 1;
+        } else {
+            $nearestIndex = $this->newlineCountBefore($offset);
+
+            if ($nearestIndex === $this->newlineCount) {
+                // Past the last newline.
+                $lastOffsetKey = $this->documentOffsetKeys[$nearestIndex - 1];
+                $lastOffset = $this->documentOffsets[$lastOffsetKey];
+                $lineToUse = $lastOffset[self::K_LINE] + 1 + $this->lineShift;
+                $charToUse = $offset - $lastOffsetKey;
             } else {
-                $nearestOffset = null;
-                $nearestOffsetIndex = null;
-                foreach ($this->documentOffsets as $documentOffset => $details) {
-                    if ($documentOffset >= $offset) {
-                        $nearestOffset = $details;
-                        $nearestOffsetIndex = $documentOffset;
-                        break;
-                    }
-                }
+                $nearestOffsetIndex = $this->documentOffsetKeys[$nearestIndex];
+                $nearestOffset = $this->documentOffsets[$nearestOffsetIndex];
 
-                if ($nearestOffset != null) {
-                    if ($isRelativeOffset) {
-                        $charToUse = $offset - $nearestOffset[self::K_CHAR];
-                        $lineToUse = $nearestOffset[self::K_LINE];
+                if ($nearestOffsetIndex === $offset) {
+                    // Exactly on a newline.
+                    $lineToUse = $nearestOffset[self::K_LINE] + $this->lineShift;
+                    $charToUse = $nearestOffset[self::K_CHAR];
+                } elseif ($isRelativeOffset) {
+                    $charToUse = $offset - $nearestOffset[self::K_CHAR];
+                    $lineToUse = $nearestOffset[self::K_LINE] + $this->lineShift;
 
-                        if ($offset <= $nearestOffsetIndex) {
-                            $lineToUse = $nearestOffset[self::K_LINE];
-                            $charToUse = $offset + 1;
-                        } else {
-                            $lineToUse = $nearestOffset[self::K_LINE] + 1;
-                        }
+                    if ($offset <= $nearestOffsetIndex) {
+                        $charToUse = $offset + 1;
                     } else {
-                        $offsetDelta = $nearestOffset[self::K_CHAR] - $nearestOffsetIndex + $offset;
-                        $charToUse = $offsetDelta;
-                        $lineToUse = $nearestOffset[self::K_LINE];
+                        $lineToUse += 1;
                     }
                 } else {
-                    $lastOffsetKey = array_key_last($this->documentOffsets);
-                    $lastOffset = $this->documentOffsets[$lastOffsetKey];
-                    $lineToUse = $lastOffset['line'] + 1;
-                    $charToUse = $offset - $lastOffsetKey;
+                    $charToUse = $nearestOffset[self::K_CHAR] - $nearestOffsetIndex + $offset;
+                    $lineToUse = $nearestOffset[self::K_LINE] + $this->lineShift;
                 }
             }
-        } else {
-            $details = $this->documentOffsets[$offset];
-
-            $lineToUse = $details[self::K_LINE];
-            $charToUse = $details[self::K_CHAR];
         }
 
         $position = new Position();
@@ -1536,17 +1829,7 @@ class DocumentParser
         if (($this->currentIndex + 1) < $this->inputLen) {
             $doPeek = true;
             if ($this->currentIndex == $this->charLen - 1) {
-                $nextChunk = mb_str_split(mb_substr($this->content, $this->currentChunkOffset + $this->chunkSize, $this->chunkSize));
-                $this->currentChunkOffset += $this->chunkSize;
-
-                if ($this->currentChunkOffset == $this->inputLen) {
-                    $doPeek = false;
-                }
-
-                foreach ($nextChunk as $nextChar) {
-                    $this->chars[] = $nextChar;
-                    $this->charLen += 1;
-                }
+                $doPeek = $this->appendSourceChunk();
             }
 
             if ($doPeek && array_key_exists($this->currentIndex + 1, $this->chars)) {
@@ -1559,6 +1842,7 @@ class DocumentParser
     {
         $this->chars = [];
         $this->charLen = 0;
+        $this->nextChunkOffset = 0;
         $this->currentIndex = 0;
         $this->currentContent = [];
         $this->cur = null;
@@ -1586,6 +1870,10 @@ class DocumentParser
         }
 
         $this->seedOffset = 0;
+        $this->nextChunkOffset = 0;
+        $this->sourceByteOffsets = [];
+        $this->isMultibyteContent = false;
+        $this->lineShift = 0;
 
         $this->content = '';
         $this->chars = [];
@@ -1597,9 +1885,13 @@ class DocumentParser
         $this->prev = null;
         $this->inputLen = 0;
         $this->documentOffsets = [];
+        $this->documentOffsetKeys = [];
+        $this->newlineCount = 0;
         $this->nodes = [];
         $this->isDoubleBrace = false;
         $this->interpolationRegions = [];
+        $this->prefixCharacterLengths = [];
+        $this->neutralizedContent = null;
         $this->interpolationEndOffsets = [];
     }
 }

--- a/src/View/Antlers/Language/Parser/DocumentParser.php
+++ b/src/View/Antlers/Language/Parser/DocumentParser.php
@@ -64,31 +64,13 @@ class DocumentParser
 
     private $interpolationRegions = [];
 
-    /**
-     * Character length of each neutralized document prefix handed to an interpolation
-     * sub-parser, keyed by the prefix's byte length, so the sub-parse loop can recover
-     * it from the region text without recounting the prefix.
-     *
-     * @var array<int, int>
-     */
+    /** @var array<int, int> */
     private $prefixCharacterLengths = [];
 
-    /**
-     * The document content with every "{" replaced by "~", built on first use and
-     * released once the interpolation regions have been parsed. The replacement is
-     * byte-for-byte, which is what lets a prefix of it share the document's offsets.
-     *
-     * @var string|null
-     */
+    /** @var string|null */
     private $neutralizedContent = null;
 
-    /**
-     * Added to every line number read from the newline table. Non-zero only in an
-     * interpolation sub-parser whose inherited table was numbered from a different
-     * seed line than its own.
-     *
-     * @var int
-     */
+    /** @var int */
     private $lineShift = 0;
 
     /**
@@ -118,12 +100,6 @@ class DocumentParser
     private $isInterpolatedParser = false;
 
     private $inputLen = 0;
-    /**
-     * The newline table: character offset of each "\n" => [K_CHAR => column, K_LINE => line],
-     * and the same offsets as a sorted list for binary searching. An interpolation
-     * sub-parser shares its parent's arrays and only the first $newlineCount entries
-     * belong to its own document, so every reader goes through that bound.
-     */
     private $documentOffsets = [];
     private $documentOffsetKeys = [];
     private $newlineCount = 0;
@@ -140,12 +116,7 @@ class DocumentParser
     private $currentChunkOffset = 0;
     private $nextChunkOffset = 0;
 
-    /**
-     * Character offset => byte offset for every offset the scanner has touched.
-     * Only maintained for multibyte content; otherwise the two are equal.
-     *
-     * @var array<int, int>
-     */
+    /** @var array<int, int> */
     private $sourceByteOffsets = [];
     private $isMultibyteContent = false;
     private $jumpToIndex = null;
@@ -204,10 +175,6 @@ class DocumentParser
     }
 
     /**
-     * Extracts characters from the content by character offset, with mb_substr()
-     * semantics: a negative start counts from the end, a negative length omits that
-     * many characters from the end, and an empty range yields an empty string.
-     *
      * @param  int  $start
      * @param  int|null  $length
      * @return string
@@ -240,9 +207,6 @@ class DocumentParser
     }
 
     /**
-     * Returns the byte offset of a character offset, resolving and memoizing it
-     * when the scanner has not touched that offset yet.
-     *
      * @param  int  $character
      * @return int
      */
@@ -441,7 +405,6 @@ class DocumentParser
 
     /**
      * @param  string  $input
-     * @param  array|null  $prefix  Set when parsing an interpolation region for a parent parser; see interpolatedRegionPrefix().
      * @return bool
      */
     private function processInputText($input, ?array $prefix)
@@ -450,10 +413,6 @@ class DocumentParser
             $this->content = StringUtilities::normalizeLineEndings($input);
             $this->inputLen = mb_strlen($this->content);
         } else {
-            // Interpolation sub-parse: the input is the parent's already-normalized
-            // document prefix (braces neutralized) followed by the interpolated tail.
-            // The prefix's newline table is inherited from the parent below, so only
-            // the tail is scanned.
             $this->content = $input;
             $this->inputLen = $prefix['characters'] + $prefix['tailCharacters'];
         }
@@ -473,9 +432,6 @@ class DocumentParser
         if ($prefix !== null) {
             $this->sourceByteOffsets[$prefix['characters']] = $prefix['bytes'];
 
-            // The parent's table is shared as-is (only the first $newlineCount entries
-            // fall inside the prefix) and stays numbered from the parent's seed line;
-            // the difference from this parser's seed is applied on read.
             $this->documentOffsets = $prefix['newlineOffsets'];
             $this->documentOffsetKeys = $prefix['newlineKeys'];
             $newlineCount = $prefix['newlineCount'];
@@ -498,7 +454,6 @@ class DocumentParser
         );
 
         if ($prefix !== null && $newLineByteOffsets !== []) {
-            // The tail adds entries, so this parser needs its own copy cut at the prefix.
             $this->documentOffsets = array_slice($this->documentOffsets, 0, $newlineCount, true);
             $this->documentOffsetKeys = array_slice($this->documentOffsetKeys, 0, $newlineCount);
         }
@@ -519,12 +474,6 @@ class DocumentParser
 
         $this->newlineCount = $newlineCount;
 
-        // An inherited prefix contains no "{" and any directive in it would be discarded
-        // by the sub-parse loop, so only the tail is scanned for candidates. The byte
-        // before the tail is included so that an "@" ending the prefix still escapes
-        // the tail's braces exactly as a scan of the whole text would; that loses the
-        // interpolation (a pre-existing quirk kept for compatibility, see
-        // InterpolationRegionTest::test_an_at_sign_just_before_an_interpolation_escapes_it).
         $candidateScanFromByte = $scanFromByte;
 
         if ($candidateScanFromByte > 0 && $this->content[$candidateScanFromByte - 1] === self::AtChar) {
@@ -602,8 +551,6 @@ class DocumentParser
                 continue;
             }
 
-            // A "{{" sitting exactly where the last escaped region ended overlaps it
-            // (as in "@{{{"), and every "{{" after it is skipped until the next escape.
             if ($lastWasEscaped && substr($this->content, $lastAntlersByteOffset, 2) === '{{') {
                 continue;
             }
@@ -617,13 +564,7 @@ class DocumentParser
         return true;
     }
 
-    /**
-     * Returns the document content with every left brace replaced by "~". This is
-     * the prefix handed to interpolation sub-parsers so their positions line up
-     * with the document without the prefix producing Antlers nodes.
-     *
-     * @return string
-     */
+    /** @return string */
     private function neutralizedContent()
     {
         if ($this->neutralizedContent === null) {
@@ -634,21 +575,13 @@ class DocumentParser
     }
 
     /**
-     * Describes the document prefix inside an interpolation region's text so that
-     * the sub-parser can inherit this parser's newline table for it instead of
-     * rescanning it: the prefix's lengths, and the table entries that fall inside it.
-     *
      * @param  string  $regionText
      * @return array|null
      */
     private function interpolatedRegionPrefix($regionText)
     {
-        // The prefix is brace-neutralized, so the first "{" is where the tail starts.
         $prefixBytes = strpos($regionText, self::LeftBrace);
 
-        // Regions this parser did not build (a DirectiveNode carries the regions of
-        // the parser that handled its arguments) belong to another document and are
-        // parsed from scratch, as are any this parser has no record of.
         if ($prefixBytes === false
             || ! isset($this->prefixCharacterLengths[$prefixBytes])
             || strncmp($regionText, $this->neutralizedContent(), $prefixBytes) !== 0) {
@@ -660,10 +593,7 @@ class DocumentParser
         return [
             'characters' => $prefixCharacters,
             'bytes' => $prefixBytes,
-            // The tail is short; counting it directly keeps a region whose prefix is
-            // empty independent of this parser's own encoding flag.
             'tailCharacters' => mb_strlen(substr($regionText, $prefixBytes)),
-            // The line the table is numbered from, which may itself be inherited.
             'startLine' => $this->seedStartLine - $this->lineShift,
             'newlineCount' => $this->newlineCountBefore($prefixCharacters),
             'newlineKeys' => $this->documentOffsetKeys,
@@ -672,8 +602,6 @@ class DocumentParser
     }
 
     /**
-     * Counts the newline offsets of this document that fall before $offset.
-     *
      * @param  int  $offset
      * @return int
      */
@@ -726,7 +654,6 @@ class DocumentParser
 
     /**
      * @param  string  $text
-     * @param  array|null  $interpolationPrefix  Set when $text is an interpolation region of a parent parser: its neutralized document prefix followed by the interpolated tail. See interpolatedRegionPrefix().
      * @return array
      */
     private function parseDocument($text, ?array $interpolationPrefix)
@@ -757,9 +684,6 @@ class DocumentParser
                 $this->seedOffset = $offset;
 
                 if ($i == 0 && $offset > 0 && $interpolationPrefix === null) {
-                    // Create a literal node representing the start of the document. In an
-                    // interpolation sub-parse it would be the neutralized prefix, which the
-                    // parent discards, so it is not built at all.
                     $node = new LiteralNode();
                     $node->isVirtual = $this->isVirtual;
                     $node->content = $this->prepareLiteralContent($this->sourceSubstr(0, $offset));
@@ -1015,10 +939,6 @@ class DocumentParser
 
                     $parseResults = $docParser->parseDocument($content, $this->interpolatedRegionPrefix($content));
 
-                    // The interpolated content is parsed with the document prefix in front of it so
-                    // positions line up. The interpolation itself is the final Antlers or PHP node;
-                    // a region that could not be prefixed (parsed from scratch) may also yield the
-                    // prefix's literal and directive nodes, which are skipped.
                     $interpolationNode = null;
 
                     foreach ($parseResults as $parseResult) {
@@ -1039,7 +959,6 @@ class DocumentParser
             }
         }
 
-        // Only the interpolation sub-parses need these; the nodes keep their own copies.
         $this->neutralizedContent = null;
         $this->prefixCharacterLengths = [];
 
@@ -1396,10 +1315,6 @@ class DocumentParser
             $varContent .= str_repeat('x', $padLen);
         }
 
-        // The sub-parser is handed the document prefix (braces neutralized) followed by
-        // the interpolated content so that its node positions line up with the document.
-        // The cut is chunk-aligned and can fall before the document start, in which case
-        // it counts from the end like mb_substr() would.
         $prefixLength = $this->currentChunkOffset - $origLen;
 
         if ($prefixLength < 0) {
@@ -1768,7 +1683,6 @@ class DocumentParser
             $nearestIndex = $this->newlineCountBefore($offset);
 
             if ($nearestIndex === $this->newlineCount) {
-                // Past the last newline.
                 $lastOffsetKey = $this->documentOffsetKeys[$nearestIndex - 1];
                 $lastOffset = $this->documentOffsets[$lastOffsetKey];
                 $lineToUse = $lastOffset[self::K_LINE] + 1 + $this->lineShift;
@@ -1778,7 +1692,6 @@ class DocumentParser
                 $nearestOffset = $this->documentOffsets[$nearestOffsetIndex];
 
                 if ($nearestOffsetIndex === $offset) {
-                    // Exactly on a newline.
                     $lineToUse = $nearestOffset[self::K_LINE] + $this->lineShift;
                     $charToUse = $nearestOffset[self::K_CHAR];
                 } elseif ($isRelativeOffset) {

--- a/src/View/Antlers/Language/Utilities/CharacterOffsets.php
+++ b/src/View/Antlers/Language/Utilities/CharacterOffsets.php
@@ -2,22 +2,8 @@
 
 namespace Statamic\View\Antlers\Language\Utilities;
 
-/**
- * Converts between UTF-8 byte offsets and character offsets without walking the
- * string in PHP. Byte offsets are what preg_* report; character offsets are what
- * the document parser and the rest of the Antlers runtime work with.
- *
- * Every conversion keeps the scan at the C level (preg / mbstring); a PHP per-byte
- * loop over a large template costs milliseconds per call, and the parser can make
- * hundreds of these calls while parsing a single document.
- */
 class CharacterOffsets
 {
-    /**
-     * PCRE limits a fixed repetition to 65535, so longer advances are split into
-     * power-of-two steps. Restricting the steps to powers of two also keeps the
-     * number of distinct compiled patterns tiny.
-     */
     const MAX_ADVANCE_STEP = 32768;
 
     /**
@@ -38,7 +24,7 @@ class CharacterOffsets
 
     /**
      * @param  string  $source
-     * @param  bool|null  $known  The caller's answer, when it already has one.
+     * @param  bool|null  $known
      * @return bool
      */
     protected static function isMultibyte($source, $known)
@@ -47,12 +33,9 @@ class CharacterOffsets
     }
 
     /**
-     * Maps character offsets to byte offsets. Offsets past the end of the string
-     * map to the byte length; negative offsets map to zero.
-     *
      * @param  string  $source
      * @param  int[]  $characterOffsets
-     * @param  bool|null  $sourceIsMultibyte  Pass it when known to skip the check.
+     * @param  bool|null  $sourceIsMultibyte
      * @return array<int, int>
      */
     public static function toBytes($source, array $characterOffsets, $sourceIsMultibyte = null)
@@ -67,7 +50,6 @@ class CharacterOffsets
             return self::identity($characterOffsets, $byteLength);
         }
 
-        // PCRE remembers a validated string, so this is free after the first call.
         if (! preg_match('//u', $source)) {
             return self::toBytesByteLoop($source, $characterOffsets);
         }
@@ -105,9 +87,6 @@ class CharacterOffsets
     }
 
     /**
-     * Returns the byte offset $characters code points after $byte, or null when the
-     * string ends first. The source must be valid UTF-8.
-     *
      * @param  string  $source
      * @param  int  $byte
      * @param  int  $characters
@@ -136,8 +115,6 @@ class CharacterOffsets
     }
 
     /**
-     * The original per-byte conversion, kept for strings that are not valid UTF-8.
-     *
      * @param  string  $source
      * @param  int[]  $characterOffsets
      * @return array<int, int>
@@ -171,16 +148,9 @@ class CharacterOffsets
     }
 
     /**
-     * Maps byte offsets to character offsets. A byte inside a multibyte sequence maps
-     * to the character that contains it; offsets past the end map to the length.
-     *
-     * When the caller already knows that byte $anchorByte is character
-     * $anchorCharacter (a boundary), offsets at or after it are counted from there
-     * instead of from the start of the string.
-     *
      * @param  string  $source
      * @param  int[]  $byteOffsets
-     * @param  bool|null  $sourceIsMultibyte  Pass it when known to skip the check.
+     * @param  bool|null  $sourceIsMultibyte
      * @param  int  $anchorByte
      * @param  int  $anchorCharacter
      * @return array<int, int>
@@ -197,8 +167,6 @@ class CharacterOffsets
             return self::identity($byteOffsets, $byteLength);
         }
 
-        // Walk the requested offsets in order and count characters over each gap
-        // with a C-level continuation-byte scan.
         $sorted = array_values(array_unique($byteOffsets));
         sort($sorted, SORT_NUMERIC);
 
@@ -230,8 +198,6 @@ class CharacterOffsets
     }
 
     /**
-     * Counts the non-continuation bytes in [$start, $end) with a C-level scan.
-     *
      * @param  string  $source
      * @param  int  $start
      * @param  int  $end

--- a/src/View/Antlers/Language/Utilities/CharacterOffsets.php
+++ b/src/View/Antlers/Language/Utilities/CharacterOffsets.php
@@ -1,0 +1,246 @@
+<?php
+
+namespace Statamic\View\Antlers\Language\Utilities;
+
+/**
+ * Converts between UTF-8 byte offsets and character offsets without walking the
+ * string in PHP. Byte offsets are what preg_* report; character offsets are what
+ * the document parser and the rest of the Antlers runtime work with.
+ *
+ * Every conversion keeps the scan at the C level (preg / mbstring); a PHP per-byte
+ * loop over a large template costs milliseconds per call, and the parser can make
+ * hundreds of these calls while parsing a single document.
+ */
+class CharacterOffsets
+{
+    /**
+     * PCRE limits a fixed repetition to 65535, so longer advances are split into
+     * power-of-two steps. Restricting the steps to powers of two also keeps the
+     * number of distinct compiled patterns tiny.
+     */
+    const MAX_ADVANCE_STEP = 32768;
+
+    /**
+     * @param  int[]  $offsets
+     * @param  int  $length
+     * @return array<int, int>
+     */
+    protected static function identity(array $offsets, $length)
+    {
+        $mapped = [];
+
+        foreach ($offsets as $offset) {
+            $mapped[$offset] = min($offset, $length);
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @param  string  $source
+     * @param  bool|null  $known  The caller's answer, when it already has one.
+     * @return bool
+     */
+    protected static function isMultibyte($source, $known)
+    {
+        return $known ?? strlen($source) !== mb_strlen($source);
+    }
+
+    /**
+     * Maps character offsets to byte offsets. Offsets past the end of the string
+     * map to the byte length; negative offsets map to zero.
+     *
+     * @param  string  $source
+     * @param  int[]  $characterOffsets
+     * @param  bool|null  $sourceIsMultibyte  Pass it when known to skip the check.
+     * @return array<int, int>
+     */
+    public static function toBytes($source, array $characterOffsets, $sourceIsMultibyte = null)
+    {
+        if ($characterOffsets === []) {
+            return [];
+        }
+
+        $byteLength = strlen($source);
+
+        if (! self::isMultibyte($source, $sourceIsMultibyte)) {
+            return self::identity($characterOffsets, $byteLength);
+        }
+
+        // PCRE remembers a validated string, so this is free after the first call.
+        if (! preg_match('//u', $source)) {
+            return self::toBytesByteLoop($source, $characterOffsets);
+        }
+
+        $sorted = array_values(array_unique($characterOffsets));
+        sort($sorted, SORT_NUMERIC);
+
+        $offsets = [];
+        $byte = 0;
+        $character = 0;
+        $reachedEnd = false;
+
+        foreach ($sorted as $target) {
+            if ($target <= 0) {
+                $offsets[$target] = 0;
+
+                continue;
+            }
+
+            if (! $reachedEnd && $target > $character) {
+                $advanced = self::advanceCharacters($source, $byte, $target - $character);
+
+                if ($advanced === null) {
+                    $reachedEnd = true;
+                } else {
+                    $byte = $advanced;
+                    $character = $target;
+                }
+            }
+
+            $offsets[$target] = $reachedEnd ? $byteLength : $byte;
+        }
+
+        return $offsets;
+    }
+
+    /**
+     * Returns the byte offset $characters code points after $byte, or null when the
+     * string ends first. The source must be valid UTF-8.
+     *
+     * @param  string  $source
+     * @param  int  $byte
+     * @param  int  $characters
+     * @return int|null
+     */
+    protected static function advanceCharacters($source, $byte, $characters)
+    {
+        $step = self::MAX_ADVANCE_STEP;
+
+        while ($characters > 0) {
+            if ($step > $characters) {
+                $step >>= 1;
+
+                continue;
+            }
+
+            if (preg_match('/\G.{'.$step.'}/us', $source, $match, 0, $byte) !== 1) {
+                return null;
+            }
+
+            $byte += strlen($match[0]);
+            $characters -= $step;
+        }
+
+        return $byte;
+    }
+
+    /**
+     * The original per-byte conversion, kept for strings that are not valid UTF-8.
+     *
+     * @param  string  $source
+     * @param  int[]  $characterOffsets
+     * @return array<int, int>
+     */
+    protected static function toBytesByteLoop($source, array $characterOffsets)
+    {
+        $byteLength = strlen($source);
+        $needed = array_fill_keys($characterOffsets, true);
+        $offsets = [];
+        $character = 0;
+
+        for ($byte = 0; $byte < $byteLength; $byte++) {
+            if ((ord($source[$byte]) & 0xC0) === 0x80) {
+                continue;
+            }
+
+            if (isset($needed[$character])) {
+                $offsets[$character] = $byte;
+            }
+
+            $character++;
+        }
+
+        foreach ($needed as $neededCharacter => $unused) {
+            if (! isset($offsets[$neededCharacter])) {
+                $offsets[$neededCharacter] = $neededCharacter <= 0 ? 0 : $byteLength;
+            }
+        }
+
+        return $offsets;
+    }
+
+    /**
+     * Maps byte offsets to character offsets. A byte inside a multibyte sequence maps
+     * to the character that contains it; offsets past the end map to the length.
+     *
+     * When the caller already knows that byte $anchorByte is character
+     * $anchorCharacter (a boundary), offsets at or after it are counted from there
+     * instead of from the start of the string.
+     *
+     * @param  string  $source
+     * @param  int[]  $byteOffsets
+     * @param  bool|null  $sourceIsMultibyte  Pass it when known to skip the check.
+     * @param  int  $anchorByte
+     * @param  int  $anchorCharacter
+     * @return array<int, int>
+     */
+    public static function toCharacters($source, array $byteOffsets, $sourceIsMultibyte = null, $anchorByte = 0, $anchorCharacter = 0)
+    {
+        if ($byteOffsets === []) {
+            return [];
+        }
+
+        $byteLength = strlen($source);
+
+        if (! self::isMultibyte($source, $sourceIsMultibyte)) {
+            return self::identity($byteOffsets, $byteLength);
+        }
+
+        // Walk the requested offsets in order and count characters over each gap
+        // with a C-level continuation-byte scan.
+        $sorted = array_values(array_unique($byteOffsets));
+        sort($sorted, SORT_NUMERIC);
+
+        $offsets = [];
+        $character = 0;
+        $previousByte = 0;
+
+        foreach ($sorted as $byte) {
+            if ($byte >= $anchorByte && $previousByte < $anchorByte) {
+                $previousByte = $anchorByte;
+                $character = $anchorCharacter;
+            }
+
+            $lead = min($byte, $byteLength);
+
+            while ($lead > 0 && $lead < $byteLength && (ord($source[$lead]) & 0xC0) === 0x80) {
+                $lead--;
+            }
+
+            if ($lead > $previousByte) {
+                $character += self::countCharacters($source, $previousByte, $lead);
+                $previousByte = $lead;
+            }
+
+            $offsets[$byte] = $character;
+        }
+
+        return $offsets;
+    }
+
+    /**
+     * Counts the non-continuation bytes in [$start, $end) with a C-level scan.
+     *
+     * @param  string  $source
+     * @param  int  $start
+     * @param  int  $end
+     * @return int
+     */
+    protected static function countCharacters($source, $start, $end)
+    {
+        $length = $end - $start;
+
+        return $length - preg_match_all('/[\x80-\xBF]/', substr($source, $start, $length));
+    }
+}

--- a/src/View/Antlers/Language/Utilities/StringUtilities.php
+++ b/src/View/Antlers/Language/Utilities/StringUtilities.php
@@ -23,8 +23,6 @@ class StringUtilities
 
     protected static function getMethod($text)
     {
-        // Not memoized: hashing the text as an array key costs as much as
-        // counting its characters, and a per-string cache grew without bound.
         return mb_strlen($text, 'utf-8') < strlen($text);
     }
 

--- a/src/View/Antlers/Language/Utilities/StringUtilities.php
+++ b/src/View/Antlers/Language/Utilities/StringUtilities.php
@@ -21,15 +21,11 @@ class StringUtilities
         }
     }
 
-    protected static $methodCache = [];
-
     protected static function getMethod($text)
     {
-        if (! array_key_exists($text, self::$methodCache)) {
-            self::$methodCache[$text] = mb_strlen($text, 'utf-8') < strlen($text);
-        }
-
-        return self::$methodCache[$text];
+        // Not memoized: hashing the text as an array key costs as much as
+        // counting its characters, and a per-string cache grew without bound.
+        return mb_strlen($text, 'utf-8') < strlen($text);
     }
 
     public static function substr($string, $start = null, $length = null)

--- a/tests/Antlers/Parser/BasicNodeTest.php
+++ b/tests/Antlers/Parser/BasicNodeTest.php
@@ -62,6 +62,39 @@ class BasicNodeTest extends ParserTestCase
         $this->assertTrue($php->isEchoNode);
     }
 
+    public function test_multibyte_literals_keep_character_based_region_boundaries_and_lines()
+    {
+        $nodes = $this->parseNodes("caf\u{00E9}\n\u{65E5}\u{672C} {{ first }}\n\u{1F389} {{ second }} tail");
+
+        $this->assertSame("caf\u{00E9}\n\u{65E5}\u{672C} ", $nodes[0]->content);
+        $this->assertSame(' first ', $nodes[1]->content);
+        $this->assertSame("\n\u{1F389} ", $nodes[2]->content);
+        $this->assertSame(' second ', $nodes[3]->content);
+        $this->assertSame(' tail', $nodes[4]->content);
+
+        $this->assertSame(8, $nodes[1]->startPosition->offset);
+        $this->assertSame(2, $nodes[1]->startPosition->line);
+        $this->assertSame(4, $nodes[1]->startPosition->char);
+        $this->assertSame(22, $nodes[3]->startPosition->offset);
+        $this->assertSame(3, $nodes[3]->startPosition->line);
+        $this->assertSame(3, $nodes[3]->startPosition->char);
+    }
+
+    public function test_columns_are_correct_after_a_document_initial_newline()
+    {
+        foreach (["\n", "\r", "\r\n"] as $newline) {
+            $nodes = $this->parseNodes($newline."\u{65E5}\u{672C}{{ first }}".$newline.'ab{{ second }}');
+
+            $this->assertSame(3, $nodes[1]->startPosition->offset);
+            $this->assertSame(2, $nodes[1]->startPosition->line);
+            $this->assertSame(3, $nodes[1]->startPosition->char);
+
+            $this->assertSame(17, $nodes[3]->startPosition->offset);
+            $this->assertSame(3, $nodes[3]->startPosition->line);
+            $this->assertSame(3, $nodes[3]->startPosition->char);
+        }
+    }
+
     public function test_it_doesnt_trim_off_content_start()
     {
         $nodes = $this->parseNodes('{{ meta_title ?? title ?? "No Title Set" }}');

--- a/tests/Antlers/Parser/CharacterOffsetsTest.php
+++ b/tests/Antlers/Parser/CharacterOffsetsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Tests\Antlers\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Statamic\View\Antlers\Language\Utilities\CharacterOffsets;
+
+class CharacterOffsetsTest extends TestCase
+{
+    // a(0) é(1-2) 日(3-5) 🎉(6-9) b(10); 5 characters, 11 bytes.
+    const MIXED = "a\u{00E9}\u{65E5}\u{1F389}b";
+
+    public function test_ascii_offsets_map_to_themselves_and_clamp_to_the_length()
+    {
+        $this->assertSame([0 => 0, 3 => 3, 5 => 5, 9 => 5], CharacterOffsets::toBytes('hello', [0, 3, 5, 9]));
+        $this->assertSame([0 => 0, 3 => 3, 5 => 5, 9 => 5], CharacterOffsets::toCharacters('hello', [0, 3, 5, 9]));
+        $this->assertSame([], CharacterOffsets::toBytes('hello', []));
+        $this->assertSame([], CharacterOffsets::toCharacters('hello', []));
+    }
+
+    public function test_character_offsets_map_to_lead_bytes()
+    {
+        $this->assertSame(
+            [0 => 0, 1 => 1, 2 => 3, 3 => 6, 4 => 10, 5 => 11],
+            CharacterOffsets::toBytes(self::MIXED, [0, 1, 2, 3, 4, 5])
+        );
+    }
+
+    public function test_byte_offsets_map_to_the_containing_character()
+    {
+        $this->assertSame(
+            [0 => 0, 1 => 1, 2 => 1, 3 => 2, 5 => 2, 6 => 3, 9 => 3, 10 => 4, 11 => 5],
+            CharacterOffsets::toCharacters(self::MIXED, [0, 1, 2, 3, 5, 6, 9, 10, 11])
+        );
+    }
+
+    public function test_offsets_past_the_end_map_to_the_length()
+    {
+        $this->assertSame([7 => 11, 40 => 11], CharacterOffsets::toBytes(self::MIXED, [7, 40]));
+        $this->assertSame([12 => 5, 40 => 5], CharacterOffsets::toCharacters(self::MIXED, [12, 40]));
+    }
+
+    public function test_input_order_and_duplicates_do_not_matter()
+    {
+        $expected = [4 => 10, 0 => 0, 2 => 3];
+
+        $this->assertEquals($expected, CharacterOffsets::toBytes(self::MIXED, [4, 0, 2, 4, 0]));
+        $this->assertEquals([10 => 4, 0 => 0, 3 => 2], CharacterOffsets::toCharacters(self::MIXED, [10, 0, 3, 10]));
+    }
+
+    public function test_negative_character_offsets_map_to_the_start()
+    {
+        $this->assertSame([-2 => 0, 0 => 0, 1 => 1], CharacterOffsets::toBytes(self::MIXED, [-2, 0, 1]));
+    }
+
+    public function test_large_advances_are_split_into_steps()
+    {
+        $source = str_repeat("\u{00E9}", 40000).str_repeat('x', 100);
+
+        $this->assertSame(
+            [1 => 2, 32768 => 65536, 39999 => 79998, 40000 => 80000, 40050 => 80050, 50000 => 80100],
+            CharacterOffsets::toBytes($source, [1, 32768, 39999, 40000, 40050, 50000])
+        );
+    }
+
+    public function test_byte_offsets_can_be_counted_from_a_known_anchor()
+    {
+        // Anchor: byte 6 is character 3 (the emoji). Offsets before it still count from the start.
+        $this->assertSame(
+            [1 => 1, 6 => 3, 10 => 4, 11 => 5],
+            CharacterOffsets::toCharacters(self::MIXED, [1, 6, 10, 11], true, 6, 3)
+        );
+
+        // A wrong anchor is trusted, which is what makes it an anchor.
+        $this->assertSame([10 => 41], CharacterOffsets::toCharacters(self::MIXED, [10], true, 6, 40));
+    }
+
+    public function test_conversions_round_trip_on_mixed_content()
+    {
+        $source = str_repeat("plain ascii line\n", 40).str_repeat("\u{65E5}\u{672C}\u{8A9E} \u{1F389} caf\u{00E9}\n", 40);
+        $characters = range(0, mb_strlen($source), 7);
+
+        $bytes = CharacterOffsets::toBytes($source, $characters);
+        $back = CharacterOffsets::toCharacters($source, array_values($bytes));
+
+        foreach ($characters as $character) {
+            $this->assertSame(strlen(mb_substr($source, 0, $character)), $bytes[$character], "byte offset of character {$character}");
+            $this->assertSame($character, $back[$bytes[$character]], "round trip of character {$character}");
+        }
+    }
+
+    public function test_invalid_utf8_counts_lead_bytes_without_failing()
+    {
+        // A stray continuation byte attaches to nothing, so "a" is character 0.
+        $this->assertSame([0 => 1, 1 => 2, 2 => 4], CharacterOffsets::toBytes("\xA9a\u{00E9}", [0, 1, 2]));
+        $this->assertSame([0 => 0, 1 => 0, 2 => 1, 4 => 2], CharacterOffsets::toCharacters("\xA9a\u{00E9}", [0, 1, 2, 4]));
+
+        // A truncated sequence still counts as one character.
+        $this->assertSame([0 => 0, 1 => 2, 2 => 3], CharacterOffsets::toBytes("\xE6\x97{{", [0, 1, 2]));
+        $this->assertSame([0 => 0, 2 => 1, 3 => 2], CharacterOffsets::toCharacters("\xE6\x97{{", [0, 2, 3]));
+    }
+}

--- a/tests/Antlers/Parser/CharacterOffsetsTest.php
+++ b/tests/Antlers/Parser/CharacterOffsetsTest.php
@@ -65,13 +65,11 @@ class CharacterOffsetsTest extends TestCase
 
     public function test_byte_offsets_can_be_counted_from_a_known_anchor()
     {
-        // Anchor: byte 6 is character 3 (the emoji). Offsets before it still count from the start.
         $this->assertSame(
             [1 => 1, 6 => 3, 10 => 4, 11 => 5],
             CharacterOffsets::toCharacters(self::MIXED, [1, 6, 10, 11], true, 6, 3)
         );
 
-        // A wrong anchor is trusted, which is what makes it an anchor.
         $this->assertSame([10 => 41], CharacterOffsets::toCharacters(self::MIXED, [10], true, 6, 40));
     }
 
@@ -91,11 +89,9 @@ class CharacterOffsetsTest extends TestCase
 
     public function test_invalid_utf8_counts_lead_bytes_without_failing()
     {
-        // A stray continuation byte attaches to nothing, so "a" is character 0.
         $this->assertSame([0 => 1, 1 => 2, 2 => 4], CharacterOffsets::toBytes("\xA9a\u{00E9}", [0, 1, 2]));
         $this->assertSame([0 => 0, 1 => 0, 2 => 1, 4 => 2], CharacterOffsets::toCharacters("\xA9a\u{00E9}", [0, 1, 2, 4]));
 
-        // A truncated sequence still counts as one character.
         $this->assertSame([0 => 0, 1 => 2, 2 => 3], CharacterOffsets::toBytes("\xE6\x97{{", [0, 1, 2]));
         $this->assertSame([0 => 0, 2 => 1, 3 => 2], CharacterOffsets::toCharacters("\xE6\x97{{", [0, 2, 3]));
     }

--- a/tests/Antlers/Parser/InterpolationRegionTest.php
+++ b/tests/Antlers/Parser/InterpolationRegionTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Antlers\Parser;
+
+use Statamic\View\Antlers\Language\Nodes\AntlersNode;
+use Statamic\View\Antlers\Language\Nodes\LiteralNode;
+use Statamic\View\Antlers\Language\Parser\DocumentParser;
+use Tests\Antlers\ParserTestCase;
+
+/**
+ * Interpolated parameters are parsed by a sub-parser that is handed the document
+ * prefix (braces neutralized) followed by the interpolated content so that the
+ * resulting node positions line up with the document. These tests pin the
+ * positions and the sub-parser's document text, which must not change when the
+ * sub-parser inherits the parent's newline table instead of rescanning the prefix.
+ */
+class InterpolationRegionTest extends ParserTestCase
+{
+    private function assertPosition(string $expected, $node)
+    {
+        $this->assertSame($expected, sprintf(
+            '%d/%d/%d-%d/%d/%d',
+            $node->startPosition->offset, $node->startPosition->line, $node->startPosition->char,
+            $node->endPosition->offset, $node->endPosition->line, $node->endPosition->char
+        ));
+    }
+
+    private function interpolation(AntlersNode $node, int $index = 0)
+    {
+        $regions = array_values($node->processedInterpolationRegions);
+
+        $this->assertCount(1, $regions[$index]);
+
+        return $regions[$index][0];
+    }
+
+    public function test_interpolation_positions_follow_document_lines()
+    {
+        $template = "line one\nline two {{ partial:card title=\"{{ title | upper }}\" }}\nline three {{ tag :x=\"{{ y }}\" }}";
+        $nodes = $this->parseNodes($template);
+
+        $this->assertPosition('18/2/10-63/2/55', $nodes[1]);
+        $first = $this->interpolation($nodes[1]);
+        $this->assertPosition('39/2/31-59/2/51', $first);
+        $inner = $this->interpolation($first);
+        $this->assertSame(' title | upper ', $inner->content);
+        $this->assertPosition('37/2/29-55/2/47', $inner);
+
+        $this->assertPosition('76/3/12-97/3/33', $nodes[3]);
+        $second = $this->interpolation($nodes[3]);
+        $this->assertPosition('84/3/20-92/3/28', $second);
+        $inner = $this->interpolation($second);
+        $this->assertSame(' y ', $inner->content);
+        $this->assertPosition('84/3/20-90/3/26', $inner);
+    }
+
+    public function test_interpolation_sub_parser_keeps_the_neutralized_document_prefix()
+    {
+        $template = "line one\nline two {{ partial:card title=\"{{ title | upper }}\" }}";
+        $nodes = $this->parseNodes($template);
+        $interpolation = $this->interpolation($nodes[1]);
+
+        $this->assertSame(
+            str_replace('{', '~', mb_substr($template, 0, 39)).'{{{ title | upper }}}',
+            $interpolation->getParser()->getParsedContent()
+        );
+        $this->assertSame('{{{ title | upper }}}', $interpolation->getNodeDocumentText());
+    }
+
+    public function test_interpolation_positions_after_multibyte_content()
+    {
+        $template = "caf\u{00E9}\n\u{65E5}\u{672C} {{ partial:card title=\"{{ title }}\" }}\n\u{1F389} {{ tag :x=\"{{ y | upper }}\" }}";
+        $nodes = $this->parseNodes($template);
+
+        $this->assertPosition('8/2/4-45/2/41', $nodes[1]);
+        $first = $this->interpolation($nodes[1]);
+        $this->assertPosition('27/2/23-39/2/35', $first);
+        $this->assertPosition('28/2/24-38/2/34', $this->interpolation($first));
+
+        $this->assertPosition('49/3/3-78/3/32', $nodes[3]);
+        $second = $this->interpolation($nodes[3]);
+        $this->assertPosition('59/3/13-75/3/29', $second);
+        $inner = $this->interpolation($second);
+        $this->assertSame(' y | upper ', $inner->content);
+        $this->assertPosition('61/3/15-75/3/29', $inner);
+    }
+
+    public function test_interpolation_positions_with_crlf_line_endings()
+    {
+        $nodes = $this->parseNodes("line one\r\nline two {{ partial:card title=\"{{ title }}\" }}");
+
+        $this->assertPosition('18/2/10-55/2/47', $nodes[1]);
+        $first = $this->interpolation($nodes[1]);
+        $this->assertPosition('37/2/29-49/2/41', $first);
+        $this->assertPosition('38/2/30-48/2/40', $this->interpolation($first));
+    }
+
+    public function test_multi_line_interpolations_continue_line_numbering()
+    {
+        $nodes = $this->parseNodes("{{ tag a=\"{{\n  b\n}}\" }}\n{{ c }}");
+
+        $this->assertPosition('0/1/1-22/3/6', $nodes[0]);
+        $first = $this->interpolation($nodes[0]);
+        $this->assertPosition('6/1/7-16/3/3', $first);
+        $inner = $this->interpolation($first);
+        $this->assertSame("\n  b\n", $inner->content);
+        $this->assertPosition('4/1/5-12/3/2', $inner);
+        $this->assertPosition('24/4/1-30/4/7', $nodes[2]);
+    }
+
+    public function test_nested_interpolations_keep_their_positions()
+    {
+        $nodes = $this->parseNodes("a\n{{ tag a=\"{{ b c=\"{{ d }}\" }}\" }}");
+
+        $level1 = $this->interpolation($nodes[1]);
+        $this->assertPosition('8/2/7-28/2/27', $level1);
+        $level2 = $this->interpolation($level1);
+        $this->assertSame(' b c="int_ee2" ', $level2->content);
+        $this->assertPosition('6/2/5-24/2/23', $level2);
+        $level3 = $this->interpolation($level2);
+        $this->assertPosition('14/2/13-22/2/21', $level3);
+        $level4 = $this->interpolation($level3);
+        $this->assertSame(' d ', $level4->content);
+        $this->assertPosition('14/2/13-20/2/19', $level4);
+    }
+
+    public function test_nested_interpolations_keep_their_own_line_numbering_under_a_seeded_parser()
+    {
+        // RuntimeParser seeds the document parser for views with front matter. The
+        // document's own nodes follow the seed; interpolation sub-parsers have always
+        // numbered from line 1, at every nesting level.
+        $parser = new DocumentParser();
+        $parser->setStartLineSeed(5);
+        $parser->parse("a\n\n\n{{ tag a=\"{{ b c=\"{{ d }}\" }}\" }}");
+        $nodes = $parser->getNodes();
+
+        $this->assertPosition('4/8/1-36/8/33', $nodes[1]);
+        $level1 = $this->interpolation($nodes[1]);
+        $this->assertPosition('10/4/7-30/4/27', $level1);
+        $level2 = $this->interpolation($level1);
+        $this->assertPosition('8/4/5-26/4/23', $level2);
+        $level3 = $this->interpolation($level2);
+        $this->assertPosition('16/4/13-24/4/21', $level3);
+        $level4 = $this->interpolation($level3);
+        $this->assertSame(' d ', $level4->content);
+        $this->assertPosition('16/4/13-22/4/19', $level4);
+    }
+
+    public function test_single_brace_interpolation_at_the_document_start()
+    {
+        // The prefix handed to the sub-parser is cut before the interpolation start,
+        // which is negative here; the multibyte tail must not change the result.
+        foreach (["{{{abcdefghi}}} \u{00E9}", '{{{abcdefghi}}} e'] as $template) {
+            $nodes = $this->parseNodes($template);
+
+            $this->assertSame('int_2b2b4ee', $nodes[0]->content);
+            $this->assertPosition('0/1/1-14/1/15', $nodes[0]);
+            $interpolation = $this->interpolation($nodes[0]);
+            $this->assertSame('abcdefghi', $interpolation->content);
+            $this->assertPosition('16/1/17-28/1/29', $interpolation);
+            $this->assertInstanceOf(LiteralNode::class, $nodes[1]);
+            $this->assertPosition('15/1/16-16/1/17', $nodes[1]);
+        }
+    }
+
+    public function test_directive_like_text_inside_comments_does_not_break_interpolations()
+    {
+        // The sub-parser sees a neutralized copy of the document prefix, in which a
+        // "@props(" inside a comment or noparse region used to be parsed as a directive.
+        foreach ([
+            '{{# @props( #}}<div>{{ tag x="{{ y }}" }}</div>',
+            '{{ noparse }}@props(<b>{{ /noparse }}<div>{{ tag x="{{ y }}" }}</div>',
+        ] as $template) {
+            $nodes = $this->parseNodes($template);
+            $tag = $nodes[count($nodes) - 2];
+
+            $this->assertSame(' tag x="int_dc5" ', $tag->content);
+            $this->assertSame(' y ', $this->interpolation($this->interpolation($tag))->content);
+        }
+    }
+
+    public function test_an_at_sign_just_before_an_interpolation_escapes_it()
+    {
+        // Pre-existing behavior kept for compatibility: the prefix handed to the
+        // sub-parser is cut a few characters before the interpolation, so an "@"
+        // that lands right before the cut makes the sub-parser treat the
+        // interpolation's braces as escaped and the region resolves to nothing.
+        $nodes = $this->parseNodes('{{ tag @a="{{ v }}" }}');
+
+        $this->assertSame([], array_values($nodes[0]->processedInterpolationRegions)[0]);
+
+        // An "@" further away is unaffected.
+        $nodes = $this->parseNodes('{{ tag x="{{ v }}" @a="{{ w }}" }}');
+        $this->assertSame(' v ', $this->interpolation($this->interpolation($nodes[0]))->content);
+        $this->assertSame(' w ', $this->interpolation($this->interpolation($nodes[0], 1))->content);
+    }
+}

--- a/tests/Antlers/Parser/InterpolationRegionTest.php
+++ b/tests/Antlers/Parser/InterpolationRegionTest.php
@@ -7,13 +7,6 @@ use Statamic\View\Antlers\Language\Nodes\LiteralNode;
 use Statamic\View\Antlers\Language\Parser\DocumentParser;
 use Tests\Antlers\ParserTestCase;
 
-/**
- * Interpolated parameters are parsed by a sub-parser that is handed the document
- * prefix (braces neutralized) followed by the interpolated content so that the
- * resulting node positions line up with the document. These tests pin the
- * positions and the sub-parser's document text, which must not change when the
- * sub-parser inherits the parent's newline table instead of rescanning the prefix.
- */
 class InterpolationRegionTest extends ParserTestCase
 {
     private function assertPosition(string $expected, $node)
@@ -126,9 +119,6 @@ class InterpolationRegionTest extends ParserTestCase
 
     public function test_nested_interpolations_keep_their_own_line_numbering_under_a_seeded_parser()
     {
-        // RuntimeParser seeds the document parser for views with front matter. The
-        // document's own nodes follow the seed; interpolation sub-parsers have always
-        // numbered from line 1, at every nesting level.
         $parser = new DocumentParser();
         $parser->setStartLineSeed(5);
         $parser->parse("a\n\n\n{{ tag a=\"{{ b c=\"{{ d }}\" }}\" }}");
@@ -148,8 +138,6 @@ class InterpolationRegionTest extends ParserTestCase
 
     public function test_single_brace_interpolation_at_the_document_start()
     {
-        // The prefix handed to the sub-parser is cut before the interpolation start,
-        // which is negative here; the multibyte tail must not change the result.
         foreach (["{{{abcdefghi}}} \u{00E9}", '{{{abcdefghi}}} e'] as $template) {
             $nodes = $this->parseNodes($template);
 
@@ -165,8 +153,6 @@ class InterpolationRegionTest extends ParserTestCase
 
     public function test_directive_like_text_inside_comments_does_not_break_interpolations()
     {
-        // The sub-parser sees a neutralized copy of the document prefix, in which a
-        // "@props(" inside a comment or noparse region used to be parsed as a directive.
         foreach ([
             '{{# @props( #}}<div>{{ tag x="{{ y }}" }}</div>',
             '{{ noparse }}@props(<b>{{ /noparse }}<div>{{ tag x="{{ y }}" }}</div>',
@@ -181,15 +167,10 @@ class InterpolationRegionTest extends ParserTestCase
 
     public function test_an_at_sign_just_before_an_interpolation_escapes_it()
     {
-        // Pre-existing behavior kept for compatibility: the prefix handed to the
-        // sub-parser is cut a few characters before the interpolation, so an "@"
-        // that lands right before the cut makes the sub-parser treat the
-        // interpolation's braces as escaped and the region resolves to nothing.
         $nodes = $this->parseNodes('{{ tag @a="{{ v }}" }}');
 
         $this->assertSame([], array_values($nodes[0]->processedInterpolationRegions)[0]);
 
-        // An "@" further away is unaffected.
         $nodes = $this->parseNodes('{{ tag x="{{ v }}" @a="{{ w }}" }}');
         $this->assertSame(' v ', $this->interpolation($this->interpolation($nodes[0]))->content);
         $this->assertSame(' w ', $this->interpolation($this->interpolation($nodes[0], 1))->content);

--- a/tests/Antlers/Parser/StringUtilitiesTest.php
+++ b/tests/Antlers/Parser/StringUtilitiesTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Antlers\Parser;
+
+use PHPUnit\Framework\TestCase;
+use Statamic\View\Antlers\Language\Utilities\StringUtilities;
+
+class StringUtilitiesTest extends TestCase
+{
+    public function test_encoding_detection_selects_multibyte_operations()
+    {
+        StringUtilities::prepareSplit("caf\u{00E9}");
+
+        $this->assertSame(StringUtilities::SPLIT_METHOD_MB_STR_SPLIT, StringUtilities::$splitMethod);
+        $this->assertSame(['c', 'a', 'f', "\u{00E9}"], StringUtilities::split("caf\u{00E9}"));
+        $this->assertSame("f\u{00E9}", StringUtilities::substr("caf\u{00E9}", 2));
+
+        StringUtilities::prepareSplit('cafe');
+
+        $this->assertSame(StringUtilities::SPLIT_METHOD_STR_SPLIT, StringUtilities::$splitMethod);
+        $this->assertSame(['c', 'a', 'f', 'e'], StringUtilities::split('cafe'));
+        $this->assertSame('fe', StringUtilities::substr('cafe', 2));
+    }
+}


### PR DESCRIPTION
This PR resolves some inefficiencies within the Antlers parser, mainly around offsets and how it incrementally scanned the document.

Expectation management: this PR won't introduce _super_ noticeable impacts on a single request, unless you happen to have hit some of the multibyte edge cases. The improvements here really shine in the aggregate where repeated items are parsed (SSG, routing, etc.)

The updated parser produces the same output as before for valid templates.

## Benchmark results

Benchmark script is attached.

| Template | 6.x | Current | Faster | Less memory |
| --- | --- | --- | --- | --- |
| ascii, 150 sections (69KB) | 1651 ms / 336 MB | 348 ms / 60 MB | 79% | 82% |
| crlf, 150 sections (70KB) | 2011 ms / 336 MB | 321 ms / 60 MB | 84% | 82% |
| oneaccent, 150 sections (69KB) | 1690 ms / 348 MB | 328 ms / 64 MB | 81% | 82% |
| multibyte, 150 sections (71KB) | 2041 ms / 350 MB | 338 ms / 66 MB | 83% | 81% |
| escaped, 150 sections (65KB) | 1539 ms / 326 MB | 258 ms / 56 MB | 83% | 83% |
| adversarial, 30 sections (69KB) | 2989 ms / 188 MB | 275 ms / 56 MB | 91% | 70% |
| ascii, 30 sections (14KB) | 120 ms / 30 MB | 60 ms / 18 MB | 50% | 40% |
| ascii, 600 sections (275KB) | 31376 ms / 4902 MB | 1767 ms / 508 MB | 94% | 90% |
| adversarial, 150 sections (346KB) | 292342 ms / 3902 MB | 2191 ms / 698 MB | 99% | 82% |

[antlers-parser-benchmark.php](https://github.com/user-attachments/files/31848648/antlers-parser-benchmark.php)
