### PR TITLE
[6.x] Prevent Cascade hydrated-callback accumulation on error renders

### DIFF
--- a/src/Exceptions/Concerns/RendersHttpExceptions.php
+++ b/src/Exceptions/Concerns/RendersHttpExceptions.php
@@ -52,7 +52,7 @@ trait RendersHttpExceptions
 
     protected function contents()
     {
-        Cascade::hydrated(function ($cascade) {
+        Cascade::hydratedOnce(function ($cascade) {
             $cascade->set('response_code', $this->getStatusCode());
         });
 

--- a/src/Facades/Cascade.php
+++ b/src/Facades/Cascade.php
@@ -18,6 +18,7 @@ use Statamic\Sites\Site;
  * @method static void set(string $key, $value)
  * @method static void data(array $data)
  * @method static self hydrated(Closure $callback)
+ * @method static self hydratedOnce(Closure $callback)
  * @method static self hydrate()
  * @method static array getViewData(string $view)
  * @method static Collection sections()

--- a/src/View/Cascade.php
+++ b/src/View/Cascade.php
@@ -19,6 +19,7 @@ class Cascade
     protected $content;
     protected $sections;
     protected $hydratedCallbacks = [];
+    protected $hydratedOnceCallbacks = [];
 
     public function __construct(Request $request, Site $site, array $data = [])
     {
@@ -86,6 +87,13 @@ class Cascade
         return $this;
     }
 
+    public function hydratedOnce($callback)
+    {
+        $this->hydratedOnceCallbacks[] = $callback;
+
+        return $this;
+    }
+
     public function hydrate()
     {
         $this->data([]);
@@ -103,6 +111,13 @@ class Cascade
     private function runHydratedCallbacks()
     {
         foreach ($this->hydratedCallbacks as $callback) {
+            $callback($this);
+        }
+
+        $callbacks = $this->hydratedOnceCallbacks;
+        $this->hydratedOnceCallbacks = [];
+
+        foreach ($callbacks as $callback) {
             $callback($this);
         }
 

--- a/tests/FrontendTest.php
+++ b/tests/FrontendTest.php
@@ -699,6 +699,23 @@ class FrontendTest extends TestCase
     }
 
     #[Test]
+    public function a_404_does_not_leak_its_response_code_into_later_requests()
+    {
+        // In a long-lived process the Cascade is reused between requests. A 404 render
+        // must not poison the response_code seen by subsequent successful requests.
+        $this->withFakeViews();
+        $this->viewShouldReturnRaw('layout', '{{ template_content }}');
+        $this->viewShouldReturnRaw('some_template', 'Page {{ response_code }}');
+        $this->viewShouldReturnRaw('errors.404', 'Not found {{ response_code }}');
+
+        $this->createPage('about', ['with' => ['template' => 'some_template']]);
+
+        $this->get('unknown')->assertNotFound()->assertSee('Not found 404');
+
+        $this->get('/about')->assertOk()->assertSee('Page 200');
+    }
+
+    #[Test]
     public function it_sets_the_translation_locale_based_on_site()
     {
         app('translator')->addNamespace('test', __DIR__.'/__fixtures__/lang');

--- a/tests/View/CascadeTest.php
+++ b/tests/View/CascadeTest.php
@@ -525,6 +525,60 @@ class CascadeTest extends TestCase
     }
 
     #[Test]
+    public function a_hydrated_once_callback_only_runs_on_the_next_hydration()
+    {
+        $cascade = $this->cascade();
+
+        $cascade->hydratedOnce(function ($cascade) {
+            $cascade->set('response_code', 404);
+        });
+
+        // The callback runs during this hydration...
+        $this->assertEquals(404, $cascade->hydrate()->toArray()['response_code']);
+
+        // ...but not on subsequent ones, so the value falls back to its default.
+        $this->assertEquals(200, $cascade->hydrate()->toArray()['response_code']);
+    }
+
+    #[Test]
+    public function hydrated_once_callbacks_do_not_accumulate_across_hydrations()
+    {
+        $cascade = $this->cascade();
+
+        $runs = 0;
+        $register = function () use ($cascade, &$runs) {
+            $cascade->hydratedOnce(function () use (&$runs) {
+                $runs++;
+            });
+        };
+
+        // Simulate two error renders on the same long-lived process.
+        $register();
+        $cascade->hydrate();
+        $register();
+        $cascade->hydrate();
+
+        // Two registrations, two runs — not three (which is what accumulation would cause).
+        $this->assertEquals(2, $runs);
+    }
+
+    #[Test]
+    public function persistent_hydrated_callbacks_still_run_every_hydration()
+    {
+        $cascade = $this->cascade();
+
+        $runs = 0;
+        $cascade->hydrated(function () use (&$runs) {
+            $runs++;
+        });
+
+        $cascade->hydrate();
+        $cascade->hydrate();
+
+        $this->assertEquals(2, $runs);
+    }
+
+    #[Test]
     public function page_data_overrides_globals()
     {
         Event::fake(); // prevents taxonomy term tracker from kicking in.


### PR DESCRIPTION
When rendering an HTTP error page, `RendersHttpExceptions::contents()` registers a `Cascade::hydrated()` callback to set `response_code`. But hydrated callbacks are persistent — they run on every hydration — and nothing removes it. In a long-lived process (e.g. Laravel Octane, or a queue worker), that's a latent bug:

- **Wrong `response_code` on later pages.** `hydrate()` sets `response_code` to `200`, then runs the callbacks, which overwrite it. After a single 404, every later page rendered by that process reports the stale error code in its cascade.
- **Unbounded growth.** Each error render appends another callback that's never removed, and each retains its exception, so they accumulate for the life of the process.

#### The fix

Add a one-shot variant, `Cascade::hydratedOnce()`, that runs on the next hydration and is then discarded, and use it for the error `response_code`. Persistent `hydrated()` callbacks (e.g. static caching's `setCascade`) are untouched and keep running every hydration.

Tests cover the new one-shot behavior directly and, end-to-end, that a rendered 404 no longer leaks its status into a subsequent successful request on the same process.
