### PR TITLE
[6.x] Give modals a dialog role and accessible name

### DIFF
--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { cva } from 'cva';
 import { hasComponent } from '@/composables/has-component.js';
-import { computed, getCurrentInstance, nextTick, onBeforeUnmount, onMounted, provide, ref, useAttrs, useSlots, watch } from 'vue';
+import { computed, getCurrentInstance, nextTick, onBeforeUnmount, onMounted, provide, ref, useAttrs, useId, useSlots, watch } from 'vue';
 import Icon from '../Icon/Icon.vue';
 import Heading from '../Heading.vue';
 import { portals, keys } from '@api';
@@ -64,6 +64,8 @@ const escBinding = ref(null);
 
 const instance = getCurrentInstance();
 const hasModalTitleComponent = hasComponent('ModalTitle');
+const titleId = useId();
+const labelledBy = computed(() => (hasModalTitleComponent.value || props.title) ? titleId : undefined);
 const isUsingOpenProp = computed(() => instance?.vnode.props?.hasOwnProperty('open'));
 const portal = computed(() => modal.value ? `#portal-target-${modal.value.id}` : null);
 const isTopPortal = computed(() => portals.all()[portals.all().length - 1].id === modal.value.id);
@@ -164,6 +166,7 @@ defineExpose({
 });
 
 provide('closeModal', close);
+provide('modalTitleId', titleId);
 </script>
 
 <template>
@@ -190,9 +193,9 @@ provide('closeModal', close);
                 leave-from-class="opacity-100 scale-100"
                 leave-to-class="opacity-0 scale-95"
             >
-                <div ref="modalContent" v-if="visible" v-bind="restAttrs" :class="[modalClasses, attrs.class]" data-ui-modal-content>
+                <div ref="modalContent" v-if="visible" role="dialog" aria-modal="true" :aria-labelledby="labelledBy" v-bind="restAttrs" :class="[modalClasses, attrs.class]" data-ui-modal-content>
                     <div class="relative space-y-3 rounded-xl overflow-auto max-h-[60vh] border border-gray-400/60 bg-white p-4 shadow-[0_1px_16px_-2px_rgba(63,63,71,0.2)] dark:border-none dark:bg-gray-800 dark:shadow-[0_1px_16px_-2px_rgba(0,0,0,.5)] dark:inset-shadow-2xs dark:inset-shadow-white/10">
-                        <div v-if="!hasModalTitleComponent && (title || icon)" data-ui-modal-title class="flex items-center gap-2">
+                        <div v-if="!hasModalTitleComponent && (title || icon)" :id="titleId" data-ui-modal-title class="flex items-center gap-2">
                             <Icon :name="icon" v-if="icon" class="size-4" />
                             <Heading :text="title" size="lg" class="font-semibold text-gray-950 dark:text-gray-100" />
                         </div>

--- a/resources/js/components/ui/Modal/Modal.vue
+++ b/resources/js/components/ui/Modal/Modal.vue
@@ -65,7 +65,7 @@ const escBinding = ref(null);
 const instance = getCurrentInstance();
 const hasModalTitleComponent = hasComponent('ModalTitle');
 const titleId = useId();
-const labelledBy = computed(() => (hasModalTitleComponent.value || props.title) ? titleId : undefined);
+const labelledBy = computed(() => hasModalTitleComponent.value || props.title ? titleId : undefined);
 const isUsingOpenProp = computed(() => instance?.vnode.props?.hasOwnProperty('open'));
 const portal = computed(() => modal.value ? `#portal-target-${modal.value.id}` : null);
 const isTopPortal = computed(() => portals.all()[portals.all().length - 1].id === modal.value.id);

--- a/resources/js/components/ui/Modal/Title.vue
+++ b/resources/js/components/ui/Modal/Title.vue
@@ -1,11 +1,15 @@
 <script setup>
+import { inject } from 'vue';
+
 defineOptions({
     name: 'ModalTitle',
 });
+
+const titleId = inject('modalTitleId', undefined);
 </script>
 
 <template>
-    <div data-ui-modal-title>
+    <div :id="titleId" data-ui-modal-title>
         <slot />
     </div>
 </template>

--- a/resources/js/components/ui/Modal/Title.vue
+++ b/resources/js/components/ui/Modal/Title.vue
@@ -5,7 +5,7 @@ defineOptions({
     name: 'ModalTitle',
 });
 
-const titleId = inject('modalTitleId', undefined);
+const titleId = inject('modalTitleId', null);
 </script>
 
 <template>

