### PR TITLE
[6.x] Reset remaining CP statics between requests in long-lived processes

### DIFF
--- a/src/Http/Middleware/SnapshotJsonVariables.php
+++ b/src/Http/Middleware/SnapshotJsonVariables.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Statamic\Http\Middleware;
+
+use Closure;
+use Statamic\Statamic;
+
+class SnapshotJsonVariables
+{
+    /**
+     * In long-lived processes, Statamic::$jsonVariables outlives the request, so
+     * per-request additions (CSRF token, current user, permissions) would leak
+     * into later requests. To prevent that, we snapshot the boot-time
+     * registrations so we can revert to them after each request, wiping out
+     * anything that was added while handling it.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        Statamic::snapshotJsonVariables();
+
+        return $next($request);
+    }
+}

--- a/src/Listeners/ClearState.php
+++ b/src/Listeners/ClearState.php
@@ -2,7 +2,9 @@
 
 namespace Statamic\Listeners;
 
+use Statamic\CP\Breadcrumbs\Breadcrumbs;
 use Statamic\Facades\URL;
+use Statamic\Statamic;
 use Statamic\View\State\StateManager;
 
 class ClearState
@@ -11,5 +13,8 @@ class ClearState
     {
         StateManager::resetState();
         URL::clearUrlCache();
+        Statamic::restoreJsonVariablesSnapshot();
+        Statamic::$isRenderingCpException = false;
+        Breadcrumbs::$pushed = [];
     }
 }

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -60,7 +60,10 @@ class AppServiceProvider extends ServiceProvider
             ->pushMiddleware(\Statamic\Http\Middleware\CheckComposerJsonScripts::class)
             ->pushMiddleware(\Statamic\Http\Middleware\CheckMultisite::class)
             ->pushMiddleware(\Statamic\Http\Middleware\StopImpersonating::class)
-            ->pushMiddleware(PingOutpost::class);
+            ->pushMiddleware(PingOutpost::class)
+            // Prepended so the snapshot runs before any middleware that could
+            // throw and render a page (which would register json variables).
+            ->prependMiddleware(\Statamic\Http\Middleware\SnapshotJsonVariables::class);
 
         $this->loadViewsFrom("{$this->root}/resources/views", 'statamic');
 

--- a/src/Statamic.php
+++ b/src/Statamic.php
@@ -38,6 +38,7 @@ class Statamic
     protected static $webRoutes = [];
     protected static $actionRoutes = [];
     protected static $jsonVariables = [];
+    protected static $jsonVariablesSnapshot = null;
     protected static $bootedCallbacks = [];
     protected static $afterInstalledCallbacks = [];
     public static bool $isRenderingCpException = false;
@@ -244,6 +245,21 @@ class Statamic
         static::$jsonVariables = array_merge(static::$jsonVariables, $variables);
 
         return new static;
+    }
+
+    public static function snapshotJsonVariables()
+    {
+        // Once per process: the first request's starting state is the boot-time
+        // state, and keeping it pristine means a request that fails mid-cycle
+        // can never bake its own variables into the baseline.
+        static::$jsonVariablesSnapshot ??= static::$jsonVariables;
+    }
+
+    public static function restoreJsonVariablesSnapshot()
+    {
+        if (static::$jsonVariablesSnapshot !== null) {
+            static::$jsonVariables = static::$jsonVariablesSnapshot;
+        }
     }
 
     public static function svg($name, $attrs = null, $fallback = null)

--- a/tests/Listeners/ClearStateTest.php
+++ b/tests/Listeners/ClearStateTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Listeners;
+
+use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use Statamic\CP\Breadcrumbs\Breadcrumb;
+use Statamic\CP\Breadcrumbs\Breadcrumbs;
+use Statamic\Listeners\ClearState;
+use Statamic\Statamic;
+use Tests\TestCase;
+
+class ClearStateTest extends TestCase
+{
+    private array $originalJsonVariables;
+    private ?array $originalJsonVariablesSnapshot;
+
+    protected function resolveApplicationConfiguration($app)
+    {
+        parent::resolveApplicationConfiguration($app);
+
+        $app->booted(function () {
+            Route::get('/provide-to-script', function () {
+                Statamic::provideToScript(['request' => 'value']);
+
+                return 'ok';
+            });
+        });
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalJsonVariables = $this->getStatamicStatic('jsonVariables');
+        $this->originalJsonVariablesSnapshot = $this->getStatamicStatic('jsonVariablesSnapshot');
+    }
+
+    public function tearDown(): void
+    {
+        $this->setStatamicStatic('jsonVariables', $this->originalJsonVariables);
+        $this->setStatamicStatic('jsonVariablesSnapshot', $this->originalJsonVariablesSnapshot);
+        Statamic::$isRenderingCpException = false;
+        Breadcrumbs::$pushed = [];
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function it_resets_cp_exception_and_breadcrumb_state()
+    {
+        Statamic::$isRenderingCpException = true;
+        Breadcrumbs::$pushed = [new Breadcrumb(text: 'Test')];
+
+        (new ClearState)->handle();
+
+        $this->assertFalse(Statamic::$isRenderingCpException);
+        $this->assertSame([], Breadcrumbs::$pushed);
+    }
+
+    #[Test]
+    public function it_registers_the_snapshot_middleware()
+    {
+        $this->assertTrue(
+            $this->app[\Illuminate\Contracts\Http\Kernel::class]
+                ->hasMiddleware(\Statamic\Http\Middleware\SnapshotJsonVariables::class)
+        );
+    }
+
+    #[Test]
+    public function it_restores_json_variables_to_the_snapshot()
+    {
+        $this->setStatamicStatic('jsonVariablesSnapshot', null);
+        Statamic::provideToScript(['boot' => 'value']);
+        Statamic::snapshotJsonVariables();
+        Statamic::provideToScript(['request' => 'value']);
+
+        (new ClearState)->handle();
+
+        $variables = Statamic::jsonVariables(request());
+
+        $this->assertSame('value', $variables['boot']);
+        $this->assertArrayNotHasKey('request', $variables);
+    }
+
+    #[Test]
+    public function it_leaves_json_variables_alone_when_no_snapshot_was_taken()
+    {
+        $this->setStatamicStatic('jsonVariablesSnapshot', null);
+        Statamic::provideToScript(['foo' => 'bar']);
+
+        (new ClearState)->handle();
+
+        $this->assertSame('bar', Statamic::jsonVariables(request())['foo']);
+    }
+
+    #[Test]
+    public function json_variables_registered_before_a_request_survive_the_reset_but_ones_registered_during_it_do_not()
+    {
+        $this->setStatamicStatic('jsonVariablesSnapshot', null);
+        Statamic::provideToScript(['boot' => 'value']);
+
+        $this->get('/provide-to-script')->assertOk();
+
+        $variables = Statamic::jsonVariables(request());
+        $this->assertSame('value', $variables['boot']);
+        $this->assertArrayNotHasKey('request', $variables);
+
+        $this->get('/provide-to-script')->assertOk();
+
+        $variables = Statamic::jsonVariables(request());
+        $this->assertSame('value', $variables['boot']);
+        $this->assertArrayNotHasKey('request', $variables);
+    }
+
+    private function getStatamicStatic(string $property)
+    {
+        return (new ReflectionProperty(Statamic::class, $property))->getValue();
+    }
+
+    private function setStatamicStatic(string $property, $value): void
+    {
+        (new ReflectionProperty(Statamic::class, $property))->setValue(null, $value);
+    }
+}


### PR DESCRIPTION
Under long-lived processes (e.g. Laravel Octane), the process serves many requests, and we need to be super careful that data doesn't leak between requests. Most of that is already taken care of by the `ClearState` listener, which resets Antlers runtime state, stateful tags, and the URL cache after every request — but `$jsonVariables`, `$isRenderingCpException`, and breadcrumbs still leaked. This PR closes those gaps.

#### How it solves request-to-request leakage

- **Restoring `$jsonVariables` to a boot-time snapshot** - `$jsonVariables` can't just be cleared — boot-time registrations must survive. So we snapshot it once, at the start of the process's first request (the one moment where all boot-time registrations exist and no request-time ones do), and revert to that snapshot after every response.
- **Resetting `$isRenderingCpException`** - it's set to `true` when a CP error page renders and never set back, so one CP error would degrade every later CP response from the process. Now it's set back to `false` after every response.
- **Clearing breadcrumbs** - `Breadcrumbs::$pushed` only ever accumulates, so one request's breadcrumbs would show up on every later one. Now it's emptied after every response.

Like the earlier fixes in this class (#9240, #9241, #11283), this is unconditional: it's behavior-neutral under PHP-FPM, since the resets run after the response is built and the process exits right after anyway (and with no snapshot taken — console, queue — the restore is a no-op).
