### PR TITLE
[6.x] Increase the hit area of the breadcrumb options button

### DIFF
--- a/resources/js/components/global-header/Breadcrumbs.vue
+++ b/resources/js/components/global-header/Breadcrumbs.vue
@@ -88,7 +88,7 @@ function setDropdownItemActive(breadcrumbIndex, linkIndex, breadcrumb) {
                     <ui-button
                         variant="ghost"
                         icon="chevron-vertical"
-                        class="[&_svg]:size-3! h-8! w-4! hover:bg-gray-300/5! -ml-3 mr-1 animate-in fade-in duration-500"
+                        class="[&_svg]:size-3! h-8! w-6! hover:bg-gray-300/5! -ml-4 animate-in fade-in duration-500"
                         :aria-label="`${__('Options for')} ${__(breadcrumb.display)}`"
                         aria-haspopup
                         :aria-expanded="false"


### PR DESCRIPTION
This pull request fixes an issue where the "Options for …" buttons render at 16x32 pixels, which is under the 24x24 minimum in WCAG 2.2 SC 2.5.8. They also sit flush against the breadcrumb link beside them, so they don't get the spacing exception either. The issue describes them as sidebar buttons, but that label only exists on the global header breadcrumb dropdown triggers and nowhere else.

The button's width was pinned to `w-4`, which left 2px around the 12px chevron icon.

This PR widens it to `w-6` and absorbs the extra 4px on each side by bumping the negative left margin and dropping the right one, so the icon stays put and the breadcrumb layout doesn't shift.

The date picker segment mentioned at the end of the issue is a reka-ui field segment rather than a button, so I've left that one for a separate PR.

Fixes #15416
