### PR TITLE
[6.x] Fix nested <li> in the CP nav

### DIFF
--- a/resources/views/nav/duplicates.blade.php
+++ b/resources/views/nav/duplicates.blade.php
@@ -2,12 +2,10 @@
     use function Statamic\trans as __;
 @endphp
 
-<li>
-    <a href="{{ $item->url() }}" class="flex items-center gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
-        <i>{!! $item->svg() !!}</i>
-        <span>{{ __($item->name()) }}</span>
-        <ui-badge color="red" size="sm" pill>
-            {{ Statamic\Facades\Stache::duplicates()->count() }}
-        </ui-badge>
-    </a>
-</li>
+<a href="{{ $item->url() }}" class="flex items-center gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
+    <i>{!! $item->svg() !!}</i>
+    <span>{{ __($item->name()) }}</span>
+    <ui-badge color="red" size="sm" pill>
+        {{ Statamic\Facades\Stache::duplicates()->count() }}
+    </ui-badge>
+</a>

--- a/resources/views/nav/updates.blade.php
+++ b/resources/views/nav/updates.blade.php
@@ -2,10 +2,8 @@
     use function Statamic\trans as __;
 @endphp
 
-<li>
-    <inertia-link href="{{ $item->url() }}" class="flex items-center gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
-        @cp_svg('icons/updates', 'size-4 shrink-0')
-        <span v-pre>{{ __($item->name()) }}</span>
-        <updates-badge class="-ml-1.5"></updates-badge>
-    </inertia-link>
-</li>
+<inertia-link href="{{ $item->url() }}" class="flex items-center gap-2 sm:gap-3 {{ $item->isActive() ? 'active' : '' }}">
+    @cp_svg('icons/updates', 'size-4 shrink-0')
+    <span v-pre>{{ __($item->name()) }}</span>
+    <updates-badge class="-ml-1.5"></updates-badge>
+</inertia-link>


### PR DESCRIPTION
Fixes #15395.

`Nav.vue` already wraps every nav item in an `<li>`:

https://github.com/statamic/cms/blob/v6.31.0/resources/js/components/nav/Nav.vue#L206-L208

The `updates` and `duplicates` nav views each opened with their own `<li>` as well, so the rendered sidebar contained `<li><li>…</li></li>` on **every authenticated Control Panel page**:

```
main#main > nav.nav-main > div > ul > li > li
```

An `<li>` whose parent is an `<li>` is not part of any list, so the item falls out of the list structure and screen readers announce the wrong item count for the navigation. WCAG 2.1 SC 1.3.1 (Level A).

This PR removes the redundant wrapper from both views. `Nav.vue:208` is the only consumer of `$item->view()`, so nothing else was relying on those views bringing their own `<li>`.

### Verification

Applied to a vanilla 6.31.0 install and re-checked three CP pages with axe-core:

| Page | nested `<li>` before | after | `listitem` / `list` violations after |
|---|---|---|---|
| `/cp/dashboard` | 1 | **0** | none |
| `/cp/collections` | 1 | **0** | none |
| `/cp/utilities` | 1 | **0** | none |

The Updates nav link still renders and still links to `/cp/updater` in each case.

### Notes

- No behaviour or styling change. The link markup and classes are untouched; only the wrapper element is removed.
- No test added: this is Blade output with no existing view-level test to extend. Happy to add one if you'd like it, and happy to take a different approach if you'd rather keep the `<li>` in the views and drop it from `Nav.vue` instead.
- Found during a WCAG 2.1 AA audit of the CP. AI tools were used to draft this; the change and the verification above were reviewed by hand.