### PR TITLE
[6.x] Improve secondary text contrast

### DIFF
--- a/resources/js/components/ui/Button/Button.vue
+++ b/resources/js/components/ui/Button/Button.vue
@@ -66,7 +66,7 @@ const buttonClasses = computed(() => {
                 filled: 'bg-gray-950/5 hover:bg-gray-950/10 hover:text-gray-900 dark:hover:text-white dark:bg-white/4 dark:hover:bg-white/20 [&_svg]:opacity-70',
                 ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200',
                 'ghost-pressed': 'bg-transparent hover:bg-gray-400/10 text-gray-925 dark:text-white dark:hover:bg-white/7 dark:hover:text-white [&_svg]:opacity-100',
-                subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200 [&_svg]:opacity-35',
+                subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-600 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200 [&_svg]:opacity-35',
                 pressed: [
                     'bg-linear-to-b from-gray-200 to-gray-150 text-gray-900 border border-gray-300 inset-shadow-sm/10',
                     'dark:from-gray-950 dark:to-gray-900 dark:text-white dark:border-gray-700/80',

--- a/resources/js/components/ui/Combobox/Combobox.vue
+++ b/resources/js/components/ui/Combobox/Combobox.vue
@@ -97,7 +97,7 @@ const triggerClasses = computed(() => cva({
             ],
             filled: 'bg-gray-950/5 hover:bg-gray-950/10 text-gray-900 border-none dark:bg-white/15 dark:hover:bg-white/20 dark:text-white focus-within:focus-outline dark:placeholder:text-red-500/60',
             ghost: 'bg-transparent hover:bg-gray-400/10 text-gray-900 border-none dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200 focus-within:focus-outline',
-            subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 border-none dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200 focus-within:focus-outline',
+            subtle: 'bg-transparent hover:bg-gray-400/10 text-gray-600 hover:text-gray-700 border-none dark:text-gray-300 dark:hover:bg-white/7 dark:hover:text-gray-200 focus-within:focus-outline',
         },
         size: {
             xl: 'px-5 h-12 text-lg rounded-lg',

--- a/resources/js/components/ui/Pagination.vue
+++ b/resources/js/components/ui/Pagination.vue
@@ -154,7 +154,7 @@ function getRange(start, end) {
 <template>
     <div class="flex">
         <div class="flex flex-1 items-center">
-            <div class="text-sm text-gray-600 dark:text-gray-500" v-if="showTotals && totalItems > 0">
+            <div class="text-sm text-gray-600 dark:text-gray-400" v-if="showTotals && totalItems > 0">
                 {{ __(':range of :total', {
                     range: $number.formatRange(fromItem, toItem),
                     total: $number.format(totalItems)

--- a/resources/js/components/ui/Tabs/List.vue
+++ b/resources/js/components/ui/Tabs/List.vue
@@ -8,7 +8,7 @@ const hasTabIndicatorComponent = hasComponent('TabsIndicator');
 <template>
     <TabsList
         class="relative flex shrink-0 mx-2 lg:mx-0 space-x-2 lg:space-x-4 border-b border-gray-200 text-sm text-gray-500 
-        dark:border-gray-700
+        dark:border-gray-700 dark:text-gray-400
         [.live-preview_&]:px-1 [.live-preview_&]:py-2 [.live-preview_&]:mb-3"
         data-ui-tabs-list
     >

--- a/resources/js/components/ui/Tabs/List.vue
+++ b/resources/js/components/ui/Tabs/List.vue
@@ -7,7 +7,7 @@ const hasTabIndicatorComponent = hasComponent('TabsIndicator');
 
 <template>
     <TabsList
-        class="relative flex shrink-0 mx-2 lg:mx-0 space-x-2 lg:space-x-4 border-b border-gray-200 text-sm text-gray-500 
+        class="relative flex shrink-0 mx-2 lg:mx-0 space-x-2 lg:space-x-4 border-b border-gray-200 text-sm text-gray-600
         dark:border-gray-700 dark:text-gray-400
         [.live-preview_&]:px-1 [.live-preview_&]:py-2 [.live-preview_&]:mb-3"
         data-ui-tabs-list

--- a/resources/js/components/ui/Tabs/Trigger.vue
+++ b/resources/js/components/ui/Tabs/Trigger.vue
@@ -16,7 +16,7 @@ defineProps({
 <template>
     <TabsTrigger
         :value="name"
-        class="translate-y-px cursor-pointer px-2 py-1 focus-visible:rounded-lg hover:text-gray-600 data-[state=active]:text-gray-900 dark:hover:text-gray-300 dark:data-[state=active]:text-gray-200"
+        class="translate-y-px cursor-pointer px-2 py-1 focus-visible:rounded-lg hover:text-gray-700 data-[state=active]:text-gray-900 dark:hover:text-gray-300 dark:data-[state=active]:text-gray-200"
     >
         <slot v-if="hasSlot" />
         <span v-else>{{ text }}</span>

--- a/resources/js/components/ui/Tabs/Trigger.vue
+++ b/resources/js/components/ui/Tabs/Trigger.vue
@@ -16,7 +16,7 @@ defineProps({
 <template>
     <TabsTrigger
         :value="name"
-        class="translate-y-px cursor-pointer px-2 py-1 focus-visible:rounded-lg hover:text-gray-600 data-[state=active]:text-gray-900 dark:hover:text-gray-400 dark:data-[state=active]:text-gray-200"
+        class="translate-y-px cursor-pointer px-2 py-1 focus-visible:rounded-lg hover:text-gray-600 data-[state=active]:text-gray-900 dark:hover:text-gray-300 dark:data-[state=active]:text-gray-200"
     >
         <slot v-if="hasSlot" />
         <span v-else>{{ text }}</span>

--- a/resources/js/components/ui/Toggle/Item.vue
+++ b/resources/js/components/ui/Toggle/Item.vue
@@ -52,7 +52,7 @@ const toggleItemClasses = computed(() => {
                     'dark:from-white dark:to-gray-200 dark:hover:from-gray-200 dark:text-gray-900 dark:border-0 dark:data-[state=on]:from-gray-300 dark:data-[state=on]:to-gray-300',
                 ],
                 filled: 'bg-gray-100 hover:bg-gray-200 dark:bg-gray-700/80 dark:hover:bg-gray-700 data-[state=on]:bg-gray-300 data-[state=on]:border-gray-500 dark:data-[state=on]:bg-gray-925',
-                ghost: 'bg-transparent rounded-lg hover:bg-gray-400/10 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700/80 dark:hover:text-gray-200 data-[state=on]:bg-gray-400/20 data-[state=on]:text-gray-700 dark:data-[state=on]:bg-gray-700/80 dark:data-[state=on]:text-white',
+                ghost: 'bg-transparent rounded-lg hover:bg-gray-400/10 text-gray-600 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700/80 dark:hover:text-gray-200 data-[state=on]:bg-gray-400/20 data-[state=on]:text-gray-700 dark:data-[state=on]:bg-gray-700/80 dark:data-[state=on]:text-white',
             },
             size: {
                 base: 'px-3 h-10 text-sm [&_svg]:size-3.5',

--- a/resources/js/pages/utilities/Licensing.vue
+++ b/resources/js/pages/utilities/Licensing.vue
@@ -90,7 +90,7 @@ const props = defineProps([
                                     <span class="little-dot mt-[0.45rem]" :class="statamic.valid ? 'bg-green-500' : 'bg-red-500'" />
                                     <span>
                                     {{ __('Statamic') }}
-                                    <span v-if="statamic.pro" class="text-pink">{{ __('Pro') }}</span>
+                                    <span v-if="statamic.pro" class="text-pink-dark dark:text-pink">{{ __('Pro') }}</span>
                                     <template v-else>{{ __('Free') }}</template>
                                 </span>
                                 </div>


### PR DESCRIPTION
This pull request fixes an issue where grey secondary text in the Control Panel sits below the 4.5:1 contrast ratio WCAG 2.1 SC 1.4.3 asks for. None of it is large text, so the 3:1 allowance doesn't apply.

Three of the reported failures use `gray-500`: the subtle button variant on a light panel (4.24:1), tab labels in dark mode (3.67:1) and the pagination totals in dark mode (3.84:1). The fourth is the brand pink used as text for the "Pro" label on the licensing screen, which only reaches 3.48:1 on white.

This PR moves secondary text to `gray-600` in light mode and `gray-400` in dark, and points the "Pro" label at the existing `pink-dark` token in light mode. That puts everything between 4.5:1 and 7.7:1. Hover colours move down a step where the old ones would otherwise have collided with the new resting colour. Light mode tab labels are included even though the report only measured them in dark, since they fail at 4.35:1 on the body background, and the same `text-gray-500 hover:text-gray-700` pairing in the Combobox and Toggle variants is fixed alongside Button's so the three stay consistent.

I've done this in the components rather than in the tokens, as the issue suggested, because the greys are user-selectable palettes and `gray-500` is also used for borders and icons where 3:1 is the bar. The steps hold across all five palettes, since they're all the standard Tailwind scales.

Fixes #15407
