### PR TITLE
[6.x] Add autocomplete defaults to the user blueprint's name and email fields

### DIFF
--- a/src/Auth/UserRepository.php
+++ b/src/Auth/UserRepository.php
@@ -66,11 +66,11 @@ abstract class UserRepository implements RepositoryContract
         }
 
         $blueprint = Blueprint::find('user') ?? Blueprint::makeFromFields([
-            'name' => ['type' => 'text', 'display' => __('Name'), 'listable' => true],
-            'email' => ['type' => 'text', 'input_type' => 'email', 'display' => __('Email Address'), 'listable' => true],
+            'name' => ['type' => 'text', 'autocomplete' => 'name', 'display' => __('Name'), 'listable' => true],
+            'email' => ['type' => 'text', 'input_type' => 'email', 'autocomplete' => 'email', 'display' => __('Email Address'), 'listable' => true],
         ])->setHandle('user');
 
-        $blueprint->ensureField('email', ['type' => 'text', 'input_type' => 'email', 'display' => __('Email Address'), 'listable' => true]);
+        $blueprint->ensureField('email', ['type' => 'text', 'input_type' => 'email', 'autocomplete' => 'email', 'display' => __('Email Address'), 'listable' => true]);
 
         if (Statamic::pro()) {
             $blueprint->ensureField('roles', ['type' => 'user_roles', 'mode' => 'select', 'width' => 50, 'listable' => true, 'filterable' => false]);

--- a/tests/Auth/UserContractTests.php
+++ b/tests/Auth/UserContractTests.php
@@ -419,17 +419,31 @@ trait UserContractTests
         $this->assertTrue($this->user()->blueprint()->hasField('email'));
         $this->assertEquals('Email Address', $this->user()->blueprint()->fields()->get('email')->display());
         $this->assertEquals('email', $this->user()->blueprint()->fields()->get('email')->get('input_type'));
+        $this->assertEquals('email', $this->user()->blueprint()->fields()->get('email')->get('autocomplete'));
     }
 
     #[Test]
     public function it_allows_email_field_customizations_in_blueprint()
     {
-        $blueprint = Blueprint::makeFromFields(['email' => ['display' => 'Custom Email Display']]);
+        $blueprint = Blueprint::makeFromFields(['email' => ['display' => 'Custom Email Display', 'autocomplete' => 'off']]);
         Blueprint::shouldReceive('find')->with('user')->andReturn($blueprint);
 
         $this->assertTrue($this->user()->blueprint()->hasField('email'));
         $this->assertEquals('Custom Email Display', $this->user()->blueprint()->fields()->get('email')->display());
         $this->assertEquals('email', $this->user()->blueprint()->fields()->get('email')->get('input_type'));
+        $this->assertEquals('off', $this->user()->blueprint()->fields()->get('email')->get('autocomplete'));
+    }
+
+    #[Test]
+    public function it_provides_name_and_email_fields_when_no_blueprint_is_defined()
+    {
+        Blueprint::partialMock()->shouldReceive('find')->with('user')->andReturnNull();
+
+        $fields = $this->user()->blueprint()->fields();
+
+        $this->assertEquals('name', $fields->get('name')->get('autocomplete'));
+        $this->assertEquals('email', $fields->get('email')->get('autocomplete'));
+        $this->assertEquals('email', $fields->get('email')->get('input_type'));
     }
 
     #[Test]

--- a/tests/Tags/User/ProfileFormTest.php
+++ b/tests/Tags/User/ProfileFormTest.php
@@ -74,8 +74,8 @@ EOT
         preg_match_all($this->regex(), $output, $actual);
 
         $expected = [
-            '<label>Name</label><input id="userprofile-form-name-field" type="text" name="name" value="Test User">',
-            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com">',
+            '<label>Name</label><input id="userprofile-form-name-field" type="text" name="name" value="Test User" autocomplete="name">',
+            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com" autocomplete="email">',
         ];
 
         $this->assertEquals($expected, $actual[0]);
@@ -112,7 +112,7 @@ EOT
             '<h2 class="tab">Main</h2>',
             '<h3 class="section">Account</h3>',
             '<label>Full Name</label><input id="userprofile-form-name-field" type="text" name="name" value="Test User">',
