### PR TITLE
[6.x] Add a text alternative to the status indicator dot

### DIFF
--- a/resources/js/components/ui/StatusIndicator.vue
+++ b/resources/js/components/ui/StatusIndicator.vue
@@ -40,6 +40,7 @@ const label = computed(() => {
 <template>
     <span class="flex items-center gap-2">
         <span v-if="showDot" class="size-2 rounded-full" :class="statusClass" v-tooltip="label" />
+        <span v-if="showDot && !showLabel" class="sr-only" v-text="label" />
         <span v-if="showLabel" class="status-index-field select-none" :class="`status-${status}`" v-text="label" />
     </span>
 </template>

--- a/resources/js/components/ui/StatusIndicator.vue
+++ b/resources/js/components/ui/StatusIndicator.vue
@@ -32,6 +32,7 @@ const label = computed(() => {
         scheduled: __('Scheduled'),
         expired: __('Expired'),
         draft: __('Draft'),
+        hidden: __('Hidden'),
     };
     return labels[props.status];
 });

--- a/resources/js/tests/components/ui/StatusIndicator.test.js
+++ b/resources/js/tests/components/ui/StatusIndicator.test.js
@@ -1,0 +1,21 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+import { StatusIndicator } from '@/components/ui';
+
+window.__ = (key) => key;
+
+test('the dot has a text alternative when the label is hidden', () => {
+    const wrapper = mount(StatusIndicator, {
+        props: { status: 'draft' },
+    });
+
+    expect(wrapper.text()).toBe('Draft');
+});
+
+test('the label is not duplicated when it is shown', () => {
+    const wrapper = mount(StatusIndicator, {
+        props: { status: 'draft', showLabel: true },
+    });
+
+    expect(wrapper.text()).toBe('Draft');
+});

--- a/resources/js/tests/components/ui/StatusIndicator.test.js
+++ b/resources/js/tests/components/ui/StatusIndicator.test.js
@@ -19,3 +19,11 @@ test('the label is not duplicated when it is shown', () => {
 
     expect(wrapper.text()).toBe('Draft');
 });
+
+test('the hidden status has a label', () => {
+    const wrapper = mount(StatusIndicator, {
+        props: { status: 'hidden' },
+    });
+
+    expect(wrapper.text()).toBe('Hidden');
+});


### PR DESCRIPTION
This pull request fixes an issue where the publish status of an entry is only conveyed by the colour of a dot, with nothing for a screen reader to announce.

`StatusIndicator` renders the dot without a label in the entry and term publish forms, the collection widget, listings and the relationship fields. The dot carries a tooltip, but a tooltip isn't an accessible name, and it can't be reached by keyboard or touch anyway.

This PR fixes it by rendering an `sr-only` span with the status label alongside the dot whenever the visible label is hidden. Where the indicator sits inside a link or a heading, like the entry listings and the publish form title, that status word becomes part of the accessible name. The `hidden` status had no entry in the label map, so it's had one added, otherwise the blueprint listing would still announce nothing.

Pairing each status with a shape or icon would go further and satisfy 1.4.1 too, but that's a visual change to the component so I've left it out.

Fixes #15412
