### PR TITLE
[6.x] Fix default values and fieldtype meta after saving entries and terms

### DIFF
--- a/resources/js/components/ui/Publish/Container.vue
+++ b/resources/js/components/ui/Publish/Container.vue
@@ -372,6 +372,7 @@ onUnmounted(() => {
 defineExpose({
     name: props.name,
     values,
+    meta,
     saving,
     saved,
     revealerFields,

--- a/resources/js/components/ui/Publish/SavePipeline.js
+++ b/resources/js/components/ui/Publish/SavePipeline.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import resetValuesFromResponse from '@/util/resetValuesFromResponse.js';
+import resetMetaFromResponse from '@/util/resetMetaFromResponse.js';
 import { reveal } from '@api';
 import { UPDATE_DEBOUNCE_MS } from '@/components/fieldtypes/constants';
 
@@ -78,7 +79,7 @@ export class Request extends Step {
                         container.value.setExtraValues(response.data.data.extraValues);
                     }
                     if (container && response.data.data?.hasOwnProperty('meta')) {
-                        container.value.setMeta(response.data.data.meta);
+                        container.value.setMeta(resetMetaFromResponse(response.data.data.meta, container.value));
                     }
                     resolve(response);
                 })

--- a/resources/js/components/ui/Publish/SavePipeline.js
+++ b/resources/js/components/ui/Publish/SavePipeline.js
@@ -77,6 +77,9 @@ export class Request extends Step {
                         );
                         container.value.setExtraValues(response.data.data.extraValues);
                     }
+                    if (container && response.data.data?.hasOwnProperty('meta')) {
+                        container.value.setMeta(response.data.data.meta);
+                    }
                     resolve(response);
                 })
                 .catch((e) => {

--- a/resources/js/tests/components/ui/Publish/SavePipeline.test.js
+++ b/resources/js/tests/components/ui/Publish/SavePipeline.test.js
@@ -44,6 +44,7 @@ beforeEach(() => {
         saved: vi.fn(),
         visibleValues: {},
         values: { id: 'the-id' },
+        meta: {},
         revealerFields: [],
         setValues: vi.fn(),
         setExtraValues: vi.fn(),
@@ -68,6 +69,25 @@ test('the request applies the values, extra values and meta from the response', 
     expect(container.value.setValues).toHaveBeenCalledWith({ id: 'the-id', title: 'Saved' });
     expect(container.value.setExtraValues).toHaveBeenCalledWith({ depth: 1 });
     expect(container.value.setMeta).toHaveBeenCalledWith({ tags: { data: [{ id: 'tags::alfa', title: 'Alfa' }] } });
+});
+
+test('the request keeps whether the slug is automatic when refreshing the meta', async () => {
+    container.value.meta = { slug: { auto: true }, tags: { data: [] } };
+    axios.patch.mockResolvedValue({
+        data: {
+            data: {
+                values: { title: 'Saved' },
+                meta: { slug: null, tags: { data: [{ id: 'tags::alfa', title: 'Alfa' }] } },
+            },
+        },
+    });
+
+    await pipeline([new Request('/entries/1', 'PATCH', {})]);
+
+    expect(container.value.setMeta).toHaveBeenCalledWith({
+        slug: { auto: true },
+        tags: { data: [{ id: 'tags::alfa', title: 'Alfa' }] },
+    });
 });
 
 test('the request leaves the meta alone when the response has none', async () => {

--- a/resources/js/tests/components/ui/Publish/SavePipeline.test.js
+++ b/resources/js/tests/components/ui/Publish/SavePipeline.test.js
@@ -1,7 +1,12 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { ref } from 'vue';
+import axios from 'axios';
 import Hooks from '@/components/Hooks.js';
-import { AfterSaveHooks, BeforeSaveHooks, Pipeline, PipelineStopped } from '@/components/ui/Publish/SavePipeline.js';
+import { AfterSaveHooks, BeforeSaveHooks, Pipeline, PipelineStopped, Request } from '@/components/ui/Publish/SavePipeline.js';
+
+vi.mock('axios', () => ({
+    default: { patch: vi.fn() },
+}));
 
 let saving;
 let errors;
@@ -34,8 +39,43 @@ function throwingStep(error) {
 beforeEach(() => {
     saving = ref(false);
     errors = ref({});
-    container = ref({ saving: vi.fn(), saved: vi.fn() });
+    container = ref({
+        saving: vi.fn(),
+        saved: vi.fn(),
+        visibleValues: {},
+        values: { id: 'the-id' },
+        revealerFields: [],
+        setValues: vi.fn(),
+        setExtraValues: vi.fn(),
+        setMeta: vi.fn(),
+    });
     global.Statamic = { $hooks: new Hooks() };
+});
+
+test('the request applies the values, extra values and meta from the response', async () => {
+    axios.patch.mockResolvedValue({
+        data: {
+            data: {
+                values: { title: 'Saved' },
+                extraValues: { depth: 1 },
+                meta: { tags: { data: [{ id: 'tags::alfa', title: 'Alfa' }] } },
+            },
+        },
+    });
+
+    await pipeline([new Request('/entries/1', 'PATCH', {})]);
+
+    expect(container.value.setValues).toHaveBeenCalledWith({ id: 'the-id', title: 'Saved' });
+    expect(container.value.setExtraValues).toHaveBeenCalledWith({ depth: 1 });
+    expect(container.value.setMeta).toHaveBeenCalledWith({ tags: { data: [{ id: 'tags::alfa', title: 'Alfa' }] } });
+});
+
+test('the request leaves the meta alone when the response has none', async () => {
+    axios.patch.mockResolvedValue({ data: { data: { values: { title: 'Saved' } } } });
+
+    await pipeline([new Request('/entries/1', 'PATCH', {})]);
+
+    expect(container.value.setMeta).not.toHaveBeenCalled();
 });
 
 test('it runs the steps and finishes', async () => {

--- a/resources/js/util/resetMetaFromResponse.js
+++ b/resources/js/util/resetMetaFromResponse.js
@@ -1,0 +1,12 @@
+export default function resetMetaFromResponse(responseMeta, container) {
+    const existingMeta = container.meta;
+
+    if (!responseMeta) return existingMeta;
+
+    // The slug fieldtype tracks whether the slug still follows its source. The server never sends it.
+    const auto = existingMeta?.slug?.auto;
+
+    if (auto === undefined) return responseMeta;
+
+    return { ...responseMeta, slug: { ...responseMeta.slug, auto } };
+}

--- a/resources/js/util/resetMetaFromResponse.js
+++ b/resources/js/util/resetMetaFromResponse.js
@@ -1,10 +1,6 @@
 export default function resetMetaFromResponse(responseMeta, container) {
-    const existingMeta = container.meta;
-
-    if (!responseMeta) return existingMeta;
-
     // The slug fieldtype tracks whether the slug still follows its source. The server never sends it.
-    const auto = existingMeta?.slug?.auto;
+    const auto = container.meta.slug?.auto;
 
     if (auto === undefined) return responseMeta;
 

--- a/src/Http/Controllers/CP/Collections/EntriesController.php
+++ b/src/Http/Controllers/CP/Collections/EntriesController.php
@@ -271,6 +271,7 @@ class EntriesController extends CpController
         return [
             'data' => array_merge((new EntryResource($entry->fresh()))->resolve()['data'], [
                 'values' => $values,
+                'meta' => $meta,
                 'extraValues' => $extraValues,
             ]),
             'saved' => $saved,

--- a/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
+++ b/src/Http/Controllers/CP/Collections/ExtractsFromEntryFields.php
@@ -2,6 +2,8 @@
 
 namespace Statamic\Http\Controllers\CP\Collections;
 
+use Statamic\Support\Arr;
+
 trait ExtractsFromEntryFields
 {
     protected function extractFromFields($entry, $blueprint)
@@ -11,7 +13,8 @@ trait ExtractsFromEntryFields
         $values = collect();
         $target = $entry;
         while ($target) {
-            $values = $target->data()->merge($target->computedData())->merge($values);
+            $data = $target->isRoot() ? collect(Arr::removeNullValues($target->data()->all())) : $target->data();
+            $values = $data->merge($target->computedData())->merge($values);
             $target = $target->origin();
         }
         $values = $values->all();

--- a/src/Http/Controllers/CP/Taxonomies/ExtractsFromTermFields.php
+++ b/src/Http/Controllers/CP/Taxonomies/ExtractsFromTermFields.php
@@ -2,15 +2,19 @@
 
 namespace Statamic\Http\Controllers\CP\Taxonomies;
 
+use Statamic\Support\Arr;
+
 trait ExtractsFromTermFields
 {
     protected function extractFromFields($term, $blueprint)
     {
         // The values should only be data merged with the origin data.
         // We don't want injected taxonomy values, which $term->values() would have given us.
-        $values = $term->inDefaultLocale()->data()->merge(
-            $term->data()
-        );
+        $values = collect(Arr::removeNullValues($term->inDefaultLocale()->data()->all()));
+
+        if (! $term->isRoot()) {
+            $values = $values->merge($term->data());
+        }
 
         $fields = $blueprint
             ->fields()

--- a/src/Http/Controllers/CP/Taxonomies/TermsController.php
+++ b/src/Http/Controllers/CP/Taxonomies/TermsController.php
@@ -196,13 +196,14 @@ class TermsController extends CpController
 
         $saved = $term->updateLastModified(User::current())->save();
 
-        [$values] = $this->extractFromFields($term, $term->blueprint());
+        [$values, $meta] = $this->extractFromFields($term, $term->blueprint());
 
         return (new TermResource($term))
             ->additional([
                 'saved' => $saved,
                 'data' => [
                     'values' => $values,
+                    'meta' => $meta,
                 ],
             ]);
     }

--- a/tests/Feature/Entries/UpdateEntryTest.php
+++ b/tests/Feature/Entries/UpdateEntryTest.php
@@ -12,6 +12,8 @@ use Statamic\Facades\Blueprint;
 use Statamic\Facades\Collection;
 use Statamic\Facades\Entry;
 use Statamic\Facades\Role;
+use Statamic\Facades\Taxonomy;
+use Statamic\Facades\Term;
 use Statamic\Facades\User;
 use Statamic\Structures\CollectionStructure;
 use Tests\FakesRoles;
@@ -384,6 +386,61 @@ class UpdateEntryTest extends TestCase
         $this->assertEquals('Auto Avada Kedavra', $entry->value('title'));
         $this->assertEquals('auto-avada-kedavra', $entry->slug());
         $this->assertEquals('auto-avada-kedavra.md', pathinfo($entry->path(), PATHINFO_BASENAME));
+    }
+
+    #[Test]
+    public function default_values_are_returned_for_fields_saved_empty()
+    {
+        [$user, $collection] = $this->seedUserAndCollection();
+        $this->seedBlueprintFields($collection, [
+            'nutrition_table' => [
+                'type' => 'grid',
+                'default' => [['name' => 'Sugar'], ['name' => 'Salt']],
+                'fields' => [['handle' => 'name', 'field' => ['type' => 'text']]],
+            ],
+        ]);
+
+        $entry = EntryFactory::collection($collection)
+            ->slug('existing-entry')
+            ->data(['title' => 'Existing Entry'])
+            ->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->update($entry)
+            ->assertOk();
+
+        $this->assertEquals(['Sugar', 'Salt'], collect($response->json('data.values.nutrition_table'))->pluck('name')->all());
+    }
+
+    #[Test]
+    public function meta_reflects_values_changed_while_saving()
+    {
+        [$user, $collection] = $this->seedUserAndCollection();
+        $this->seedBlueprintFields($collection, [
+            'tags' => ['type' => 'terms', 'taxonomies' => ['tags']],
+        ]);
+
+        Role::find('test')->addPermission('view tags terms');
+        Taxonomy::make('tags')->save();
+        Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alfa')->data(['title' => 'Alfa'])->save();
+
+        Event::listen(EntrySaving::class, function (EntrySaving $event) {
+            $event->entry->set('tags', ['alfa']);
+        });
+
+        $entry = EntryFactory::collection($collection)
+            ->slug('existing-entry')
+            ->data(['title' => 'Existing Entry'])
+            ->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->update($entry)
+            ->assertOk();
+
+        $this->assertEquals(['tags::alfa'], $response->json('data.values.tags'));
+        $this->assertEquals('Alfa', $response->json('data.meta.tags.data.0.title'));
     }
 
     #[Test]

--- a/tests/Feature/Entries/UpdateEntryTest.php
+++ b/tests/Feature/Entries/UpdateEntryTest.php
@@ -414,6 +414,44 @@ class UpdateEntryTest extends TestCase
     }
 
     #[Test]
+    public function localized_fields_saved_empty_stay_empty()
+    {
+        $this->setSites([
+            'en' => ['locale' => 'en', 'url' => '/'],
+            'fr' => ['locale' => 'fr', 'url' => '/fr/'],
+        ]);
+
+        [$user, $collection] = $this->seedUserAndCollection();
+        $collection->sites(['en', 'fr'])->save();
+        $this->seedBlueprintFields($collection, [
+            'nutrition_table' => [
+                'type' => 'grid',
+                'default' => [['name' => 'Sugar'], ['name' => 'Salt']],
+                'fields' => [['handle' => 'name', 'field' => ['type' => 'text']]],
+            ],
+        ]);
+
+        $origin = EntryFactory::collection($collection)
+            ->locale('en')
+            ->slug('origin')
+            ->data(['title' => 'Origin', 'nutrition_table' => [['name' => 'Fat']]])
+            ->create();
+
+        $localization = EntryFactory::collection($collection)
+            ->locale('fr')
+            ->origin($origin)
+            ->slug('localization')
+            ->create();
+
+        $response = $this
+            ->actingAs($user)
+            ->update($localization, ['nutrition_table' => [], '_localized' => ['nutrition_table']])
+            ->assertOk();
+
+        $this->assertSame([], $response->json('data.values.nutrition_table'));
+    }
+
+    #[Test]
     public function meta_reflects_values_changed_while_saving()
     {
         [$user, $collection] = $this->seedUserAndCollection();

--- a/tests/Feature/Taxonomies/UpdateTermTest.php
+++ b/tests/Feature/Taxonomies/UpdateTermTest.php
@@ -106,6 +106,41 @@ class UpdateTermTest extends TestCase
     }
 
     #[Test]
+    public function localized_fields_saved_empty_stay_empty()
+    {
+        $this->setSites([
+            'en' => ['locale' => 'en', 'url' => '/'],
+            'fr' => ['locale' => 'fr', 'url' => '/fr'],
+        ]);
+        $this->setTestRoles(['test' => ['access cp', 'edit tags terms', 'access fr site']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        Taxonomy::make('tags')->save();
+        $this->seedBlueprintFields('tags', [
+            'nutrition_table' => [
+                'type' => 'grid',
+                'default' => [['name' => 'Sugar'], ['name' => 'Salt']],
+                'fields' => [['handle' => 'name', 'field' => ['type' => 'text']]],
+            ],
+        ]);
+        $term = tap(Term::make()->taxonomy('tags')->slug('alfa')
+            ->dataForLocale('en', ['title' => 'alfa', 'nutrition_table' => [['name' => 'Fat']]])
+            ->dataForLocale('fr', ['title' => 'le alfa'])
+        )->save();
+
+        $response = $this
+            ->actingAs($user)
+            ->update($term->in('fr'), [
+                'title' => 'le alfa',
+                'nutrition_table' => [],
+                '_localized' => ['title', 'nutrition_table'],
+            ])
+            ->assertOk();
+
+        $this->assertSame([], $response->json('data.values.nutrition_table'));
+    }
+
+    #[Test]
     public function meta_reflects_values_changed_while_saving()
     {
         $this->setTestRoles(['test' => ['access cp', 'edit tags terms', 'view topics terms']]);

--- a/tests/Feature/Taxonomies/UpdateTermTest.php
+++ b/tests/Feature/Taxonomies/UpdateTermTest.php
@@ -2,7 +2,11 @@
 
 namespace Tests\Feature\Taxonomies;
 
+use Facades\Statamic\Fields\BlueprintRepository;
+use Illuminate\Support\Facades\Event;
 use PHPUnit\Framework\Attributes\Test;
+use Statamic\Events\TermSaving;
+use Statamic\Facades\Blueprint;
 use Statamic\Facades\Taxonomy;
 use Statamic\Facades\Term;
 use Statamic\Facades\User;
@@ -75,6 +79,68 @@ class UpdateTermTest extends TestCase
 
         $term = $term->fresh();
         $this->assertEquals('Updated alfa', $term->title);
+    }
+
+    #[Test]
+    public function default_values_are_returned_for_fields_saved_empty()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'edit tags terms']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        Taxonomy::make('tags')->save();
+        $this->seedBlueprintFields('tags', [
+            'nutrition_table' => [
+                'type' => 'grid',
+                'default' => [['name' => 'Sugar'], ['name' => 'Salt']],
+                'fields' => [['handle' => 'name', 'field' => ['type' => 'text']]],
+            ],
+        ]);
+        $term = tap(Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alfa')->data(['title' => 'alfa']))->save();
+
+        $response = $this
+            ->actingAs($user)
+            ->update($term, ['title' => 'Updated alfa'])
+            ->assertOk();
+
+        $this->assertEquals(['Sugar', 'Salt'], collect($response->json('data.values.nutrition_table'))->pluck('name')->all());
+    }
+
+    #[Test]
+    public function meta_reflects_values_changed_while_saving()
+    {
+        $this->setTestRoles(['test' => ['access cp', 'edit tags terms', 'view topics terms']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        Taxonomy::make('tags')->save();
+        Taxonomy::make('topics')->save();
+        $this->seedBlueprintFields('tags', [
+            'topics' => ['type' => 'terms', 'taxonomies' => ['topics']],
+        ]);
+        $this->seedBlueprintFields('topics', []);
+        Term::make()->taxonomy('topics')->inDefaultLocale()->slug('bravo')->data(['title' => 'Bravo'])->save();
+        $term = tap(Term::make()->taxonomy('tags')->inDefaultLocale()->slug('alfa')->data(['title' => 'alfa']))->save();
+
+        Event::listen(TermSaving::class, function (TermSaving $event) {
+            $event->term->set('topics', ['bravo']);
+        });
+
+        $response = $this
+            ->actingAs($user)
+            ->update($term, ['title' => 'Updated alfa'])
+            ->assertOk();
+
+        $this->assertEquals(['topics::bravo'], $response->json('data.values.topics'));
+        $this->assertEquals('Bravo', $response->json('data.meta.topics.data.0.title'));
+    }
+
+    private function seedBlueprintFields($taxonomy, $fields)
+    {
+        $blueprint = Blueprint::makeFromFields($fields);
+
+        BlueprintRepository::partialMock();
+        BlueprintRepository::shouldReceive('in')
+            ->with('taxonomies/'.$taxonomy)
+            ->andReturn(collect([$blueprint]));
     }
 
     private function update($term, $attrs = [])


### PR DESCRIPTION
This pull request fixes two issues with the publish form after saving an entry or term and continuing to edit.

Firstly, it fixes an issue where default values weren't applied to fields that had been saved empty (for example, a grid hidden behind a toggle with `always_save: false`), until the Stache was cleared.

This was happening because `Entry::fileData()` and `Term::fileData()` strip null and empty values before writing to disk, but the in-memory object (which is what the save response is built from, and what the Stache caches) keeps them. A hidden grid is processed to `[]`, which isn't null, so `Field::preProcess()` never fell back to the field's default.

This PR fixes it by mirroring the writer's rule when extracting publish form values: empty values are dropped for root entries and default-locale terms. Localizations are left alone since explicit nulls are meaningful there.

Secondly, it fixes an issue where relationship values set in an `EntrySaving` or `TermSaving` listener rendered as broken items after "Save & continue editing", until the page was reloaded.

This was happening because the save pipeline re-applied the response's `values`, but nothing refreshed the fieldtype `meta`, so the Relationship fieldtype had no item data for the newly added IDs.

This PR fixes it by returning `meta` from the entry and term update endpoints and applying it in the save pipeline alongside the values.

The same missing `meta` was also behind #15418: a conditionally hidden nested Replicator with `default:` rows gets fresh row IDs on every request, so after saving, the Assets fieldtypes inside those rows couldn't find their meta and threw, leaving the Control Panel unresponsive until a hard refresh.

Fixes #11355
Fixes #11396
Fixes #15418
Fixes #15428
Replaces #11356