### PR TITLE
[6.x] Preserve hidden collection settings on update

### DIFF
--- a/src/Http/Controllers/CP/Collections/CollectionsController.php
+++ b/src/Http/Controllers/CP/Collections/CollectionsController.php
@@ -332,7 +332,6 @@ class CollectionsController extends CpController
             ->defaultPublishState($values['default_publish_state'])
             ->sortDirection($values['sort_direction'])
             ->mount($values['mount'] ?? null)
-            ->revisionsEnabled($values['revisions'] ?? false)
             ->taxonomies($values['taxonomies'] ?? [])
             ->futureDateBehavior(Arr::get($values, 'future_date_behavior'))
             ->pastDateBehavior(Arr::get($values, 'past_date_behavior'))
@@ -341,6 +340,10 @@ class CollectionsController extends CpController
             ->titleFormats($values['title_formats'])
             ->requiresSlugs($values['require_slugs'])
             ->previewTargets($values['preview_targets']);
+
+        if (array_key_exists('revisions', $values)) {
+            $collection->revisionsEnabled($values['revisions']);
+        }
 
         if ($sites = Arr::get($values, 'sites')) {
             $collection

--- a/tests/Feature/Collections/UpdateCollectionTest.php
+++ b/tests/Feature/Collections/UpdateCollectionTest.php
@@ -83,6 +83,24 @@ class UpdateCollectionTest extends TestCase
     }
 
     #[Test]
+    public function it_preserves_revisions_when_the_field_is_hidden()
+    {
+        config(['statamic.revisions.enabled' => true]);
+        $collection = tap(Collection::make('test')->revisionsEnabled(true))->save();
+
+        config(['statamic.revisions.enabled' => false]);
+
+        $this
+            ->actingAs($this->userWithPermission())
+            ->update($collection)
+            ->assertOk();
+
+        config(['statamic.revisions.enabled' => true]);
+
+        $this->assertTrue(Collection::find('test')->revisionsEnabled());
+    }
+
+    #[Test]
     public function setting_links_to_true_will_create_a_blueprint_if_it_doesnt_already_exist()
     {
         BlueprintRepository::swap(new FakeBlueprintRepository(BlueprintRepository::getFacadeRoot()));


### PR DESCRIPTION
Closes #15430

Saving a collection's config always applied `revisionsEnabled($values['revisions'] ?? false)`, so if `revisions` isn't in the submitted request it gets forced to `false`. The `revisions` field is only shown on the config screen when `STATAMIC_REVISIONS_ENABLED` is `true`, so on an instance/environment where that's `false`, saving a collection's config silently wipes out `revisions: true` in its YAML even though nothing related was touched.

Fixed by only calling `revisionsEnabled()` when `revisions` is actually present in the request, so the existing value survives when the field is hidden. Added a regression test that saves a collection with revisions enabled while the config flag (and therefore the field) is disabled, then confirms the setting wasn't overwritten.

Kept the fix scoped to this field since other conditionally-hidden collection settings have different defaults/semantics and widening this would need its own look.
