### PR TITLE
[6.x] Give reference updater fields the item being updated as their parent

### DIFF
--- a/src/Data/DataReferenceUpdater.php
+++ b/src/Data/DataReferenceUpdater.php
@@ -85,7 +85,23 @@ abstract class DataReferenceUpdater
      */
     protected function getTopLevelFields()
     {
-        return $this->item->blueprint()->fields()->all();
+        return $this->fieldsWithItemAsParent($this->item->blueprint()->fields());
+    }
+
+    /**
+     * While updating references, the parent of every field is the item being updated.
+     *
+     * Blueprints hand back a Fields instance that's cached globally by handle, and nested fields
+     * are constructed without a parent at all, so neither can be relied upon to have the right
+     * one. The fields are cloned rather than mutated in place, otherwise the item would leak
+     * into every other consumer of that blueprint for the rest of the request.
+     *
+     * @param  \Statamic\Fields\Fields  $fields
+     * @return \Illuminate\Support\Collection
+     */
+    private function fieldsWithItemAsParent($fields)
+    {
+        return $fields->all()->map(fn ($field) => (clone $field)->setParent($this->item));
     }
 
     /**
@@ -120,7 +136,7 @@ abstract class DataReferenceUpdater
      */
     public function processNestedFields($fields, $dottedPrefix): void
     {
-        $this->recursivelyUpdateFields($fields->all(), $dottedPrefix);
+        $this->recursivelyUpdateFields($this->fieldsWithItemAsParent($fields), $dottedPrefix);
     }
 
     /**

--- a/tests/Data/DataReferenceUpdaterTest.php
+++ b/tests/Data/DataReferenceUpdaterTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Tests\Data;
+
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Assets\AssetReferenceUpdater;
+use Statamic\Facades;
+use Statamic\Fields\Fieldtype;
+use Statamic\Fieldtypes\UpdatesReferences;
+use Tests\PreventSavingStacheItemsToDisk;
+use Tests\TestCase;
+
+class DataReferenceUpdaterTest extends TestCase
+{
+    use PreventSavingStacheItemsToDisk;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        ParentRecorderFieldtype::register();
+        ParentRecorderFieldtype::$parents = [];
+
+        tap(Facades\Collection::make('articles'))->save();
+    }
+
+    #[Test]
+    public function it_gives_top_level_fields_the_item_being_updated_as_their_parent()
+    {
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                ['handle' => 'hero', 'field' => ['type' => 'parent_recorder']],
+            ],
+        ]);
+
+        $one = tap(Facades\Entry::make()->collection('articles')->slug('one')->data(['hero' => 'hoff.jpg']))->save();
+        $two = tap(Facades\Entry::make()->collection('articles')->slug('two')->data(['hero' => 'hoff.jpg']))->save();
+
+        $this->updateReferences($one);
+        $this->updateReferences($two);
+
+        $this->assertCount(2, ParentRecorderFieldtype::$parents);
+        $this->assertSame($one, ParentRecorderFieldtype::$parents[0]);
+        $this->assertSame($two, ParentRecorderFieldtype::$parents[1]);
+    }
+
+    #[Test]
+    public function it_gives_nested_fields_the_item_being_updated_as_their_parent()
+    {
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                [
+                    'handle' => 'grid',
+                    'field' => [
+                        'type' => 'grid',
+                        'fields' => [
+                            ['handle' => 'hero', 'field' => ['type' => 'parent_recorder']],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection('articles')->slug('one')->data([
+            'grid' => [['hero' => 'hoff.jpg']],
+        ]))->save();
+
+        $this->updateReferences($entry);
+
+        $this->assertCount(1, ParentRecorderFieldtype::$parents);
+        $this->assertSame($entry, ParentRecorderFieldtype::$parents[0]);
+    }
+
+    #[Test]
+    public function it_doesnt_leave_the_item_on_the_blueprints_shared_fields()
+    {
+        $this->setInBlueprints('collections/articles', [
+            'fields' => [
+                ['handle' => 'hero', 'field' => ['type' => 'parent_recorder']],
+            ],
+        ]);
+
+        $entry = tap(Facades\Entry::make()->collection('articles')->slug('one')->data(['hero' => 'hoff.jpg']))->save();
+
+        $blueprint = Facades\Collection::find('articles')->entryBlueprint();
+        $blueprint->setParent(null);
+
+        $this->updateReferences($entry);
+
+        $this->assertNull($blueprint->fields()->get('hero')->parent());
+    }
+
+    private function setInBlueprints($namespace, $blueprintContents)
+    {
+        $blueprint = tap(Facades\Blueprint::make('set-in-blueprints')->setContents($blueprintContents))->save();
+
+        Facades\Blueprint::shouldReceive('in')->with($namespace)->andReturn(collect([$blueprint]));
+    }
+
+    private function updateReferences($item)
+    {
+        AssetReferenceUpdater::item($item)
+            ->filterByContainer('test_container')
+            ->updateReferences('hoff.jpg', 'norris.jpg');
+    }
+}
+
+class ParentRecorderFieldtype extends Fieldtype
+{
+    use UpdatesReferences;
+
+    public static $parents = [];
+
+    public function replaceAssetReferences($data, ?string $newValue, string $oldValue, string $container)
+    {
+        static::$parents[] = $this->field->parent();
+
+        return $data;
+    }
+}


### PR DESCRIPTION
When a term is renamed or an asset is moved, `DataReferenceUpdater` loops over every entry, term, global and user, and hands each item's fields to the fieldtypes that participate in reference updating. Those fields were not reliably carrying the item as their parent, so any fieldtype reading `$field->parent()` during a reference update would read the wrong thing.

Two separate causes:

- **Top-level fields.** `getTopLevelFields()` used `$this->item->blueprint()->fields()->all()`. `Blueprint::fields()` returns `$this->fieldsCache` before it re-applies the parent, and the `Fields` object underneath comes from `Blink::once($this->fieldsBlinkKey(), ...)` — cached globally by blueprint handle, not per `Blueprint` instance. In a loop over many items, the parent stuck on whichever item got there first.
- **Nested fields.** `processNestedFields()` called `$fields->all()` with no parent at all. Replicator, Bard, Grid and Group each build a bare `new Fields($fields)` for the reference-update path, so there was nothing to inherit.

Both call sites now go through one helper. It clones each field rather than calling `setParent()` on the shared `Fields`, because `Fields::setParent()` mutates in place and propagates to every child `Field` — setting the parent there would fix the loop but leave the last-updated item pinned to the blueprint's cached fields for the rest of the request, where an unrelated reader would pick it up.

### Scope

This is a latent bug on `6.x`: nothing currently on the reference-update path reads `$field->parent()`. I checked every implementation — `Assets`, `Link`, `Markdown`, `Bard`, `Replicator`, `Grid`, `Group` and `Terms` — and none of them do. The one asset-side parent read, `Assets::dynamicFolder()`, is on the publish path, not this one.

So this is a contract fix rather than a user-visible bug fix: during a reference update, a field's parent is the item being updated, and now it says so. It's being fixed on its own because the hierarchical taxonomies work (#15192) adds the first fieldtype that would misread it, and the fix doesn't belong in a taxonomy PR.

### Tests

`tests/Data/DataReferenceUpdaterTest.php` registers a fieldtype that records the parent it was handed, since no stock fieldtype exercises this yet. Each test was checked to fail for the right reason:

| Test | Before | With `setParent()` on the shared fields | This PR |
|---|---|---|---|
| top-level parent across two entries | fails — both record the first entry | passes | passes |
| nested (grid) field parent | fails — records `null` | passes | passes |
| parent doesn't leak onto the blueprint's shared fields | passes — nothing was ever set | fails | passes |