-            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com">',
+            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com" autocomplete="email">',
             '<h3 class="section">About you</h3>',
             '<label>Phone Number</label><input id="userprofile-form-phone-field" type="text" name="phone" value="12345">',
             '<label>Over 18 years of age?</label><input id="userprofile-form-age-field" type="text" name="age" value="" required>',
@@ -150,7 +150,7 @@ EOT
         $expected = [
             '<h3 class="section">Account</h3>',
             '<label>Full Name</label><input id="userprofile-form-name-field" type="text" name="name" value="Test User">',
-            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com">',
+            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com" autocomplete="email">',
             '<h3 class="section">About you</h3>',
             '<label>Phone Number</label><input id="userprofile-form-phone-field" type="text" name="phone" value="12345">',
             '<label>Over 18 years of age?</label><input id="userprofile-form-age-field" type="text" name="age" value="" required>',
@@ -183,7 +183,7 @@ EOT
 
         $expected = [
             '<label>Full Name</label><input id="userprofile-form-name-field" type="text" name="name" value="Test User">',
-            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com">',
+            '<label>Email Address</label><input id="userprofile-form-email-field" type="email" name="email" value="test@example.com" autocomplete="email">',
             '<label>Phone Number</label><input id="userprofile-form-phone-field" type="text" name="phone" value="12345">',
             '<label>Over 18 years of age?</label><input id="userprofile-form-age-field" type="text" name="age" value="" required>',
             '<label>Newsletter</label><label><input type="hidden" name="newsletter" value="0"><input id="userprofile-form-newsletter-field" type="checkbox" name="newsletter" value="1" checked></label>',

--- a/tests/Tags/User/RegisterFormTest.php
+++ b/tests/Tags/User/RegisterFormTest.php
@@ -70,10 +70,10 @@ EOT
         preg_match_all('/<label>.+<\/label><input.+>/U', $output, $actual);
 
         $expected = [
-            '<label>Email Address</label><input id="userregister-form-email-field" type="email" name="email" value="">',
+            '<label>Email Address</label><input id="userregister-form-email-field" type="email" name="email" value="" autocomplete="email">',
             '<label>Password</label><input id="userregister-form-password-field" type="password" name="password" value="">',
             '<label>Password Confirmation</label><input id="userregister-form-password-confirmation-field" type="password" name="password_confirmation" value="">',
-            '<label>Name</label><input id="userregister-form-name-field" type="text" name="name" value="">',
+            '<label>Name</label><input id="userregister-form-name-field" type="text" name="name" value="" autocomplete="name">',
         ];
 
         $this->assertEquals($expected, $actual[0]);
@@ -96,7 +96,7 @@ EOT
         preg_match_all('/<label>.+<\/label><input.+>/U', $output, $actual);
 
         $expected = [
-            '<label>Email Address</label><input id="userregister-form-email-field" type="email" name="email" value="">',
+            '<label>Email Address</label><input id="userregister-form-email-field" type="email" name="email" value="" autocomplete="email">',
             '<label>Password</label><input id="userregister-form-password-field" type="password" name="password" value="">',
             '<label>Password Confirmation</label><input id="userregister-form-password-confirmation-field" type="password" name="password_confirmation" value="">',
             '<label>Full Name</label><input id="userregister-form-name-field" type="text" name="name" value="">',


### PR DESCRIPTION
This pull request fixes an issue where the user create and account forms in the Control Panel set no `autocomplete` attribute on the name and email fields, so browsers and assistive technology can't identify them for autofill (WCAG 2.1 SC 1.3.5).

This was happening because the default user blueprint never sets the Text fieldtype's `autocomplete` option, even though the option has existed since #8623 and is passed through to the input.

This PR fixes it by giving the `email` field an `autocomplete: email` default via the existing `ensureField()` call in `UserRepository::blueprint()`, the same route that already gives every site's email field its `input_type`. Blueprint-defined config still wins, so an explicit `autocomplete: off` is respected. The fallback blueprint used when no `user.yaml` exists also gets `autocomplete: name` on the `name` field.

Since `{{ user:register_form }}` and `{{ user:profile_form }}` render the same blueprint, front-end forms pick up the attribute too.

The `name` field isn't ensured by the CMS (blueprints may use `first_name`/`last_name` instead), so existing sites will want `autocomplete: name` added to their own `user.yaml`. The starter kit's blueprint should get the same.

Fixes #15408
