### PR TITLE
[6.x] Don't reset revisions when saving a collection with the field hidden

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -332,7 +332,6 @@ class CollectionsController extends CpController
             ->defaultPublishState($values['default_publish_state'])
             ->sortDirection($values['sort_direction'])
             ->mount($values['mount'] ?? null)
-            ->revisionsEnabled($values['revisions'] ?? false)
             ->taxonomies($values['taxonomies'] ?? [])
             ->futureDateBehavior(Arr::get($values, 'future_date_behavior'))
             ->pastDateBehavior(Arr::get($values, 'past_date_behavior'))
@@ -341,6 +340,10 @@ class CollectionsController extends CpController
             ->titleFormats($values['title_formats'])
             ->requiresSlugs($values['require_slugs'])
             ->previewTargets($values['preview_targets']);
+
+        if (array_key_exists('revisions', $values)) {
+            $collection->revisionsEnabled($values['revisions']);
+        }
 
         if ($sites = Arr::get($values, 'sites')) {
             $collection

--- a/tests/Feature/Collections/UpdateCollectionTest.php
+++ b/tests/Feature/Collections/UpdateCollectionTest.php
@@ -153,6 +153,40 @@ class UpdateCollectionTest extends TestCase
         $this->assertEquals(['test', 'link'], $blueprints->map->handle()->values()->all());
     }
 
+    #[Test]
+    public function it_updates_revisions()
+    {
+        config(['statamic.revisions.enabled' => true]);
+
+        $collection = tap(Collection::make('test')->revisionsEnabled(false))->save();
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($collection, ['revisions' => true])
+            ->assertOk();
+
+        $this->assertTrue(Collection::findByHandle('test')->revisionsEnabled());
+    }
+
+    #[Test]
+    public function it_doesnt_update_revisions_when_the_field_is_hidden()
+    {
+        config(['statamic.revisions.enabled' => true]);
+
+        $collection = tap(Collection::make('test')->revisionsEnabled(true))->save();
+
+        config(['statamic.revisions.enabled' => false]);
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($collection)
+            ->assertOk();
+
+        config(['statamic.revisions.enabled' => true]);
+
+        $this->assertTrue(Collection::findByHandle('test')->revisionsEnabled());
+    }
+
     private function userWithoutPermission()
     {
         $this->setTestRoles(['test' => ['access cp']]);


### PR DESCRIPTION
Saving a collection's config writes `revisions: false` into the collection YAML on any instance where revisions are switched off, even though the toggle was never on screen. If a site keeps `STATAMIC_REVISIONS_ENABLED` true in production and false locally, editing anything else in the collection config from local quietly turns revisions off for everyone.

The revisions field only gets added to the config blueprint when `statamic.revisions.enabled` is on and the site is Pro. Without it, the submitted values carry no `revisions` key at all, and the update fell back to `$values['revisions'] ?? false`.

The setter now only runs when the field was part of the form, so a hidden toggle leaves whatever is already in the YAML alone.

There's a related one I've left alone: with revisions on, `defaultPublishState()` always reports `false`, so the config form posts that value back and the collection picks up `default_status: draft` on a save that changed nothing. That needs a decision about what the getter should return rather than a guard, so it felt like a separate PR. Happy to pick it up if you want it.

Fixes #15430
