### PR TITLE
[6.x] Fix listing search label and empty table header cells

### DIFF
--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -84,7 +84,7 @@
 
                             <div class="flex items-center gap-2 sm:gap-3 py-3 relative overflow-clip st-overflow-clip-margin">
                                 <div class="flex flex-1 items-center gap-2 sm:gap-3">
-                                    <ListingSearch />
+                                    <ListingSearch label="Search assets" />
                                     <ListingFilters @filters-updated="filtersUpdated" />
                                 </div>
                                 <ListingCustomizeColumns v-if="mode === 'table'" />

--- a/resources/js/components/assets/Browser/Browser.vue
+++ b/resources/js/components/assets/Browser/Browser.vue
@@ -84,7 +84,7 @@
 
                             <div class="flex items-center gap-2 sm:gap-3 py-3 relative overflow-clip st-overflow-clip-margin">
                                 <div class="flex flex-1 items-center gap-2 sm:gap-3">
-                                    <ListingSearch label="Search assets" />
+                                    <ListingSearch :label="__('Search assets')" />
                                     <ListingFilters @filters-updated="filtersUpdated" />
                                 </div>
                                 <ListingCustomizeColumns v-if="mode === 'table'" />

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -47,7 +47,7 @@
                         <template #header="{ canUpload, openFileBrowser, canCreateFolders, startCreatingFolder, mode, modeChanged }">
                             <div class="flex items-center gap-2 sm:gap-3 mb-4">
                                 <div class="flex flex-1 items-center gap-2 sm:gap-3">
-                                    <Search ref="search" />
+                                    <Search ref="search" label="Search assets" />
                                 </div>
 
                                 <Button v-if="canUpload" :text="__('Upload')" icon="upload" @click="openFileBrowser" />

--- a/resources/js/components/assets/Selector.vue
+++ b/resources/js/components/assets/Selector.vue
@@ -47,7 +47,7 @@
                         <template #header="{ canUpload, openFileBrowser, canCreateFolders, startCreatingFolder, mode, modeChanged }">
                             <div class="flex items-center gap-2 sm:gap-3 mb-4">
                                 <div class="flex flex-1 items-center gap-2 sm:gap-3">
-                                    <Search ref="search" label="Search assets" />
+                                    <Search ref="search" :label="__('Search assets')" />
                                 </div>
 
                                 <Button v-if="canUpload" :text="__('Upload')" icon="upload" @click="openFileBrowser" />

--- a/resources/js/components/ui/Listing/Search.vue
+++ b/resources/js/components/ui/Listing/Search.vue
@@ -5,7 +5,7 @@ import debounce from '@/util/debounce.js';
 import { useId, useTemplateRef } from 'vue';
 
 defineProps({
-    /** Accessible label for the search field. Pass the listing's own noun, e.g. "Search assets". */
+    /** Accessible label for the search field. Already translated, e.g. `:label="__('Search assets')"`. */
     label: { type: String, default: null },
 });
 
@@ -21,7 +21,7 @@ defineExpose({ focus });
 
 <template>
     <div class="flex-1 max-w-sm" :class="{ 'max-w-60!': activeFilterBadgeCount > 2 }">
-        <label :for="id" class="sr-only">{{ label ? __(label) : __('Search') }}</label>
+        <label :for="id" class="sr-only">{{ label || __('Search') }}</label>
         <Input
             :focus="true"
             ref="input"

--- a/resources/js/components/ui/Listing/Search.vue
+++ b/resources/js/components/ui/Listing/Search.vue
@@ -2,8 +2,14 @@
 import { injectListingContext } from '../Listing/Listing.vue';
 import { Input } from '@ui';
 import debounce from '@/util/debounce.js';
-import { useTemplateRef } from 'vue';
+import { useId, useTemplateRef } from 'vue';
 
+defineProps({
+    /** Accessible label for the search field. Pass the listing's own noun, e.g. "Search assets". */
+    label: { type: String, default: null },
+});
+
+const id = useId();
 const { activeFilterBadgeCount, searchQuery, setSearchQuery, reorderable } = injectListingContext();
 const searchQueryUpdated = debounce((value) => setSearchQuery(value), 300);
 
