### PR TITLE
[6.x] Fix Composer script events crashing when locating composer.json

### DIFF
--- a/src/Console/Composer/Json.php
+++ b/src/Console/Composer/Json.php
@@ -2,7 +2,6 @@
 
 namespace Statamic\Console\Composer;
 
-use Illuminate\Support\Env;
 use Statamic\Facades\File;
 use Statamic\Facades\Path;
 use Statamic\Support\Arr;
@@ -11,7 +10,12 @@ class Json
 {
     public static function filename(): string
     {
-        return trim((string) Env::get('COMPOSER')) ?: 'composer.json';
+        // Read the env var using vanilla PHP so that this can be run in a Composer hook, where
+        // Composer registers the class autoloader but never runs the `autoload.files` entries.
+        // That means Laravel's helper functions don't exist, and `Env::get()` relies on `value()`.
+        $filename = $_ENV['COMPOSER'] ?? $_SERVER['COMPOSER'] ?? getenv('COMPOSER');
+
+        return trim((string) $filename) ?: 'composer.json';
     }
 
     public static function path(): string

--- a/tests/Composer/ComposerJsonTest.php
+++ b/tests/Composer/ComposerJsonTest.php
@@ -3,9 +3,11 @@
 namespace Tests\Composer;
 
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Composer\Json;
 use Statamic\Console\Composer\Scripts;
+use Symfony\Component\Process\Process;
 use Tests\TestCase;
 
 class ComposerJsonTest extends TestCase
@@ -75,6 +77,57 @@ class ComposerJsonTest extends TestCase
         ]));
 
         $this->assertFalse(Json::isMissingPreUpdateCmd());
+    }
+
+    #[Test]
+    #[DataProvider('composerScriptContextProvider')]
+    public function it_resolves_the_filenames_in_a_composer_script_context($composerEnv, $expected)
+    {
+        $this->assertEquals($expected, $this->runInComposerScriptContext($composerEnv));
+    }
+
+    public static function composerScriptContextProvider()
+    {
+        return [
+            'without the env var' => [false, "composer.json\ncomposer.lock\n"],
+            'with the env var' => ['composer.testing.json', "composer.testing.json\ncomposer.testing.lock\n"],
+        ];
+    }
+
+    /**
+     * When Composer runs a script event, it registers the class autoloader but never runs the
+     * `autoload.files` entries, so none of Laravel's helper functions exist. Replicate that
+     * in a subprocess to ensure we don't reach for anything that depends on them.
+     */
+    private function runInComposerScriptContext($composerEnv)
+    {
+        $script = <<<'EOT'
+require 'vendor/composer/ClassLoader.php';
+
+$loader = new Composer\Autoload\ClassLoader;
+
+foreach (require 'vendor/composer/autoload_psr4.php' as $namespace => $paths) {
+    $loader->setPsr4($namespace, $paths);
+}
+
+$loader->addClassMap(require 'vendor/composer/autoload_classmap.php');
+$loader->register();
+
+echo Statamic\Console\Composer\Json::filename()."\n";
+echo Statamic\Console\Composer\Lock::filename()."\n";
+EOT;
+
+        $process = new Process(
+            ['php', '-r', $script],
+            realpath(__DIR__.'/../..'),
+            ['COMPOSER' => $composerEnv],
+        );
+
+        $process->run();
+
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+
+        return $process->getOutput();
     }
 
     #[Test]

--- a/tests/Composer/ComposerJsonTest.php
+++ b/tests/Composer/ComposerJsonTest.php
@@ -3,11 +3,9 @@
 namespace Tests\Composer;
 
 use Illuminate\Filesystem\Filesystem;
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Composer\Json;
 use Statamic\Console\Composer\Scripts;
-use Symfony\Component\Process\Process;
 use Tests\TestCase;
 
 class ComposerJsonTest extends TestCase
@@ -77,57 +75,6 @@ class ComposerJsonTest extends TestCase
         ]));
 
         $this->assertFalse(Json::isMissingPreUpdateCmd());
-    }
-
-    #[Test]
-    #[DataProvider('composerScriptContextProvider')]
-    public function it_resolves_the_filenames_in_a_composer_script_context($composerEnv, $expected)
-    {
-        $this->assertEquals($expected, $this->runInComposerScriptContext($composerEnv));
-    }
-
-    public static function composerScriptContextProvider()
-    {
-        return [
-            'without the env var' => [false, "composer.json\ncomposer.lock\n"],
-            'with the env var' => ['composer.testing.json', "composer.testing.json\ncomposer.testing.lock\n"],
-        ];
-    }
-
-    /**
-     * When Composer runs a script event, it registers the class autoloader but never runs the
-     * `autoload.files` entries, so none of Laravel's helper functions exist. Replicate that
-     * in a subprocess to ensure we don't reach for anything that depends on them.
-     */
-    private function runInComposerScriptContext($composerEnv)
-    {
-        $script = <<<'EOT'
-require 'vendor/composer/ClassLoader.php';
-
-$loader = new Composer\Autoload\ClassLoader;
-
-foreach (require 'vendor/composer/autoload_psr4.php' as $namespace => $paths) {
-    $loader->setPsr4($namespace, $paths);
-}
-
-$loader->addClassMap(require 'vendor/composer/autoload_classmap.php');
-$loader->register();
-
-echo Statamic\Console\Composer\Json::filename()."\n";
-echo Statamic\Console\Composer\Lock::filename()."\n";
-EOT;
-
-        $process = new Process(
-            ['php', '-r', $script],
-            realpath(__DIR__.'/../..'),
-            ['COMPOSER' => $composerEnv],
-        );
-
-        $process->run();
-
-        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
-
-        return $process->getOutput();
     }
 
     #[Test]

