### PR TITLE
[6.x] Fix infinite recursion when evaluating cyclic link fields

### DIFF
--- a/src/Data/AugmentedCollection.php
+++ b/src/Data/AugmentedCollection.php
@@ -10,6 +10,7 @@ use JsonSerializable;
 use Statamic\Contracts\Data\Augmentable;
 use Statamic\Contracts\Query\Builder as StatamicQueryBuilder;
 use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Link\ArrayableLink;
 
 class AugmentedCollection extends Collection
 {
@@ -78,6 +79,10 @@ class AugmentedCollection extends Collection
 
             if ($this->shouldEvaluate && $value instanceof Value) {
                 $value = $value->value();
+            }
+
+            if ($this->shouldEvaluate && $value instanceof ArrayableLink) {
+                $value = $value->toShallowArray();
             }
 
             if ($this->isQueryBuilder($value)) {

--- a/src/Fieldtypes/Link/ArrayableLink.php
+++ b/src/Fieldtypes/Link/ArrayableLink.php
@@ -19,12 +19,17 @@ class ArrayableLink extends ArrayableString
             : ['url' => $this->url()];
     }
 
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function toShallowArray()
     {
         return is_object($this->value)
             ? $this->value->toShallowAugmentedArray()
             : ['url' => $this->url()];
+    }
+
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
+    {
+        return $this->toShallowArray();
     }
 
     public function url()

--- a/tests/Data/AugmentedCollectionTest.php
+++ b/tests/Data/AugmentedCollectionTest.php
@@ -13,6 +13,7 @@ use Statamic\Contracts\Query\Builder as StatamicQueryBuilder;
 use Statamic\Data\AugmentedCollection;
 use Statamic\Data\HasAugmentedData;
 use Statamic\Fields\Value;
+use Statamic\Fieldtypes\Link\ArrayableLink;
 use Tests\TestCase;
 
 class AugmentedCollectionTest extends TestCase
@@ -114,6 +115,24 @@ class AugmentedCollectionTest extends TestCase
             ],
             'golf',
         ], $results);
+    }
+
+    #[Test]
+    public function links_get_converted_to_their_shallow_array_with_flag()
+    {
+        $entry = m::mock(Augmentable::class);
+        $entry->shouldReceive('toShallowAugmentedArray')->andReturn(['id' => '1', 'title' => new Value('The Entry')]);
+        $entry->shouldReceive('toAugmentedArray')->never();
+
+        $c = new AugmentedCollection([
+            new Value(new ArrayableLink($entry)),
+            new Value(new ArrayableLink('/hardcoded')),
+        ]);
+
+        $this->assertEquals([
+            ['id' => '1', 'title' => 'The Entry'],
+            ['url' => '/hardcoded'],
+        ], $c->withEvaluation()->toArray());
     }
 
     #[Test]

--- a/tests/Fieldtypes/LinkTest.php
+++ b/tests/Fieldtypes/LinkTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Fieldtypes;
 
+use Facades\Statamic\Fields\BlueprintRepository;
 use Facades\Statamic\Routing\ResolveRedirect;
 use Mockery;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -44,6 +45,7 @@ class LinkTest extends TestCase
         $this->assertInstanceOf(ArrayableString::class, $augmented);
         $this->assertEquals('/foo', $augmented->value());
         $this->assertEquals(['url' => '/foo'], $augmented->toArray());
+        $this->assertEquals(['url' => '/foo'], $augmented->toShallowArray());
     }
 
     #[Test]
@@ -52,6 +54,7 @@ class LinkTest extends TestCase
         $entry = Mockery::mock();
         $entry->shouldReceive('url')->once()->andReturn('/the-entry-url');
         $entry->shouldReceive('toAugmentedArray')->once()->andReturn('augmented entry array');
+        $entry->shouldReceive('toShallowAugmentedArray')->once()->andReturn('shallow augmented entry array');
 
         ResolveRedirect::shouldReceive('item')
             ->with('entry::test', $parent = new Entry, true)
@@ -67,6 +70,33 @@ class LinkTest extends TestCase
         $this->assertEquals($entry, $augmented->value());
         $this->assertEquals('/the-entry-url', (string) $augmented);
         $this->assertEquals('augmented entry array', $augmented->toArray());
+        $this->assertEquals('shallow augmented entry array', $augmented->toShallowArray());
+    }
+
+    #[Test]
+    public function it_evaluates_entries_linking_to_each_other_in_a_cycle()
+    {
+        $blueprint = Facades\Blueprint::makeFromFields(['link' => ['type' => 'link']]);
+        BlueprintRepository::shouldReceive('in')->with('collections/pages')->andReturn(collect(['page' => $blueprint]));
+        Facades\Collection::make('pages')->routes('{slug}')->save();
+
+        $a = tap(Facades\Entry::make()->collection('pages')->id('a')->slug('a')->data(['title' => 'A', 'link' => 'entry::b']))->save();
+        tap(Facades\Entry::make()->collection('pages')->id('b')->slug('b')->data(['title' => 'B', 'link' => 'entry::c']))->save();
+        tap(Facades\Entry::make()->collection('pages')->id('c')->slug('c')->data(['title' => 'C', 'link' => 'entry::a']))->save();
+
+        $this->assertEquals('/b', $a->toAugmentedArray()['link']->value()['url']);
+        $this->assertEquals('B', $a->toAugmentedArray()['link']->value()['title']);
+        $this->assertEquals('/c', $a->toAugmentedArray()['link']->value()['link']->value()['url']);
+
+        $this->assertEquals([
+            'id' => 'b',
+            'title' => 'B',
+            'url' => '/b',
+            'permalink' => 'http://localhost/b',
+            'api_url' => 'http://localhost/api/collections/pages/entries/b',
+        ], $a->toArray()['link']);
+
+        $this->assertEquals($a->toArray()['link'], json_decode(json_encode($a), true)['link']);
     }
 
     #[Test]


### PR DESCRIPTION
This pull request fixes an issue where entries whose `link` fields point at each other (A → B → C → A) would cause infinite recursion when the entry was converted to an array or JSON, eg. via `Entry::toArray()`, `json_encode($entry)` or `{{ collection:pages as="menu" }}{{ menu | to_json }}`.

This was happening because `AugmentedCollection::toArray()`, when evaluating, eagerly walks whatever `ArrayableLink::toArray()` returns. That's the full augmented array of the linked entry, which contains its own `link` field, and so on until the stack overflows. Even without a cycle, this expanded the whole link graph into the array.

This PR fixes it by representing links shallowly in evaluated arrays, matching how they're already represented in JSON since #11375. `ArrayableLink` gains a `toShallowArray()` method, which `jsonSerialize()` now uses too. Deep `{{ link:field }}` / `$link['field']` access in templates is unchanged.

Fixes #9105