--- a/resources/js/tests/components/ui/Modal.test.js
+++ b/resources/js/tests/components/ui/Modal.test.js
@@ -1,0 +1,39 @@
+import { mount } from '@vue/test-utils';
+import { expect, test } from 'vitest';
+import { h, nextTick } from 'vue';
+import { portals } from '@api';
+import { Modal, ModalTitle } from '@/components/ui';
+
+async function openModal(options = {}) {
+    const wrapper = mount(Modal, { props: { open: true }, ...options });
+
+    const target = document.createElement('div');
+    target.id = `portal-target-${portals.all()[portals.all().length - 1].id}`;
+    document.body.appendChild(target);
+
+    await nextTick();
+    await nextTick();
+    await nextTick();
+
+    return wrapper;
+}
+
+test('content is a dialog labelled by its title', async () => {
+    await openModal({ props: { open: true, title: 'Delete Entry' } });
+
+    const content = document.querySelector('[data-ui-modal-content]');
+
+    expect(content.getAttribute('role')).toBe('dialog');
+    expect(content.getAttribute('aria-modal')).toBe('true');
+    expect(document.getElementById(content.getAttribute('aria-labelledby')).textContent).toContain('Delete Entry');
+});
+
+test('content is labelled by the modal title component', async () => {
+    await openModal({
+        slots: { default: h(ModalTitle, () => 'Delete Entry') },
+    });
+
+    const content = document.querySelector('[data-ui-modal-content]');
+
+    expect(document.getElementById(content.getAttribute('aria-labelledby')).textContent).toContain('Delete Entry');
+});

--- a/resources/js/tests/components/ui/Modal.test.js
+++ b/resources/js/tests/components/ui/Modal.test.js
@@ -1,25 +1,27 @@
-import { mount } from '@vue/test-utils';
-import { expect, test } from 'vitest';
-import { h, nextTick } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, expect, test } from 'vitest';
+import { h } from 'vue';
 import { portals } from '@api';
 import { Modal, ModalTitle } from '@/components/ui';
 
-async function openModal(options = {}) {
-    const wrapper = mount(Modal, { props: { open: true }, ...options });
+async function openModal(props = {}, options = {}) {
+    const wrapper = mount(Modal, { props: { open: true, ...props }, ...options });
 
     const target = document.createElement('div');
     target.id = `portal-target-${portals.all()[portals.all().length - 1].id}`;
     document.body.appendChild(target);
 
-    await nextTick();
-    await nextTick();
-    await nextTick();
+    await flushPromises();
 
     return wrapper;
 }
 
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
 test('content is a dialog labelled by its title', async () => {
-    await openModal({ props: { open: true, title: 'Delete Entry' } });
+    await openModal({ title: 'Delete Entry' });
 
     const content = document.querySelector('[data-ui-modal-content]');
 
@@ -29,11 +31,17 @@ test('content is a dialog labelled by its title', async () => {
 });
 
 test('content is labelled by the modal title component', async () => {
-    await openModal({
-        slots: { default: h(ModalTitle, () => 'Delete Entry') },
-    });
+    await openModal({}, { slots: { default: h(ModalTitle, () => 'Remove Page') } });
 
     const content = document.querySelector('[data-ui-modal-content]');
 
-    expect(document.getElementById(content.getAttribute('aria-labelledby')).textContent).toContain('Delete Entry');
+    expect(document.getElementById(content.getAttribute('aria-labelledby')).textContent).toContain('Remove Page');
+});
+
+test('content has no accessible name when there is no title', async () => {
+    await openModal();
+
+    const content = document.querySelector('[data-ui-modal-content]');
+
+    expect(content.hasAttribute('aria-labelledby')).toBe(false);
 });


### PR DESCRIPTION
This pull request fixes an issue where the Control Panel's modals are announced as plain groups of text rather than dialogs. Every confirmation modal inherits from `ui/Modal`, so deleting an entry, removing a nav page or dismissing the licensing alert gives a screen reader a Cancel/Delete choice with no indication that a dialog opened, and no name for it.

This was happening because the modal content is a bare `<div data-ui-modal-content>` with no `role`, no `aria-modal` and no `aria-labelledby`. The command palette avoids this because it uses reka-ui's `DialogContent` instead of this component.

This PR fixes it by adding `role="dialog"` and `aria-modal="true"` to the content element, and pointing `aria-labelledby` at the title the modal already renders. The title gets an id from `useId()`, shared with `ModalTitle` through a provide so both ways of setting a title work. `aria-labelledby` is left off when there's no title at all, and the attributes come before the fallthrough attrs so a consumer can still pass `role="alertdialog"`.

Focus is already trapped by the `FocusScope`, so I left the `inert` suggestion out of this one.

Fixes #15410