--- a/tests/Composer/ComposerLockBackupTest.php
+++ b/tests/Composer/ComposerLockBackupTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Composer;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Console\Composer\Lock;
+use Symfony\Component\Process\Process;
 
 /**
  * Test that we can backup a composer lock file using vanilla PHP so that it can be run in a Composer hook.
@@ -15,6 +17,7 @@ class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
     protected $customLockPath = './custom/composer.lock';
     protected $backupLockPath = './storage/statamic/updater/composer.lock.bak';
     protected $customBackupLockPath = './custom/storage/statamic/updater/composer.lock.bak';
+    protected $tempDir;
 
     public function setUp(): void
     {
@@ -26,6 +29,7 @@ class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
     public function tearDown(): void
     {
         $this->removeLockFiles();
+        $this->removeTempDir();
 
         unset($_ENV['COMPOSER']);
 
@@ -84,6 +88,69 @@ class ComposerLockBackupTest extends \PHPUnit\Framework\TestCase
 
         $this->assertFileExists($this->customBackupLockPath);
         $this->assertEquals($content, file_get_contents($this->customBackupLockPath));
+    }
+
+    #[Test]
+    #[DataProvider('composerScriptContextProvider')]
+    public function it_can_backup_the_lock_file_in_a_composer_script_context($composerEnv, $expected)
+    {
+        $dir = $this->makeTempDir();
+
+        file_put_contents($dir.'/composer.lock', 'default lock file content');
+        file_put_contents($dir.'/composer.testing.lock', 'env lock file content');
+
+        // Composer builds a class autoloader for script events but never runs the `autoload.files`
+        // entries, so none of Laravel's or Statamic's helper functions exist. Replicate that here
+        // to ensure nothing reachable from the hook depends on them.
+        $script = str_replace('{{ vendor }}', realpath(__DIR__.'/../../vendor'), <<<'EOT'
+require '{{ vendor }}/composer/ClassLoader.php';
+
+$loader = new Composer\Autoload\ClassLoader;
+
+foreach (require '{{ vendor }}/composer/autoload_psr4.php' as $namespace => $paths) {
+    $loader->setPsr4($namespace, $paths);
+}
+
+$loader->addClassMap(require '{{ vendor }}/composer/autoload_classmap.php');
+$loader->register();
+
+Statamic\Console\Composer\Lock::backup();
+EOT);
+
+        $process = new Process(['php', '-r', $script], $dir, ['COMPOSER' => $composerEnv]);
+
+        $process->run();
+
+        $this->assertTrue($process->isSuccessful(), $process->getErrorOutput());
+        $this->assertEquals($expected, file_get_contents($dir.'/storage/statamic/updater/composer.lock.bak'));
+    }
+
+    public static function composerScriptContextProvider()
+    {
+        return [
+            'without the env var' => [false, 'default lock file content'],
+            'with the env var' => ['composer.testing.json', 'env lock file content'],
+        ];
+    }
+
+    private function makeTempDir()
+    {
+        mkdir($dir = sys_get_temp_dir().'/statamic-composer-hook-'.bin2hex(random_bytes(6)));
+
+        return $this->tempDir = $dir;
+    }
+
+    private function removeTempDir($dir = null)
+    {
+        if (! ($dir ??= $this->tempDir) || ! is_dir($dir)) {
+            return;
+        }
+
+        foreach (array_diff(scandir($dir), ['.', '..']) as $item) {
+            is_dir($path = $dir.'/'.$item) ? $this->removeTempDir($path) : unlink($path);
+        }
+
+        rmdir($dir);
     }
 
     private function removeLockFiles()


### PR DESCRIPTION
#15362 switched `Json::filename()` to `Illuminate\Support\Env::get('COMPOSER')`. That call is reachable from the `pre-update-cmd` hook, and Composer registers only the class autoloader for script events — it never runs the `autoload.files` entries, so none of Laravel's helper functions exist.

`Env::get()` evaluates `value($default)` when the variable is missing, so every `composer update` / `composer require` fataled with `Call to undefined function Illuminate\Support\value()`. Setups actually using the `COMPOSER` env var were unaffected, since that takes the other branch.

Reads the env var in vanilla PHP instead, using the same lookup order as `Env`.