### PR TITLE
[6.x] Keep augmentable tag results as objects inside Antlers interpolations

### DIFF
--- a/src/View/Antlers/Language/Runtime/NodeProcessor.php
+++ b/src/View/Antlers/Language/Runtime/NodeProcessor.php
@@ -57,6 +57,7 @@ use Statamic\View\Antlers\SyntaxError;
 use Statamic\View\Cascade;
 use Statamic\View\Slot;
 use Statamic\View\State\CachesOutput;
+use Stringable;
 use Throwable;
 
 class NodeProcessor
@@ -1802,7 +1803,9 @@ class NodeProcessor
                                 $output = RuntimeValues::resolveWithRuntimeIsolation($output);
                             }
 
-                            $output = PathDataManager::reduceForAntlers($output, $this->antlersParser, $this->getActiveData(), $node->isClosedBy != null);
+                            if (! $this->interpolatingAugmentable($output)) {
+                                $output = PathDataManager::reduceForAntlers($output, $this->antlersParser, $this->getActiveData(), $node->isClosedBy != null);
+                            }
                         }
 
                         if ($this->isInterpolationProcessor) {
@@ -2510,6 +2513,13 @@ class NodeProcessor
         }
 
         return $buffer;
+    }
+
+    private function interpolatingAugmentable($output): bool
+    {
+        return $this->isInterpolationProcessor
+            && $output instanceof Augmentable
+            && $output instanceof Stringable;
     }
 
     /**

--- a/tests/Antlers/Runtime/TagsTest.php
+++ b/tests/Antlers/Runtime/TagsTest.php
@@ -2,6 +2,10 @@
 
 namespace Tests\Antlers\Runtime;
 
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Statamic\Facades\Asset;
+use Statamic\Facades\AssetContainer;
 use Statamic\Tags\Tags;
 use Tests\Antlers\ParserTestCase;
 
@@ -45,5 +49,23 @@ class TagsTest extends ParserTestCase
         })::register();
 
         $this->assertSame('b', $this->renderString('{{ test_tag }}{{ a }}{{ /test_tag }}', [], true));
+    }
+
+    /**
+     * @see https://github.com/statamic/cms/issues/11257
+     */
+    public function test_objects_returned_from_tags_keep_their_data_when_assigned_to_a_variable()
+    {
+        Storage::fake('test', ['url' => '/assets']);
+        Storage::disk('test')->put('a.jpg', UploadedFile::fake()->image('a.jpg')->getContent());
+        tap(AssetContainer::make('test')->disk('test'))->save();
+        Asset::find('test::a.jpg')->data(['alt' => 'Alpha'])->save();
+
+        $template = <<<'EOT'
+{{ img = { asset url="/assets/a.jpg" } }}
+{{ img }}|{{ img.url }}|{{ img.alt }}|{{ img:alt }}
+EOT;
+
+        $this->assertSame('/assets/a.jpg|/assets/a.jpg|Alpha|Alpha', trim($this->renderString($template, [], true)));
     }
 }


### PR DESCRIPTION
This pull request fixes an issue where assigning the `asset` tag's result to a variable, like `{{ img = { asset url="/img/logo.png" } }}`, gave you the URL string rather than the asset, so `{{ img.alt }}`, `{{ img.width }}` and friends were empty.

This was happening because tag output inside an interpolation was reduced as if it were being rendered directly, and that path casts any object with `__toString` (like an `Asset`) to a string before the value is handed back.

This PR fixes it by keeping augmentable objects intact only when the interpolation is the right-hand side of an assignment. Interpolations used anywhere else, like dynamic keys (`{{ items.{tag} }}`), condition operands and expressions, are reduced to strings exactly as before. The Antlers runtime already knows how to work with an `Asset` held in a variable, so `{{ img }}` still outputs the URL, while `{{ img.alt }}`, `{{ img:width }}` and looping over `{{ img }}` now work too.

Since `img` now holds the asset rather than a string, `{{ if img === "/img/logo.png" }}` is false, the same as it is for an asset from a field. Loose `==` still matches.

Fixes #11257
