### PR TITLE
[6.x] Add `guard` param to user tags

### DIFF
--- a/src/Auth/UserTags.php
+++ b/src/Auth/UserTags.php
@@ -76,12 +76,21 @@ class UserTags extends Tags
 
         // No user found? Get the current one.
         if (! $user) {
-            if (! $user = User::current()) {
+            if (! $user = $this->currentUser()) {
                 return $this->parseNoResults();
             }
         }
 
         return $this->aliasedResult($user);
+    }
+
+    private function currentUser()
+    {
+        if (! $guard = $this->params->get('guard')) {
+            return User::current();
+        }
+
+        return User::fromUser(auth($guard)->user());
     }
 
     /**
@@ -420,6 +429,10 @@ class UserTags extends Tags
             $queryParams['redirect'] = $redirect;
         }
 
+        if ($guard = $this->params->get('guard')) {
+            $queryParams['guard'] = $guard;
+        }
+
         return route('statamic.logout', $queryParams);
     }
 
@@ -430,7 +443,7 @@ class UserTags extends Tags
      */
     public function logout()
     {
-        auth()->logout();
+        auth($this->params->get('guard'))->logout();
 
         abort(redirect($this->params->get('redirect', '/'), $this->params->get('response', 302)));
     }
@@ -575,12 +588,12 @@ class UserTags extends Tags
      */
     public function can()
     {
-        if (! $user = User::current()) {
+        if (! $user = $this->currentUser()) {
             return $this->parser ? null : false;
         }
 
         $permissions = Arr::wrap($this->params->explode(['permission', 'do']));
-        $arguments = $this->params->except(['permission', 'do'])->all();
+        $arguments = $this->params->except(['permission', 'do', 'guard'])->all();
 
         foreach ($permissions as $permission) {
             if ($user->can($permission, $arguments)) {
@@ -600,12 +613,12 @@ class UserTags extends Tags
      */
     public function cant()
     {
-        if (! $user = User::current()) {
+        if (! $user = $this->currentUser()) {
             return $this->parser ? $this->parse() : true;
         }
 
         $permissions = Arr::wrap($this->params->explode(['permission', 'do']));
-        $arguments = $this->params->except(['permission', 'do'])->all();
+        $arguments = $this->params->except(['permission', 'do', 'guard'])->all();
 
         $can = false;
 
@@ -632,7 +645,7 @@ class UserTags extends Tags
      */
     public function is()
     {
-        if (! $user = User::current()) {
+        if (! $user = $this->currentUser()) {
             return $this->parser ? null : false;
         }
 
@@ -660,7 +673,7 @@ class UserTags extends Tags
      */
     public function isnt()
     {
-        if (! $user = User::current()) {
+        if (! $user = $this->currentUser()) {
             return $this->parser ? $this->parse() : true;
         }
 
@@ -695,7 +708,7 @@ class UserTags extends Tags
      */
     public function in()
     {
-        if (! $user = User::current()) {
+        if (! $user = $this->currentUser()) {
             return $this->parser ? null : false;
         }
 
@@ -719,7 +732,7 @@ class UserTags extends Tags
      */
     public function notIn()
     {
-        if (! $user = User::current()) {
+        if (! $user = $this->currentUser()) {
             return $this->parser ? $this->parse() : true;
         }
 

--- a/src/Http/Controllers/User/LoginController.php
+++ b/src/Http/Controllers/User/LoginController.php
@@ -3,6 +3,7 @@
 namespace Statamic\Http\Controllers\User;
 
 use Illuminate\Auth\Events\Failed;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -108,11 +109,7 @@ class LoginController extends Controller
 
     public function logout()
     {
-        if ($guard = request()->get('guard')) {
-            abort_unless(array_key_exists($guard, config('auth.guards')), 404);
-        }
-
-        Auth::guard($guard)->logout();
+        Auth::guard($this->requestedGuard())->logout();
 
         $redirect = request()->get('redirect');
 
@@ -121,6 +118,25 @@ class LoginController extends Controller
             : route('statamic.site');
 
         return redirect($url);
+    }
+
+    private function requestedGuard(): ?string
+    {
+        $guard = request()->query('guard');
+
+        if ($guard === null || $guard === '') {
+            return null;
+        }
+
+        abort_unless(is_string($guard) && $this->isStatefulGuard($guard), 404);
+
+        return $guard;
+    }
+
+    private function isStatefulGuard(string $guard): bool
+    {
+        return array_key_exists($guard, config('auth.guards'))
+            && Auth::guard($guard) instanceof StatefulGuard;
     }
 
     protected function username()

--- a/src/Http/Controllers/User/LoginController.php
+++ b/src/Http/Controllers/User/LoginController.php
@@ -108,7 +108,11 @@ class LoginController extends Controller
 
     public function logout()
     {
-        Auth::logout();
+        if ($guard = request()->get('guard')) {
+            abort_unless(array_key_exists($guard, config('auth.guards')), 404);
+        }
+
+        Auth::guard($guard)->logout();
 
         $redirect = request()->get('redirect');
 

--- a/src/Http/Controllers/User/LoginController.php
+++ b/src/Http/Controllers/User/LoginController.php
@@ -124,7 +124,7 @@ class LoginController extends Controller
     {
         $guard = request()->query('guard');
 
-        if ($guard === null || $guard === '') {
+        if (! $guard) {
             return null;
         }
 

--- a/tests/Tags/User/LogoutTest.php
+++ b/tests/Tags/User/LogoutTest.php
@@ -94,6 +94,21 @@ class LogoutTest extends TestCase
         $this->assertAuthenticated();
     }
 
+    #[Test]
+    public function it_ignores_the_guard_param_on_the_cp_logout_route()
+    {
+        config()->set('auth.guards.statamic', config('auth.guards.web'));
+
+        $this
+            ->actingAs($this->createUser(), 'statamic')
+            ->actingAs(User::make()->id('web-user')->email('web@example.com')->save(), 'web')
+            ->get(cp_route('logout', ['guard' => 'statamic']))
+            ->assertRedirect('/');
+
+        $this->assertAuthenticated('statamic');
+        $this->assertGuest('web');
+    }
+
     private function createUser()
     {
         return tap(User::make()->id('test-user')->email('test@example.com')->password('secret'))->save();

--- a/tests/Tags/User/LogoutTest.php
+++ b/tests/Tags/User/LogoutTest.php
@@ -62,8 +62,10 @@ class LogoutTest extends TestCase
 
     #[Test]
     #[DataProvider('invalidGuardProvider')]
-    public function it_does_not_logout_an_invalid_guard($guard)
+    public function it_does_not_logout_an_invalid_guard(string $guard)
     {
+        config()->set('auth.guards.api', ['driver' => 'token', 'provider' => 'users']);
+
         $this
             ->actingAs($this->createUser())
             ->get(route('statamic.logout', ['guard' => $guard]))
@@ -72,23 +74,20 @@ class LogoutTest extends TestCase
         $this->assertAuthenticated();
     }
 
-    public static function invalidGuardProvider()
+    public static function invalidGuardProvider(): array
     {
         return [
             'unknown guard' => ['nope'],
-            'falsy string' => ['0'],
-            'array' => [['web']],
+            'non-session guard' => ['api'],
         ];
     }
 
     #[Test]
-    public function it_does_not_logout_a_non_session_guard()
+    public function it_does_not_logout_an_array_of_guards()
     {
-        config()->set('auth.guards.api', ['driver' => 'token', 'provider' => 'users']);
-
         $this
             ->actingAs($this->createUser())
-            ->get(route('statamic.logout', ['guard' => 'api']))
+            ->get(route('statamic.logout', ['guard' => ['web']]))
             ->assertNotFound();
 
         $this->assertAuthenticated();

--- a/tests/Tags/User/LogoutTest.php
+++ b/tests/Tags/User/LogoutTest.php
@@ -44,6 +44,32 @@ class LogoutTest extends TestCase
         $this->assertGuest();
     }
 
+    #[Test]
+    public function it_can_logout_a_specific_guard()
+    {
+        config()->set('auth.guards.statamic', config('auth.guards.web'));
+
+        $this
+            ->actingAs($this->createUser(), 'statamic')
+            ->actingAs(User::make()->id('web-user')->email('web@example.com')->save(), 'web')
+            ->get(route('statamic.logout', ['guard' => 'statamic']))
+            ->assertRedirect('/');
+
+        $this->assertGuest('statamic');
+        $this->assertAuthenticated('web');
+    }
+
+    #[Test]
+    public function it_does_not_logout_an_unknown_guard()
+    {
+        $this
+            ->actingAs($this->createUser())
+            ->get(route('statamic.logout', ['guard' => 'nope']))
+            ->assertNotFound();
+
+        $this->assertAuthenticated();
+    }
+
     private function createUser()
     {
         return tap(User::make()->id('test-user')->email('test@example.com')->password('secret'))->save();

--- a/tests/Tags/User/LogoutTest.php
+++ b/tests/Tags/User/LogoutTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Tags\User;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Facades\User;
 use Tests\PreventSavingStacheItemsToDisk;
@@ -60,11 +61,34 @@ class LogoutTest extends TestCase
     }
 
     #[Test]
-    public function it_does_not_logout_an_unknown_guard()
+    #[DataProvider('invalidGuardProvider')]
+    public function it_does_not_logout_an_invalid_guard($guard)
     {
         $this
             ->actingAs($this->createUser())
-            ->get(route('statamic.logout', ['guard' => 'nope']))
+            ->get(route('statamic.logout', ['guard' => $guard]))
+            ->assertNotFound();
+
+        $this->assertAuthenticated();
+    }
+
+    public static function invalidGuardProvider()
+    {
+        return [
+            'unknown guard' => ['nope'],
+            'falsy string' => ['0'],
+            'array' => [['web']],
+        ];
+    }
+
+    #[Test]
+    public function it_does_not_logout_a_non_session_guard()
+    {
+        config()->set('auth.guards.api', ['driver' => 'token', 'provider' => 'users']);
+
+        $this
+            ->actingAs($this->createUser())
+            ->get(route('statamic.logout', ['guard' => 'api']))
             ->assertNotFound();
 
         $this->assertAuthenticated();

--- a/tests/Tags/User/UserTagsTest.php
+++ b/tests/Tags/User/UserTagsTest.php
@@ -134,6 +134,30 @@ class UserTagsTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('guardProvider')]
+    public function it_renders_tag_content_for_a_specific_guard($tag, $expected)
+    {
+        config()->set('auth.guards.statamic', config('auth.guards.web'));
+        $this->setTestRoles(['admin' => ['configure collections']]);
+        $this->setTestUserGroups(['favourite' => ['admin']]);
+
+        auth('statamic')->login(User::make()->email('admin@example.com')->assignRole('admin')->addToGroup('favourite')->save());
+
+        $this->assertEquals('', $this->tag(sprintf($tag, '')));
+        $this->assertEquals($expected, $this->tag(sprintf($tag, ' guard="statamic"')));
+    }
+
+    public static function guardProvider()
+    {
+        return [
+            'user' => ['{{ user%s }}{{ email }}{{ /user }}', 'admin@example.com'],
+            'can' => ['{{ user:can%s do="configure collections" }}yes{{ /user:can }}', 'yes'],
+            'is' => ['{{ user:is%s role="admin" }}yes{{ /user:is }}', 'yes'],
+            'in' => ['{{ user:in%s group="favourite" }}yes{{ /user:in }}', 'yes'],
+        ];
+    }
+
+    #[Test]
     public function it_can_logout_user()
     {
         $this->actingAs(User::make()->save());
@@ -168,11 +192,31 @@ class UserTagsTest extends TestCase
     }
 
     #[Test]
+    public function it_can_logout_user_from_a_specific_guard()
+    {
+        config()->set('auth.guards.statamic', config('auth.guards.web'));
+
+        auth('statamic')->login(User::make()->save());
+        auth('web')->login(User::make()->save());
+
+        try {
+            $this->tag('{{ user:logout guard="statamic" }}');
+        } catch (HttpResponseException $exception) {
+            //
+        }
+
+        $this->assertFalse(auth('statamic')->check());
+        $this->assertTrue(auth('web')->check());
+    }
+
+    #[Test]
     public function it_can_render_logout_url()
     {
         $this->assertEquals(route('statamic.logout'), $this->tag('{{ user:logout_url }}'));
 
         $this->assertEquals(route('statamic.logout', ['redirect' => 'home']), $this->tag('{{ user:logout_url redirect="home" }}'));
+
+        $this->assertEquals(route('statamic.logout', ['guard' => 'statamic']), $this->tag('{{ user:logout_url guard="statamic" }}'));
     }
 
     #[Test]


### PR DESCRIPTION
This pull request implements a `guard` parameter on the user tags, so a template can read a user from a guard other than the one configured in `statamic.users.guards.web`.

Sites running two user populations (say, website customers on Laravel's `web` guard and Statamic users on a `statamic` guard) can't express that with the config alone, because the front-end guard config sets one default guard for the whole request. An admin toolbar rendered on the front-end for the logged-in CP user therefore had no way of checking permissions or building a logout link for that user.

The parameter is accepted by the tags that read the current user: `{{ user }}`, `{{ user:can }}`, `{{ user:cant }}`, `{{ user:is }}`, `{{ user:isnt }}`, `{{ user:in }}`, `{{ user:not_in }}`, `{{ user:logout }}` and `{{ user:logout_url }}`. When it's omitted, the tags behave exactly as before.

```antlers
{{ user:can guard="statamic" do="edit pages entries" }}
    <a href="{{ user:logout_url guard="statamic" redirect="{url}" }}">Log out</a>
{{ /user:can }}
```

This PR also lets the logout route accept a `guard` query parameter, which is what `{{ user:logout_url }}` appends. Unknown guards return a 404 rather than being passed through to the auth manager.

The form tags (login, register, profile, password and so on) are unchanged. They post to controllers that rely on the configured guard, and nobody has asked for those to be guard-aware.

Closes #10490