### PR TITLE
[6.x] Flush the file cache after each mounting test

### DIFF
--- a/tests/Feature/Entries/MountingTest.php
+++ b/tests/Feature/Entries/MountingTest.php
@@ -14,6 +14,13 @@ class MountingTest extends TestCase
 {
     use PreventSavingStacheItemsToDisk;
 
+    public function tearDown(): void
+    {
+        Cache::store('file')->flush();
+
+        parent::tearDown();
+    }
+
     #[Test]
     public function updating_a_mounted_page_will_update_the_uris_for_each_entry_in_that_collection()
     {


### PR DESCRIPTION
This pull request fixes an issue where `IncludeNocacheTest` and `HalfMeasureStaticCachingTest` fail with 404s whenever `MountingTest` runs earlier in the same process.

This was happening because `MountingTest` switches to the `file` cache driver and clears it *before* each test, but never after. Any later test using the file driver then reads the Stache from stale entries on disk, so pages like `/about` don't exist. Which tests share a process depends on how the shards are split, so this only showed up on the Windows shards of #15385, where adding a test file shifted `MountingTest` ahead of `IncludeNocacheTest`.

This PR fixes it by flushing the file store in `MountingTest`'s `tearDown()`.

You can reproduce it on `6.x` with:

```
./vendor/bin/phpunit tests/Feature/Entries/MountingTest.php tests/StaticCaching/IncludeNocacheTest.php
```

Related: #15385
