### PR TITLE
[6.x] Fix page: 0 corrupting the collection tree in ReorderEntriesController

### DIFF
--- a/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
+++ b/src/Http/Controllers/CP/Collections/ReorderEntriesController.php
@@ -15,8 +15,8 @@ class ReorderEntriesController extends CpController
 
         $request->validate([
             'ids' => 'required|array',
-            'page' => 'required|integer',
-            'perPage' => 'required|integer',
+            'page' => 'required|integer|min:1',
+            'perPage' => 'required|integer|min:1',
             'site' => 'required',
         ]);
 

--- a/tests/Feature/Entries/ReorderEntriesTest.php
+++ b/tests/Feature/Entries/ReorderEntriesTest.php
@@ -212,6 +212,64 @@ class ReorderEntriesTest extends TestCase
     }
 
     #[Test]
+    public function it_doesnt_reorder_when_the_page_is_zero()
+    {
+        EntryFactory::id('1')->slug('one')->collection('test')->create();
+        EntryFactory::id('2')->slug('two')->collection('test')->create();
+        EntryFactory::id('3')->slug('three')->collection('test')->create();
+        EntryFactory::id('4')->slug('four')->collection('test')->create();
+
+        $tree = [
+            ['entry' => '1'],
+            ['entry' => '2'],
+            ['entry' => '3'],
+            ['entry' => '4'],
+        ];
+
+        $this->structure->in('en')->tree($tree)->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'reorder test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        // A zero page would otherwise give a negative offset, which slices the last
+        // entries off the tree and then writes negative keys back onto it.
+        $this
+            ->actingAs($user)
+            ->reorder(['page' => 0, 'perPage' => 2, 'ids' => [4, 3]])
+            ->assertSessionHasErrors('page');
+
+        $this->assertEquals($tree, $this->structure->in('en')->tree());
+    }
+
+    #[Test]
+    public function it_doesnt_reorder_when_the_per_page_is_zero()
+    {
+        EntryFactory::id('1')->slug('one')->collection('test')->create();
+        EntryFactory::id('2')->slug('two')->collection('test')->create();
+        EntryFactory::id('3')->slug('three')->collection('test')->create();
+        EntryFactory::id('4')->slug('four')->collection('test')->create();
+
+        $tree = [
+            ['entry' => '1'],
+            ['entry' => '2'],
+            ['entry' => '3'],
+            ['entry' => '4'],
+        ];
+
+        $this->structure->in('en')->tree($tree)->save();
+
+        $this->setTestRoles(['test' => ['access cp', 'reorder test entries']]);
+        $user = tap(User::make()->assignRole('test'))->save();
+
+        $this
+            ->actingAs($user)
+            ->reorder(['page' => 1, 'perPage' => 0, 'ids' => [4, 3]])
+            ->assertSessionHasErrors('perPage');
+
+        $this->assertEquals($tree, $this->structure->in('en')->tree());
+    }
+
+    #[Test]
     public function creating_an_entry_gives_it_the_correct_order_when_the_tree_has_already_been_read()
     {
         EntryFactory::id('1')->slug('one')->collection('test')->create();


### PR DESCRIPTION
`page: 0` (or `perPage: 0`) produces a negative array offset, which slices from the end of the tree, passes the out-of-date guard (the submitted ids genuinely match that slice), and then writes negative keys back onto the tree — appending duplicates instead of overwriting. The corrupt tree reaches disk before a 500 is thrown, permanently breaking the collection's entries listing until someone hand-edits the tree YAML.

Not reachable by clicking — the CP always posts the page it fetched — but a forged/malformed request can hit it via devtools, curl, or a buggy addon, so it's worth hardening.

Adds `min:1` to the `page`/`perPage` validation rules, matching what already ships for taxonomy reordering.