### PR TITLE
[6.x] Fix deleted terms reappearing after clearing the Stache

### DIFF
--- a/src/Stache/Stores/TaxonomyTermsStore.php
+++ b/src/Stache/Stores/TaxonomyTermsStore.php
@@ -73,6 +73,8 @@ class TaxonomyTermsStore extends ChildStore
         $this->handleFileChanges();
 
         if ($item = $this->getCachedItem($key)) {
+            $item->term()->syncOriginal();
+
             return $item;
         }
 
@@ -86,6 +88,8 @@ class TaxonomyTermsStore extends ChildStore
                 ->set('title', $this->index('title')->get($key))
                 ->in($site);
         }
+
+        $item->term()->syncOriginal();
 
         $this->cacheItem($item);
 

--- a/tests/Listeners/UpdateTermReferencesTest.php
+++ b/tests/Listeners/UpdateTermReferencesTest.php
@@ -315,6 +315,68 @@ class UpdateTermReferencesTest extends TestCase
     }
 
     #[Test]
+    public function it_nullifies_references_when_deleting_a_term_loaded_from_its_file()
+    {
+        $collection = tap(Facades\Collection::make('articles'))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'favourites',
+                    'field' => [
+                        'type' => 'terms',
+                        'taxonomies' => ['topics'],
+                        'mode' => 'select',
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'favourites' => ['hoff', 'norris'],
+        ]))->save();
+
+        $this->assertEquals(['hoff', 'norris'], $entry->get('favourites'));
+
+        Facades\Stache::store('terms')->store('topics')->forgetItem('en::hoff');
+
+        Facades\Term::find('topics::hoff')->delete();
+
+        $this->assertEquals(['norris'], $entry->fresh()->get('favourites'));
+    }
+
+    /** @see https://github.com/statamic/cms/issues/11264 */
+    #[Test]
+    public function it_nullifies_references_when_deleting_a_term_that_only_exists_in_entry_data()
+    {
+        $collection = tap(Facades\Collection::make('articles')->taxonomies(['topics']))->save();
+
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'topics',
+                    'field' => [
+                        'type' => 'terms',
+                        'taxonomies' => ['topics'],
+                        'mode' => 'select',
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection($collection)->data([
+            'topics' => ['hoff', 'ghost'],
+        ]))->save();
+
+        $this->assertEquals(['hoff', 'ghost'], $entry->get('topics'));
+
+        Facades\Term::find('topics::ghost')->delete();
+
+        $this->assertEquals(['hoff'], $entry->fresh()->get('topics'));
+        $this->assertNull(Facades\Term::find('topics::ghost'));
+    }
+
+    #[Test]
     public function it_nullifies_references_when_deleting_a_scoped_term()
     {
         $collection = tap(Facades\Collection::make('articles'))->save();


### PR DESCRIPTION
Deleting a taxonomy term left its slug behind in any entries referencing it, so the term reappeared as a "ghost" the next time the Stache was rebuilt.

`UpdateTermReferences` is what strips the slug from entries, but it bails when `$term->getOriginal('slug')` is empty — so the delete silently did nothing, and the leftover reference regenerated the term.

The original state was empty because `TaxonomyTermsStore` overrides `BasicStore::getItem` (to support terms which only exist in entry data), and #5502 removed the `syncOriginal()` that used to live in `makeItemFromFile`. Every other store still gets it from `BasicStore`.

This syncs the original state when a term is hydrated, before it's cached. The cache-hit branch backfills too, since items are cached with `forever()` and terms cached by an older version would otherwise never get one — but only when it's missing. Syncing unconditionally there mutates the shared cached instance, and both `TaxonomyTermsStore::save()` and `Term::save()` re-enter `getItem()` mid-save, which would reset the original and break renaming.

Fixes #11264
Caused by #5502
Related: #11058
