### PR TITLE
[6.x] Fix Bard sets showing the wrong values after saving

### DIFF
--- a/resources/js/components/fieldtypes/bard/BardFieldtype.vue
+++ b/resources/js/components/fieldtypes/bard/BardFieldtype.vue
@@ -449,18 +449,20 @@ export default {
             }
         },
 
-        value(value, oldValue) {
+        value(value) {
             if (!this.editor) return;
-
-            if (this.editor.view.dom.contains(document.activeElement)) return;
 
             const oldContent = this.editor.getJSON();
             const content = this.valueToContent(value);
 
-            if (JSON.stringify(content) !== JSON.stringify(oldContent)) {
-                this.editor.commands.clearContent(false);
-                this.editor.commands.setContent(content, true);
-            }
+            if (JSON.stringify(content) === JSON.stringify(oldContent)) return;
+
+            // Sets sync their own values into the editor, so while it's focused those changes
+            // don't need a rebuild, which would destroy the field being typed in.
+            if (this.editorIsFocused() && this.onlySetValuesDiffer(value, oldContent.content ?? [])) return;
+
+            this.editor.commands.clearContent(false);
+            this.editor.commands.setContent(content, true);
         },
 
         readOnly(readOnly) {
@@ -950,6 +952,24 @@ export default {
 
         valueToContent(value) {
             return value.length ? { type: 'doc', content: value } : null;
+        },
+
+        editorIsFocused() {
+            return this.editor.view.dom.contains(document.activeElement);
+        },
+
+        onlySetValuesDiffer(nodes, oldNodes) {
+            return JSON.stringify(this.withoutSetValues(nodes)) === JSON.stringify(this.withoutSetValues(oldNodes));
+        },
+
+        withoutSetValues(nodes) {
+            return nodes.map((node) => {
+                if (node.type === 'set') return { ...node, attrs: { ...node.attrs, values: null } };
+
+                if (node.content) return { ...node, content: this.withoutSetValues(node.content) };
+
+                return node;
+            });
         },
 
         getExtensions() {

--- a/resources/js/tests/components/fieldtypes/bard/BardFieldtype.test.js
+++ b/resources/js/tests/components/fieldtypes/bard/BardFieldtype.test.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, expect, test, vi } from 'vitest';
 import { Editor } from '@tiptap/vue-3';
 import * as Globals from '@/bootstrap/globals';
 import BardFieldtype from '@/components/fieldtypes/bard/BardFieldtype.vue';
+import Provider from '@/components/portals/Provider.vue';
 import { containerContextKey } from '@/components/ui/Publish/Container.vue';
 
 Object.keys(Globals).forEach((fn) => (window[fn] = Globals[fn]));
@@ -14,16 +15,27 @@ window.__n = (key, count) => key.split('|')[count === 1 ? 0 : 1].replace(/:count
 // Five words, twenty four characters.
 const value = [{ type: 'paragraph', content: [{ type: 'text', text: 'One two three four five.' }] }];
 
-async function mountField(config = {}) {
+const sets = [{ handle: 'main', sets: [{ handle: 'card', display: 'Card', fields: [] }] }];
+
+function set(id, label) {
+    return { type: 'set', attrs: { id, enabled: true, values: { type: 'card', label } } };
+}
+
+async function mountField(config = {}, initialValue = value) {
     const wrapper = mount(BardFieldtype, {
         props: {
-            value,
+            value: initialValue,
             handle: 'content',
             config: { sets: [], buttons: ['bold'], ...config },
             meta: { existing: {}, collapsed: [], defaults: {}, new: {} },
         },
         global: {
             stubs: {
+                portal: {
+                    components: { Provider },
+                    props: ['provide'],
+                    template: '<provider :variables="provide"><slot /></provider>',
+                },
                 'publish-field-fullscreen-header': true,
                 'ui-icon': true,
                 'set-picker': true,
@@ -53,6 +65,10 @@ async function mountField(config = {}) {
 async function type(wrapper, text) {
     wrapper.vm.editor.commands.insertContent(text);
     await wrapper.vm.$nextTick();
+}
+
+function focusEditor(wrapper) {
+    vi.spyOn(document, 'activeElement', 'get').mockReturnValue(wrapper.vm.editor.view.dom);
 }
 
 beforeEach(() => {
@@ -116,4 +132,42 @@ test('word and character counts are rendered when reading time is disabled', asy
     const wrapper = await mountField({ reading_time: false, word_count: true, character_limit: 100 });
 
     expect(wrapper.find('.bard-footer-toolbar').text()).toBe('5 words, 24/100 characters');
+});
+
+// After saving with a keyboard shortcut the editor keeps focus, and the server may have
+// removed empty nodes. The editor has to follow that, otherwise the sets it renders
+// point at the wrong indexes in the saved value.
+// @see https://github.com/statamic/cms/issues/15440
+test('the editor is rebuilt when the value loses nodes while the editor is focused', async () => {
+    const wrapper = await mountField({ sets }, [
+        { type: 'paragraph' },
+        set('set-a', 'A'),
+        { type: 'paragraph' },
+        set('set-b', 'B'),
+    ]);
+    focusEditor(wrapper);
+
+    await wrapper.setProps({ value: [set('set-a', 'A'), set('set-b', 'B')] });
+
+    expect(wrapper.vm.editor.getJSON().content).toEqual([set('set-a', 'A'), set('set-b', 'B')]);
+});
+
+// Typing inside a set's fields changes the value from within the editor. Rebuilding the
+// editor for that would destroy the field being typed in.
+test('the editor is left alone when only set values change while the editor is focused', async () => {
+    const wrapper = await mountField({ sets }, [set('set-a', 'A'), { type: 'paragraph' }]);
+    focusEditor(wrapper);
+    const setContent = vi.spyOn(wrapper.vm.editor.commands, 'setContent');
+
+    await wrapper.setProps({ value: [set('set-a', 'Changed'), { type: 'paragraph' }] });
+
+    expect(setContent).not.toHaveBeenCalled();
+});
+
+test('the editor is rebuilt when the value changes while the editor is not focused', async () => {
+    const wrapper = await mountField({ sets }, [set('set-a', 'A'), { type: 'paragraph' }]);
+
+    await wrapper.setProps({ value: [set('set-a', 'Changed'), { type: 'paragraph' }] });
+
+    expect(wrapper.vm.editor.getJSON().content).toEqual([set('set-a', 'Changed'), { type: 'paragraph' }]);
 });


### PR DESCRIPTION
This pull request fixes an issue where Bard sets would show the next set's values after saving, when the field has `remove_empty_nodes` enabled. Saving a second time would then write those wrong values to the entry.

This was happening because the `value` watcher skips rebuilding the editor from the save response while the editor is focused. With `remove_empty_nodes: true`, the server had stripped the empty paragraphs, so the sets in the editor were pointing at the wrong indexes in the saved value.

This PR fixes it by only skipping the rebuild while focused when the change is confined to set values (which sets sync into the editor themselves). Anything else rebuilds the editor, like it does when the editor isn't focused.

Fixes #15440
Caused by #14808

