### PR TITLE
[6.x] Sort strings naturally

### DIFF
--- a/src/Support/Comparator.php
+++ b/src/Support/Comparator.php
@@ -8,6 +8,7 @@ use Statamic\Facades\Site;
 class Comparator
 {
     protected $locale;
+    private ?Collator $collator = null;
     private static bool $canUseCollator;
 
     public function __construct()
@@ -22,6 +23,7 @@ class Comparator
     public function locale($locale)
     {
         $this->locale = $locale;
+        $this->collator = null;
     }
 
     /**
@@ -94,10 +96,22 @@ class Comparator
         $two = mb_strtolower($two);
 
         if (! self::$canUseCollator) {
-            return strcmp($one, $two);
+            return strnatcmp($one, $two);
         }
 
-        return (new Collator($this->locale))->compare($one, $two);
+        return $this->collator()->compare($one, $two);
+    }
+
+    private function collator(): Collator
+    {
+        if ($this->collator) {
+            return $this->collator;
+        }
+
+        $collator = new Collator($this->locale);
+        $collator->setAttribute(Collator::NUMERIC_COLLATION, Collator::ON);
+
+        return $this->collator = $collator;
     }
 
     /**

--- a/tests/Data/DataCollectionTest.php
+++ b/tests/Data/DataCollectionTest.php
@@ -23,6 +23,19 @@ class DataCollectionTest extends TestCase
     }
 
     #[Test]
+    public function it_sorts_naturally()
+    {
+        $collection = new DataCollection([
+            ['foo' => 'Heading 10'],
+            ['foo' => 'Heading 2'],
+            ['foo' => 'Heading 1'],
+        ]);
+
+        $this->assertEquals(['Heading 1', 'Heading 2', 'Heading 10'], $collection->multisort('foo')->pluck('foo')->all());
+        $this->assertEquals(['Heading 10', 'Heading 2', 'Heading 1'], $collection->multisort('foo:desc')->pluck('foo')->all());
+    }
+
+    #[Test]
     public function it_sorts_by_first_item_in_arrays()
     {
         $collection = new DataCollection([

--- a/tests/Data/Entries/EntryQueryBuilderTest.php
+++ b/tests/Data/Entries/EntryQueryBuilderTest.php
@@ -1207,6 +1207,18 @@ class EntryQueryBuilderTest extends TestCase
     }
 
     #[Test]
+    public function entries_are_sorted_naturally()
+    {
+        Collection::make('headings')->save();
+        EntryFactory::id('a')->slug('heading-10')->collection('headings')->data(['title' => 'Heading 10'])->create();
+        EntryFactory::id('b')->slug('heading-2')->collection('headings')->data(['title' => 'Heading 2'])->create();
+        EntryFactory::id('c')->slug('heading-1')->collection('headings')->data(['title' => 'Heading 1'])->create();
+
+        $this->assertSame(['heading-1', 'heading-2', 'heading-10'], Entry::query()->where('collection', 'headings')->orderBy('title')->get()->map->slug()->all());
+        $this->assertSame(['heading-10', 'heading-2', 'heading-1'], Entry::query()->where('collection', 'headings')->orderBy('title', 'desc')->get()->map->slug()->all());
+    }
+
+    #[Test]
     public function filtering_using_where_status_column_throws_exception()
     {
         $this->withoutDeprecationHandling();

--- a/tests/Support/ComparatorTest.php
+++ b/tests/Support/ComparatorTest.php
@@ -39,6 +39,15 @@ class ComparatorTest extends TestCase
     }
 
     #[Test]
+    public function it_compares_strings_naturally()
+    {
+        $this->assertSecond(Compare::strings('Heading 2', 'Heading 10'));
+        $this->assertFirst(Compare::strings('Heading 10', 'Heading 2'));
+        $this->assertSecond(Compare::strings('Heading 9', 'Heading 10'));
+        $this->assertEqual(Compare::strings('Heading 10', 'heading 10'));
+    }
+
+    #[Test]
     public function it_compares_numbers()
     {
         $this->assertSecond(Compare::numbers(1, 2));


### PR DESCRIPTION
This pull request changes string comparisons to sort naturally, so entries titled "Heading 1" through "Heading 12" are ordered `1, 2, 3 … 10, 11, 12` rather than `1, 10, 11, 12, 2, 3 …`.

This was happening because `Comparator::strings()` compares titles character by character, so `1` always comes before `2` regardless of what follows it.

This PR fixes it by enabling ICU's `NUMERIC_COLLATION` on the `Collator`, and falling back to `strnatcmp` when the intl extension isn't available. The `Collator` is now memoised rather than rebuilt for every comparison. Since everything sorts through the comparator, this applies to the Control Panel listings, `{{ collection }}`, `{{ assets }}`, `{{ get_files }}`, the `sort` modifier and search results.

## Things to be aware of

* Sites with numbered titles will see a different order after upgrading.
* Decimal or version-like strings compare digit runs as integers, so `1.10` now sorts after `1.9`.
* The Eloquent driver sorts with SQL `ORDER BY`, so numbered titles will still sort differently on Eloquent sites until it gets the same treatment. It already differs from the Stache today (JSON data fields sort case-sensitively there), and natural, case-insensitive ordering is achievable per database (MySQL `regexp_replace`, MariaDB `NATURAL_SORT_KEY`, Postgres ICU collation, SQLite custom collation), so I'll follow up with a PR on the driver.

Feel free to close this if you think it might be a breaking change.

---

Closes #10449
Related: #11276
