### PR TITLE
[6.x] Fix ARIA roles on the combobox trigger

### DIFF
--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -219,6 +219,12 @@ const shouldShowInput = computed(() => {
     return dropdownOpen.value || props.modelValue === null || (props.multiple && props.placeholder);
 });
 
+// The search input is the combobox whenever it's rendered, so the trigger wrapping it has to give up
+// the role, the tab stop and the popup attributes that reka-ui puts on every trigger.
+const triggerAttrs = computed(() => shouldShowInput.value
+    ? { 'aria-label': undefined, 'aria-haspopup': undefined, 'aria-expanded': undefined }
+    : { role: 'combobox', tabindex: props.disabled || props.readOnly ? -1 : 0 });
+
 const placeholder = computed(() => {
     if (props.multiple && selectedOptions.value.length > 0) {
         return __n(':count item selected|:count items selected', selectedOptions.value.length);
@@ -390,7 +396,7 @@ defineExpose({
                     <ComboboxTrigger
                         as="div"
                         ref="trigger"
-                        :tabindex="disabled || readOnly ? -1 : 0"
+                        v-bind="triggerAttrs"
                         :class="triggerClasses"
                         data-ui-combobox-trigger
                         @keydown.enter="openDropdown"

--- a/resources/js/tests/components/ui/Combobox.test.js
+++ b/resources/js/tests/components/ui/Combobox.test.js
@@ -1,0 +1,25 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+import { Combobox } from '@/components/ui';
+
+window.__ = (key) => key;
+
+const options = [{ label: 'Alfa', value: 'alfa' }];
+
+test('trigger is exposed as a combobox when there is no search input', () => {
+    const wrapper = mount(Combobox, { props: { options, modelValue: 'alfa' } });
+
+    expect(wrapper.get('[data-ui-combobox-trigger]').attributes()).toMatchObject({
+        role: 'combobox',
+        tabindex: '0',
+    });
+});
+
+test('trigger gives up its role and tab stop when the search input is shown', () => {
+    const trigger = mount(Combobox, { props: { options, modelValue: null } }).get('[data-ui-combobox-trigger]');
+
+    expect(trigger.attributes('role')).toBeUndefined();
+    expect(trigger.attributes('aria-label')).toBeUndefined();
+    expect(trigger.attributes('aria-haspopup')).toBeUndefined();
+    expect(trigger.attributes('tabindex')).toBe('-1');
+});


### PR DESCRIPTION
This pull request fixes an issue where the combobox trigger rendered as a plain `div` carrying `aria-haspopup`, `aria-expanded` and `aria-label="Show popup"` with no role, so axe-core reported `aria-allowed-attr` and `aria-prohibited-attr` on every field built on Combobox, and screen readers announced the control as text with no role and no state.

The trigger is passed `as="div"` because it wraps the search input and the clear button, which rules out reka-ui's default `as="button"`. reka-ui still puts the popup attributes on it, and the manual `tabindex="0"` made it a tab stop even when the search input inside it was the real focusable control.

This PR fixes it by making the trigger take the `combobox` role and the tab stop only when the search input isn't rendered. When the input is there it is already the combobox, so the trigger drops the role, the popup attributes and the tab stop, leaving one control instead of two.

Fixes #15388