@@ -15,12 +21,12 @@ defineExpose({ focus });
 
 <template>
     <div class="flex-1 max-w-sm" :class="{ 'max-w-60!': activeFilterBadgeCount > 2 }">
-        <label for="listings-search" class="sr-only">{{ __('Search entries') }}</label>
+        <label :for="id" class="sr-only">{{ label ? __(label) : __('Search') }}</label>
         <Input
             :focus="true"
             ref="input"
             icon="magnifying-glass"
-            id="listings-search"
+            :id="id"
             variant="light"
             clearable
             :placeholder="__('Search...')"

--- a/resources/js/components/ui/Listing/Search.vue
+++ b/resources/js/components/ui/Listing/Search.vue
@@ -5,7 +5,7 @@ import debounce from '@/util/debounce.js';
 import { useId, useTemplateRef } from 'vue';
 
 defineProps({
-    /** Accessible label for the search field. Already translated, e.g. `:label="__('Search assets')"`. */
+    /** Accessible label for the search field. Pass the listing's own noun, e.g. "Search assets". */
     label: { type: String, default: null },
 });
 
@@ -21,7 +21,7 @@ defineExpose({ focus });
 
 <template>
     <div class="flex-1 max-w-sm" :class="{ 'max-w-60!': activeFilterBadgeCount > 2 }">
-        <label :for="id" class="sr-only">{{ label || __('Search') }}</label>
+        <label :for="id" class="sr-only">{{ label ? __(label) : __('Search') }}</label>
         <Input
             :focus="true"
             ref="input"

--- a/resources/js/components/ui/Listing/TableHead.vue
+++ b/resources/js/components/ui/Listing/TableHead.vue
@@ -28,13 +28,16 @@ const hasVisibleHeader = computed(() => {
                 scope="col"
             >
                 <ToggleAll v-if="allowsSelections && allowsMultipleSelections" />
+                <span v-else class="sr-only">{{ reorderable ? __('Reorder') : __('Select') }}</span>
             </th>
             <HeaderCell v-for="column in visibleColumns" :key="column.field" :column :data-column="column.field" />
             <!-- <th class="type-column" v-if="type">
                 <template v-if="type === 'entries'">{{ __('Collection') }}</template>
                 <template v-if="type === 'terms'">{{ __('Taxonomy') }}</template>
             </th> -->
-            <th scope="col" class="actions-column" v-if="hasActions" />
+            <th scope="col" class="actions-column" v-if="hasActions">
+                <span class="sr-only">{{ __('Actions') }}</span>
+            </th>
         </tr>
     </thead>
 

--- a/resources/js/tests/components/ListingSearch.test.js
+++ b/resources/js/tests/components/ListingSearch.test.js
@@ -1,0 +1,59 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+import { h } from 'vue';
+import * as Globals from '@/bootstrap/globals';
+import Listing from '@/components/ui/Listing/Listing.vue';
+import Search from '@/components/ui/Listing/Search.vue';
+import TableHead from '@/components/ui/Listing/TableHead.vue';
+
+Object.keys(Globals).forEach((fn) => (window[fn] = Globals[fn]));
+
+window.Statamic = {
+    $config: { get: () => undefined },
+    $progress: { loading: () => {}, complete: () => {} },
+    $preferences: { get: () => undefined },
+    $events: { $on: () => {}, $off: () => {}, $emit: () => {} },
+};
+
+const mountInListing = (child, listingProps = {}) =>
+    mount(Listing, { props: { items: [], ...listingProps }, slots: { default: () => child } });
+
+test('the search label defaults to a listing-agnostic string', () => {
+    const wrapper = mountInListing(h(Search));
+
+    expect(wrapper.find('label').text()).toBe('Search');
+});
+
+test('the search label can be set per listing', () => {
+    const wrapper = mountInListing(h(Search, { label: 'Search assets' }));
+
+    expect(wrapper.find('label').text()).toBe('Search assets');
+});
+
+test('the search label is associated with the input', () => {
+    const wrapper = mountInListing(h(Search));
+    const id = wrapper.find('input').attributes('id');
+
+    expect(id).toBeTruthy();
+    expect(wrapper.find('label').attributes('for')).toBe(id);
+});
+
+test('two search fields in the same listing do not share an id', () => {
+    const wrapper = mountInListing(h('div', [h(Search), h(Search)]));
+    const [a, b] = wrapper.findAll('input').map((input) => input.attributes('id'));
+
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a).not.toBe(b);
+});
+
+test('the actions header cell has an accessible name', () => {
+    const wrapper = mountInListing(h(TableHead), {
+        columns: [{ field: 'title', label: 'Title' }],
+        actionUrl: '/cp/collections/pages/actions',
+    });
+    const actionsHeader = wrapper.find('th.actions-column');
+
+    expect(actionsHeader.exists()).toBe(true);
+    expect(actionsHeader.text()).toBe('Actions');
+});

--- a/resources/js/tests/components/ListingSearch.test.js
+++ b/resources/js/tests/components/ListingSearch.test.js
@@ -25,6 +25,8 @@ test('the search label defaults to a listing-agnostic string', () => {
 });
 
 test('the search label can be set per listing', () => {
+    // Labels are translated at the call site, e.g. :label="__('Search assets')",
+    // so the component renders the string it is given without translating again.
     const wrapper = mountInListing(h(Search, { label: 'Search assets' }));
 
     expect(wrapper.find('label').text()).toBe('Search assets');

--- a/resources/js/tests/components/ListingSearch.test.js
+++ b/resources/js/tests/components/ListingSearch.test.js
@@ -25,8 +25,6 @@ test('the search label defaults to a listing-agnostic string', () => {
 });
 
 test('the search label can be set per listing', () => {
-    // Labels are translated at the call site, e.g. :label="__('Search assets')",
-    // so the component renders the string it is given without translating again.
     const wrapper = mountInListing(h(Search, { label: 'Search assets' }));
 
     expect(wrapper.find('label').text()).toBe('Search assets');


### PR DESCRIPTION
Two small accessibility fixes in `ui/Listing/`, found during a WCAG 2.1 AA audit of the CP. Filing as a PR rather than issues since both are a few lines.

### 1. The search field says "Search entries" on listings that hold no entries

`Search.vue` hardcoded the label:

```html
<label for="listings-search" class="sr-only">{{ __('Search entries') }}</label>
```

On `/cp/assets/browse/assets` and `/cp/users` a screen reader user is told they are searching entries while looking at files or people. WCAG 2.1 SC 2.4.6 (AA).

The same line hardcodes `id="listings-search"`, which is also bound to the input. Two listings rendered on one page (the asset selector opened over a listing, for example) produce duplicate ids and a label pointing at whichever one wins.

Changed to:

- an optional `label` prop, defaulting to the listing-agnostic `'Search'` — accurate everywhere, and no worse than today on any screen
- `useId()` for the input id, matching what `Switch.vue` and friends already do

Passed `label="Search assets"` at the two asset call sites. The generic default covers the rest; individual listings can opt in as their nouns are known.

Note: `'Search entries'` is no longer referenced. Left the translation key in place rather than touching lang files in an a11y PR — say the word if you'd like it removed.

### 2. Empty `<th>` cells

The select/reorder column and the actions column rendered header cells with no content, so screen readers announce an empty column header when moving across a row. axe-core `empty-table-header` fired on 9 screens.

Added `sr-only` names: `Select` / `Reorder` for the first column when no toggle-all is rendered, and `Actions` for the last.

### Tests

Added `resources/js/tests/components/ListingSearch.test.js` with 5 cases:

- the label defaults to `Search`
- the label can be set per listing
- the label is associated with the input
- two search fields in one listing do not share an id
- the actions header cell has an accessible name

4 of the 5 fail against the unpatched components; the association test passes either way and stays as a regression guard.

Full unit suite: **568 passed, 9 failed**. Those 9 are pre-existing `LivePreview` failures on a clean `6.x` checkout — identical without this branch. Net effect: +5 tests, no change to existing results.

### Notes

AI tools were used to draft this; the changes, the tests, and the before/after runs were reviewed by hand. Happy to split this into two PRs if you'd rather review them separately.